### PR TITLE
Fixed: preconditions weren't checked anymore

### DIFF
--- a/tests/functional.coffee
+++ b/tests/functional.coffee
@@ -7,9 +7,9 @@ filesHelpers = require './helpers/files'
 
 {syncPath} = helpers.options
 
-describe.only "Functional Tests", ->
+describe "Functional Tests", ->
 
-    #before helpers.ensurePreConditions
+    before helpers.ensurePreConditions
 
     # Prepares the local system
     before filesHelpers.deleteAll


### PR DESCRIPTION
This commit enables the preconditions check, so if you have something that would prevent the tests from running properly, it'll tell you.
