### PR TITLE
Enable insecure HTTPS at runtime

### DIFF
--- a/backend/config.coffee
+++ b/backend/config.coffee
@@ -131,4 +131,17 @@ module.exports = config =
         fs.writeFileSync config.configPath, JSON.stringify @config, null, 2
         console.log 'Configuration file successfully updated'
 
+    setInsecure: (bool) ->
+        @config.insecure = bool
+        @saveConfig()
+        @config
+
+    augmentPouchOptions: (options) ->
+        if @config.insecure
+            options.ajax =
+                rejectUnauthorized: false
+                requestCert: true
+                agent: false
+        options
+
 config.init()

--- a/backend/db.coffee
+++ b/backend/db.coffee
@@ -385,6 +385,10 @@ module.exports = dbHelpers =
                 or (doc._deleted and (doc.docType is 'Folder' or doc.docType is 'File'))
             live: false
             since: startChangeSeq
+            ajax:
+                rejectUnauthorized: false
+                requestCert: true
+                agent: false
 
         if not @replicatorTo or Object.keys(@replicatorTo._events).length is 0
             @replicatorTo = db.replicate.to(url, opts)

--- a/backend/db.coffee
+++ b/backend/db.coffee
@@ -385,10 +385,8 @@ module.exports = dbHelpers =
                 or (doc._deleted and (doc.docType is 'Folder' or doc.docType is 'File'))
             live: false
             since: startChangeSeq
-            ajax:
-                rejectUnauthorized: false
-                requestCert: true
-                agent: false
+
+        opts = config.augmentPouchOptions opts
 
         if not @replicatorTo or Object.keys(@replicatorTo._events).length is 0
             @replicatorTo = db.replicate.to(url, opts)

--- a/backend/remote_event_watcher.coffee
+++ b/backend/remote_event_watcher.coffee
@@ -95,10 +95,8 @@ remoteEventWatcher =
                 res
             live: false
             since: config.getRemoteSeq()
-            ajax:
-                rejectUnauthorized: false
-                requestCert: true
-                agent: false
+
+        options = config.augmentPouchOptions options
 
         if pouch.replicationDelay is 0 and (not @replicatorFrom \
         or Object.keys(@replicatorFrom._events).length is 0)

--- a/backend/remote_event_watcher.coffee
+++ b/backend/remote_event_watcher.coffee
@@ -95,6 +95,10 @@ remoteEventWatcher =
                 res
             live: false
             since: config.getRemoteSeq()
+            ajax:
+                rejectUnauthorized: false
+                requestCert: true
+                agent: false
 
         if pouch.replicationDelay is 0 and (not @replicatorFrom \
         or Object.keys(@replicatorFrom._events).length is 0)

--- a/cli.coffee
+++ b/cli.coffee
@@ -102,6 +102,8 @@ displayQuery = (query) ->
 # Start database sync process and setup file change watcher.
 sync = (args) ->
 
+    config.setInsecure(args.insecure?)
+
     config = config.getConfig()
 
     if not (config.deviceName? and config.url? and config.path?)
@@ -148,6 +150,8 @@ program
             'only apply remote changes to local folder')
     .option('-f, --force',
             'Run sync from the beginning of all the Cozy changes.')
+    .option('-k, --insecure',
+            'Turn off HTTPS certificate verification.')
     .action sync
 
 program


### PR DESCRIPTION
So these two commits fixes #81, by adding an option --insecure (short flag is -k, which is the same in curl).  This option disables certificate validation.  Will be useful once https://github.com/pouchdb/pouchdb/issues/3504 gets fixed.