### PR TITLE
Updated path-extra to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-notifier": "4.3.1",
     "node-uuid": "1.4.3",
     "open": "0.0.5",
-    "path-extra": "1.0.3",
+    "path-extra": "2.0.0",
     "ping": "0.1.10",
     "pouchdb": "4.0.3",
     "printit": "0.1.9",


### PR DESCRIPTION
:rocket:

path-extra just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 6 commits (ahead by 6, behind by 0).

- [07260c7](https://github.com/jprichardson/node-path-extra/commit/07260c7caf5cc2908b7b41ce246d9b94c2ce3eb5): 2.0.0
- [051c724](https://github.com/jprichardson/node-path-extra/commit/051c724f7d92e2c4a7e5f9b7ae9b1f9dd5d752af): Merge pull request #13 from nono/env
- [c9061f3](https://github.com/jprichardson/node-path-extra/commit/c9061f339a5ad2c67a7759677a1110c86f127ff2): Respect XDG Base Directory Specification
- [acf71ed](https://github.com/jprichardson/node-path-extra/commit/acf71ed95a09b77dfa8d457e3d8fcfa42ed69186): Respect the TMPDIR env
- [429336f](https://github.com/jprichardson/node-path-extra/commit/429336fabcf7581643d75f86e2dae2c650875301): Merge pull request #12 from 1j01/patch-1
- [bd21988](https://github.com/jprichardson/node-path-extra/commit/bd21988c0d0025bf5c762c507f94618b99ee1116): Improve documentation

See the [full diff](https://github.com/jprichardson/node-path-extra/compare/ed7a6ff43d0e247168b3455351037feacb2b6517...07260c7caf5cc2908b7b41ce246d9b94c2ce3eb5).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>