### PR TITLE
Work-around for nested deletion

### DIFF
--- a/backend/merge.coffee
+++ b/backend/merge.coffee
@@ -396,6 +396,8 @@ class Merge
                         # before their parents, hence the reverse order.
                         docs = docs.reverse()
                         docs.push folder
+                        # TODO find why we have undefined values here sometimes
+                        docs = (doc for doc in docs when doc?)
                         for doc in docs
                             doc._deleted = true
                         @pouch.db.bulkDocs docs, callback


### PR DESCRIPTION
Cozy-desktop failed after doing `mkdir a/b/c/d ; rm -rf a` in a watched folder. I think it's a race condition in PouchDB, but I didn't reproduce it on a simpler test case. For the moment, this commit is a work-around for this bug. But for the long-term, we should find the real bug.