### PR TITLE
Fix for images on write-only

### DIFF
--- a/tests/unit/remote/index.coffee
+++ b/tests/unit/remote/index.coffee
@@ -314,6 +314,12 @@ describe 'Remote', ->
         it 'does not ignore conflict for important changes'
 
 
+    describe 'removeRemoteDoc', ->
+        it 'removes the doc on the remote cozy'
+        it 'resolves conflict with trivial changes'
+        it 'does not ignore conflict for important changes'
+
+
     describe 'addFile', ->
         it 'adds a file to couchdb', (done) ->
             checksum = 'fc7e0b72b8e64eb05e05aef652d6bbed950f85df'

--- a/tests/unit/remote/index.coffee
+++ b/tests/unit/remote/index.coffee
@@ -240,6 +240,80 @@ describe 'Remote', ->
                             done()
 
 
+    describe 'sameRemoteDoc', ->
+        it 'returns true if the documents are the same', ->
+            one =
+                _id: '5e93939833e147a78c61b115f50cc77d'
+                _rev: '12-e91c1c55d2b82087682e32a30036a22b'
+                docType: 'file'
+                path: ''
+                name: 'planche.jpg'
+                creationDate: '2015-11-23T15:30:01.831Z'
+                lastModification: '2015-11-23T15:30:01.831Z'
+                checksum: 'd0d3ddb1ccc7b4362c928b5f194dae5f7a0005f9'
+                size: 539118
+                class: 'image'
+                mime: 'image/jpeg'
+                binary:
+                    file:
+                        id: 'd0d3ddb1ccc7b4362c928b5f194dae5f7a0005f9'
+                        rev: '7-39a6777ab539b47d046888011f4f089d'
+                    thumb:
+                        id: 'df8d4874a4d8316877abf61b3e0057a0'
+                        rev: '2-d3540f14ece76cd5104c0059871f0373'
+            two =
+                _id: '24af4c7ae9454f7e9d1f78219554cf19'
+                docType: 'file'
+                path: ''
+                name: 'planche.jpg'
+                creationDate: '2015-11-23T15:30:01.831Z'
+                lastModification: '2015-11-23T15:30:01.831Z'
+                checksum: 'd0d3ddb1ccc7b4362c928b5f194dae5f7a0005f9'
+                size: 539118
+                class: 'image'
+                mime: 'image/jpeg'
+            @remote.sameRemoteDoc(one, two).should.be.true()
+
+        it 'returns false if the documents are different', ->
+            one =
+                _id: '5e93939833e147a78c61b115f50cc77d'
+                _rev: '12-e91c1c55d2b82087682e32a30036a22b'
+                docType: 'file'
+                path: ''
+                name: 'planche.jpg'
+                creationDate: '2015-11-23T15:30:01.831Z'
+                lastModification: '2015-11-23T15:30:01.831Z'
+                checksum: 'd0d3ddb1ccc7b4362c928b5f194dae5f7a0005f9'
+                size: 539118
+                class: 'image'
+                mime: 'image/jpeg'
+                binary:
+                    file:
+                        id: 'd0d3ddb1ccc7b4362c928b5f194dae5f7a0005f9'
+                        rev: '7-39a6777ab539b47d046888011f4f089d'
+                    thumb:
+                        id: 'df8d4874a4d8316877abf61b3e0057a0'
+                        rev: '2-d3540f14ece76cd5104c0059871f0373'
+            two =
+                _id: '85f39bb308ea4340a606970c1b9e2bb8'
+                docType: 'file'
+                path: ''
+                name: 'planche.jpg'
+                creationDate: '2015-11-23T15:23:46.352Z'
+                lastModification: '2015-11-23T15:23:46.352Z'
+                checksum: 'c584315c6fd2155030808ee96fdf80bf20161cc3',
+                size: 84980,
+                class: 'image'
+                mime: 'image/jpeg'
+            @remote.sameRemoteDoc(one, two).should.be.false()
+
+
+    describe 'putRemoteDoc', ->
+        it 'puts the doc on the remote cozy'
+        it 'resolves conflict with trivial changes'
+        it 'does not ignore conflict for important changes'
+
+
     describe 'addFile', ->
         it 'adds a file to couchdb', (done) ->
             checksum = 'fc7e0b72b8e64eb05e05aef652d6bbed950f85df'


### PR DESCRIPTION
When an image is uploaded on the cozy, its metadata are updated in the
CouchDB to include a thumbnail. So, for the write-only mode, it is
expected that the remote revision can sometimes be desynchronized with
the revision stored in the local PouchDB. This commit adds a way to
bypass this desynchronization and allow to update/remove the images.