### PR TITLE
Case insensitive fs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
     - 5
 env:
     global:
-        - NODE_ENV=test
         - CXX=g++-4.8
 services:
     - couchdb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0 - 2015-11-??
+## 0.5.0 - 2015-11-30
 
 - Add a write-only mode
 - Fix some bugs with the read-only mode

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ it simple and easy. So, it has some limitations:
 - For OSX, filenames with weird unicode characters may be problematic in some
   rare cases.
 
+- Symbolic links and ACL are not yet handled.
+
 - The full sync directory must be on the same partition.
 
 - Large files must be uploaded/downloaded in one time (we are thinking about

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ it simple and easy. So, it has some limitations:
   - not too many changes
   - etc.
 
+- For OSX, filenames with weird unicode characters may be problematic in some
+  rare cases.
+
 - The full sync directory must be on the same partition.
 
 - Large files must be uploaded/downloaded in one time (we are thinking about

--- a/backend/local/index.coffee
+++ b/backend/local/index.coffee
@@ -25,7 +25,7 @@ class Local
     # Create a readable stream for the given doc
     createReadStream: (doc, callback) ->
         try
-            filePath = path.resolve @basePath, doc._id
+            filePath = path.resolve @basePath, doc.path
             stream = fs.createReadStream filePath
             callback null, stream
         catch err
@@ -37,7 +37,7 @@ class Local
 
     # Return a function that will update last modification date
     utimesUpdater: (doc) =>
-        filePath = path.resolve @basePath, doc._id
+        filePath = path.resolve @basePath, doc.path
         (callback) ->
             if doc.lastModification
                 lastModification = new Date doc.lastModification
@@ -60,7 +60,7 @@ class Local
                 callback null, false
             else
                 paths = for doc in docs when @isUpToDate doc
-                    path.resolve @basePath, doc._id
+                    path.resolve @basePath, doc.path
                 async.detect paths, fs.exists, (foundPath) ->
                     callback null, foundPath
 
@@ -68,11 +68,9 @@ class Local
     ### Write operations ###
 
     # Steps to create a file:
-    #   * Checks if the doc is valid: has a path and a name
-    #   * Ensure that the temporary directory exists
     #   * Try to find a similar file based on his checksum
     #     (in that case, it just requires a local copy)
-    #   * Download the linked binary from remote
+    #   * Or download the linked binary from remote
     #   * Write to a temporary file
     #   * Ensure parent folder exists
     #   * Move the temporay file to its final destination
@@ -84,9 +82,9 @@ class Local
     # TODO verify the checksum -> remove file if not ok
     # TODO save the checksum if it didn't have one
     addFile: (doc, callback) =>
-        tmpFile  = path.resolve @tmpPath, path.basename doc._id
-        filePath = path.resolve @basePath, doc._id
-        parent   = path.resolve @basePath, path.dirname doc._id
+        tmpFile  = path.resolve @tmpPath, path.basename doc.path
+        filePath = path.resolve @basePath, doc.path
+        parent   = path.resolve @basePath, path.dirname doc.path
 
         log.info "put file #{filePath}"
 
@@ -125,7 +123,7 @@ class Local
 
     # Create a new folder
     addFolder: (doc, callback) =>
-        folderPath = path.join @basePath, doc._id
+        folderPath = path.join @basePath, doc.path
         log.info "put folder #{folderPath}"
         fs.ensureDir folderPath, (err) =>
             if err
@@ -150,9 +148,9 @@ class Local
     # Move a file from one place to another
     # TODO verify checksum
     moveFile: (doc, old, callback) =>
-        oldPath = path.join @basePath, old._id
-        newPath = path.join @basePath, doc._id
-        parent  = path.join @basePath, path.dirname doc._id
+        oldPath = path.join @basePath, old.path
+        newPath = path.join @basePath, doc.path
+        parent  = path.join @basePath, path.dirname doc.path
 
         async.waterfall [
             (next) ->
@@ -182,9 +180,9 @@ class Local
 
     # Move a folder
     moveFolder: (doc, old, callback) =>
-        oldPath = path.join @basePath, old._id
-        newPath = path.join @basePath, doc._id
-        parent  = path.join @basePath, path.dirname doc._id
+        oldPath = path.join @basePath, old.path
+        newPath = path.join @basePath, doc.path
+        parent  = path.join @basePath, path.dirname doc.path
 
         async.waterfall [
             (next) ->
@@ -215,8 +213,8 @@ class Local
 
     # Delete a file from the local filesystem
     deleteFile: (doc, callback) =>
-        log.info "delete #{doc._id}"
-        fullpath = path.join @basePath, doc._id
+        log.info "delete #{doc.path}"
+        fullpath = path.join @basePath, doc.path
         fs.remove fullpath, callback
 
     # Delete a folder from the local filesystem

--- a/backend/local/watcher.coffee
+++ b/backend/local/watcher.coffee
@@ -68,7 +68,7 @@ class LocalWatcher
         [mimeType, fileClass] = @getFileClass absPath
         @checksum absPath, (err, checksum) ->
             doc =
-                _id: filePath
+                path: filePath
                 docType: 'file'
                 checksum: checksum
                 creationDate: stats.ctime
@@ -124,7 +124,7 @@ class LocalWatcher
             log.debug 'Folder added', folderPath
             @paths?.push folderPath
             doc =
-                _id: folderPath
+                path: folderPath
                 docType: 'folder'
                 creationDate: stats.ctime
                 lastModification: stats.mtime
@@ -133,12 +133,12 @@ class LocalWatcher
     # File deletion detected
     onUnlink: (filePath) =>
         log.debug 'File deleted', filePath
-        @merge.deleteFile @side, _id: filePath, @done
+        @merge.deleteFile @side, path: filePath, @done
 
     # Folder deletion detected
     onUnlinkDir: (folderPath) =>
         log.debug 'Folder deleted', folderPath
-        @merge.deleteFolder @side, _id: folderPath, @done
+        @merge.deleteFolder @side, path: folderPath, @done
 
     # File update detected
     onChange: (filePath, stats) =>
@@ -158,6 +158,7 @@ class LocalWatcher
                     callback err
                 else
                     async.eachSeries docs.reverse(), (doc, next) =>
+                        # TODO _id vs path -> normalize @paths
                         if doc._id in @paths
                             next()
                         else

--- a/backend/merge.coffee
+++ b/backend/merge.coffee
@@ -133,7 +133,6 @@ class Merge
 
     # Be sure that the tree structure for the given path exists
     # TODO bulk create/update and check status, instead of recursive?
-    # TODO path vs _id
     ensureParentExist: (side, doc, callback) =>
         parent = path.dirname doc._id
         if parent is '.'
@@ -143,11 +142,14 @@ class Merge
                 if folder
                     callback()
                 else
-                    @ensureParentExist side, _id: parent, (err) =>
+                    parentDoc =
+                        _id: parent
+                        path: path.dirname doc.path
+                    @ensureParentExist side, parentDoc, (err) =>
                         if err
                             callback err
                         else
-                            @putFolder side, _id: parent, callback
+                            @putFolder side, parentDoc, callback
 
     # Simple helper to add a file or a folder
     addDoc: (side, doc, callback) =>
@@ -354,7 +356,7 @@ class Merge
                 doc.size             ?= was.size
                 doc.class            ?= was.class
                 doc.mime             ?= was.mime
-                was.moveTo            = doc._id  # TODO doc._id or doc.path?
+                was.moveTo            = doc._id
                 was._deleted          = true
                 if file
                     # TODO should be a conflict?

--- a/backend/remote/index.coffee
+++ b/backend/remote/index.coffee
@@ -72,7 +72,7 @@ class Remote
 
     # Transform a local document in a remote one, with optional binary ref
     createRemoteDoc: (local, remote) ->
-        [dir, name] = @extractDirAndName local._id
+        [dir, name] = @extractDirAndName local.path
         doc =
             docType: local.docType
             path: dir
@@ -156,12 +156,12 @@ class Remote
     # Create a file on the remote cozy instance
     # It can also be an overwrite of the file
     addFile: (doc, callback) =>
-        log.info "Add file #{doc._id}"
+        log.info "Add file #{doc.path}"
         @addOrOverwriteFile doc, null, callback
 
     # Create a folder on the remote cozy instance
     addFolder: (doc, callback) =>
-        log.info "Add folder #{doc._id}"
+        log.info "Add folder #{doc.path}"
         folder = @createRemoteDoc doc
         @couch.put folder, (err, created) ->
             unless err
@@ -172,7 +172,7 @@ class Remote
 
     # Overwrite a file
     overwriteFile: (doc, old, callback) =>
-        log.info "Overwrite file #{doc._id}"
+        log.info "Overwrite file #{doc.path}"
         @addOrOverwriteFile doc, old, callback
 
     # Add or overwrite a file
@@ -215,7 +215,7 @@ class Remote
 
     # Update the metadata of a file
     updateFileMetadata: (doc, old, callback) ->
-        log.info "Update file #{doc._id}"
+        log.info "Update file #{doc.path}"
         if old.remote
             remoteDoc = @createRemoteDoc doc, old.remote
             @putRemoteDoc remoteDoc, old, (err, updated) ->
@@ -230,13 +230,13 @@ class Remote
 
     # Update metadata of a folder
     updateFolder: (doc, old, callback) ->
-        log.info "Update folder #{doc._id}"
+        log.info "Update folder #{doc.path}"
         if old.remote
             @couch.get old.remote._id, (err, folder) =>
                 if err
                     callback err
                 else
-                    # TODO what if folder.path+name != doc._id ?
+                    # TODO what if folder.path+name != doc.path ?
                     # TODO Or folder._rev != doc.remote._rev
                     folder.tags = doc.tags
                     folder.lastModification = doc.lastModification
@@ -251,13 +251,13 @@ class Remote
 
     # Move a file on the remote cozy instance
     moveFile: (doc, old, callback) ->
-        log.info "Move file #{old._id} → #{doc._id}"
+        log.info "Move file #{old.path} → #{doc.path}"
         if old.remote
             @couch.get old.remote._id, (err, remoteDoc) =>
                 if err
                     @addFile doc, callback
                 else
-                    [dir, name] = @extractDirAndName doc._id
+                    [dir, name] = @extractDirAndName doc.path
                     remoteDoc.path = dir
                     remoteDoc.name = name
                     remoteDoc.lastModification = doc.lastModification
@@ -273,15 +273,15 @@ class Remote
 
     # Move a folder on the remote cozy instance
     moveFolder: (doc, old, callback) =>
-        log.info "Move folder #{old._id} → #{doc._id}"
+        log.info "Move folder #{old.path} → #{doc.path}"
         if old.remote
             @couch.get old.remote._id, (err, folder) =>
                 if err
                     callback err
                 else
-                    # TODO what if folder.path+name != old._id ?
+                    # TODO what if folder.path+name != old.path ?
                     # TODO Or folder._rev != doc.remote._rev
-                    [dir, name] = @extractDirAndName doc._id
+                    [dir, name] = @extractDirAndName doc.path
                     folder.path = dir
                     folder.name = name
                     folder.tags = doc.tags
@@ -292,7 +292,7 @@ class Remote
 
     # Delete a file on the remote cozy instance
     deleteFile: (doc, callback) =>
-        log.info "Delete file #{doc._id}"
+        log.info "Delete file #{doc.path}"
         return callback() unless doc.remote
         remoteDoc = @createRemoteDoc doc, doc.remote
         @removeRemoteDoc remoteDoc, (err, removed) =>
@@ -304,7 +304,7 @@ class Remote
 
     # Delete a folder on the remote cozy instance
     deleteFolder: (doc, callback) =>
-        log.info "Delete folder #{doc._id}"
+        log.info "Delete folder #{doc.path}"
         if doc.remote
             remoteDoc = @createRemoteDoc doc, doc.remote
             remoteDoc._deleted = true

--- a/backend/remote/watcher.coffee
+++ b/backend/remote/watcher.coffee
@@ -119,7 +119,7 @@ class RemoteWatcher
         docPath = remote.path or ''
         docName = remote.name or ''
         doc =
-            _id: path.join docPath, docName
+            path: path.join docPath, docName
             docType: remote.docType.toLowerCase()
             creationDate: remote.creationDate
             lastModification: remote.lastModification
@@ -137,17 +137,17 @@ class RemoteWatcher
     # Transform the doc and save it in pouchdb
     #
     # In CouchDB, the filepath is in the path and name fields.
-    # In PouchDB, the filepath is in the _id.
+    # In PouchDB, the filepath is in the path only.
     # And the _id/_rev from CouchDB are saved in the remote field in PouchDB.
     putDoc: (remote, was, callback) =>
         doc = @createLocalDoc remote
-        if @merge.invalidId doc
+        if @merge.invalidPath doc
             log.error "Invalid id"
             log.error doc
             callback new Error 'Invalid path/name'
         else if not was
             @merge.addDoc @side, doc, callback
-        else if was._id is doc._id
+        else if was.path is doc.path
             @merge.updateDoc @side, doc, callback
         else if doc.checksum? and was.checksum is doc.checksum
             @merge.moveDoc @side, doc, was, callback

--- a/doc/design.md
+++ b/doc/design.md
@@ -52,3 +52,41 @@ Documents schema
 ----------------
 
 See [`backend/merge.coffee`](https://github.com/cozy-labs/cozy-desktop/blob/master/backend/merge.coffee#L15-L37)
+
+
+Differences between file systems
+--------------------------------
+
+In short, the file systems have some differences between Linux, BSD, OSX and
+Windows. In short:
+
+- The path separator is `/` everywhere, except on Windows where it's `\\ `.
+- Linux and BSD file systems are sensible to the case, OSX and Windows are not
+  (they preserve the original case, but they consider `foo` and `FOO` to be
+  the same file).
+- Linux and BSD use UTF-8 encoding for filenames, with no normalization.
+  Windows uses UTF-16. OSX does something stupid: UTF-8 with a normalization
+  that is nearly the unicode NFD, but not exactly.
+- `/` and the NULL character are forbidden on all the OSes. On Windows, the
+  list is longer: `"/\\*?<>|:`.
+- They are a bunch more restrictions on Windows:
+  - the length of a path is limited to 260 characters
+  - some names are reserved, like `AUX`, `COM1` or `LPT1`
+  - a file or directory name cannot end with a space or a period.
+
+Node.js helps us a bit, but we are on our own for most of the things in this
+list.
+
+For detecting conflicts, we need to know if two paths are the same. With the
+issue of case sensitivity and NFD normalization, it's not as easy as it seems.
+For Linux and BSD, we take the path and we put it in the `_id` field. For
+Windows and OSX, we make the path upper case before putting it in `_id` field.
+For OSX, we also does a string normalization on this field. Now, when a new
+file is added, we can check in pouchdb and see if another file has path that
+will collide with this new path.
+
+So, even if `path` and `_id` are very similar, they have distinct roles:
+
+- `_id` is the normalized form and is used for comparison of paths
+- `path` is the prefered form and used for actions on local file system and
+  remote cozy.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-uuid": "1.4.7",
     "path-extra": "3.0.0",
     "pouchdb": "5.1.0",
-    "printit": "0.1.10",
+    "printit": "0.1.15",
     "progress": "1.1.8",
     "read": "1.0.7",
     "request-json-light": "0.5.22"

--- a/tests/helpers/pouch.coffee
+++ b/tests/helpers/pouch.coffee
@@ -16,6 +16,7 @@ module.exports =
     createParentFolder: (pouch, callback) ->
         doc =
             _id: 'my-folder'
+            path: 'my-folder'
             docType: 'folder'
             creationDate: new Date()
             lastModification: new Date()
@@ -23,8 +24,10 @@ module.exports =
         pouch.db.put doc, callback
 
     createFolder: (pouch, i, callback) ->
+        id = path.join 'my-folder', "folder-#{i}"
         doc =
-            _id: path.join 'my-folder', "folder-#{i}"
+            _id: id
+            path: id
             docType: 'folder'
             creationDate: new Date()
             lastModification: new Date()
@@ -34,8 +37,10 @@ module.exports =
         pouch.db.put doc, callback
 
     createFile: (pouch, i, callback) ->
+        id = path.join 'my-folder', "file-#{i}"
         doc =
-            _id: path.join 'my-folder', "file-#{i}"
+            _id: id
+            path: id
             docType: 'file'
             checksum: "111111111111111111111111111111111111111#{i}"
             creationDate: new Date()

--- a/tests/unit/local/index.coffee
+++ b/tests/unit/local/index.coffee
@@ -34,7 +34,7 @@ describe 'Local', ->
 
     describe 'createReadStream', ->
         it 'throws an error if no file for this document', (done) ->
-            doc = _id: 'no-such-file'
+            doc = path: 'no-such-file'
             @local.createReadStream doc, (err, stream) ->
                 should.exist err
                 err.message.should.equal 'Cannot read the file'
@@ -45,7 +45,7 @@ describe 'Local', ->
             dst = path.join @basePath, 'read-stream.jpg'
             fs.copySync src, dst
             doc =
-                _id: 'read-stream.jpg'
+                path: 'read-stream.jpg'
                 checksum: 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
             @local.createReadStream doc, (err, stream) ->
                 should.not.exist err
@@ -65,7 +65,7 @@ describe 'Local', ->
             filePath = path.join @basePath, "utimes-file"
             fs.ensureFileSync filePath
             updater = @local.utimesUpdater
-                _id: 'utimes-file'
+                path: 'utimes-file'
                 lastModification: date
             updater (err) ->
                 should.not.exist err
@@ -78,7 +78,7 @@ describe 'Local', ->
             folderPath = path.join @basePath, "utimes-folder"
             fs.ensureDirSync folderPath
             updater = @local.utimesUpdater
-                _id: 'utimes-folder'
+                path: 'utimes-folder'
                 lastModification: date
             updater (err) ->
                 should.not.exist err
@@ -92,6 +92,7 @@ describe 'Local', ->
             doc =
                 _id: 'foo/bar'
                 _rev: '1-0123456'
+                path: 'foo/bar'
                 docType: 'file'
                 checksum: '22f7aca0d717eb322d5ae1c97d8aa26eb440287b'
                 sides:
@@ -114,6 +115,7 @@ describe 'Local', ->
                 fs.ensureFileSync filePath
                 doc =
                     _id: 'folder/testfile'
+                    path: 'folder/testfile'
                     docType: 'file'
                     checksum: 'deadcafe'
                     sides:
@@ -129,7 +131,7 @@ describe 'Local', ->
     describe 'addFile', ->
         it 'creates the file by downloading it', (done) ->
             doc =
-                _id: 'files/file-from-remote'
+                path: 'files/file-from-remote'
                 lastModification: new Date '2015-10-09T04:05:06Z'
                 checksum: '9876'
             @local.other =
@@ -142,7 +144,7 @@ describe 'Local', ->
                         stream.push null
                     , 100
                     callback null, stream
-            filePath = path.join @basePath, doc._id
+            filePath = path.join @basePath, doc.path
             @local.addFile doc, (err) =>
                 @local.other = null
                 should.not.exist err
@@ -155,13 +157,13 @@ describe 'Local', ->
 
         it 'creates the file from another file with same checksum', (done) ->
             doc =
-                _id: 'files/file-with-same-checksum'
+                path: 'files/file-with-same-checksum'
                 lastModification: new Date '2015-10-09T04:05:07Z'
                 checksum: '456'
             alt = path.join @basePath, 'files', 'my-checkum-is-456'
             fs.writeFileSync alt, 'foo bar baz'
             stub = sinon.stub(@local, "fileExistsLocally").yields null, alt
-            filePath = path.join @basePath, doc._id
+            filePath = path.join @basePath, doc.path
             @local.addFile doc, (err) ->
                 stub.restore()
                 stub.calledWith('456').should.be.true()
@@ -177,7 +179,7 @@ describe 'Local', ->
 
         it 'can create a file in the root', (done) ->
             doc =
-                _id: 'file-in-root'
+                path: 'file-in-root'
                 lastModification: new Date '2015-10-09T04:05:19Z'
                 checksum: '987642'
             @local.other =
@@ -190,7 +192,7 @@ describe 'Local', ->
                         stream.push null
                     , 100
                     callback null, stream
-            filePath = path.join @basePath, doc._id
+            filePath = path.join @basePath, doc.path
             @local.addFile doc, (err) =>
                 @local.other = null
                 should.not.exist err
@@ -205,9 +207,9 @@ describe 'Local', ->
     describe 'addFolder', ->
         it 'creates the folder', (done) ->
             doc =
-                _id: 'parent/folder-to-create'
+                path: 'parent/folder-to-create'
                 lastModification: new Date '2015-10-09T05:06:08Z'
-            folderPath = path.join @basePath, doc._id
+            folderPath = path.join @basePath, doc.path
             @local.addFolder doc, (err) ->
                 should.not.exist err
                 fs.statSync(folderPath).isDirectory().should.be.true()
@@ -217,9 +219,9 @@ describe 'Local', ->
 
         it 'updates mtime if the folder already exists', (done) ->
             doc =
-                _id: 'parent/folder-to-create'
+                path: 'parent/folder-to-create'
                 lastModification: new Date '2015-10-09T05:06:08Z'
-            folderPath = path.join @basePath, doc._id
+            folderPath = path.join @basePath, doc.path
             fs.ensureDirSync folderPath
             @local.addFolder doc, (err) ->
                 should.not.exist err
@@ -232,7 +234,7 @@ describe 'Local', ->
     describe 'overwriteFile', ->
         it 'writes the new content of a file', (done) ->
             doc =
-                _id: 'a-file-to-overwrite'
+                path: 'a-file-to-overwrite'
                 docType: 'file'
                 lastModification: new Date '2015-10-09T05:06:07Z'
                 checksum: '98765'
@@ -246,7 +248,7 @@ describe 'Local', ->
                         stream.push null
                     , 100
                     callback null, stream
-            filePath = path.join @basePath, doc._id
+            filePath = path.join @basePath, doc.path
             fs.writeFileSync filePath, 'old content'
             @local.overwriteFile doc, {}, (err) =>
                 @local.other = null
@@ -262,10 +264,10 @@ describe 'Local', ->
     describe 'updateFileMetadata', ->
         it 'updates metadata', (done) ->
             doc =
-                _id: 'file-to-update'
+                path: 'file-to-update'
                 docType: 'file'
                 lastModification: new Date '2015-11-10T05:06:07Z'
-            filePath = path.join @basePath, doc._id
+            filePath = path.join @basePath, doc.path
             fs.ensureFileSync filePath
             @local.updateFileMetadata doc, {}, (err) ->
                 should.not.exist err
@@ -278,7 +280,7 @@ describe 'Local', ->
     describe 'updateFolder', ->
         it 'calls addFolder', (done) ->
             doc =
-                _id: 'a-folder-to-update'
+                path: 'a-folder-to-update'
                 docType: 'folder'
                 lastModification: new Date
             sinon.stub(@local, 'addFolder').yields()
@@ -292,13 +294,13 @@ describe 'Local', ->
     describe 'moveFile', ->
         it 'moves the file', (done) ->
             old =
-                _id: 'old-parent/file-to-move'
+                path: 'old-parent/file-to-move'
                 lastModification: new Date '2016-10-08T05:05:09Z'
             doc =
-                _id: 'new-parent/file-moved'
+                path: 'new-parent/file-moved'
                 lastModification: new Date '2015-10-09T05:05:10Z'
-            oldPath = path.join @basePath, old._id
-            newPath = path.join @basePath, doc._id
+            oldPath = path.join @basePath, old.path
+            newPath = path.join @basePath, doc.path
             fs.ensureDirSync path.dirname oldPath
             fs.writeFileSync oldPath, 'foobar'
             @local.moveFile doc, old, (err) ->
@@ -313,10 +315,10 @@ describe 'Local', ->
 
         it 'creates the file is the current file is missing', (done) ->
             old =
-                _id: 'old-parent/missing-file'
+                path: 'old-parent/missing-file'
                 lastModification: new Date '2016-10-08T05:05:11Z'
             doc =
-                _id: 'new-parent/recreated-file'
+                path: 'new-parent/recreated-file'
                 lastModification: new Date '2015-10-09T05:05:12Z'
             stub = sinon.stub(@local, "addFile").yields()
             @local.moveFile doc, old, (err) ->
@@ -327,12 +329,12 @@ describe 'Local', ->
 
         it 'does nothing if the file has already been moved', (done) ->
             old =
-                _id: 'old-parent/already-moved'
+                path: 'old-parent/already-moved'
                 lastModification: new Date '2016-10-08T05:05:11Z'
             doc =
-                _id: 'new-parent/already-here'
+                path: 'new-parent/already-here'
                 lastModification: new Date '2015-10-09T05:05:12Z'
-            newPath = path.join @basePath, doc._id
+            newPath = path.join @basePath, doc.path
             fs.ensureDirSync path.dirname newPath
             fs.writeFileSync newPath, 'foobar'
             stub = sinon.stub(@local, "addFile").yields()
@@ -348,15 +350,15 @@ describe 'Local', ->
     describe 'moveFolder', ->
         it 'moves the folder', (done) ->
             old =
-                _id: 'old-parent/folder-to-move'
+                path: 'old-parent/folder-to-move'
                 docType: 'folder'
                 lastModification: new Date '2016-10-08T05:06:09Z'
             doc =
-                _id: 'new-parent/folder-moved'
+                path: 'new-parent/folder-moved'
                 docType: 'folder'
                 lastModification: new Date '2015-10-09T05:06:10Z'
-            oldPath = path.join @basePath, old._id
-            folderPath = path.join @basePath, doc._id
+            oldPath = path.join @basePath, old.path
+            folderPath = path.join @basePath, doc.path
             fs.ensureDirSync oldPath
             @local.moveFolder doc, old, (err) ->
                 should.not.exist err
@@ -368,14 +370,14 @@ describe 'Local', ->
 
         it 'creates the folder is the current directory is missing', (done) ->
             old =
-                _id: 'old-parent/missing-folder'
+                path: 'old-parent/missing-folder'
                 docType: 'folder'
                 lastModification: new Date '2016-10-08T05:06:09Z'
             doc =
-                _id: 'new-parent/recreated-folder'
+                path: 'new-parent/recreated-folder'
                 docType: 'folder'
                 lastModification: new Date '2015-10-09T05:06:10Z'
-            folderPath = path.join @basePath, doc._id
+            folderPath = path.join @basePath, doc.path
             @local.moveFolder doc, old, (err) ->
                 should.not.exist err
                 fs.statSync(folderPath).isDirectory().should.be.true()
@@ -385,12 +387,12 @@ describe 'Local', ->
 
         it 'does nothing if the folder has already been moved', (done) ->
             old =
-                _id: 'old-parent/folder-already-moved'
+                path: 'old-parent/folder-already-moved'
                 lastModification: new Date '2016-10-08T05:05:11Z'
             doc =
-                _id: 'new-parent/folder-already-here'
+                path: 'new-parent/folder-already-here'
                 lastModification: new Date '2015-10-09T05:05:12Z'
-            newPath = path.join @basePath, doc._id
+            newPath = path.join @basePath, doc.path
             fs.ensureDirSync newPath
             stub = sinon.stub(@local, "addFolder").yields()
             @local.moveFolder doc, old, (err) ->
@@ -402,13 +404,13 @@ describe 'Local', ->
 
         it 'remove the old directory if everything has been moved', (done) ->
             old =
-                _id: 'old-parent/folder-already-moved'
+                path: 'old-parent/folder-already-moved'
                 lastModification: new Date '2016-10-08T05:05:11Z'
             doc =
-                _id: 'new-parent/folder-already-here'
+                path: 'new-parent/folder-already-here'
                 lastModification: new Date '2015-10-09T05:05:12Z'
-            oldPath = path.join @basePath, old._id
-            newPath = path.join @basePath, doc._id
+            oldPath = path.join @basePath, old.path
+            newPath = path.join @basePath, doc.path
             fs.ensureDirSync oldPath
             fs.ensureDirSync newPath
             stub = sinon.stub(@local, "addFolder").yields()
@@ -424,9 +426,10 @@ describe 'Local', ->
     describe 'deleteFile', ->
         it 'deletes a file from the local filesystem', (done) ->
             doc =
-                _id: 'file-to-delete'
+                _id: 'FILE-TO-DELETE'
+                path: 'FILE-TO-DELETE'
                 docType: 'file'
-            filePath = path.join @basePath, "file-to-delete"
+            filePath = path.join @basePath, doc.path
             fs.ensureFileSync filePath
             @pouch.db.put doc, (err, inserted) =>
                 should.not.exist err
@@ -442,9 +445,10 @@ describe 'Local', ->
     describe 'deleteFolder', ->
         it 'deletes a folder from the local filesystem', (done) ->
             doc =
-                _id: 'folder-to-delete'
+                _id: 'FOLDER-TO-DELETE'
+                path: 'FOLDER-TO-DELETE'
                 docType: 'folder'
-            folderPath = path.join @basePath, "folder-to-delete"
+            folderPath = path.join @basePath, doc.path
             fs.ensureDirSync folderPath
             fs.ensureFileSync path.join(folderPath, "file-inside-folder")
             @pouch.db.put doc, (err, inserted) =>

--- a/tests/unit/local/watcher.coffee
+++ b/tests/unit/local/watcher.coffee
@@ -37,10 +37,10 @@ describe "LocalWatcher Tests", ->
             setTimeout =>
                 @merge.putFolder.called.should.be.true()
                 @merge.putFolder.args[0][0].should.equal 'local'
-                @merge.putFolder.args[0][1]._id.should.equal 'aa'
+                @merge.putFolder.args[0][1].path.should.equal 'aa'
                 @merge.addFile.called.should.be.true()
                 @merge.addFile.args[0][0].should.equal 'local'
-                @merge.addFile.args[0][1]._id.should.equal 'aa/ab'
+                @merge.addFile.args[0][1].path.should.equal 'aa/ab'
                 done()
             , 1100
             @watcher.start ->
@@ -71,7 +71,7 @@ describe "LocalWatcher Tests", ->
                 @watcher.createDoc 'chat-mignon.jpg', stats, (err, doc) ->
                     should.not.exist err
                     doc.should.have.properties
-                        _id: 'chat-mignon.jpg'
+                        path: 'chat-mignon.jpg'
                         docType: 'file'
                         checksum: 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
                         size: 29865
@@ -122,7 +122,7 @@ describe "LocalWatcher Tests", ->
                 @merge.addFile = (side, doc) ->
                     side.should.equal 'local'
                     doc.should.have.properties
-                        _id: 'aaa.jpg'
+                        path: 'aaa.jpg'
                         docType: 'file'
                         checksum: 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
                         size: 29865
@@ -140,7 +140,7 @@ describe "LocalWatcher Tests", ->
                 @merge.putFolder = (side, doc) ->
                     side.should.equal 'local'
                     doc.should.have.properties
-                        _id: 'aba'
+                        path: 'aba'
                         docType: 'folder'
                     doc.should.have.properties [
                         'creationDate'
@@ -155,7 +155,7 @@ describe "LocalWatcher Tests", ->
                 @merge.putFolder = (side, doc) ->
                     side.should.equal 'local'
                     doc.should.have.properties
-                        _id: 'abb/abc'
+                        path: 'abb/abc'
                         docType: 'folder'
                     doc.should.have.properties [
                         'creationDate'
@@ -173,7 +173,7 @@ describe "LocalWatcher Tests", ->
                 @merge.deleteFile = (side, doc) ->
                     side.should.equal 'local'
                     doc.should.have.properties
-                        _id: 'aca'
+                        path: 'aca'
                     done()
                 fs.unlinkSync path.join @basePath, 'aca'
             @watcher.start ->
@@ -186,7 +186,7 @@ describe "LocalWatcher Tests", ->
                 @merge.deleteFolder = (side, doc) ->
                     side.should.equal 'local'
                     doc.should.have.properties
-                        _id: 'ada'
+                        path: 'ada'
                     done()
                 fs.rmdirSync path.join @basePath, 'ada'
             @watcher.start ->
@@ -201,7 +201,7 @@ describe "LocalWatcher Tests", ->
                 @merge.updateFile = (side, doc) ->
                     side.should.equal 'local'
                     doc.should.have.properties
-                        _id: 'aea.jpg'
+                        path: 'aea.jpg'
                         docType: 'file'
                         checksum: 'fc7e0b72b8e64eb05e05aef652d6bbed950f85df'
                         size: 36901
@@ -226,7 +226,7 @@ describe "LocalWatcher Tests", ->
                     @merge.addFile = (side, doc) =>
                         side.should.equal 'local'
                         doc.should.have.properties
-                            _id: 'afb.jpg'
+                            path: 'afb.jpg'
                             docType: 'file'
                             checksum: 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
                             size: 29865
@@ -235,7 +235,7 @@ describe "LocalWatcher Tests", ->
                         setTimeout =>
                             @merge.deleteFile.called.should.be.true()
                             @merge.deleteFile.args[0][1].should.have.properties
-                                _id: 'afa.jpg'
+                                path: 'afa.jpg'
                             done()
                         , 10
                     fs.renameSync dst, path.join @basePath, 'afb.jpg'
@@ -258,18 +258,18 @@ describe "LocalWatcher Tests", ->
                     @merge.putFolder = (side, doc) =>
                         side.should.equal 'local'
                         doc.should.have.properties
-                            _id: 'agb'
+                            path: 'agb'
                             docType: 'folder'
                         setTimeout =>
                             @merge.addFile.called.should.be.true()
                             args = @merge.addFile.args[0][1]
-                            args.should.have.properties _id: 'agb/agc'
+                            args.should.have.properties path: 'agb/agc'
                             @merge.deleteFile.called.should.be.true()
                             args = @merge.deleteFile.args[0][1]
-                            args.should.have.properties _id: 'aga/agc'
+                            args.should.have.properties path: 'aga/agc'
                             @merge.deleteFolder.called.should.be.true()
                             args = @merge.deleteFolder.args[0][1]
-                            args.should.have.properties _id: 'aga'
+                            args.should.have.properties path: 'aga'
                             done()
                         , 1100
                     fs.renameSync src, dst

--- a/tests/unit/merge.coffee
+++ b/tests/unit/merge.coffee
@@ -23,35 +23,38 @@ describe 'Merge', ->
 
     describe 'Helpers', ->
 
-        describe 'invalidId', ->
-            it 'returns true if the id is incorrect', ->
-                ret = @merge.invalidId _id: '/'
+        describe 'buildId', ->
+            it 'TODO'
+
+        describe 'invalidPath', ->
+            it 'returns true if the path is incorrect', ->
+                ret = @merge.invalidPath path: '/'
                 ret.should.be.true()
-                ret = @merge.invalidId _id: ''
+                ret = @merge.invalidPath path: ''
                 ret.should.be.true()
-                ret = @merge.invalidId _id: '.'
+                ret = @merge.invalidPath path: '.'
                 ret.should.be.true()
-                ret = @merge.invalidId _id: '..'
+                ret = @merge.invalidPath path: '..'
                 ret.should.be.true()
-                ret = @merge.invalidId _id: '../foo/bar.png'
+                ret = @merge.invalidPath path: '../foo/bar.png'
                 ret.should.be.true()
-                ret = @merge.invalidId _id: 'foo/..'
+                ret = @merge.invalidPath path: 'foo/..'
                 ret.should.be.true()
-                ret = @merge.invalidId _id: 'f/../oo/../../bar/./baz'
+                ret = @merge.invalidPath path: 'f/../oo/../../bar/./baz'
                 ret.should.be.true()
 
             it 'returns false if everything is OK', ->
-                ret = @merge.invalidId _id: 'foo'
+                ret = @merge.invalidPath path: 'foo'
                 ret.should.be.false()
-                ret = @merge.invalidId _id: 'foo/bar'
+                ret = @merge.invalidPath path: 'foo/bar'
                 ret.should.be.false()
-                ret = @merge.invalidId _id: 'foo/bar/baz.jpg'
+                ret = @merge.invalidPath path: 'foo/bar/baz.jpg'
                 ret.should.be.false()
 
             it 'returns false for paths with a leading slash', ->
-                ret = @merge.invalidId _id: '/foo/bar'
+                ret = @merge.invalidPath path: '/foo/bar'
                 ret.should.be.false()
-                ret = @merge.invalidId _id: '/foo/bar/baz.bmp'
+                ret = @merge.invalidPath path: '/foo/bar/baz.bmp'
                 ret.should.be.false()
 
         describe 'invalidChecksum', ->
@@ -165,10 +168,10 @@ describe 'Merge', ->
         describe 'moveDoc', ->
             it 'calls moveFile for a file', (done) ->
                 doc =
-                    _id: 'move/name'
+                    path: 'move/name'
                     docType: 'file'
                 was =
-                    _id: 'move/old-name'
+                    path: 'move/old-name'
                     docType: 'file'
                 @merge.moveFile = sinon.stub().yields null
                 @merge.moveDoc @side, doc, was, (err) =>
@@ -178,10 +181,10 @@ describe 'Merge', ->
 
             it 'calls moveFolder for a folder', (done) ->
                 doc =
-                    _id: 'move/folder'
+                    path: 'move/folder'
                     docType: 'folder'
                 was =
-                    _id: 'move/old-folder'
+                    path: 'move/old-folder'
                     docType: 'folder'
                 spy = @merge.moveFolder = sinon.stub().yields null
                 @merge.moveDoc @side, doc, was, (err) =>
@@ -191,10 +194,10 @@ describe 'Merge', ->
 
             it 'throws an error if we move a file to a folder', (done) ->
                 doc =
-                    _id: 'move/folder'
+                    path: 'move/folder'
                     docType: 'folder'
                 was =
-                    _id: 'move/old-file'
+                    path: 'move/old-file'
                     docType: 'file'
                 @merge.moveDoc @side, doc, was, (err) ->
                     should.exist err
@@ -203,10 +206,10 @@ describe 'Merge', ->
 
             it 'throws an error if we move a folder to a file', (done) ->
                 doc =
-                    _id: 'move/file'
+                    path: 'move/file'
                     docType: 'file'
                 was =
-                    _id: 'move/old-folder'
+                    path: 'move/old-folder'
                     docType: 'folder'
                 @merge.moveDoc @side, doc, was, (err) ->
                     should.exist err
@@ -216,7 +219,7 @@ describe 'Merge', ->
         describe 'deleteDoc', ->
             it 'calls deleteFile for a file', (done) ->
                 doc =
-                    _id: 'delete/name'
+                    path: 'delete/name'
                     docType: 'file'
                 @merge.deleteFile = sinon.stub().yields null
                 @merge.deleteDoc @side, doc, (err) =>
@@ -226,7 +229,7 @@ describe 'Merge', ->
 
             it 'calls deleteFolder for a folder', (done) ->
                 doc =
-                    _id: 'delete/folder'
+                    path: 'delete/folder'
                     docType: 'folder'
                 @merge.deleteFolder = sinon.stub().yields null
                 @merge.deleteDoc @side, doc, (err) =>
@@ -256,16 +259,16 @@ describe 'Merge', ->
     describe 'Put', ->
 
         describe 'addFile', ->
-            it 'expects a doc with a valid id', (done) ->
-                @merge.addFile @side, _id: '/', (err) ->
+            it 'expects a doc with a valid path', (done) ->
+                @merge.addFile @side, path: '/', (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
             it 'accepts doc with no checksum', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'no-checksum'
+                    path: 'no-checksum'
                     docType: 'file'
                 @merge.addFile @side, doc, (err) ->
                     should.not.exist err
@@ -273,7 +276,7 @@ describe 'Merge', ->
 
             it 'rejects doc with an invalid checksum', (done) ->
                 doc =
-                    _id: 'no-checksum'
+                    path: 'no-checksum'
                     checksum: 'foobar'
                 @merge.addFile @side, doc, (err) ->
                     should.exist err
@@ -283,7 +286,7 @@ describe 'Merge', ->
             it 'saves the new file', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foo/new-file'
+                    path: 'foo/new-file'
                     checksum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
                     docType: 'file'
                     creationDate: new Date
@@ -302,7 +305,7 @@ describe 'Merge', ->
             it 'adds missing fields', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foo/missing-fields'
+                    path: 'foo/missing-fields'
                     checksum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
                 @merge.addFile @side, doc, (err) =>
                     should.not.exist err
@@ -323,7 +326,8 @@ describe 'Merge', ->
             describe 'when a file with the same path exists', ->
                 before 'create a file', (done) ->
                     @file =
-                        _id: 'buzz.jpg'
+                        _id: 'BUZZ.JPG'
+                        path: 'BUZZ.JPG'
                         docType: 'file'
                         checksum: '1111111111111111111111111111111111111111'
                         creationDate: new Date
@@ -361,16 +365,16 @@ describe 'Merge', ->
 
 
         describe 'updateFile', ->
-            it 'expects a doc with a valid id', (done) ->
-                @merge.updateFile @side, _id: '/', (err) ->
+            it 'expects a doc with a valid path', (done) ->
+                @merge.updateFile @side, path: '/', (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
             it 'accepts doc with no checksum', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'no-checksum'
+                    path: 'no-checksum'
                     docType: 'file'
                 @merge.updateFile @side, doc, (err) ->
                     should.not.exist err
@@ -378,7 +382,7 @@ describe 'Merge', ->
 
             it 'rejects doc with an invalid checksum', (done) ->
                 doc =
-                    _id: 'no-checksum'
+                    path: 'no-checksum'
                     checksum: 'foobar'
                 @merge.updateFile @side, doc, (err) ->
                     should.exist err
@@ -388,7 +392,7 @@ describe 'Merge', ->
             it 'saves the new file', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foobar/new-file'
+                    path: 'foobar/new-file'
                     checksum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
                     docType: 'file'
                     creationDate: new Date
@@ -407,7 +411,7 @@ describe 'Merge', ->
             it 'adds missing fields', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foobar/missing-fields'
+                    path: 'foobar/missing-fields'
                     checksum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
                 @merge.updateFile @side, doc, (err) =>
                     should.not.exist err
@@ -428,7 +432,8 @@ describe 'Merge', ->
             describe 'when a file with the same path exists', ->
                 before 'create a file', (done) ->
                     @file =
-                        _id: 'fizzbuzz.jpg'
+                        _id: 'FIZZBUZZ.JPG'
+                        path: 'FIZZBUZZ.JPG'
                         docType: 'file'
                         checksum: '1111111111111111111111111111111111111111'
                         creationDate: new Date
@@ -464,7 +469,7 @@ describe 'Merge', ->
                 it 'can overwrite the content of a file', (done) ->
                     @merge.ensureParentExist = sinon.stub().yields null
                     doc =
-                        _id: 'fizzbuzz.jpg'
+                        path: 'FIZZBUZZ.JPG'
                         docType: 'file'
                         checksum: '3333333333333333333333333333333333333333'
                         tags: ['qux', 'quux']
@@ -481,16 +486,16 @@ describe 'Merge', ->
 
 
         describe 'putFolder', ->
-            it 'expects a doc with a valid id', (done) ->
-                @merge.putFolder @side, _id: '..', (err) ->
+            it 'expects a doc with a valid path', (done) ->
+                @merge.putFolder @side, path: '..', (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
             it 'saves the new folder', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foo/new-folder'
+                    path: 'foo/new-folder'
                     docType: 'folder'
                     creationDate: new Date
                     lastModification: new Date
@@ -507,7 +512,7 @@ describe 'Merge', ->
 
             it 'adds missing fields', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
-                doc = _id: 'foo/folder-missing-fields'
+                doc = path: 'foo/folder-missing-fields'
                 @merge.putFolder @side, doc, (err) =>
                     should.not.exist err
                     @pouch.db.get doc._id, (err, res) ->
@@ -527,7 +532,8 @@ describe 'Merge', ->
             describe 'when a folder with the same path exists', ->
                 before 'create a folder', (done) ->
                     @folder =
-                        _id: 'fizz'
+                        _id: 'FIZZ'
+                        path: 'FIZZ'
                         docType: 'folder'
                         creationDate: new Date
                         lastModification: new Date
@@ -556,28 +562,28 @@ describe 'Merge', ->
     describe 'Move', ->
 
         describe 'moveFile', ->
-            it 'expects a doc with a valid id', (done) ->
-                doc = _id: ''
-                was = _id: 'foo/baz'
+            it 'expects a doc with a valid path', (done) ->
+                doc = path: ''
+                was = path: 'foo/baz'
                 @merge.moveFile @side, doc, was, (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
-            it 'expects a was with a valid id', (done) ->
-                doc = _id: 'foo/bar'
-                was = _id: ''
+            it 'expects a was with a valid path', (done) ->
+                doc = path: 'foo/bar'
+                was = path: ''
                 @merge.moveFile @side, doc, was, (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
             it 'expects a doc with a valid checksum', (done) ->
                 doc =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'file'
                     checksum: 'invalid'
-                was = _id: 'foo/baz'
+                was = path: 'foo/baz'
                 @merge.moveFile @side, doc, was, (err) ->
                     should.exist err
                     err.message.should.equal 'Invalid checksum'
@@ -585,11 +591,11 @@ describe 'Merge', ->
 
             it 'expects two different paths', (done) ->
                 doc =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'file'
                     checksum: '5555555555555555555555555555555555555555'
                 was =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'file'
                     checksum: '5555555555555555555555555555555555555555'
                 @merge.moveFile @side, doc, was, (err) ->
@@ -599,11 +605,11 @@ describe 'Merge', ->
 
             it 'expects a revision for was', (done) ->
                 doc =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'file'
                     checksum: '5555555555555555555555555555555555555555'
                 was =
-                    _id: 'foo/baz'
+                    path: 'foo/baz'
                     docType: 'file'
                     checksum: '5555555555555555555555555555555555555555'
                 @merge.moveFile @side, doc, was, (err) ->
@@ -614,14 +620,15 @@ describe 'Merge', ->
             it 'saves the new file and deletes the old one', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foo/new'
+                    path: 'FOO/new'
                     checksum: 'ba1368789cce95b574dec70dfd476e61cbf00517'
                     docType: 'file'
                     creationDate: new Date
                     lastModification: new Date
                     tags: ['courge', 'quux']
                 was =
-                    _id: 'foo/old'
+                    _id: 'FOO/OLD'
+                    path: 'FOO/OLD'
                     checksum: 'ba1368789cce95b574dec70dfd476e61cbf00517'
                     docType: 'file'
                     creationDate: new Date
@@ -632,6 +639,7 @@ describe 'Merge', ->
                     was._rev = inserted.rev
                     @merge.moveFile @side, clone(doc), clone(was), (err) =>
                         should.not.exist err
+                        @merge.buildId doc
                         @pouch.db.get doc._id, (err, res) =>
                             should.not.exist err
                             for date in ['creationDate', 'lastModification']
@@ -646,10 +654,11 @@ describe 'Merge', ->
             it 'adds missing fields', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foo/new-missing-fields.jpg'
+                    path: 'FOO/new-missing-fields.jpg'
                     checksum: 'ba1368789cce95b574dec70dfd476e61cbf00517'
                 was =
-                    _id: 'foo/old-missing-fields.jpg'
+                    _id: 'FOO/OLD-MISSING-FIELDS.JPG'
+                    path: 'FOO/OLD-MISSING-FIELDS.JPG'
                     checksum: 'ba1368789cce95b574dec70dfd476e61cbf00517'
                     docType: 'file'
                     creationDate: new Date
@@ -679,14 +688,15 @@ describe 'Merge', ->
             it 'adds a hint for writers to know that it is a move', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foo/new-hint'
+                    path: 'FOO/new-hint'
                     checksum: 'ba1368789cce95b574dec70dfd476e61cbf00517'
                     docType: 'file'
                     creationDate: new Date
                     lastModification: new Date
                     tags: ['courge', 'quux']
                 was =
-                    _id: 'foo/old-hint'
+                    _id: 'FOO/OLD-HINT'
+                    path: 'FOO/OLD-HINT'
                     checksum: 'ba1368789cce95b574dec70dfd476e61cbf00517'
                     docType: 'file'
                     creationDate: new Date
@@ -696,6 +706,7 @@ describe 'Merge', ->
                     include_docs: true
                     live: true
                     since: 'now'
+                @merge.buildId doc
                 @pouch.db.put clone(was), (err, inserted) =>
                     should.not.exist err
                     was._rev = inserted.rev
@@ -713,7 +724,8 @@ describe 'Merge', ->
             describe 'when a file with the same path exists', ->
                 before 'create a file', (done) ->
                     @file =
-                        _id: 'fuzz.jpg'
+                        _id: 'FUZZ.JPG'
+                        path: 'FUZZ.JPG'
                         docType: 'file'
                         checksum: '1111111111111111111111111111111111111111'
                         creationDate: new Date
@@ -727,12 +739,13 @@ describe 'Merge', ->
                 it 'can overwrite the content of a file', (done) ->
                     @merge.ensureParentExist = sinon.stub().yields null
                     doc =
-                        _id: 'fuzz.jpg'
+                        path: 'FUZZ.JPG'
                         docType: 'file'
                         checksum: '3333333333333333333333333333333333333333'
                         tags: ['qux', 'quux']
                     was =
                         _id: 'old-fuzz.jpg'
+                        path: 'old-fuzz.jpg'
                         checksum: '3333333333333333333333333333333333333333'
                         docType: 'file'
                         creationDate: new Date
@@ -760,28 +773,28 @@ describe 'Merge', ->
 
 
         describe 'moveFolder', ->
-            it 'expects a doc with a valid id', (done) ->
-                doc = _id: ''
-                was = _id: 'foo/baz'
+            it 'expects a doc with a valid path', (done) ->
+                doc = path: ''
+                was = path: 'foo/baz'
                 @merge.moveFolder @side, doc, was, (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
             it 'expects a was with a valid id', (done) ->
-                doc = _id: 'foo/bar'
-                was = _id: ''
+                doc = path: 'foo/bar'
+                was = path: ''
                 @merge.moveFolder @side, doc, was, (err) ->
                     should.exist err
-                    err.message.should.equal 'Invalid id'
+                    err.message.should.equal 'Invalid path'
                     done()
 
             it 'expects two different paths', (done) ->
                 doc =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'folder'
                 was =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'folder'
                 @merge.moveFolder @side, doc, was, (err) ->
                     should.exist err
@@ -790,10 +803,10 @@ describe 'Merge', ->
 
             it 'expects a revision for was', (done) ->
                 doc =
-                    _id: 'foo/bar'
+                    path: 'foo/bar'
                     docType: 'folder'
                 was =
-                    _id: 'foo/baz'
+                    path: 'foo/baz'
                     docType: 'folder'
                 @merge.moveFolder @side, doc, was, (err) ->
                     should.exist err
@@ -803,13 +816,14 @@ describe 'Merge', ->
             it 'saves the new folder and deletes the old one', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foobar/new'
+                    path: 'FOOBAR/new'
                     docType: 'folder'
                     creationDate: new Date
                     lastModification: new Date
                     tags: ['courge', 'quux']
                 was =
-                    _id: 'foobar/old'
+                    _id: 'FOOBAR/OLD'
+                    path: 'FOOBAR/OLD'
                     docType: 'folder'
                     creationDate: new Date
                     lastModification: new Date
@@ -819,6 +833,7 @@ describe 'Merge', ->
                     was._rev = inserted.rev
                     @merge.moveFolder @side, clone(doc), clone(was), (err) =>
                         should.not.exist err
+                        @merge.buildId doc
                         @pouch.db.get doc._id, (err, res) =>
                             should.not.exist err
                             for date in ['creationDate', 'lastModification']
@@ -833,9 +848,10 @@ describe 'Merge', ->
             it 'adds missing fields', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foobar/new-missing-fields'
+                    path: 'FOOBAR/new-missing-fields'
                 was =
-                    _id: 'foobar/old-missing-fields'
+                    _id: 'FOOBAR/OLD-MISSING-FIELDS'
+                    path: 'FOOBAR/OLD-MISSING-FIELDS'
                     docType: 'folder'
                     creationDate: new Date
                     lastModification: new Date
@@ -858,13 +874,14 @@ describe 'Merge', ->
             it 'adds a hint for writers to know that it is a move', (done) ->
                 @merge.ensureParentExist = sinon.stub().yields null
                 doc =
-                    _id: 'foobar/new-hint'
+                    path: 'FOOBAR/NEW-HINT'
                     docType: 'folder'
                     creationDate: new Date
                     lastModification: new Date
                     tags: ['courge', 'quux']
                 was =
-                    _id: 'foobar/old-hint'
+                    _id: 'FOOBAR/OLD-HINT'
+                    path: 'FOOBAR/OLD-HINT'
                     docType: 'folder'
                     creationDate: new Date
                     lastModification: new Date
@@ -873,6 +890,7 @@ describe 'Merge', ->
                     include_docs: true
                     live: true
                     since: 'now'
+                @merge.buildId doc
                 @pouch.db.put clone(was), (err, inserted) =>
                     should.not.exist err
                     was._rev = inserted.rev
@@ -890,7 +908,8 @@ describe 'Merge', ->
             describe 'when a folder with the same path exists', ->
                 before 'create a folder', (done) ->
                     @folder =
-                        _id: 'foobaz'
+                        _id: 'FOOBAZ'
+                        path: 'FOOBAZ'
                         docType: 'folder'
                         creationDate: new Date
                         lastModification: new Date
@@ -900,11 +919,12 @@ describe 'Merge', ->
                 it 'can overwrite the content of a folder', (done) ->
                     @merge.ensureParentExist = sinon.stub().yields null
                     doc =
-                        _id: 'foobaz'
+                        path: 'FOOBAZ'
                         docType: 'folder'
                         tags: ['qux', 'quux']
                     was =
-                        _id: 'old-foobaz'
+                        _id: 'OLD-FOOBAZ'
+                        path: 'OLD-FOOBAZ'
                         docType: 'folder'
                         creationDate: new Date
                         lastModification: new Date
@@ -926,44 +946,14 @@ describe 'Merge', ->
                 it 'can resolve a conflict', ->
                     it 'TODO'
 
-        describe 'moveFolderRecursively', ->
-            before (done) ->
-                pouchHelpers.createParentFolder @pouch, =>
-                    pouchHelpers.createFolder @pouch, 9, =>
-                        pouchHelpers.createFile @pouch, 9, done
-
-            it 'move the folder and files/folders inside it', (done) ->
-                doc =
-                    _id: 'destination'
-                    docType: 'folder'
-                    creationDate: new Date
-                    lastModification: new Date
-                    tags: []
-                @pouch.db.get 'my-folder', (err, was) =>
-                    should.not.exist err
-                    @merge.moveFolderRecursively doc, was, (err) =>
-                        should.not.exist err
-                        ids = [
-                            '',
-                            '/folder-9',
-                            '/file-9'
-                        ]
-                        async.eachSeries ids, (id, next) =>
-                            @pouch.db.get "destination#{id}", (err, res) =>
-                                should.not.exist err
-                                should.exist res
-                                @pouch.db.get "my-folder#{id}", (err, res) ->
-                                    err.status.should.equal 404
-                                    next()
-                        , done
-
 
     describe 'Delete', ->
 
         describe 'deleteFile', ->
             it 'deletes a file', (done) ->
                 doc =
-                    _id: 'to-delete/file'
+                    _id: 'TO-DELETE/FILE'
+                    path: 'TO-DELETE/FILE'
                     docType: 'file'
                 @pouch.db.put doc, (err) =>
                     should.not.exist err
@@ -976,7 +966,8 @@ describe 'Merge', ->
         describe 'deleteFolder', ->
             it 'deletes a folder', (done) ->
                 doc =
-                    _id: 'to-delete/folder'
+                    _id: 'TO-DELETE/FOLDER'
+                    path: 'TO-DELETE/FOLDER'
                     docType: 'folder'
                 @pouch.db.put doc, (err) =>
                     should.not.exist err
@@ -988,35 +979,39 @@ describe 'Merge', ->
 
             it 'remove files in the folder', (done) ->
                 doc =
-                    _id: 'foo/to-remove'
+                    _id: 'FOO/TO-REMOVE'
+                    path: 'FOO/TO-REMOVE'
                     docType: 'folder'
                 @pouch.db.put doc, (err) =>
                     should.not.exist err
                     async.eachSeries ['baz', 'qux', 'quux'], (name, next) =>
                         file =
-                            _id: "foo/to-remove/#{name}"
+                            _id: "FOO/TO-REMOVE/#{name}"
+                            path: "FOO/TO-REMOVE/#{name}"
                             docType: 'file'
                         @pouch.db.put file, next
                     , (err) =>
                         should.not.exist err
                         @merge.deleteFolder @side, doc, (err) =>
                             should.not.exist err
-                            @pouch.byPath 'foo/to-remove', (err, docs) ->
+                            @pouch.byPath 'FOO/TO-REMOVE', (err, docs) ->
                                 docs.length.should.be.equal 0
                                 done()
 
             it 'remove nested folders', (done) ->
+                base = 'NESTED/TO-DELETE'
                 async.eachSeries ['', '/b', '/b/c', '/b/d'], (name, next) =>
                     doc =
-                        _id: "nested/to-delete#{name}"
+                        _id: "#{base}#{name}"
+                        path: "#{base}#{name}"
                         docType: 'folder'
                     @pouch.db.put doc, next
                 , (err) =>
                     should.not.exist err
-                    @merge.deleteFolder @side, _id: 'nested/to-delete', (err) =>
+                    @merge.deleteFolder @side, path: base, (err) =>
                         should.not.exist err
                         @pouch.db.allDocs (err, res) ->
                             should.not.exist err
                             for row in res.rows
-                                row.id.should.not.match /^nested/
+                                row.id.should.not.match /^NESTED/i
                             done()

--- a/tests/unit/merge.coffee
+++ b/tests/unit/merge.coffee
@@ -146,23 +146,30 @@ describe 'Merge', ->
 
             it 'creates the parent directory if missing', (done) ->
                 @merge.putFolder = sinon.stub().yields null, 'OK'
-                @merge.ensureParentExist @side, _id: 'missing/child', (err) =>
+                doc =
+                    _id: 'MISSING/CHILD'
+                    path: 'missing/child'
+                @merge.ensureParentExist @side, doc, (err) =>
                     should.not.exist err
                     @merge.putFolder.called.should.be.true()
-                    parent = _id: 'missing'
+                    parent =
+                        _id: 'MISSING'
+                        path: 'missing'
                     @merge.putFolder.calledWith(@side, parent).should.be.true()
                     done()
 
             it 'creates the full tree if needed', (done) ->
                 @merge.putFolder = sinon.stub().yields null, 'OK'
-                @merge.ensureParentExist @side, _id: 'a/b/c/d/e', (err) =>
+                doc =
+                    _id: 'a/b/c/d/e'
+                    path: 'a/b/c/d/e'
+                @merge.ensureParentExist @side, doc, (err) =>
                     should.not.exist err
                     method = @merge.putFolder
                     method.called.should.be.true()
-                    method.calledWith(@side, _id: 'a').should.be.true()
-                    method.calledWith(@side, _id: 'a/b').should.be.true()
-                    method.calledWith(@side, _id: 'a/b/c').should.be.true()
-                    method.calledWith(@side, _id: 'a/b/c/d').should.be.true()
+                    for id in ['a', 'a/b', 'a/b/c', 'a/b/c/d']
+                        folder = _id: id, path: id
+                        method.calledWith(@side, folder).should.be.true()
                     done()
 
         describe 'moveDoc', ->

--- a/tests/unit/merge.coffee
+++ b/tests/unit/merge.coffee
@@ -24,7 +24,22 @@ describe 'Merge', ->
     describe 'Helpers', ->
 
         describe 'buildId', ->
-            it 'TODO'
+            it 'is available', ->
+                doc = path: 'FOO'
+                @merge.buildId doc
+                doc._id.should.equal 'FOO'
+
+            if process.platform in ['linux', 'freebsd', 'sunos']
+                it 'is case insensitive on UNIX', ->
+                    doc = path: 'foo/bar/café'
+                    @merge.buildId doc
+                    doc._id.should.equal 'foo/bar/café'
+
+            if process.platform is 'darwin'
+                it 'is case sensitive on OSX', ->
+                    doc = path: 'foo/bar/café'
+                    @merge.buildId doc
+                    doc._id.should.equal 'FOO/BAR/CAFÉ'
 
         describe 'invalidPath', ->
             it 'returns true if the path is incorrect', ->

--- a/tests/unit/remote/index.coffee
+++ b/tests/unit/remote/index.coffee
@@ -36,7 +36,7 @@ describe 'Remote', ->
             checksum = '53a547469e98b667671803adc814d6d1376fae6b'
             fixture = 'tests/fixtures/cool-pillow.jpg'
             doc =
-                _id: 'pillow.jpg'
+                path: 'pillow.jpg'
                 checksum: checksum
                 remote:
                     binary:
@@ -67,7 +67,7 @@ describe 'Remote', ->
             checksum = 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
             fixture = 'tests/fixtures/chat-mignon.jpg'
             doc =
-                _id: 'chat.jpg'
+                path: 'chat.jpg'
                 checksum: checksum
             @remote.other =
                 createReadStream: (localDoc, callback) ->
@@ -90,7 +90,7 @@ describe 'Remote', ->
         it 'does not reupload an existing file', (done) ->
             checksum = 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
             doc =
-                _id: 'chat-bis.jpg'
+                path: 'chat-bis.jpg'
                 checksum: checksum
             @remote.uploadBinary doc, (err, binary) ->
                 should.not.exist err
@@ -114,7 +114,8 @@ describe 'Remote', ->
     describe 'createRemoteDoc', ->
         it 'transforms a local file in remote file', ->
             local =
-                _id: 'foo/bar/baz.jpg'
+                _id: 'FOO/BAR/BAZ.JPG'
+                path: 'foo/bar/baz.jpg'
                 docType: 'file'
                 lastModification: "2015-11-12T13:14:32.384Z"
                 creationDate: "2015-11-12T13:14:32.384Z"
@@ -146,7 +147,7 @@ describe 'Remote', ->
 
         it 'transforms a local folder in remote folder', ->
             local =
-                _id: 'foo/bar/baz'
+                path: 'foo/bar/baz'
                 docType: 'folder'
                 lastModification: "2015-11-12T13:14:33.384Z"
                 creationDate: "2015-11-12T13:14:33.384Z"
@@ -162,7 +163,7 @@ describe 'Remote', ->
 
         it 'has the good path when in root folder', ->
             local =
-                _id: 'in-root-folder'
+                path: 'in-root-folder'
                 docType: 'folder'
             doc = @remote.createRemoteDoc local
             doc.should.have.properties
@@ -172,7 +173,7 @@ describe 'Remote', ->
 
         it 'transforms an existing local file in remote file', ->
             local =
-                _id: 'foo/bar/baz.jpg'
+                path: 'foo/bar/baz.jpg'
                 docType: 'file'
                 lastModification: "2015-11-12T13:14:32.384Z"
                 creationDate: "2015-11-12T13:14:32.384Z"
@@ -218,7 +219,8 @@ describe 'Remote', ->
                 checksum: 'b410ffdd571d6e86bb8e8bdd054df91e16dfa75e'
                 docType: 'Binary'
             file =
-                _id: 'a-file-with-b410'
+                _id: 'A-FILE-WITH-B410'
+                path: 'A-FILE-WITH-B410'
                 docType: 'file'
                 checksum: 'b410ffdd571d6e86bb8e8bdd054df91e16dfa75e'
                 remote:
@@ -324,7 +326,7 @@ describe 'Remote', ->
         it 'adds a file to couchdb', (done) ->
             checksum = 'fc7e0b72b8e64eb05e05aef652d6bbed950f85df'
             doc =
-                _id: 'cat2.jpg'
+                path: 'cat2.jpg'
                 docType: 'file'
                 checksum: checksum
                 creationDate: new Date()
@@ -358,14 +360,15 @@ describe 'Remote', ->
         it 'does not reupload an existing file', (done) ->
             checksum = 'fc7e0b72b8e64eb05e05aef652d6bbed950f85df'
             doc =
-                _id: 'backup/cat3.jpg'
+                path: 'backup/cat3.jpg'
                 docType: 'file'
                 checksum: checksum
                 creationDate: new Date()
                 lastModification: new Date()
                 size: 36901
             same =
-                _id: 'original/cat3.jpg'
+                _id: 'ORIGINAL/CAT3.JPG'
+                path: 'ORIGINAL/CAT3.JPG'
                 docType: 'file'
                 checksum: checksum
                 creationDate: new Date()
@@ -399,7 +402,7 @@ describe 'Remote', ->
     describe 'addFolder', ->
         it 'adds a folder to couchdb', (done) ->
             doc =
-                _id: 'couchdb-folder/folder-1'
+                path: 'couchdb-folder/folder-1'
                 docType: 'folder'
                 creationDate: new Date()
                 lastModification: new Date()
@@ -423,12 +426,12 @@ describe 'Remote', ->
             couchHelpers.createFile @couch, 6, (err, created) =>
                 should.not.exist err
                 doc =
-                    _id: 'couchdb-folder/file-6'
+                    path: 'couchdb-folder/file-6'
                     docType: 'file'
                     checksum: '9999999999999999999999999999999999999926'
                     lastModification: '2015-11-16T16:12:01.002Z'
                 old =
-                    _id: 'couchdb-folder/file-6'
+                    path: 'couchdb-folder/file-6'
                     docType: 'file'
                     checksum: '1111111111111111111111111111111111111126'
                     remote:
@@ -468,12 +471,12 @@ describe 'Remote', ->
             couchHelpers.createFile @couch, 7, (err, created) =>
                 should.not.exist err
                 doc =
-                    _id: 'couchdb-folder/file-7'
+                    path: 'couchdb-folder/file-7'
                     docType: 'file'
                     checksum: '1111111111111111111111111111111111111127'
                     lastModification: '2015-11-16T16:13:01.001Z'
                 old =
-                    _id: 'couchdb-folder/file-7'
+                    path: 'couchdb-folder/file-7'
                     docType: 'file'
                     checksum: '1111111111111111111111111111111111111127'
                     remote:
@@ -504,12 +507,12 @@ describe 'Remote', ->
         it 'updates the metadata of a folder in couchdb', (done) ->
             couchHelpers.createFolder @couch, 2, (err, created) =>
                 doc =
-                    _id: 'couchdb-folder/folder-2'
+                    path: 'couchdb-folder/folder-2'
                     docType: 'folder'
                     creationDate: new Date()
                     lastModification: new Date()
                 old =
-                    _id: 'couchdb-folder/folder-2'
+                    path: 'couchdb-folder/folder-2'
                     docType: 'folder'
                     remote:
                         _id: created.id
@@ -529,7 +532,7 @@ describe 'Remote', ->
 
         it 'adds a folder to couchdb if the folder does not exist', (done) ->
             doc =
-                _id: 'couchdb-folder/folder-3'
+                path: 'couchdb-folder/folder-3'
                 docType: 'folder'
                 creationDate: new Date()
                 lastModification: new Date()
@@ -553,14 +556,14 @@ describe 'Remote', ->
                 _id: checksum
                 _rev: '1-0123456789'
             old =
-                _id: 'cat6.jpg'
+                path: 'cat6.jpg'
                 docType: 'file'
                 checksum: checksum
                 creationDate: new Date()
                 lastModification: new Date()
                 size: 36901
             doc =
-                _id: 'moved-to/cat7.jpg'
+                path: 'moved-to/cat7.jpg'
                 docType: 'file'
                 checksum: checksum
                 creationDate: new Date()
@@ -598,7 +601,7 @@ describe 'Remote', ->
         it 'moves the folder in couchdb', (done) ->
             couchHelpers.createFolder @couch, 4, (err, created) =>
                 doc =
-                    _id: 'couchdb-folder/folder-5'
+                    path: 'couchdb-folder/folder-5'
                     docType: 'folder'
                     creationDate: new Date()
                     lastModification: new Date()
@@ -606,7 +609,7 @@ describe 'Remote', ->
                         _id: created.id
                         _rev: created.rev
                 old =
-                    _id: 'couchdb-folder/folder-4'
+                    path: 'couchdb-folder/folder-4'
                     docType: 'folder'
                     remote:
                         _id: created.id
@@ -624,12 +627,12 @@ describe 'Remote', ->
 
         it 'adds a folder to couchdb if the folder does not exist', (done) ->
             doc =
-                _id: 'couchdb-folder/folder-7'
+                path: 'couchdb-folder/folder-7'
                 docType: 'folder'
                 creationDate: new Date()
                 lastModification: new Date()
             old =
-                _id: 'couchdb-folder/folder-6'
+                path: 'couchdb-folder/folder-6'
                 docType: 'folder'
             @remote.moveFolder doc, old, (err, created) =>
                 should.not.exist err
@@ -649,7 +652,7 @@ describe 'Remote', ->
             couchHelpers.createFile @couch, 8, (err, file) =>
                 should.not.exist err
                 doc =
-                    _id: 'couchdb-folder/file-8'
+                    path: 'couchdb-folder/file-8'
                     _deleted: true
                     docType: 'file'
                     checksum: '1111111111111111111111111111111111111128'
@@ -671,7 +674,7 @@ describe 'Remote', ->
             couchHelpers.createFile @couch, 9, (err, file) =>
                 should.not.exist err
                 doc =
-                    _id: 'couchdb-folder/file-9'
+                    path: 'couchdb-folder/file-9'
                     _deleted: true
                     docType: 'file'
                     checksum: '1111111111111111111111111111111111111129'
@@ -701,7 +704,7 @@ describe 'Remote', ->
             couchHelpers.createFolder @couch, 9, (err, folder) =>
                 should.not.exist err
                 doc =
-                    _id: 'couchdb-folder/folder-9'
+                    path: 'couchdb-folder/folder-9'
                     _deleted: true
                     docType: 'folder'
                     remote:

--- a/tests/unit/remote/watcher.coffee
+++ b/tests/unit/remote/watcher.coffee
@@ -20,7 +20,7 @@ describe "RemoteWatcher Tests", ->
     before 'start couch server', couchHelpers.startServer
     before 'instanciate couch', couchHelpers.createCouchClient
     before 'instanciate remote watcher', ->
-        @merge   = invalidId: Merge::invalidId
+        @merge   = invalidPath: Merge::invalidPath
         @watcher = new Watcher @couch, @merge, @pouch
     after 'stop couch server', couchHelpers.stopServer
     after 'clean pouch', pouchHelpers.cleanDatabase
@@ -81,7 +81,7 @@ describe "RemoteWatcher Tests", ->
                 args = @merge.addDoc.args[0]
                 args[0].should.equal 'remote'
                 args[1].should.have.properties
-                    _id: path.join doc.path, doc.name
+                    path: path.join doc.path, doc.name
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -114,7 +114,7 @@ describe "RemoteWatcher Tests", ->
                 args = @merge.updateDoc.args[0]
                 args[0].should.equal 'remote'
                 args[1].should.have.properties
-                    _id: path.join doc.path, doc.name
+                    path: path.join doc.path, doc.name
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -147,7 +147,7 @@ describe "RemoteWatcher Tests", ->
                 args = @merge.updateDoc.args[0]
                 args[0].should.equal 'remote'
                 args[1].should.have.properties
-                    _id: 'my-folder/file-1'
+                    path: 'my-folder/file-1'
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -181,7 +181,7 @@ describe "RemoteWatcher Tests", ->
                 args[0].should.equal 'remote'
                 src = args[2]
                 src.should.have.properties
-                    _id: 'my-folder/file-2'
+                    path: 'my-folder/file-2'
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -189,7 +189,7 @@ describe "RemoteWatcher Tests", ->
                         _id: '12345678902'
                 dst = args[1]
                 dst.should.have.properties
-                    _id: path.join doc.path, doc.name
+                    path: path.join doc.path, doc.name
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -221,7 +221,7 @@ describe "RemoteWatcher Tests", ->
                 @merge.moveDoc.called.should.be.true()
                 src = @merge.moveDoc.args[0][2]
                 src.should.have.properties
-                    _id: 'my-folder/file-2'
+                    path: 'my-folder/file-2'
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -229,7 +229,7 @@ describe "RemoteWatcher Tests", ->
                         _id: '12345678902'
                 dst = @merge.moveDoc.args[0][1]
                 dst.should.have.properties
-                    _id: path.join doc.path, doc.name
+                    path: path.join doc.path, doc.name
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -260,13 +260,13 @@ describe "RemoteWatcher Tests", ->
             @watcher.onChange clone(doc), (err) =>
                 should.not.exist err
                 @merge.deleteDoc.called.should.be.true()
-                id = @merge.deleteDoc.args[0][1]._id
+                id = @merge.deleteDoc.args[0][1].path
                 id.should.equal 'my-folder/file-3'
                 @merge.addDoc.called.should.be.true()
                 args = @merge.addDoc.args[0]
                 args[0].should.equal 'remote'
                 args[1].should.have.properties
-                    _id: path.join doc.path, doc.name
+                    path: path.join doc.path, doc.name
                     docType: 'file'
                     checksum: doc.checksum
                     tags: doc.tags
@@ -288,7 +288,7 @@ describe "RemoteWatcher Tests", ->
             @watcher.onChange doc, (err) =>
                 should.not.exist err
                 @merge.deleteDoc.called.should.be.true()
-                id = @merge.deleteDoc.args[0][1]._id
+                id = @merge.deleteDoc.args[0][1].path
                 id.should.equal 'my-folder/file-1'
                 done()
 
@@ -307,7 +307,7 @@ describe "RemoteWatcher Tests", ->
                 should.not.exist err
                 @merge.addDoc.called.should.be.true()
                 @merge.addDoc.args[0][1].should.have.properties
-                    _id: 'Photos from devices'
+                    path: 'Photos from devices'
                     docType: 'folder'
                     lastModification: "2015-09-29T14:13:33.384Z"
                     creationDate: "2015-09-29T14:13:33.384Z"


### PR DESCRIPTION
On OSX, the file system (HFS+) is case insensitive. So, we can have a conflict for 2 documents from the remote cozy if their paths differ only by the case, like `foo` and `FOO`. This PR is only for detecting these potentiel conflicts. The resolution of conflicts (in a general sense) is for a next PR.