### PR TITLE
Fix a race condition when deleting a folder

### DIFF
--- a/backend/remote/watcher.coffee
+++ b/backend/remote/watcher.coffee
@@ -105,7 +105,7 @@ class RemoteWatcher
             if err and err.status isnt 404
                 callback err
             else if doc._deleted
-                if err
+                if err or not was?
                     # It's fine if the file was deleted on local and on remote
                     callback()
                 else


### PR DESCRIPTION
A small fix for a race condition when a file is deleted at the same time from the local and the remote, because it was on a folder that was removed.