### PR TITLE
Fix loop for images

### DIFF
--- a/backend/merge.coffee
+++ b/backend/merge.coffee
@@ -155,7 +155,8 @@ class Merge
                 doc._rev = file._rev
                 doc.tags ?= file.tags or []
                 doc.remote ?= file.remote
-                doc.creationDate ?= file.creationDate
+                # Preserve the creation date even if the file system lost it!
+                doc.creationDate = file.creationDate
                 if @sameBinary file, doc
                     doc.size  ?= file.size
                     doc.class ?= file.class


### PR DESCRIPTION
When an image was added to the synchronized folder, both sides tried to
update it in a loop:

- remote -> local, because cozy creates thumbnails for the image
- local -> remote, because cozy-desktop update the lastModification
  with `fs.utimes` and it as the side effect to also update the
  creationDate.

Cozy-desktop now preserve the creationDate, which breaks the loop.