### PR TITLE
Allow users to ignore somes files listed in .cozyignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ sudo npm install cozy-desktop -g
 CLI Running
 -----------
 
-Configure it with your remote Cozy
+Configure it with your remote Cozy and your local directory:
 
 ```bash
-cozy-desktop add-remote-cozy https://url.of.my.cozy/ /sync/directory
+cozy-desktop add-remote-cozy https://url.of.my.cozy/ ~/cozy
 ```
+
+It will synchronize your local directory `~/cozy` with your remote cozy.
 
 Then start synchronization daemon:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [Cozy][0] Desktop <sup>(alpha)</sup>
-=================
+====================================
 
 [![Build Status][1]][2]
 
@@ -57,6 +57,19 @@ cozy-desktop -h
 Advanced use cases
 ------------------
 
+It's possible to make cozy-desktop ignore some files and folders by using a
+`.cozyignore` file. It works pretty much like a `.gitignore`, ie you put
+patterns in this file to ignore. The rules for patterns are the same, so you
+can look at
+[git documentation](https://git-scm.com/docs/gitignore/#_pattern_format) to
+see for their format. For example:
+
+```bash
+*.mp4
+heavy-*
+/tmp
+```
+
 Cozy-desktop keeps the metadata in a pouchdb database. If you want to use
 several synchronized directories, you'll have to tell cozy-desktop to keeps
 its metadata database somewhere else. The `COZY_DESKTOP_DIR` env variable has
@@ -78,18 +91,15 @@ Cozy-desktop is designed to synchronize files and folders between a remote
 cozy instance and a local hard drive, for a personal usage. We tried to make
 it simple and easy. So, it has some limitations:
 
-- It's only a command-line interface and it works only on Linux for the moment.
-  We are working to improve this in the next weeks.
-
-- It's all or nothing for files and folders to synchronize, but we have on our
-  roadmap to add a mean to select which files and folders to synchronize.
+- It's only a command-line interface and it is tested only on Linux for the
+  moment. We are working to improve this in the next weeks.
 
 - Files and folders named like this are ignored:
   - `.cozy-desktop` (they are used to keep internal state)
   - `_design` (special meaning for pouchdb/couchdb)
 
 - It's not a particularly good idea to share code with cozy-desktop:
-  - `node_modules` can't be ignored for the moment and have tons of small files
+  - `node_modules` have tons of small files
   - compiled code often has to be recompile to works on another environment
   - git and other VCS are not meant to be share like this. You may lose your
     work if you make changes on two laptops synchronized by cozy-desktop (it's

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -52,3 +52,19 @@ You can launch cozy-desktop directly in coffee:
 ```bash
 DEBUG=true node_modules/.bin/coffee src/bin/cli.coffee sync
 ```
+
+
+Debug ignored files
+-------------------
+
+You can list the files and folder that are synchronized with:
+
+```bash
+cozy-desktop ls
+```
+
+And those which are ignored:
+
+```bash
+cozy-desktop ls --ignored
+```

--- a/doc/design.md
+++ b/doc/design.md
@@ -48,6 +48,52 @@ secure. And bugs in this part mean losing data, which is very bad. So, we
 don't try to be smart and prefer a robust solution.
 
 
+Ignores
+-------
+
+Cozy-desktop can ignore some files and folders with a `.cozyignore` file. This
+file is read only at the startup of Cozy-desktop. So, if this file is
+modified, cozy-desktop has to be relaunched for the changes to be effective.
+
+There 4 places where ignoring files and folders can have a meaning:
+
+- when a change is detected on the local file system and cozy-desktop is going
+  to save it in its internal pouchdb
+- when a change is detected on the remote cozy and cozy-desktop is going to
+  save it in its internal pouchdb
+- when a change is taken from the pouchdb and cozy-desktop is going to apply
+  on the local file system
+- when a change is taken from the pouchdb and cozy-desktop is going to apply
+  on the remote cozy.
+
+Even with the first two checks, pouchdb can have a change for an ignored file
+from a previous run of cozy-desktop where the file was not yet ignored. So, we
+have to implement the last two checks. It is enough for a file created on one
+side (local or remote) won't be replicated on the other side if it is ignored.
+
+But, there is a special case: conflicts are treated ahead of pouchdb. So, if a
+file is created in both the local file system and the remote cozy (with
+different contents) is ignored, the conflict will still be resolved by
+renaming if we implement only the last two checks. We have to avoid that by
+also implementing at least one of the first two checks.
+
+In practice, it's really convenient to let the changes from the remote couchdb
+flows to pouchdb, even for ignored files, as it is very costly to find them
+later if `.cozyignore` has changed. And it's a lot easier to detect local
+files that were ignored but are no longer at the startup, as cozy-desktop
+already does a full scan of the local file system at that moment.
+
+Thus, cozy-desktop has a check for ignored files and folder in three of the
+four relevant places:
+
+- when a change is detected on the local file system and cozy-desktop is going
+  to save it in its internal pouchdb
+- when a change is taken from the pouchdb and cozy-desktop is going to apply
+  on the local file system
+- when a change is taken from the pouchdb and cozy-desktop is going to apply
+  on the remote cozy.
+
+
 Documents schema
 ----------------
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "printit": "0.1.18",
     "progress": "1.1.8",
     "read": "1.0.7",
+    "readdirp": "2.0.0",
     "request-json-light": "0.5.22"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fs-extra": "0.26.7",
     "lodash.isequal": "4.1.1",
     "lodash.pick": "4.1.0",
+    "micromatch": "2.3.7",
     "mime": "1.3.4",
     "node-uuid": "1.4.7",
     "path-extra": "3.0.0",

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -1,9 +1,10 @@
-async = require 'async'
-fs    = require 'fs'
-path  = require 'path-extra'
-os    = require 'os'
-url   = require 'url'
-log   = require('printit')
+async    = require 'async'
+fs       = require 'fs'
+os       = require 'os'
+path     = require 'path-extra'
+readdirp = require 'readdirp'
+url      = require 'url'
+log      = require('printit')
     prefix: 'Cozy Desktop  '
     date: true
 
@@ -109,14 +110,19 @@ class App
             callback? err
 
 
-    # Instanciate some objects before sync
-    instanciate: ->
+    # Load ignore rules
+    loadIgnore: ->
         try
             ignored = fs.readFileSync(path.join @basePath, '.cozyignore')
             ignored = ignored.toString().split('\n')
         catch error
             ignored = []
         @ignore = new Ignore(ignored).addDefaultRules()
+
+
+    # Instanciate some objects before sync
+    instanciate: ->
+        @loadIgnore()
         @merge  = new Merge @pouch
         @prep   = new Prep @merge, @ignore
         @local  = @merge.local  = new Local  @config, @prep, @pouch
@@ -155,6 +161,24 @@ class App
     # Display a list of watchers for debugging purpose
     debugWatchers: ->
         @local?.watcher.debug()
+
+
+    # Call the callback for each file
+    walkFiles: (args, callback) ->
+        @loadIgnore()
+        options =
+            root: @basePath
+            directoryFilter: '!.cozy-desktop'
+            entryType: 'both'
+        readdirp options
+            .on 'warn',  (err) -> log.warn err
+            .on 'error', (err) -> log.error err
+            .on 'data', (data) =>
+                doc =
+                    _id: data.path
+                    docType: if data.stat.isFile() then 'file' else 'folder'
+                if @ignore.isIgnored(doc) is args.ignored?
+                    callback data.path
 
 
     # Recreate the local pouch database

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -116,7 +116,7 @@ class App
             ignored = ignored.toString().split('\n')
         catch error
             ignored = []
-        @ignore = new Ignore ignored
+        @ignore = new Ignore(ignored).addDefaultRules()
         @merge  = new Merge @pouch
         @prep   = new Prep @merge, @ignore
         @local  = @merge.local  = new Local  @config, @prep, @pouch

--- a/src/bin/cli.coffee
+++ b/src/bin/cli.coffee
@@ -43,7 +43,7 @@ sync = (mode, args) ->
 
 
 program
-    .command 'add-remote-cozy <url> <syncPath>'
+    .command 'add-remote-cozy <url> <localSyncPath>'
     .description 'Configure current device to sync with given cozy'
     .option '-d, --deviceName [deviceName]', 'device name to deal with'
     .action (url, syncPath, args) ->

--- a/src/bin/cli.coffee
+++ b/src/bin/cli.coffee
@@ -107,6 +107,14 @@ program
             """
 
 program
+    .command 'ls'
+    .description 'List local files that are synchronized with the remote cozy'
+    .option('-i, --ignored', 'List ignored files')
+    .action (args) ->
+        app.walkFiles args, (file) ->
+            console.log file
+
+program
     .command 'reset-database'
     .description 'Recreates the local database'
     .action app.resetDatabase

--- a/src/ignore.coffee
+++ b/src/ignore.coffee
@@ -7,6 +7,48 @@ matcher            = require('micromatch').matcher
 # See https://git-scm.com/docs/gitignore/#_pattern_format
 class Ignore
 
+    # See https://github.com/github/gitignore/tree/master/Global
+    DefaultRules = [
+        # Dropbox
+        '.dropbox'
+        '.dropbox.attr'
+        '.dropbox.cache'
+
+        # Eclipse, SublimeText and many others
+        '*.tmp'
+        '*.bak'
+
+        # Emacs
+        '*~'
+        '\\#*\\#'
+
+        # LibreOffice
+        '.~lock.*#'
+
+        # Linux
+        '.fuse_hidden*'
+        '.Trash-*'
+
+        # Microsoft Office
+        '~$*.{doc,xls,ppt}*'
+
+        # OSX
+        '.DS_Store'
+        '.DocumentRevisions-V100'
+        '.fseventsd'
+        '.Spotlight-V100'
+        '.TemporaryItems'
+        '.Trashes'
+        '.VolumeIcon.icns'
+
+        # Vim
+        '*.sw[px]'
+
+        # Windows
+        'Thumbs.db'
+        'ehthumbs.db'
+    ]
+
     # See https://github.com/jonschlinkert/micromatch#options
     MicromatchOptions =
         noextglob: true
@@ -17,28 +59,39 @@ class Ignore
         for line in lines
             continue if line is ''          # Blank line
             continue if line[0] is '#'      # Comments
-            folder   = false
-            negate   = false
-            noslash  = line.indexOf('/') is -1
-            if line.indexOf('**') isnt -1   # Detect two asterisks
-                fullpath = true
-                noslash  = false
-            if line[0] is '!'               # Detect bang prefix
-                line = line.slice 1
-                negate = true
-            if line[0] is '/'               # Detect leading slash
-                line = line.slice 1
-            if line[line.length-1] is '/'   # Detect trailing slash
-                line = line.slice 0, line.length-1
-                folder = true
-            line = line.replace /^\\/, ''   # Remove leading escaping char
-            line = line.replace /\s*$/, ''  # Remove trailing spaces
-            pattern =
-                match: matcher line, MicromatchOptions
-                basename: noslash   # The pattern can match only the basename
-                folder:   folder    # The pattern will only match a folder
-                negate:   negate    # The pattern is negated
-            @patterns.push pattern
+            @patterns.push @buildPattern line
+
+    # Parse a line and build the corresponding pattern
+    buildPattern: (line) ->
+        folder   = false
+        negate   = false
+        noslash  = line.indexOf('/') is -1
+        if line.indexOf('**') isnt -1   # Detect two asterisks
+            fullpath = true
+            noslash  = false
+        if line[0] is '!'               # Detect bang prefix
+            line = line.slice 1
+            negate = true
+        if line[0] is '/'               # Detect leading slash
+            line = line.slice 1
+        if line[line.length-1] is '/'   # Detect trailing slash
+            line = line.slice 0, line.length-1
+            folder = true
+        line = line.replace /^\\/, ''   # Remove leading escaping char
+        line = line.replace /\s*$/, ''  # Remove trailing spaces
+        pattern =
+            match: matcher line, MicromatchOptions
+            basename: noslash   # The pattern can match only the basename
+            folder:   folder    # The pattern will only match a folder
+            negate:   negate    # The pattern is negated
+        return pattern
+
+    # Add some rules for things that should be always ignored (temporary
+    # files, thumbnails db, trash, etc.)
+    addDefaultRules: ->
+        morePatterns = (@buildPattern rule for rule in DefaultRules)
+        @patterns = morePatterns.concat @patterns
+        return @
 
     # Return true if the doc matches the pattern
     match: (path, isFolder, pattern) ->

--- a/src/ignore.coffee
+++ b/src/ignore.coffee
@@ -1,0 +1,42 @@
+# Cozy-desktop can ignore some files and folders from a list of patterns in the
+# cozyignore file. This class can be used to know if a file/folder is ignored.
+#
+# See https://git-scm.com/docs/gitignore/#_pattern_format
+class Ignore
+
+    # Load patterns for detecting ignored files and folders
+    constructor: (lines) ->
+        @patterns = []
+        for line in lines
+            continue if line is ''          # Blank line
+            continue if line[0] is '#'      # Comments
+            line = line.replace /\s*$/, ''  # Remove trailing spaces
+            if line[line.length-1] is '/'   # Detect trailing slash
+                line = line.slice 0, line.length-1
+                folder = true
+            else
+                folder = false
+            pattern =
+                description: line
+                folder: folder
+            @patterns.push pattern
+
+    # Returns true if the pattern match the give file/folder
+    match: (pattern, path, kind) ->
+        # If the rule is only for folders and it's not a folder,
+        # it can't be a match
+        return false if pattern.folder and kind isnt 'folder'
+        # Else, check if the path match the pattern description
+        return path is pattern.description
+
+    # Return true if the file or folder with the given path should be ignored
+    #
+    # kind is 'file' or 'folder'
+    # (a pattern with a trailing slash is only for folders)
+    isIgnored: (path, kind) ->
+        for pattern in @patterns
+            return true if @match pattern, path, kind
+        return false
+
+
+module.exports = Ignore

--- a/src/ignore.coffee
+++ b/src/ignore.coffee
@@ -1,4 +1,5 @@
-mm = require 'micromatch'
+{basename,dirname} = require('path')
+matcher            = require('micromatch').matcher
 
 # Cozy-desktop can ignore some files and folders from a list of patterns in the
 # cozyignore file. This class can be used to know if a file/folder is ignored.
@@ -16,23 +17,40 @@ class Ignore
         for line in lines
             continue if line is ''          # Blank line
             continue if line[0] is '#'      # Comments
+            folder   = false
+            fullpath = false
+            noslash  = line.indexOf('/') is -1
             line = line.replace /\s*$/, ''  # Remove trailing spaces
+            if line[0] is '/'               # Detect leading slash
+                line = line.slice 1
+                fullpath = true
             if line[line.length-1] is '/'   # Detect trailing slash
                 line = line.slice 0, line.length-1
                 folder = true
-            else
-                folder = false
             pattern =
-                match: mm.matcher line, MicromatchOptions
-                folder: folder
+                match: matcher line, MicromatchOptions
+                folder:   folder    # The pattern will only match a folder
+                fullpath: fullpath  # The pattern will only match the full path
+                basename: noslash   # The pattern can match only the basename
             @patterns.push pattern
+
+    # Return true if the doc matches the pattern
+    match: (path, isFolder, pattern) ->
+        if pattern.basename
+            return true if pattern.match basename path
+        if isFolder or not pattern.folder
+            return true  if pattern.match path
+        return false if pattern.fullpath
+        parent = dirname path
+        return false if parent is '.'
+        return @match parent, true, pattern
 
     # Return true if the given file/folder path should be ignored
     isIgnored: (doc) ->
+        ignored = false
         for pattern in @patterns
-            if doc.docType is 'folder' or not pattern.folder
-                return true if pattern.match doc._id
-        return false
+            ignored or= @match doc._id, doc.docType is 'folder', pattern
+        return ignored
 
 
 module.exports = Ignore

--- a/src/ignore.coffee
+++ b/src/ignore.coffee
@@ -27,14 +27,11 @@ class Ignore
                 folder: folder
             @patterns.push pattern
 
-    # Return true if the file or folder with the given path should be ignored
-    #
-    # kind is 'file' or 'folder'
-    # (a pattern with a trailing slash is only for folders)
-    isIgnored: (path, kind) ->
+    # Return true if the given file/folder path should be ignored
+    isIgnored: (doc) ->
         for pattern in @patterns
-            if kind is 'folder' or not pattern.folder
-                return true if pattern.match path
+            if doc.docType is 'folder' or not pattern.folder
+                return true if pattern.match doc._id
         return false
 
 

--- a/src/ignore.coffee
+++ b/src/ignore.coffee
@@ -1,8 +1,14 @@
+mm = require 'micromatch'
+
 # Cozy-desktop can ignore some files and folders from a list of patterns in the
 # cozyignore file. This class can be used to know if a file/folder is ignored.
 #
 # See https://git-scm.com/docs/gitignore/#_pattern_format
 class Ignore
+
+    # See https://github.com/jonschlinkert/micromatch#options
+    MicromatchOptions =
+        noextglob: true
 
     # Load patterns for detecting ignored files and folders
     constructor: (lines) ->
@@ -17,17 +23,9 @@ class Ignore
             else
                 folder = false
             pattern =
-                description: line
+                match: mm.matcher line, MicromatchOptions
                 folder: folder
             @patterns.push pattern
-
-    # Returns true if the pattern match the give file/folder
-    match: (pattern, path, kind) ->
-        # If the rule is only for folders and it's not a folder,
-        # it can't be a match
-        return false if pattern.folder and kind isnt 'folder'
-        # Else, check if the path match the pattern description
-        return path is pattern.description
 
     # Return true if the file or folder with the given path should be ignored
     #
@@ -35,7 +33,8 @@ class Ignore
     # (a pattern with a trailing slash is only for folders)
     isIgnored: (path, kind) ->
         for pattern in @patterns
-            return true if @match pattern, path, kind
+            if kind is 'folder' or not pattern.folder
+                return true if pattern.match path
         return false
 
 

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -9,7 +9,7 @@ log   = require('printit')
 # respectively.
 class Sync
 
-    constructor: (@pouch, @local, @remote) ->
+    constructor: (@pouch, @local, @remote, @ignore) ->
         @local.other = @remote
         @remote.other = @local
 
@@ -92,6 +92,12 @@ class Sync
     apply: (change, callback) =>
         log.debug 'apply', change
         doc = change.doc
+
+        if @ignore.isIgnored doc
+            @pouch.setLocalSeq change.seq, (err) ->
+                callback()
+            return
+
         [side, sideName, rev] = @selectSide doc
         done = @applied(change, sideName, callback)
 

--- a/test/unit/ignore.coffee
+++ b/test/unit/ignore.coffee
@@ -5,76 +5,50 @@ Ignore = require '../../src/ignore'
 
 describe 'Ignore', ->
 
-    describe 'Loading patterns', ->
+    it 'rejects blank lines for patterns', ->
+        @ignore = new Ignore ['foo', '', 'bar']
+        @ignore.patterns.length.should.equal 2
 
-        it 'rejects blank lines for patterns', ->
-            @ignore = new Ignore ['foo', '', 'bar']
-            descriptions = @ignore.patterns.map (p) -> p.description
-            descriptions.should.eql ['foo', 'bar']
+    it 'rejects comments for patterns', ->
+        @ignore = new Ignore ['# Blah', 'foo', 'bar']
+        @ignore.patterns.length.should.equal 2
 
-        it 'rejects comments for patterns', ->
-            @ignore = new Ignore ['# Blah', 'foo', 'bar']
-            descriptions = @ignore.patterns.map (p) -> p.description
-            descriptions.should.eql ['foo', 'bar']
+    it 'does not keep trailing spaces in patterns', ->
+        @ignore = new Ignore ['foo  ']
+        @ignore.patterns[0].match('foo').should.be.true()
 
-        it 'does not keep trailing spaces in patterns', ->
-            @ignore = new Ignore ['foo  ']
-            @ignore.patterns[0].description.should.equal 'foo'
+    it 'does not match a file when path and pattern are different', ->
+        @ignore = new Ignore ['foo']
+        @ignore.isIgnored('bar', 'file').should.be.false()
 
-        it 'detects trailing slash', ->
-            @ignore = new Ignore ['foo/', 'bar']
-            @ignore.patterns[0].description.should.equal 'foo'
-            @ignore.patterns[0].folder.should.be.true()
-            @ignore.patterns[1].folder.should.be.false()
+    it 'matches a file when its path is the pattern description', ->
+        @ignore = new Ignore ['foo']
+        @ignore.isIgnored('foo', 'file').should.be.true()
 
+    it 'matches a folder when its path is the pattern description', ->
+        @ignore = new Ignore ['foo']
+        @ignore.isIgnored('foo', 'folder').should.be.true()
 
-    describe 'Matching a pattern', ->
-        before -> @ignore = new Ignore []
+    it 'does not match a file when the pattern is for folders only', ->
+        @ignore = new Ignore ['foo/']
+        @ignore.isIgnored('foo', 'file').should.be.false()
 
-        it 'does not match a file when path and description are different', ->
-            pattern =
-                description: 'foo'
-                folder: false
-            @ignore.match(pattern, 'bar', 'folder').should.be.false()
+    it 'matches a folder, even with a folders only pattern', ->
+        @ignore = new Ignore ['foo/']
+        @ignore.isIgnored('foo', 'folder').should.be.true()
 
-        it 'matches a file when its path is the pattern description', ->
-            pattern =
-                description: 'foo'
-                folder: false
-            @ignore.match(pattern, 'foo', 'file').should.be.true()
+    it 'matches dotfiles', ->
+        @ignore = new Ignore ['.foo']
+        @ignore.isIgnored('.foo', 'file').should.be.true()
 
-        it 'matches a folder when its path is the pattern description', ->
-            pattern =
-                description: 'foo'
-                folder: false
-            @ignore.match(pattern, 'foo', 'folder').should.be.true()
+    it 'accepts glob', ->
+        @ignore = new Ignore ['*.txt']
+        @ignore.isIgnored('foo.txt', 'file').should.be.true()
 
-        it 'does not match a file when the pattern is for folders only', ->
-            pattern =
-                description: 'foo'
-                folder: true
-            @ignore.match(pattern, 'foo', 'file').should.be.false()
+    it 'accepts braces', ->
+        @ignore = new Ignore ['foo.{md,txt}']
+        @ignore.isIgnored('foo.txt', 'file').should.be.true()
 
-        it 'matches a folder, even with a folders only pattern', ->
-            pattern =
-                description: 'foo'
-                folder: true
-            @ignore.match(pattern, 'foo', 'folder').should.be.true()
-
-
-    describe 'Determining if a file/folder is ignored', ->
-
-        it 'does not ignore paths when no pattern match', ->
-            @ignore = new Ignore ['foo']
-            @ignore.isIgnored('bar', 'file').should.be.false()
-            @ignore.isIgnored('bar', 'folder').should.be.false()
-
-        it 'ignores a path that is completely matched', ->
-            @ignore = new Ignore ['foo/bar']
-            @ignore.isIgnored('foo/bar', 'file').should.be.true()
-            @ignore.isIgnored('foo/bar', 'folder').should.be.true()
-
-        it 'ignores only folders when the pattern ends with a /', ->
-            @ignore = new Ignore ['foo/']
-            @ignore.isIgnored('foo', 'file').should.be.false()
-            @ignore.isIgnored('foo', 'folder').should.be.true()
+    it 'accepts brackets', ->
+        @ignore = new Ignore ['[a-f]oo']
+        @ignore.isIgnored('foo', 'file').should.be.true()

--- a/test/unit/ignore.coffee
+++ b/test/unit/ignore.coffee
@@ -141,3 +141,80 @@ describe 'Ignore', ->
             _id: 'bar/foo'
             docType: 'file'
         @ignore.isIgnored(doc).should.be.false()
+
+    it 'accepts two asterisks at the start', ->
+        @ignore = new Ignore ['**/foo']
+        doc =
+            _id: 'abc/def/foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'accepts two asterisks at the end', ->
+        @ignore = new Ignore ['foo/**']
+        doc =
+            _id: 'foo/abc/def'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'accepts two asterisks at the middle', ->
+        @ignore = new Ignore ['a/**/b']
+        doc =
+            _id: 'a/foo/bar/b'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'accepts two asterisks at the middle (bis)', ->
+        @ignore = new Ignore ['a/**/b']
+        doc =
+            _id: 'a/b'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'accepts two asterisks at the middle (ter)', ->
+        @ignore = new Ignore ['a/**/b']
+        doc =
+            _id: 'foo/a/b'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
+
+    it 'accepts escaping char', ->
+        @ignore = new Ignore ['\\#foo']
+        doc =
+            _id: '#foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'accepts escaping char', ->
+        @ignore = new Ignore ['\\!foo']
+        doc =
+            _id: '!foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'can negate a previous rule', ->
+        @ignore = new Ignore ['*.foo', '!important.foo']
+        doc =
+            _id: 'important.foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
+
+    it 'can negate a previous rule (bis)', ->
+        @ignore = new Ignore ['/*', '!/foo', '/foo/*', '!/foo/bar']
+        doc =
+            _id: 'foo/bar/abc/def'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
+
+    it 'can negate a previous rule (ter)', ->
+        @ignore = new Ignore ['/*', '!/foo', '/foo/*', '!/foo/bar']
+        doc =
+            _id: 'a/foo/bar'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'can negate a previous rule (quater)', ->
+        @ignore = new Ignore ['bar*', '!/foo/bar*']
+        doc =
+            _id: 'foo/bar'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()

--- a/test/unit/ignore.coffee
+++ b/test/unit/ignore.coffee
@@ -66,6 +66,19 @@ describe 'Ignore', ->
             docType: 'file'
         @ignore.isIgnored(doc).should.be.true()
 
+    it 'accepts wild card', ->
+        @ignore = new Ignore ['fo?']
+        doc =
+            _id: 'foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'accepts wild card (bis)', ->
+        doc =
+            _id: 'foobar'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
+
     it 'accepts braces', ->
         @ignore = new Ignore ['foo.{md,txt}']
         doc =
@@ -79,3 +92,52 @@ describe 'Ignore', ->
             _id: 'foo'
             docType: 'file'
         @ignore.isIgnored(doc).should.be.true()
+
+    it 'ignores files only on basename', ->
+        @ignore = new Ignore ['foo']
+        doc =
+            _id: 'abc/foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'ignores files only on basename (bis)', ->
+        @ignore = new Ignore ['/foo']
+        doc =
+            _id: 'abc/foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
+
+    it 'ignores files in a ignored directory', ->
+        @ignore = new Ignore ['foo']
+        doc =
+            _id: 'foo/bar'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'ignores files in a ignored directory (bis)', ->
+        @ignore = new Ignore ['foo/']
+        doc =
+            _id: 'foo/bar'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'ignores directories in a ignored directory', ->
+        @ignore = new Ignore ['foo']
+        doc =
+            _id: 'foo/baz'
+            docType: 'folder'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'restricts ignore rules with a leading slash to a full path', ->
+        @ignore = new Ignore ['/foo']
+        doc =
+            _id: 'foo'
+            docType: 'folder'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'restricts ignore rules with a leading slash to a full path (bis)', ->
+        @ignore = new Ignore ['/foo']
+        doc =
+            _id: 'bar/foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()

--- a/test/unit/ignore.coffee
+++ b/test/unit/ignore.coffee
@@ -218,3 +218,27 @@ describe 'Ignore', ->
             _id: 'foo/bar'
             docType: 'file'
         @ignore.isIgnored(doc).should.be.false()
+
+    it 'has some defaults rules for dropbox', ->
+        @ignore = new Ignore []
+        @ignore.addDefaultRules()
+        doc =
+            _id: '.dropbox'
+            docType: 'folder'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'has some defaults rules for editors', ->
+        @ignore = new Ignore []
+        @ignore.addDefaultRules()
+        doc =
+            _id: 'foo.c.swp~'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
+
+    it 'has some defaults rules for OSes', ->
+        @ignore = new Ignore []
+        @ignore.addDefaultRules()
+        doc =
+            _id: 'Thumbs.db'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()

--- a/test/unit/ignore.coffee
+++ b/test/unit/ignore.coffee
@@ -1,0 +1,80 @@
+should = require 'should'
+
+Ignore = require '../../src/ignore'
+
+
+describe 'Ignore', ->
+
+    describe 'Loading patterns', ->
+
+        it 'rejects blank lines for patterns', ->
+            @ignore = new Ignore ['foo', '', 'bar']
+            descriptions = @ignore.patterns.map (p) -> p.description
+            descriptions.should.eql ['foo', 'bar']
+
+        it 'rejects comments for patterns', ->
+            @ignore = new Ignore ['# Blah', 'foo', 'bar']
+            descriptions = @ignore.patterns.map (p) -> p.description
+            descriptions.should.eql ['foo', 'bar']
+
+        it 'does not keep trailing spaces in patterns', ->
+            @ignore = new Ignore ['foo  ']
+            @ignore.patterns[0].description.should.equal 'foo'
+
+        it 'detects trailing slash', ->
+            @ignore = new Ignore ['foo/', 'bar']
+            @ignore.patterns[0].description.should.equal 'foo'
+            @ignore.patterns[0].folder.should.be.true()
+            @ignore.patterns[1].folder.should.be.false()
+
+
+    describe 'Matching a pattern', ->
+        before -> @ignore = new Ignore []
+
+        it 'does not match a file when path and description are different', ->
+            pattern =
+                description: 'foo'
+                folder: false
+            @ignore.match(pattern, 'bar', 'folder').should.be.false()
+
+        it 'matches a file when its path is the pattern description', ->
+            pattern =
+                description: 'foo'
+                folder: false
+            @ignore.match(pattern, 'foo', 'file').should.be.true()
+
+        it 'matches a folder when its path is the pattern description', ->
+            pattern =
+                description: 'foo'
+                folder: false
+            @ignore.match(pattern, 'foo', 'folder').should.be.true()
+
+        it 'does not match a file when the pattern is for folders only', ->
+            pattern =
+                description: 'foo'
+                folder: true
+            @ignore.match(pattern, 'foo', 'file').should.be.false()
+
+        it 'matches a folder, even with a folders only pattern', ->
+            pattern =
+                description: 'foo'
+                folder: true
+            @ignore.match(pattern, 'foo', 'folder').should.be.true()
+
+
+    describe 'Determining if a file/folder is ignored', ->
+
+        it 'does not ignore paths when no pattern match', ->
+            @ignore = new Ignore ['foo']
+            @ignore.isIgnored('bar', 'file').should.be.false()
+            @ignore.isIgnored('bar', 'folder').should.be.false()
+
+        it 'ignores a path that is completely matched', ->
+            @ignore = new Ignore ['foo/bar']
+            @ignore.isIgnored('foo/bar', 'file').should.be.true()
+            @ignore.isIgnored('foo/bar', 'folder').should.be.true()
+
+        it 'ignores only folders when the pattern ends with a /', ->
+            @ignore = new Ignore ['foo/']
+            @ignore.isIgnored('foo', 'file').should.be.false()
+            @ignore.isIgnored('foo', 'folder').should.be.true()

--- a/test/unit/ignore.coffee
+++ b/test/unit/ignore.coffee
@@ -19,36 +19,63 @@ describe 'Ignore', ->
 
     it 'does not match a file when path and pattern are different', ->
         @ignore = new Ignore ['foo']
-        @ignore.isIgnored('bar', 'file').should.be.false()
+        doc =
+            _id: 'bar'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
 
     it 'matches a file when its path is the pattern description', ->
         @ignore = new Ignore ['foo']
-        @ignore.isIgnored('foo', 'file').should.be.true()
+        doc =
+            _id: 'foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
 
     it 'matches a folder when its path is the pattern description', ->
         @ignore = new Ignore ['foo']
-        @ignore.isIgnored('foo', 'folder').should.be.true()
+        doc =
+            _id: 'foo'
+            docType: 'folder'
+        @ignore.isIgnored(doc).should.be.true()
 
     it 'does not match a file when the pattern is for folders only', ->
         @ignore = new Ignore ['foo/']
-        @ignore.isIgnored('foo', 'file').should.be.false()
+        doc =
+            _id: 'foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.false()
 
     it 'matches a folder, even with a folders only pattern', ->
         @ignore = new Ignore ['foo/']
-        @ignore.isIgnored('foo', 'folder').should.be.true()
+        doc =
+            _id: 'foo'
+            docType: 'folder'
+        @ignore.isIgnored(doc).should.be.true()
 
     it 'matches dotfiles', ->
         @ignore = new Ignore ['.foo']
-        @ignore.isIgnored('.foo', 'file').should.be.true()
+        doc =
+            _id: '.foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
 
     it 'accepts glob', ->
         @ignore = new Ignore ['*.txt']
-        @ignore.isIgnored('foo.txt', 'file').should.be.true()
+        doc =
+            _id: 'foo.txt'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
 
     it 'accepts braces', ->
         @ignore = new Ignore ['foo.{md,txt}']
-        @ignore.isIgnored('foo.txt', 'file').should.be.true()
+        doc =
+            _id: 'foo.txt'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()
 
     it 'accepts brackets', ->
         @ignore = new Ignore ['[a-f]oo']
-        @ignore.isIgnored('foo', 'file').should.be.true()
+        doc =
+            _id: 'foo'
+            docType: 'file'
+        @ignore.isIgnored(doc).should.be.true()

--- a/test/unit/prep.coffee
+++ b/test/unit/prep.coffee
@@ -2,15 +2,17 @@ clone  = require 'lodash.clone'
 sinon  = require 'sinon'
 should = require 'should'
 
-Prep = require '../../src/prep'
+Ignore = require '../../src/ignore'
+Prep   = require '../../src/prep'
 
 
 describe 'Prep', ->
 
     beforeEach 'instanciate prep', ->
-        @side  = 'local'
-        @merge = {}
-        @prep  = new Prep @merge
+        @side   = 'local'
+        @merge  = {}
+        @ignore = new Ignore ['ignored']
+        @prep   = new Prep @merge, @ignore
 
 
     describe 'Helpers', ->
@@ -205,6 +207,16 @@ describe 'Prep', ->
                     should.exist doc.lastModification
                     done()
 
+            it 'does nothing for ignored paths on local', (done) ->
+                @merge.addFile = sinon.spy()
+                doc =
+                    path: 'ignored'
+                    checksum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
+                @prep.addFile 'local', doc, (err) =>
+                    should.not.exist err
+                    @merge.addFile.called.should.be.false()
+                    done()
+
 
         describe 'updateFile', ->
             it 'expects a doc with a valid path', (done) ->
@@ -245,6 +257,16 @@ describe 'Prep', ->
                     should.exist doc.lastModification
                     done()
 
+            it 'does nothing for ignored paths on local', (done) ->
+                @merge.updateFile = sinon.spy()
+                doc =
+                    path: 'ignored'
+                    checksum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
+                @prep.updateFile 'local', doc, (err) =>
+                    should.not.exist err
+                    @merge.updateFile.called.should.be.false()
+                    done()
+
 
         describe 'putFolder', ->
             it 'expects a doc with a valid path', (done) ->
@@ -262,6 +284,14 @@ describe 'Prep', ->
                     doc.docType.should.equal 'folder'
                     should.exist doc._id
                     should.exist doc.lastModification
+                    done()
+
+            it 'does nothing for ignored paths on local', (done) ->
+                @merge.putFolder = sinon.spy()
+                doc = path: 'ignored'
+                @prep.putFolder 'local', doc, (err) =>
+                    should.not.exist err
+                    @merge.putFolder.called.should.be.false()
                     done()
 
 
@@ -430,6 +460,14 @@ describe 'Prep', ->
                     should.exist doc._id
                     done()
 
+            it 'does nothing for ignored paths on local', (done) ->
+                @merge.deleteFile = sinon.spy()
+                doc = path: 'ignored'
+                @prep.deleteFile 'local', doc, (err) =>
+                    should.not.exist err
+                    @merge.deleteFile.called.should.be.false()
+                    done()
+
         describe 'deleteFolder', ->
             it 'expects a doc with a valid path', (done) ->
                 @prep.deleteFolder @side, path: '/', (err) ->
@@ -445,4 +483,12 @@ describe 'Prep', ->
                     @merge.deleteFolder.calledWith(@side, doc).should.be.true()
                     doc.docType.should.equal 'folder'
                     should.exist doc._id
+                    done()
+
+            it 'does nothing for ignored paths on local', (done) ->
+                @merge.deleteFolder = sinon.spy()
+                doc = path: 'ignored'
+                @prep.deleteFolder 'local', doc, (err) =>
+                    should.not.exist err
+                    @merge.deleteFolder.called.should.be.false()
                     done()


### PR DESCRIPTION
Cozy-desktop can now ignore somes files and folders when doing the synchronization. The users can list what they want to ignore in the `.cozyignore` file. The syntax for this file is the same as `.gitignore`.