### PR TITLE
Explain that node 4 is recommended

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     fast_finish: true
 node_js:
     - 0.10
-    - 0.12
     - 4
     - 5
 env:
@@ -31,8 +30,8 @@ before_install:
     - export INDEXES_PATH=/home/travis/build/indexes
     - mkdir -p $INDEXES_PATH
     - TESTED_NODE=$(node -v)
-    - nvm install 0.10
-    - nvm use 0.10
+    - nvm install 4
+    - nvm use 4
     - travis_retry npm -g install npm@latest-2
     - npm install forever coffee-script -g
     - git clone git://github.com/cozy/cozy-data-system.git

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ plan to do a more stable release in the coming weeks. Stay tuned!
 CLI Install
 -----------
 
-The cozy-desktop requires node.js (at least version 0.10) and build tools.
+The cozy-desktop requires node.js (4 recommended, but it is tested on 0.10 and
+5 too) and build tools.
 
 For example, you can install them on debian with:
 


### PR DESCRIPTION
Node 0.10 and 0.12 will reach their end of life this year. So, it's time to make node 4 the default. We need to test cozy-desktop with node 5 as we will use it inside Electron for the GUI and Electron comes with node 5. Node 0.10 is still used a lot, in particular on Ubuntu and Debian, so we should keep the tests for it too. But I've disabled the build for node 0.12 to focus the support on the three other versions.