### PR TITLE
Improve stability and avoid many useless exchanges

### DIFF
--- a/src/local/index.coffee
+++ b/src/local/index.coffee
@@ -42,6 +42,13 @@ class Local
 
     # Return a function that will update last modification date
     # and does a chmod +x if the file is executable
+    #
+    # Note: UNIX has 3 timestamps for a file/folder:
+    # - atime for last access
+    # - ctime for change (metadata or content)
+    # - utime for update (content only)
+    # This function updates utime and ctime according to the last
+    # modification date.
     metadataUpdater: (doc) =>
         filePath = path.resolve @basePath, doc.path
         (callback) ->
@@ -51,9 +58,8 @@ class Local
                 else
                     callback err
             if doc.lastModification
-                creationDate = new Date doc.creationDate
                 lastModification = new Date doc.lastModification
-                fs.utimes filePath, creationDate, lastModification, ->
+                fs.utimes filePath, lastModification, lastModification, ->
                     # Ignore errors
                     next()
             else

--- a/src/merge.coffee
+++ b/src/merge.coffee
@@ -53,8 +53,9 @@ class Merge
     sameFile: (one, two) ->
         return false unless @sameDate one.creationDate, two.creationDate
         return false unless @sameDate one.lastModification, two.lastModification
+        return false unless not one.executable is not two.executable
         fields = ['_id', 'docType', 'checksum', 'remote',
-            'tags', 'size', 'class', 'mime', 'executable']
+            'tags', 'size', 'class', 'mime']
         one = pick one, fields
         two = pick two, fields
         return isEqual one, two

--- a/src/merge.coffee
+++ b/src/merge.coffee
@@ -37,10 +37,11 @@ class Merge
         return Math.abs(two - one) < 3000
 
     # Return true if the metadata of the two folders are the same
-    # For creationDate and lastModification, we accept up to 3s of differences
+    # The creationDate of the two folders are not compared, because the local
+    # filesystem can't give us a relevant information for that.
+    # For lastModification, we accept up to 3s of differences
     # because we can't rely on file systems to be precise to the millisecond.
     sameFolder: (one, two) ->
-        return false unless @sameDate one.creationDate, two.creationDate
         return false unless @sameDate one.lastModification, two.lastModification
         fields = ['_id', 'docType', 'remote', 'tags']
         one = pick one, fields
@@ -206,6 +207,7 @@ class Merge
                 doc._rev = folder._rev
                 doc.tags ?= folder.tags or []
                 doc.creationDate ?= folder.creationDate
+                doc.remote ?= folder.remote
                 if @sameFolder folder, doc
                     callback null
                 else

--- a/src/merge.coffee
+++ b/src/merge.coffee
@@ -39,8 +39,8 @@ class Merge
     # Return true if the metadata of the two folders are the same
     # The creationDate of the two folders are not compared, because the local
     # filesystem can't give us a relevant information for that.
-    # For lastModification, we accept up to 3s of differences
-    # because we can't rely on file systems to be precise to the millisecond.
+    # For lastModification, we accept up to 3s of differences because we can't
+    # rely on file systems to be precise to the millisecond.
     sameFolder: (one, two) ->
         return false unless @sameDate one.lastModification, two.lastModification
         fields = ['_id', 'docType', 'remote', 'tags']
@@ -49,10 +49,11 @@ class Merge
         return isEqual one, two
 
     # Return true if the metadata of the two files are the same
-    # For creationDate and lastModification, we accept up to 3s of differences
-    # because we can't rely on file systems to be precise to the millisecond.
+    # The creationDate of the two files are not compared, because the local
+    # filesystem can't give us a relevant information for that.
+    # For lastModification, we accept up to 3s of differences because we can't
+    # rely on file systems to be precise to the millisecond.
     sameFile: (one, two) ->
-        return false unless @sameDate one.creationDate, two.creationDate
         return false unless @sameDate one.lastModification, two.lastModification
         return false unless not one.executable is not two.executable
         fields = ['_id', 'docType', 'checksum', 'remote',

--- a/test/unit/helpers_merge.coffee
+++ b/test/unit/helpers_merge.coffee
@@ -189,6 +189,31 @@ describe 'Merge Helpers', ->
             @merge.sameFile(d, f).should.be.false()
             @merge.sameFile(e, f).should.be.false()
 
+        it 'does not fail when one file has executable: undefined', ->
+            a =
+                _id: 'FOO/BAR'
+                docType: 'file'
+                path: 'foo/bar'
+                checksum: '9440ca447681546bd781d6a5166d18737223b3f6'
+                creationDate: '2015-12-01T11:22:56.517Z'
+                lastModification: '2015-12-01T11:22:56.517Z'
+                tags: ['qux']
+                remote:
+                    id: '123'
+                    rev: '4-567'
+            b = clone a
+            b.executable = undefined
+            c = clone a
+            c.executable = false
+            d = clone a
+            d.executable = true
+            @merge.sameFile(a, b).should.be.true()
+            @merge.sameFile(a, c).should.be.true()
+            @merge.sameFile(a, d).should.be.false()
+            @merge.sameFile(b, c).should.be.true()
+            @merge.sameFile(b, d).should.be.false()
+            @merge.sameFile(c, d).should.be.false()
+
 
     describe 'sameBinary', ->
         it 'returns true for two docs with the same checksum', ->


### PR DESCRIPTION
I've modified two things for when we check if a file or a folder has changed:

1. The comparison of the executable flag failed in some rare cases previously. It should be more robust now.
2. The creation date was compared. It is no longer the case. The local filesystem can't give us it in a reliable way (it only has access time, change time and update time on a lot of cases). So, it's better to ignore it.