### PR TITLE
Install libappindicator1 as a dependency of the linux package

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -5,7 +5,10 @@
   "build": {
     "app-bundle-id": "io.cozy.desktop",
     "app-category-type": "public.app-category.productivity",
-    "iconUrl": "https://cozy.io/en/images/desktop/icon.ico"
+    "iconUrl": "https://cozy.io/en/images/desktop/icon.ico",
+    "linux": {
+      "fpm": ["--depends", "libappindicator1"]
+	}
   },
   "devDependencies": {
     "chokidar-cli": "1.2.0",


### PR DESCRIPTION
From https://github.com/electron-userland/electron-builder/issues/375