### PR TITLE
Use Electron 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
 node_js:
     - 0.10
     - 4
-    - 5
     - 6
 env:
     global:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CLI Install
 -----------
 
 The cozy-desktop requires node.js (4 recommended, but it is tested on 0.10 and
-5 too) and build tools.
+6 too) and build tools.
 
 For example, you can install them on debian with:
 

--- a/gui/README.md
+++ b/gui/README.md
@@ -86,8 +86,8 @@ it simple and easy. So, it has some limitations:
 First, you need to build cozy-desktop in the parent directory with `npm run
 build`.
 
-Electron is based on node 5 and npm 3. So, it's better to install the
-`node_modules` in `gui` with a node 5 and npm 3:
+Electron is based on node 6 and npm 3. So, it's better to install the
+`node_modules` in `gui` with a node 6 and npm 3:
 
 ```sh
 cd gui

--- a/gui/package.json
+++ b/gui/package.json
@@ -11,9 +11,9 @@
     "chokidar-cli": "1.2.0",
     "cozy-ui": "0.1.6",
     "debug-menu": "0.4.0",
-    "devtron": "1.0.1",
+    "devtron": "1.1.0",
     "electron-builder": "3.24.0",
-    "electron-prebuilt": "1.0.1",
+    "electron-prebuilt": "1.1.0",
     "elm": "0.17.0",
     "standard": "7.0.1",
     "stylus": "0.54.5"


### PR DESCRIPTION
Electron 1.1.0 is now coming with node 6. We can remove the build with node 5 on travis, as node 5 will soon be no longer supported.