### PR TITLE
Use pouchdb-server instead of couchdb for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,8 @@ addons:
 before_install:
     - cd
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-        brew install couchdb;
-        brew --cache;
-        couchdb -b;
+        npm install -g pouchdb-server;
+        pouchdb-server -n -m -p 5984;
       fi
     - export INDEXES_PATH=$HOME/build/indexes
     - mkdir -p $INDEXES_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
     - cd
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         npm install -g pouchdb-server;
-        pouchdb-server -n -m -p 5984;
+        pouchdb-server -n -m -p 5984 &
       fi
     - export INDEXES_PATH=$HOME/build/indexes
     - mkdir -p $INDEXES_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ cache:
         - cozy-data-system/node_modules
         - cozy-proxy/node_modules
         - cozy-files/node_modules
-        - /Library/Caches/Homebrew
 addons:
     apt:
         sources:


### PR DESCRIPTION
The OSX image for travis has no couchdb, and building Couchdb from brew often fails on travis. This is a try to use pouchdb-server instead of couchdb for integration tests on travis for OSX.