### PR TITLE
Show error when the sync path is invalid

### DIFF
--- a/gui/app/locales/en.json
+++ b/gui/app/locales/en.json
@@ -36,6 +36,7 @@
   "Dashboard Show more files": "Show more files",
   "Dashboard Dashboard": "Dashboard",
   "Dashboard Recent activities": "Recent activities",
+  "Error Invalid path": "Invalid path",
   "Folder All done": "All done",
   "Folder Select a location for your Cozy folder:": "Select a location for your Cozy folder:",
   "Folder Use Cozy Desktop": "Use Cozy Desktop",

--- a/gui/app/locales/fr.json
+++ b/gui/app/locales/fr.json
@@ -36,6 +36,7 @@
   "Dashboard Show more files": "Montrer plus de fichiers",
   "Dashboard Dashboard": "Tableau de bord",
   "Dashboard Recent activities": "Activités récentes",
+  "Error Invalid path": "Emplacement invalide",
   "Folder All done": "C'est bon",
   "Folder Select a location for your Cozy folder:": "Choisir un emplacement pour votre répertoire Cozy :",
   "Folder Use Cozy Desktop": "Utiliser Cozy Desktop",

--- a/gui/app/main.js
+++ b/gui/app/main.js
@@ -427,8 +427,13 @@ ipcMain.on('start-sync', (event, arg) => {
     console.error('No device!')
     return
   }
-  desktop.saveConfig(device.url, arg, device.deviceName, device.password)
-  startSync()
+  desktop.saveConfig(device.url, arg, device.deviceName, device.password, (err) => {
+    if (err) {
+      event.sender.send('folder-error', translate('Error Invalid path'))
+    } else {
+      startSync()
+    }
+  })
 })
 
 ipcMain.on('auto-launcher', (event, enabled) => {

--- a/gui/app/ports.js
+++ b/gui/app/ports.js
@@ -53,6 +53,9 @@ elmectron.ports.registerRemote.subscribe((remote) => {
 ipcRenderer.on('folder-chosen', (event, folder) => {
   elmectron.ports.folder.send(folder)
 })
+ipcRenderer.on('folder-error', (event, err) => {
+  elmectron.ports.folderError.send(err)
+})
 elmectron.ports.chooseFolder.subscribe(() => {
   ipcRenderer.send('choose-folder')
 })

--- a/gui/lib/Folder.elm
+++ b/gui/lib/Folder.elm
@@ -12,14 +12,14 @@ import Helpers exposing (Helpers)
 
 type alias Model =
     { folder : String
-    , error : Bool
+    , error : String
     }
 
 
 init : String -> Model
 init folder' =
     { folder = folder'
-    , error = False
+    , error = ""
     }
 
 
@@ -30,6 +30,7 @@ init folder' =
 type Msg
     = ChooseFolder
     | FillFolder String
+    | SetError String
     | StartSync
 
 
@@ -48,7 +49,10 @@ update msg model =
             ( model, chooseFolder () )
 
         FillFolder folder' ->
-            ( { model | folder = folder', error = False }, Cmd.none )
+            ( { model | folder = folder', error = "" }, Cmd.none )
+
+        SetError error' ->
+            ( { model | error = error' }, Cmd.none )
 
         StartSync ->
             ( model, startSync model.folder )
@@ -64,10 +68,11 @@ view helpers model =
         [ classList
             [ ( "step", True )
             , ( "step-folder", True )
-            , ( "step-error", model.error )
+            , ( "step-error", model.error /= "" )
             ]
         ]
-        [ p [ class "spacer" ] [ text "" ]
+        [ p [ class "upper error-message" ]
+            [ text (helpers.t model.error) ]
         , img
             [ src "images/done.svg"
             , class "done"

--- a/gui/lib/Main.elm
+++ b/gui/lib/Main.elm
@@ -145,6 +145,9 @@ port pong : (Maybe String -> msg) -> Sub msg
 port registration : (Maybe String -> msg) -> Sub msg
 
 
+port folderError : (String -> msg) -> Sub msg
+
+
 port folder : (String -> msg) -> Sub msg
 
 
@@ -190,6 +193,7 @@ subscriptions model =
     Sub.batch
         [ pong (WizardMsg << Wizard.AddressMsg << Address.Pong)
         , registration (WizardMsg << Wizard.PasswordMsg << Password.Registered)
+        , folderError (WizardMsg << Wizard.FolderMsg << Folder.SetError)
         , folder (WizardMsg << Wizard.FolderMsg << Folder.FillFolder)
         , synchonization SyncStart
         , gototab (TwoPanesMsg << TwoPanes.GoToStrTab)

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -133,15 +133,20 @@ class App
 
 
     # Save the config with all the informations for synchonization
-    saveConfig: (cozyUrl, syncPath, deviceName, password) =>
-        options =
-            path: path.resolve syncPath
-            url: cozyUrl
-            deviceName: deviceName
-            password: password
-        @config.addRemoteCozy options
-        log.info 'The remote Cozy has properly been configured ' +
-            'to work with current device.'
+    saveConfig: (cozyUrl, syncPath, deviceName, password, callback) =>
+        fs.ensureDir syncPath, (err) =>
+            if err
+                callback err
+            else
+                options =
+                    path: path.resolve syncPath
+                    url: cozyUrl
+                    deviceName: deviceName
+                    password: password
+                @config.addRemoteCozy options
+                log.info 'The remote Cozy has properly been configured ' +
+                    'to work with current device.'
+                callback null
 
 
     # Register current device to remote Cozy and then save related informations
@@ -160,12 +165,13 @@ class App
                     log.error err
                     if parsed.protocol is 'http:'
                         log.warn 'Did you try with an httpS URL?'
+                callback? err
             else
                 deviceName = credentials.deviceName
                 password   = credentials.password
                 log.info "Device #{deviceName} has been added to #{cozyUrl}"
-                @saveConfig cozyUrl, syncPath, deviceName, password
-            callback? err, credentials
+                @saveConfig cozyUrl, syncPath, deviceName, password, (err) ->
+                    callback? err, credentials
 
 
     # Unregister current device from remote Cozy and then remove remote from


### PR DESCRIPTION
It can happen, for example, when a file already exists at this path.