### PR TITLE
Make sure tests are never run with node_modules not matching package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "coffeelint": "1.16.0",
     "del": "2.2.2",
     "faker": "3.1.0",
+    "installed-check": "^2.1.1",
     "jsverify": "0.7.4",
     "lodash.uniq": "4.5.0",
     "mocha": "3.2.0",

--- a/test/helpers/installed_check.coffee
+++ b/test/helpers/installed_check.coffee
@@ -1,0 +1,19 @@
+installedCheck = require 'installed-check'
+
+maybeErrorMessage = (result) ->
+    if result.errors.length
+        """\n
+        =====================================================================
+        Packages installed in ./node_modules/ don't match package.json:
+
+        #{("- #{error}" for error in result.errors).join "\n"}
+
+        =====================================================================
+        """
+
+module.exports = (done) ->
+    installedCheck()
+        .then (result) -> done(maybeErrorMessage(result))
+        .catch done
+    return
+

--- a/test/spec_helper.coffee
+++ b/test/spec_helper.coffee
@@ -1,0 +1,4 @@
+installedCheck = require './helpers/installed_check'
+
+before installedCheck
+

--- a/test/unit/pouch.coffee
+++ b/test/unit/pouch.coffee
@@ -1,3 +1,5 @@
+require '../spec_helper'
+
 async  = require 'async'
 jsv    = require 'jsverify'
 path   = require 'path'


### PR DESCRIPTION
I want to make sure I could never have a test pass anymore with the wrong node modules installed.

I was planning to use [installed-check[(https://www.npmjs.com/package/installed-check) to implement this, since it seems fast enought not to add too much delay to our test suites.

I'd like the solution to work in all of those **scenarios**:
1. `npm run test`
1. `npm run test-unit` or `npm run test-integration`
1. `mocha test/**/*.js`
