### PR TITLE
build: Add missing vuvuzela and cli dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "async": "2.1.4",
     "chokidar": "1.6.1",
+    "cli" : "1.0.1",
     "commander": "2.9.0",
     "cozy-device-sdk": "1.4.0",
     "fs-extra": "1.0.0",
@@ -47,7 +48,8 @@
     "progress": "1.1.8",
     "read": "1.0.7",
     "readdirp": "2.1.0",
-    "request-json-light": "0.5.25"
+    "request-json-light": "0.5.25",
+    "vuvuzela": "1.0.3"
   },
   "devDependencies": {
     "coffee-coverage": "^1.0.1",


### PR DESCRIPTION
Reported Issue on Ubuntu 14.05 was:

module.js:340
    throw err;
          ^
Error: Cannot find module 'vuvuzela'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/cozy-desktop/node_modules/pouchdb/lib/index.js:20:32)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)

Origin: https://github.com/TizenTeam/cozy-desktop
Change-Id: If51c4de995d207f56096040eda90eed317532846
Signed-off-by: Philippe Coval <rzr@gna.org>