### PR TITLE
bin/fauxton: Fix v2's couch helpers import

### DIFF
--- a/src/bin/fauxton.js
+++ b/src/bin/fauxton.js
@@ -12,7 +12,7 @@ import PouchDB from 'pouchdb'
 import path from 'path'
 import os from 'os'
 import Config from '../config'
-import helpers from '../../test/helpers/couch'
+import helpers from '../../test/helpers/v2/couch'
 
 helpers.startServer(function (err) {
   if (err) {

--- a/test/helpers/v2/couch.js
+++ b/test/helpers/v2/couch.js
@@ -4,7 +4,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import request from 'request-json-light'
 
-import Couch from '../../src/remote/couch'
+import Couch from '../../../src/remote/v2/couch'
 
 let params = {
   db: 'cozy',


### PR DESCRIPTION
It was broken while moving v2 test helpers to a subdir.