### PR TITLE
V3/refactor/promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "async": "2.1.4",
+    "bluebird": "^3.4.7",
     "btoa": "^1.1.2",
     "chokidar": "1.6.1",
     "commander": "2.9.0",

--- a/src/pouch.js
+++ b/src/pouch.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird'
 import PouchDB from 'pouchdb'
 import async from 'async'
 import fs from 'fs-extra'
@@ -35,6 +36,8 @@ class Pouch {
         }
       })
     })
+
+    Promise.promisifyAll(this)
   }
 
   // Create database and recreate all filters

--- a/src/prep.js
+++ b/src/prep.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird'
 import path from 'path'
 let log = require('printit')({
   prefix: 'Prep          ',
@@ -26,6 +27,8 @@ class Prep {
         log.error(`Sorry, ${process.platform} is not supported!`)
         process.exit(1)
     }
+
+    Promise.promisifyAll(this)
   }
 
   /* Helpers */

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,10 @@ bluebird@^2.3.11:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
+bluebird@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+
 bluebird@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-1.2.4.tgz#5985ec23cb6ff1a5834cc6447b3c5ef010fd321a"


### PR DESCRIPTION
While we are moving to a promise-based API, we still need to deal with the existing callback-based one.
And mixing both while progressively refactoring can be quite tricky.

As of today, the [Bluebird](http://bluebirdjs.com/) library still seems to be a reference for promise implementation and tools, performing better than native promises, and providing a [very easy way](http://bluebirdjs.com/docs/working-with-callbacks.html#automatic-vs.-manual-conversion) to promisify existing node-style callback-based API. This allows us to have both the existing callback-based methods, and the promisified ones (with an `*Async` suffix), which means comsumer code still works.

Most examples deal with modules, I couldn't find any with ES6 classes promisification. The only solution I came up with was to promisify the instance in the class constructor. It should not have a significant performance impact in production since there are not so many instanciation calls.