### PR TITLE
Remote update file metadata

### DIFF
--- a/src/remote/cozy.js
+++ b/src/remote/cozy.js
@@ -45,16 +45,23 @@ export default class RemoteCozy {
     this.createFile = this.client.files.create
     this.createDirectory = this.client.files.createDirectory
     this.updateFileById = this.client.files.updateById
+    this.updateAttributesById = this.client.files.updateAttributesById
   }
 
+  // TODO: All RemoteCozy methods should resolve with RemoteDoc instances,
+  //       not JsonApiDoc ones.
+  //
   createFile: (data: Readable, options: {
     name: string, dirID?: ?string, contentType?: ?string, lastModifiedDate?: ?Date
   }) => Promise<RemoteDoc>
+
   createDirectory: ({name: string, dirID: string}) => Promise<RemoteDoc>
-  // TODO: All RemoteCozy methods should resolve with RemoteDoc instances,
-  //       not JsonApiDoc ones.
+
   updateFileById: (id: string, data: Readable,
     options: {contentType?: ?string, lastModifiedDate?: ?Date }) => Promise<JsonApiDoc>
+
+  updateAttributesById: (id: string, attrs: Object, options: {ifMatch?: string})
+    => Promise<RemoteDoc>
 
   async changes (seq: number = 0) {
     let json = await this.client.data.changesFeed(FILES_DOCTYPE, { since: seq })

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -131,12 +131,38 @@ export default class Remote implements Side {
     }
   }
 
+  async updateFileMetadataAsync (doc: Metadata, old: any): Promise<*> {
+    log.info(`${doc.path}: Updating metadata...`)
+    // TODO: v3: addFile() when no old.remote
+
+    const attrs = {}
+
+    // TODO: v3: ifMatch old rev
+    const updated = await this.remoteCozy.updateAttributesById(old.remote._id, attrs, {})
+
+    // TODO: v3: Handle trivial remote changes and conflicts.
+    // See Couch#putRemoteDoc() and #sameRemoteDoc()
+
+    doc.remote = {
+      _id: updated._id,
+      _rev: updated._rev
+    }
+
+    return updated
+  }
+
+  updateFileMetadata (doc: Metadata, old: any, callback: Callback) {
+    try {
+      this.updateFileMetadataAsync(doc, old)
+        .then(() => { callback() })
+        .catch(callback)
+    } catch (err) {
+      callback(err)
+    }
+  }
+
   // FIXME: Temporary stubs so we can do some acceptance testing on file upload
   //        without getting errors for missing methods.
-
-  updateFileMetadata (doc: Metadata, _: any, callback: Callback) {
-    callback(new Error('Remote#updateFileMetadata() is not implemented'))
-  }
 
   updateFolder (doc: Metadata, _: any, callback: Callback) {
     callback(new Error('Remote#updateFolder() is not implemented'))


### PR DESCRIPTION
I assumed remaining TODO notices were part of conflict management => to be fixed in another story.

To be merged after https://github.com/cozy-labs/cozy-desktop/pull/546