### PR TITLE
Side trash and destroy

### DIFF
--- a/src/local/index.js
+++ b/src/local/index.js
@@ -321,8 +321,8 @@ class Local implements Side {
     })
   }
 
-  // Delete a file from the local filesystem
-  deleteFile (doc, callback) {
+  // Delete a file or folder from the local filesystem
+  destroy (doc, callback) {
     log.info(`Delete ${doc.path}`)
     this.events.emit('delete-file', doc)
     let fullpath = path.join(this.syncPath, doc.path)
@@ -331,7 +331,7 @@ class Local implements Side {
 
   trash (doc, callback) {
     // TODO: v3: Put files and folders into the OS trash
-    return this.deleteFile(doc, callback)
+    return this.destroy(doc, callback)
   }
 
   // Rename a file/folder to resolve a conflict

--- a/src/local/index.js
+++ b/src/local/index.js
@@ -329,9 +329,8 @@ class Local implements Side {
     return fs.remove(fullpath, callback)
   }
 
-  // Delete a folder from the local filesystem
-  deleteFolder (doc, callback) {
-        // For now both operations are similar
+  trash (doc, callback) {
+    // TODO: v3: Put files and folders into the OS trash
     return this.deleteFile(doc, callback)
   }
 

--- a/src/remote/cozy.js
+++ b/src/remote/cozy.js
@@ -49,6 +49,7 @@ export default class RemoteCozy {
     this.createDirectory = this.client.files.createDirectory
     this.updateFileById = this.client.files.updateById
     this.updateAttributesById = composeAsync(this.client.files.updateAttributesById, this.toRemoteDoc)
+    this.trashById = this.client.files.trashById
     this.destroyById = this.client.files.destroyById
   }
 
@@ -68,6 +69,8 @@ export default class RemoteCozy {
 
   updateAttributesById: (id: string, attrs: Object, options?: {ifMatch?: string})
     => Promise<RemoteDoc>
+
+  trashById: (id: string) => Promise<void>
 
   destroyById: (id: string) => Promise<void>
 

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -207,14 +207,14 @@ export default class Remote implements Side {
     this.updateFolderAsync(doc, old).asCallback(callback)
   }
 
-  async deleteFileAsync (doc: Metadata): Promise<void> {
-    log.info(`${doc.path}: Deleting...`)
+  async destroyAsync (doc: Metadata): Promise<void> {
+    log.info(`${doc.path}: Destroying...`)
     await this.remoteCozy.destroyById(doc.remote._id)
   }
 
-  deleteFile (doc: Metadata, callback: Callback) {
+  destroy (doc: Metadata, callback: Callback) {
     // $FlowFixMe
-    this.deleteFileAsync(doc).asCallback(callback)
+    this.destroyAsync(doc).asCallback(callback)
   }
 
   async trashAsync (doc: Metadata): Promise<void> {

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -217,14 +217,14 @@ export default class Remote implements Side {
     this.deleteFileAsync(doc).asCallback(callback)
   }
 
-  async deleteFolderAsync (doc: Metadata): Promise<void> {
-    log.info(`${doc.path}: Putting directory and its content in the trash...`)
+  async trashAsync (doc: Metadata): Promise<void> {
+    log.info(`${doc.path}: Moving to the trash...`)
     await this.remoteCozy.trashById(doc.remote._id)
   }
 
-  deleteFolder (doc: Metadata, callback: Callback) {
+  trash (doc: Metadata, callback: Callback) {
     // $FlowFixMe
-    this.deleteFolderAsync(doc).asCallback(callback)
+    this.trashAsync(doc).asCallback(callback)
   }
 
   // FIXME: Temporary stubs so we can do some acceptance testing on file upload

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -217,14 +217,20 @@ export default class Remote implements Side {
     this.deleteFileAsync(doc).asCallback(callback)
   }
 
+  async deleteFolderAsync (doc: Metadata): Promise<void> {
+    log.info(`${doc.path}: Putting directory and its content in the trash...`)
+    await this.remoteCozy.trashById(doc.remote._id)
+  }
+
+  deleteFolder (doc: Metadata, callback: Callback) {
+    // $FlowFixMe
+    this.deleteFolderAsync(doc).asCallback(callback)
+  }
+
   // FIXME: Temporary stubs so we can do some acceptance testing on file upload
   //        without getting errors for missing methods.
 
   moveFolder (doc: Metadata, from: Metadata, callback: Callback) {
     callback(new Error('Remote#moveFolder() is not implemented'))
-  }
-
-  deleteFolder (doc: Metadata, callback: Callback) {
-    callback(new Error('Remote#deleteFolder() is not implemented'))
   }
 }

--- a/src/side.js
+++ b/src/side.js
@@ -13,5 +13,5 @@ export interface Side {
   moveFile (doc: Metadata, from: Metadata, callback: Callback): void;
   moveFolder (doc: Metadata, from: Metadata, callback: Callback): void;
   deleteFile (doc: Metadata, callback: Callback): void;
-  deleteFolder (doc: Metadata, callback: Callback): void;
+  trash (doc: Metadata, callback: Callback): void;
 }

--- a/src/side.js
+++ b/src/side.js
@@ -12,6 +12,6 @@ export interface Side {
   updateFolder (doc: Metadata, old: Metadata, callback: Callback): void;
   moveFile (doc: Metadata, from: Metadata, callback: Callback): void;
   moveFolder (doc: Metadata, from: Metadata, callback: Callback): void;
-  deleteFile (doc: Metadata, callback: Callback): void;
   trash (doc: Metadata, callback: Callback): void;
+  destroy (doc: Metadata, callback: Callback): void;
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -339,7 +339,7 @@ class Sync {
           log.error(doc)
           side.addFile(doc, function (err) {
             if (err) { log.error(err) }
-            side.deleteFile(from, function (err) {
+            side.destroy(from, function (err) {
               if (err) { log.error(err) }
               callback(new Error('Invalid move'))
             })
@@ -351,7 +351,7 @@ class Sync {
         callback()
         break
       case !doc._deleted:
-        side.deleteFile(doc, callback)
+        side.destroy(doc, callback)
         break
       case rev !== 0:
         side.addFile(doc, callback)

--- a/src/sync.js
+++ b/src/sync.js
@@ -389,12 +389,16 @@ class Sync {
             callback(err)
           })
         } else {
+          // Since a move requires 2 PouchDB writes, in rare cases the source
+          // and the destination may not match anymore (race condition).
+          // As a fallback, we try to add the folder that should exist, and to
+          // trash the one that shouldn't.
           log.error('Invalid move')
           log.error(from)
           log.error(doc)
           side.addFolder(doc, function (err) {
             if (err) { log.error(err) }
-            side.deleteFolder(from, function (err) {
+            side.trash(from, function (err) {
               if (err) { log.error(err) }
               callback(new Error('Invalid move'))
             })
@@ -406,7 +410,7 @@ class Sync {
         callback()
         break
       case !doc._deleted:
-        side.deleteFolder(doc, callback)
+        side.trash(doc, callback)
         break
       case rev !== 0:
         side.addFolder(doc, callback)

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -579,7 +579,7 @@ describe('Local', function () {
     })
   )
 
-  describe('deleteFolder', () =>
+  describe('trash', () =>
     it('deletes a folder from the local filesystem', function (done) {
       let doc = {
         _id: 'FOLDER-TO-DELETE',
@@ -594,7 +594,7 @@ describe('Local', function () {
         doc._rev = inserted.rev
         return this.pouch.db.remove(doc, err => {
           should.not.exist(err)
-          return this.local.deleteFolder(doc, function (err) {
+          return this.local.trash(doc, function (err) {
             should.not.exist(err)
             fs.existsSync(folderPath).should.be.false()
             done()

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -555,7 +555,7 @@ describe('Local', function () {
     })
   })
 
-  describe('deleteFile', () =>
+  describe('destroy', () =>
     it('deletes a file from the local filesystem', function (done) {
       let doc = {
         _id: 'FILE-TO-DELETE',
@@ -569,7 +569,7 @@ describe('Local', function () {
         doc._rev = inserted.rev
         return this.pouch.db.remove(doc, err => {
           should.not.exist(err)
-          return this.local.deleteFile(doc, function (err) {
+          return this.local.destroy(doc, function (err) {
             should.not.exist(err)
             fs.existsSync(filePath).should.be.false()
             done()

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -739,12 +739,12 @@ describe('Remote', function () {
     })
   })
 
-  describe('deleteFolder', () =>
-    it('deletes a folder in couchdb', async function () {
+  describe('trash', () =>
+    it('moves the file or folder to the Cozy trash', async function () {
       const folder = await builders.dir().build()
       const doc = conversion.createMetadata(folder)
 
-      await this.remote.deleteFolderAsync(doc)
+      await this.remote.trashAsync(doc)
 
       const trashed = await cozy.data.find(FILES_DOCTYPE, doc.remote._id)
       should(trashed).have.property('dir_id', TRASH_DIR_ID)

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -726,12 +726,12 @@ describe('Remote', function () {
     })
   })
 
-  describe('deleteFile', function () {
+  describe('destroy', function () {
     it('deletes a file in couchdb', async function () {
       const file = await builders.file().build()
       const doc = conversion.createMetadata(file)
 
-      await this.remote.deleteFileAsync(doc)
+      await this.remote.destroyAsync(doc)
         .should.be.fulfilled()
 
       await cozy.data.find(FILES_DOCTYPE, doc.remote._id)

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -9,7 +9,7 @@ import should from 'should'
 import * as conversion from '../../../src/conversion'
 import Prep from '../../../src/prep'
 import Remote from '../../../src/remote'
-import { FILES_DOCTYPE } from '../../../src/remote/constants'
+import { FILES_DOCTYPE, TRASH_DIR_ID } from '../../../src/remote/constants'
 import timestamp from '../../../src/timestamp'
 
 import type { Metadata } from '../../../src/metadata'
@@ -739,30 +739,15 @@ describe('Remote', function () {
     })
   })
 
-  xdescribe('deleteFolder', () =>
-    it('deletes a folder in couchdb', function (done) {
-      return couchHelpers.createFolder(this.couch, 9, (err, folder) => {
-        should.not.exist(err)
-        let doc = {
-          path: 'couchdb-folder/folder-9',
-          _deleted: true,
-          docType: 'folder',
-          remote: {
-            _id: folder.id,
-            _rev: folder.rev
-          }
-        }
-        return this.couch.get(doc.remote._id, err => {
-          should.not.exist(err)
-          return this.remote.deleteFolder(doc, err => {
-            should.not.exist(err)
-            return this.couch.get(doc.remote._id, function (err) {
-              err.status.should.equal(404)
-              done()
-            })
-          })
-        })
-      })
+  describe('deleteFolder', () =>
+    it('deletes a folder in couchdb', async function () {
+      const folder = await builders.dir().build()
+      const doc = conversion.createMetadata(folder)
+
+      await this.remote.deleteFolderAsync(doc)
+
+      const trashed = await cozy.data.find(FILES_DOCTYPE, doc.remote._id)
+      should(trashed).have.property('dir_id', TRASH_DIR_ID)
     })
   )
 

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -582,12 +582,12 @@ function(doc) {
           local: 1
         }
       }
-      this.remote.deleteFile = sinon.stub().yields()
+      this.remote.destroy = sinon.stub().yields()
       this.remote.addFile = sinon.stub().yields()
       this.remote.moveFile = sinon.stub().yields()
       return this.sync.fileChanged(was, this.remote, 2, err => {
         should.not.exist(err)
-        this.remote.deleteFile.called.should.be.false()
+        this.remote.destroy.called.should.be.false()
         return this.sync.fileChanged(doc, this.remote, 0, err => {
           should.not.exist(err)
           this.remote.addFile.called.should.be.false()
@@ -597,7 +597,7 @@ function(doc) {
       })
     })
 
-    it('calls deleteFile for a deleted file', function (done) {
+    it('calls destroy for a deleted file', function (done) {
       let doc = {
         _id: 'foo/baz',
         _rev: '4-1234567890',
@@ -608,10 +608,10 @@ function(doc) {
           remote: 2
         }
       }
-      this.local.deleteFile = sinon.stub().yields()
+      this.local.destroy = sinon.stub().yields()
       return this.sync.fileChanged(doc, this.local, 1, err => {
         should.not.exist(err)
-        this.local.deleteFile.calledWith(doc).should.be.true()
+        this.local.destroy.calledWith(doc).should.be.true()
         done()
       })
     })
@@ -626,10 +626,10 @@ function(doc) {
           local: 2
         }
       }
-      this.remote.deleteFile = sinon.stub().yields()
+      this.remote.destroy = sinon.stub().yields()
       return this.sync.fileChanged(doc, this.remote, 0, err => {
         should.not.exist(err)
-        this.remote.deleteFile.called.should.be.false()
+        this.remote.destroy.called.should.be.false()
         done()
       })
     })

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -702,12 +702,12 @@ function(doc) {
           local: 1
         }
       }
-      this.remote.deleteFolder = sinon.stub().yields()
+      this.remote.trash = sinon.stub().yields()
       this.remote.addFolder = sinon.stub().yields()
       this.remote.moveFolder = sinon.stub().yields()
       return this.sync.folderChanged(was, this.remote, 2, err => {
         should.not.exist(err)
-        this.remote.deleteFolder.called.should.be.false()
+        this.remote.trash.called.should.be.false()
         return this.sync.folderChanged(doc, this.remote, 0, err => {
           should.not.exist(err)
           this.remote.addFolder.called.should.be.false()
@@ -717,7 +717,7 @@ function(doc) {
       })
     })
 
-    it('calls deleteFolder for a deleted folder', function (done) {
+    it('calls trash for a deleted folder', function (done) {
       let doc = {
         _id: 'foobar/baz',
         _rev: '4-1234567890',
@@ -728,10 +728,10 @@ function(doc) {
           remote: 2
         }
       }
-      this.local.deleteFolder = sinon.stub().yields()
+      this.local.trash = sinon.stub().yields()
       return this.sync.folderChanged(doc, this.local, 1, err => {
         should.not.exist(err)
-        this.local.deleteFolder.calledWith(doc).should.be.true()
+        this.local.trash.calledWith(doc).should.be.true()
         done()
       })
     })
@@ -746,10 +746,10 @@ function(doc) {
           local: 2
         }
       }
-      this.remote.deleteFolder = sinon.stub().yields()
+      this.remote.trash = sinon.stub().yields()
       return this.sync.folderChanged(doc, this.remote, 0, err => {
         should.not.exist(err)
-        this.remote.deleteFolder.called.should.be.false()
+        this.remote.trash.called.should.be.false()
         done()
       })
     })


### PR DESCRIPTION
- `Local#trash()` still destroys for now
- `Remote#trash()` may eventually put some folder's content inside the trash before the folder itself, but I'd prefer to fix it in next PR.
