### PR TITLE
Fix: babel-polyfill is a runtime dependency, not a development one

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@ava/pretty-format": "^1.1.0",
     "async": "2.1.4",
+    "babel-polyfill": "^6.23.0",
     "bluebird": "3.4.7",
     "btoa": "1.1.2",
     "chalk": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,6 +674,14 @@ babel-polyfill@^6.22.0, babel-polyfill@^6.6.1:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-polyfill@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-es2015@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz#af5a98ecb35eb8af764ad8a5a05eb36dc4386835"


### PR DESCRIPTION
We will also need https://github.com/cozy/cozy-client-js/issues/88 for the packaging of cozy-desktop-gui (or include pouchdb-find in our package.json).