### PR TITLE
remote/watcher: Make sure trashed/restored content is not handled as a move

### DIFF
--- a/src/remote/watcher.js
+++ b/src/remote/watcher.js
@@ -137,14 +137,16 @@ export default class RemoteWatcher {
     } else if (was.path === doc.path) {
       log.debug(`${doc.path}: ${docType} was updated remotely`)
       return this.prep.updateDocAsync(SIDE, doc)
-    } else if ((doc.checksum != null) && (was.checksum === doc.checksum)) {
-      log.debug(`${doc.path}: ${docType} was moved remotely`)
-      return this.prep.moveDocAsync(SIDE, doc, was)
     } else if (inRemoteTrash(doc) && !inRemoteTrash(was)) {
       log.debug(`${doc.path}: ${docType} was trashed remotely`)
-      return this.prep.moveDocAsync(SIDE, doc, was)
+      await this.prep.deleteDocAsync(SIDE, was)
+      return this.prep.addDocAsync(SIDE, doc)
     } else if (inRemoteTrash(was) && !inRemoteTrash(doc)) {
       log.debug(`${doc.path}: ${docType} was restored remotely`)
+      await this.prep.deleteDocAsync(SIDE, was)
+      return this.prep.addDocAsync(SIDE, doc)
+    } else if ((doc.checksum != null) && (was.checksum === doc.checksum)) {
+      log.debug(`${doc.path}: ${docType} was moved remotely`)
       return this.prep.moveDocAsync(SIDE, doc, was)
     } else if ((doc.docType === 'folder') || (was.remote._rev === doc.remote._rev)) {
       log.debug(`${doc.path}: ${docType} was possibly modified and renamed remotely while cozy-desktop was stopped`)


### PR DESCRIPTION
A move may actually generate conflicts.

Deleting the trashed content then adding back the new metadata is safer.
Deleting the existing metadata then adding back the restored content goes the same.

This relies on some upcoming feature in cozy-stack: since files will get their
hidden flag updated when trashed/restored, they will appear in the changesfeed,
and everything should just work.