### PR TITLE
Sync promisification

### DIFF
--- a/src/local/index.js
+++ b/src/local/index.js
@@ -228,6 +228,8 @@ class Local implements Side {
     })
   }
 
+  addFileAsync: (Metadata) => Promise<*>
+
   // Create a new folder
   addFolder (doc: Metadata, callback: Callback) {
     if (inRemoteTrash(doc)) {
@@ -245,10 +247,14 @@ class Local implements Side {
     })
   }
 
+  addFolderAsync: (Metadata) => Promise<*>
+
   // Overwrite a file
   overwriteFile (doc: Metadata, old: Metadata, callback: Callback) {
     return this.addFile(doc, callback)
   }
+
+  overwriteFileAsync: (Metadata, Metadata) => Promise<*>
 
   // Update the metadata of a file
   updateFileMetadata (doc: Metadata, old: Metadata, callback: Callback) {
@@ -259,10 +265,14 @@ class Local implements Side {
     return this.metadataUpdater(doc)(callback)
   }
 
+  updateFileMetadataAsync: (Metadata, Metadata) => Promise<*>
+
   // Update a folder
   updateFolder (doc: Metadata, old: Metadata, callback: Callback) {
     return this.addFolder(doc, callback)
   }
+
+  updateFolderAsync: (Metadata, Metadata) => Promise<*>
 
   // Move a file from one place to another
   moveFile (doc: Metadata, old: Metadata, callback: Callback) {
@@ -309,6 +319,8 @@ class Local implements Side {
     })
   }
 
+  moveFileAsync: (Metadata, Metadata) => Promise<*>
+
   // Move a folder
   moveFolder (doc: Metadata, old: Metadata, callback: Callback) {
     if (inRemoteTrash(doc)) {
@@ -353,6 +365,8 @@ class Local implements Side {
     })
   }
 
+  moveFolderAsync: (Metadata, Metadata) => Promise<*>
+
   // Delete a file or folder from the local filesystem
   destroy (doc: Metadata, callback: Callback) {
     if (inRemoteTrash(doc)) {
@@ -365,10 +379,14 @@ class Local implements Side {
     return fs.remove(fullpath, callback)
   }
 
+  destroyAsync: (Metadata) => Promise<*>
+
   trash (doc: Metadata, callback: Callback) {
     // TODO: v3: Put files and folders into the OS trash
     return this.destroy(doc, callback)
   }
+
+  trashAsync: (Metadata) => Promise<*>
 
   // Rename a file/folder to resolve a conflict
   resolveConflict (dst: Metadata, src: Metadata, callback: Callback) {

--- a/src/local/index.js
+++ b/src/local/index.js
@@ -250,11 +250,11 @@ class Local implements Side {
   addFolderAsync: (Metadata) => Promise<*>
 
   // Overwrite a file
-  overwriteFile (doc: Metadata, old: Metadata, callback: Callback) {
+  overwriteFile (doc: Metadata, old: ?Metadata, callback: Callback) {
     return this.addFile(doc, callback)
   }
 
-  overwriteFileAsync: (Metadata, Metadata) => Promise<*>
+  overwriteFileAsync: (Metadata, ?Metadata) => Promise<*>
 
   // Update the metadata of a file
   updateFileMetadata (doc: Metadata, old: Metadata, callback: Callback) {
@@ -268,11 +268,11 @@ class Local implements Side {
   updateFileMetadataAsync: (Metadata, Metadata) => Promise<*>
 
   // Update a folder
-  updateFolder (doc: Metadata, old: Metadata, callback: Callback) {
+  updateFolder (doc: Metadata, old: ?Metadata, callback: Callback) {
     return this.addFolder(doc, callback)
   }
 
-  updateFolderAsync: (Metadata, Metadata) => Promise<*>
+  updateFolderAsync: (Metadata, ?Metadata) => Promise<*>
 
   // Move a file from one place to another
   moveFile (doc: Metadata, old: Metadata, callback: Callback) {

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -121,7 +121,7 @@ export default class Remote implements Side {
     }
   }
 
-  async overwriteFileAsync (doc: Metadata, old: Metadata): Promise<Metadata> {
+  async overwriteFileAsync (doc: Metadata, old: ?Metadata): Promise<Metadata> {
     log.info(`${doc.path}: Uploading new file version...`)
     const stream = await this.other.createReadStreamAsync(doc)
     const updated = await this.remoteCozy.updateFileById(doc.remote._id, stream, {
@@ -135,7 +135,7 @@ export default class Remote implements Side {
     return conversion.createMetadata(updated)
   }
 
-  async overwriteFile (doc: Metadata, old: Metadata, callback: Callback) {
+  async overwriteFile (doc: Metadata, old: ?Metadata, callback: Callback) {
     try {
       const updated = await this.overwriteFileAsync(doc, old)
       callback(null, updated)
@@ -200,14 +200,14 @@ export default class Remote implements Side {
     this.moveFileAsync(doc, from).asCallback(callback)
   }
 
-  async updateFolderAsync (doc: Metadata, old: Metadata): Promise<Metadata> {
+  async updateFolderAsync (doc: Metadata, old: ?Metadata): Promise<Metadata> {
     log.info(`${doc.path}: Updating metadata...`)
     const [newParentDirPath, newName] = conversion.extractDirAndName(doc.path)
     const newParentDir = await this.remoteCozy.findDirectoryByPath(newParentDirPath)
     // XXX: Should we recreate missing parent, or would it duplicate work in Merge#ensureParentExist()?
     let newRemoteDoc: RemoteDoc
 
-    if (!old.remote) {
+    if (!old || !old.remote) {
       return this.addFolderAsync(doc)
     }
 

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -260,10 +260,13 @@ export default class Remote implements Side {
     this.trashAsync(doc).asCallback(callback)
   }
 
-  // FIXME: Temporary stubs so we can do some acceptance testing on file upload
-  //        without getting errors for missing methods.
+  moveFolderAsync (doc: Metadata, from: Metadata): Promise<*> {
+    // TODO: v3: Remote#moveFolderAsync()
+    throw new Error('Remote#moveFolderAsync() is not implemented')
+  }
 
   moveFolder (doc: Metadata, from: Metadata, callback: Callback) {
-    callback(new Error('Remote#moveFolder() is not implemented'))
+    // $FlowFixMe
+    this.moveFolderAsync(doc, from).asCallback(callback)
   }
 }

--- a/src/side.js
+++ b/src/side.js
@@ -10,12 +10,21 @@ export type SideName =
 // eslint-disable-next-line no-undef
 export interface Side {
   addFile (doc: Metadata, callback: Callback): void;
+  addFileAsync (doc: Metadata): Promise<*>;
   addFolder (doc: Metadata, callback: Callback): void|Promise<*>;
+  addFolderAsync (doc: Metadata): Promise<*>;
   overwriteFile (doc: Metadata, old: Metadata, callback: Callback): void|Promise<*>;
+  overwriteFileAsync (doc: Metadata, old: Metadata): Promise<*>;
   updateFileMetadata (doc: Metadata, old: Metadata, callback: Callback): void;
+  updateFileMetadataAsync (doc: Metadata, old: Metadata): Promise<*>;
   updateFolder (doc: Metadata, old: Metadata, callback: Callback): void;
+  updateFolderAsync (doc: Metadata, old: Metadata): Promise<*>;
   moveFile (doc: Metadata, from: Metadata, callback: Callback): void;
+  moveFileAsync (doc: Metadata, from: Metadata): Promise<*>;
   moveFolder (doc: Metadata, from: Metadata, callback: Callback): void;
+  moveFolderAsync (doc: Metadata, from: Metadata): Promise<*>;
   trash (doc: Metadata, callback: Callback): void;
+  trashAsync (doc: Metadata): Promise<*>;
   destroy (doc: Metadata, callback: Callback): void;
+  destroyAsync (doc: Metadata): Promise<*>;
 }

--- a/src/side.js
+++ b/src/side.js
@@ -10,9 +10,9 @@ export type SideName =
 export interface Side {
   addFileAsync (doc: Metadata): Promise<*>;
   addFolderAsync (doc: Metadata): Promise<*>;
-  overwriteFileAsync (doc: Metadata, old: Metadata): Promise<*>;
+  overwriteFileAsync (doc: Metadata, old: ?Metadata): Promise<*>;
   updateFileMetadataAsync (doc: Metadata, old: Metadata): Promise<*>;
-  updateFolderAsync (doc: Metadata, old: Metadata): Promise<*>;
+  updateFolderAsync (doc: Metadata, old: ?Metadata): Promise<*>;
   moveFileAsync (doc: Metadata, from: Metadata): Promise<*>;
   moveFolderAsync (doc: Metadata, from: Metadata): Promise<*>;
   trashAsync (doc: Metadata): Promise<*>;

--- a/src/side.js
+++ b/src/side.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import type { Metadata } from './metadata'
-import type { Callback } from './utils/func'
 
 export type SideName =
   | "local"
@@ -9,22 +8,13 @@ export type SideName =
 
 // eslint-disable-next-line no-undef
 export interface Side {
-  addFile (doc: Metadata, callback: Callback): void;
   addFileAsync (doc: Metadata): Promise<*>;
-  addFolder (doc: Metadata, callback: Callback): void|Promise<*>;
   addFolderAsync (doc: Metadata): Promise<*>;
-  overwriteFile (doc: Metadata, old: Metadata, callback: Callback): void|Promise<*>;
   overwriteFileAsync (doc: Metadata, old: Metadata): Promise<*>;
-  updateFileMetadata (doc: Metadata, old: Metadata, callback: Callback): void;
   updateFileMetadataAsync (doc: Metadata, old: Metadata): Promise<*>;
-  updateFolder (doc: Metadata, old: Metadata, callback: Callback): void;
   updateFolderAsync (doc: Metadata, old: Metadata): Promise<*>;
-  moveFile (doc: Metadata, from: Metadata, callback: Callback): void;
   moveFileAsync (doc: Metadata, from: Metadata): Promise<*>;
-  moveFolder (doc: Metadata, from: Metadata, callback: Callback): void;
   moveFolderAsync (doc: Metadata, from: Metadata): Promise<*>;
-  trash (doc: Metadata, callback: Callback): void;
   trashAsync (doc: Metadata): Promise<*>;
-  destroy (doc: Metadata, callback: Callback): void;
   destroyAsync (doc: Metadata): Promise<*>;
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -499,7 +499,7 @@ class Sync {
           log.debug(`${doc.path}: will be trashed with parent directory`)
         } else {
           log.debug(`${doc.path}: should be trashed by itself`)
-          side.trash(doc, log.errorIfAny)
+          side.trashAsync(doc).catch(log.error)
         }
       }
     })

--- a/src/sync.js
+++ b/src/sync.js
@@ -352,77 +352,87 @@ class Sync {
   // If a file has been changed, we had to check what operation it is.
   // For a move, the first call will just keep a reference to the document,
   // and only at the second call, the move operation will be executed.
-  fileChanged (doc: Metadata, side: Side, rev: number, callback: Callback) {
+  async fileChangedAsync (doc: Metadata, side: Side, rev: number): Promise<void> {
     let from
     switch (true) {
       case doc._deleted && (rev === 0):
-        callback()
-        break
+        return
       case this.moveFrom != null:
         // $FlowFixMe
         from = (this.moveFrom: Metadata)
         this.moveFrom = null
         if (from.moveTo === doc._id) {
-          side.moveFile(doc, from, err => {
-            if (err) { this.moveFrom = from }
-            callback(err)
-          })
+          try {
+            await side.moveFileAsync(doc, from)
+          } catch (err) {
+            this.moveFrom = from
+            throw err
+          }
         } else {
           log.error('Invalid move')
           log.error(from)
           log.error(doc)
-          side.addFile(doc, function (err) {
-            if (err) { log.error(err) }
-            side.destroy(from, function (err) {
-              if (err) { log.error(err) }
-              callback(new Error('Invalid move'))
-            })
-          })
+          try {
+            await side.addFileAsync(doc)
+          } catch (err) {
+            log.error(err)
+          }
+          try {
+            await side.destroyAsync(from)
+          } catch (err) {
+            log.error(err)
+            throw new Error('Invalid move')
+          }
         }
         break
       case doc.moveTo != null:
         this.moveFrom = doc
-        callback()
-        break
+        return
       case doc._deleted:
-        side.destroy(doc, callback)
-        break
+        return side.destroyAsync(doc)
       case rev === 0:
-        side.addFile(doc, callback)
-        break
+        return side.addFileAsync(doc)
       default:
-        this.pouch.getPreviousRev(doc._id, rev, function (err, old) {
-          if (err) {
-            side.overwriteFile(doc, old, callback)
-          } else if (old.checksum === doc.checksum) {
-            side.updateFileMetadata(doc, old, callback)
-          } else if (old.remote && !old.checksum) {
-            // Photos uploaded by cozy-mobile have no checksum,
-            // but it's useless to reupload the binary
-            side.updateFileMetadata(doc, old, callback)
-          } else {
-            side.overwriteFile(doc, old, callback)
-          }
-        })
+        let old
+        try {
+          old = await this.pouch.getPreviousRevAsync(doc._id, rev)
+        } catch (err) {
+          return side.overwriteFileAsync(doc, null)
+        }
+
+        if (old.checksum === doc.checksum) {
+          return side.updateFileMetadataAsync(doc, old)
+        } else if (old.remote && !old.checksum) {
+          // Photos uploaded by cozy-mobile have no checksum,
+          // but it's useless to reupload the binary
+          return side.updateFileMetadataAsync(doc, old)
+        } else {
+          return side.overwriteFileAsync(doc, old)
+        }
     }
   }
 
+  fileChanged (doc: Metadata, side: Side, rev: number, callback: Callback) {
+    this.fileChangedAsync(doc, side, rev).asCallback(callback)
+  }
+
   // Same as fileChanged, but for folder
-  folderChanged (doc: Metadata, side: Side, rev: number, callback: Callback) {
+  async folderChangedAsync (doc: Metadata, side: Side, rev: number) {
     let from
     switch (true) {
       case doc._deleted && (rev === 0):
-        callback()
-        break
+        return
       case this.moveFrom != null:
         // $FlowFixMe
         from = (this.moveFrom: Metadata)
         this.moveFrom = null
         if (from.moveTo === doc._id) {
-          side.moveFolder(doc, from, err => {
-            if (err) { this.moveFrom = from }
-            callback(err)
-          })
+          try {
+            await side.moveFolderAsync(doc, from)
+          } catch (err) {
+            this.moveFrom = from
+            throw err
+          }
         } else {
           // Since a move requires 2 PouchDB writes, in rare cases the source
           // and the destination may not match anymore (race condition).
@@ -431,28 +441,40 @@ class Sync {
           log.error('Invalid move')
           log.error(from)
           log.error(doc)
-          side.addFolder(doc, function (err) {
-            if (err) { log.error(err) }
-            side.trash(from, function (err) {
-              if (err) { log.error(err) }
-              callback(new Error('Invalid move'))
-            })
-          })
+          try {
+            await side.addFolderAsync(doc)
+          } catch (err) {
+            log.error(err)
+          }
+          try {
+            await side.trashAsync(from)
+          } catch (err) {
+            log.error(err)
+            throw new Error('Invalid move')
+          }
         }
         break
       case doc.moveTo != null:
         this.moveFrom = doc
-        callback()
-        break
+        return
       case doc._deleted:
-        side.destroy(doc, callback)
-        break
+        return side.destroyAsync(doc)
       case rev === 0:
-        side.addFolder(doc, callback)
-        break
+        return side.addFolderAsync(doc)
       default:
-        this.pouch.getPreviousRev(doc._id, rev, (_, old) => side.updateFolder(doc, old, callback))
+        let old
+        try {
+          old = await this.pouch.getPreviousRevAsync(doc._id, rev)
+        } catch (_) {
+          return side.updateFolderAsync(doc, null)
+        }
+        return side.updateFolderAsync(doc, old)
     }
+  }
+
+  folderChanged (doc: Metadata, side: Side, rev: number, callback: Callback) {
+    // $FlowFixMe
+    this.folderChangedAsync(doc, side, rev).asCallback(callback)
   }
 
   // Wait for possibly trashed parent directory. Do nothing if any.

--- a/src/sync.js
+++ b/src/sync.js
@@ -64,8 +64,6 @@ class Sync {
     // $FlowFixMe
     this.remote.other = this.local
     this.pending = new PendingMap()
-
-    Promise.promisifyAll(this)
   }
 
   // Start to synchronize the remote cozy with the local filesystem

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -502,11 +502,14 @@ function(doc) {
       this.events = {}
       this.sync = new Sync(this.pouch, this.local, this.remote, this.ignore, this.events)
 
-      this.local.destroy = sinon.stub().yields()
-      this.remote.destroy = sinon.stub().yields()
+      this.local.destroyAsync = sinon.stub()
+      this.remote.destroyAsync = sinon.stub()
+
+      this.local.destroyAsync.returnsPromise().resolves()
+      this.remote.destroyAsync.returnsPromise().resolves()
     })
 
-    it('calls addFile for an added file', function (done) {
+    it('calls addFileAsync for an added file', function (done) {
       let doc = {
         _id: 'foo/bar',
         _rev: '1-abcdef0123456789',
@@ -516,15 +519,16 @@ function(doc) {
           local: 1
         }
       }
-      this.remote.addFile = sinon.stub().yields()
+      this.remote.addFileAsync = sinon.stub()
+      this.remote.addFileAsync.returnsPromise().resolves()
       this.sync.fileChanged(doc, this.remote, 0, err => {
         should.not.exist(err)
-        this.remote.addFile.calledWith(doc).should.be.true()
+        this.remote.addFileAsync.calledWith(doc).should.be.true()
         done()
       })
     })
 
-    it('calls overwriteFile for an overwritten file', function (done) {
+    it('calls overwriteFileAsync for an overwritten file', function (done) {
       let doc = {
         _id: 'overwrite/foo/bar',
         checksum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
@@ -542,19 +546,21 @@ function(doc) {
           remote: 1
         }
         this.pouch.db.put(doc, (_, updated) => {
-          this.remote.overwriteFile = sinon.stub().yields()
-          this.remote.updateFileMetadata = sinon.stub().yields()
+          this.remote.overwriteFileAsync = sinon.stub()
+          this.remote.overwriteFileAsync.returnsPromise().resolves()
+          this.remote.updateFileMetadataAsync = sinon.stub()
+          this.remote.updateFileMetadataAsync.returnsPromise().resolves()
           this.sync.fileChanged(doc, this.remote, 1, err => {
             should.not.exist(err)
-            this.remote.updateFileMetadata.called.should.be.false()
-            this.remote.overwriteFile.calledWith(doc).should.be.true()
+            this.remote.updateFileMetadataAsync.called.should.be.false()
+            this.remote.overwriteFileAsync.calledWith(doc).should.be.true()
             done()
           })
         })
       })
     })
 
-    it('calls updateFileMetadata for updated file metadata', function (done) {
+    it('calls updateFileMetadataAsync for updated file metadata', function (done) {
       let doc = {
         _id: 'update/foo/bar',
         checksum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
@@ -572,12 +578,14 @@ function(doc) {
           remote: 1
         }
         this.pouch.db.put(doc, (_, updated) => {
-          this.remote.overwriteFile = sinon.stub().yields()
-          this.remote.updateFileMetadata = sinon.stub().yields()
+          this.remote.overwriteFileAsync = sinon.stub()
+          this.remote.overwriteFileAsync.returnsPromise().resolves()
+          this.remote.updateFileMetadataAsync = sinon.stub()
+          this.remote.updateFileMetadataAsync.returnsPromise().resolves()
           this.sync.fileChanged(doc, this.remote, 1, err => {
             should.not.exist(err)
-            this.remote.overwriteFile.called.should.be.false()
-            let ufm = this.remote.updateFileMetadata
+            this.remote.overwriteFileAsync.called.should.be.false()
+            let ufm = this.remote.updateFileMetadataAsync
             ufm.calledWith(doc).should.be.true()
             done()
           })
@@ -585,7 +593,7 @@ function(doc) {
       })
     })
 
-    it('calls moveFile for a moved file', function (done) {
+    it('calls moveFileAsync for a moved file', function (done) {
       let was = {
         _id: 'foo/bar',
         _rev: '3-9876543210',
@@ -607,22 +615,25 @@ function(doc) {
           local: 1
         }
       }
-      this.remote.destroy = sinon.stub().yields()
-      this.remote.addFile = sinon.stub().yields()
-      this.remote.moveFile = sinon.stub().yields()
+      this.remote.destroyAsync = sinon.stub()
+      this.remote.destroyAsync.returnsPromise().resolves()
+      this.remote.addFileAsync = sinon.stub()
+      this.remote.addFileAsync.returnsPromise().resolves()
+      this.remote.moveFileAsync = sinon.stub()
+      this.remote.moveFileAsync.returnsPromise().resolves()
       this.sync.fileChanged(was, this.remote, 2, err => {
         should.not.exist(err)
-        this.remote.destroy.called.should.be.false()
+        this.remote.destroyAsync.called.should.be.false()
         this.sync.fileChanged(doc, this.remote, 0, err => {
           should.not.exist(err)
-          this.remote.addFile.called.should.be.false()
-          this.remote.moveFile.calledWith(doc, was).should.be.true()
+          this.remote.addFileAsync.called.should.be.false()
+          this.remote.moveFileAsync.calledWith(doc, was).should.be.true()
           done()
         })
       })
     })
 
-    it('calls destroy for a deleted file', function (done) {
+    it('calls destroyAsync for a deleted file', function (done) {
       let doc = {
         _id: 'foo/baz',
         _rev: '4-1234567890',
@@ -635,7 +646,7 @@ function(doc) {
       }
       this.sync.fileChanged(doc, this.local, 1, err => {
         should.not.exist(err)
-        this.local.destroy.calledWith(doc).should.be.true()
+        this.local.destroyAsync.calledWith(doc).should.be.true()
         done()
       })
     })
@@ -652,7 +663,7 @@ function(doc) {
       }
       this.sync.fileChanged(doc, this.remote, 0, err => {
         should.not.exist(err)
-        this.remote.destroy.called.should.be.false()
+        this.remote.destroyAsync.called.should.be.false()
         done()
       })
     })
@@ -666,11 +677,11 @@ function(doc) {
       this.events = {}
       this.sync = new Sync(this.pouch, this.local, this.remote, this.ignore, this.events)
 
-      this.local.destroy = sinon.stub().yields()
-      this.remote.destroy = sinon.stub().yields()
+      this.local.destroyAsync = sinon.stub()
+      this.remote.destroyAsync = sinon.stub()
     })
 
-    it('calls addFolder for an added folder', function (done) {
+    it('calls addFolderAsync for an added folder', function (done) {
       let doc = {
         _id: 'foobar/bar',
         _rev: '1-abcdef0123456789',
@@ -679,15 +690,16 @@ function(doc) {
           local: 1
         }
       }
-      this.remote.addFolder = sinon.stub().yields()
+      this.remote.addFolderAsync = sinon.stub()
+      this.remote.addFolderAsync.returnsPromise().resolves()
       this.sync.folderChanged(doc, this.remote, 0, err => {
         should.not.exist(err)
-        this.remote.addFolder.calledWith(doc).should.be.true()
+        this.remote.addFolderAsync.calledWith(doc).should.be.true()
         done()
       })
     })
 
-    it('calls updateFolder for an updated folder', function (done) {
+    it('calls updateFolderAsync for an updated folder', function (done) {
       let doc = {
         _id: 'foobar/bar',
         _rev: '2-abcdef9876543210',
@@ -698,15 +710,16 @@ function(doc) {
           remote: 2
         }
       }
-      this.local.updateFolder = sinon.stub().yields()
+      this.local.updateFolderAsync = sinon.stub()
+      this.local.updateFolderAsync.returnsPromise().resolves()
       this.sync.folderChanged(doc, this.local, 1, err => {
         should.not.exist(err)
-        this.local.updateFolder.calledWith(doc).should.be.true()
+        this.local.updateFolderAsync.calledWith(doc).should.be.true()
         done()
       })
     })
 
-    it('calls moveFolder for a moved folder', function (done) {
+    it('calls moveFolderAsync for a moved folder', function (done) {
       let was = {
         _id: 'foobar/bar',
         _rev: '3-9876543210',
@@ -728,22 +741,25 @@ function(doc) {
           local: 1
         }
       }
-      this.remote.trash = sinon.stub().yields()
-      this.remote.addFolder = sinon.stub().yields()
-      this.remote.moveFolder = sinon.stub().yields()
+      this.remote.trashAsync = sinon.stub()
+      this.remote.trashAsync.returnsPromise().resolves()
+      this.remote.addFolderAsync = sinon.stub()
+      this.remote.addFolderAsync.returnsPromise().resolves()
+      this.remote.moveFolderAsync = sinon.stub()
+      this.remote.moveFolderAsync.returnsPromise().resolves()
       this.sync.folderChanged(was, this.remote, 2, err => {
         should.not.exist(err)
-        this.remote.trash.called.should.be.false()
+        this.remote.trashAsync.called.should.be.false()
         this.sync.folderChanged(doc, this.remote, 0, err => {
           should.not.exist(err)
-          this.remote.addFolder.called.should.be.false()
-          this.remote.moveFolder.calledWith(doc, was).should.be.true()
+          this.remote.addFolderAsync.called.should.be.false()
+          this.remote.moveFolderAsync.calledWith(doc, was).should.be.true()
           done()
         })
       })
     })
 
-    it('calls destroy for a deleted folder', function (done) {
+    it('calls destroyAsync for a deleted folder', function (done) {
       let doc = {
         _id: 'foobar/baz',
         _rev: '4-1234567890',
@@ -756,7 +772,7 @@ function(doc) {
       }
       this.sync.folderChanged(doc, this.local, 1, err => {
         should.not.exist(err)
-        this.local.destroy.calledWith(doc).should.be.true()
+        this.local.destroyAsync.calledWith(doc).should.be.true()
         done()
       })
     })
@@ -773,7 +789,7 @@ function(doc) {
       }
       this.sync.folderChanged(doc, this.remote, 0, err => {
         should.not.exist(err)
-        this.remote.destroy.called.should.be.false()
+        this.remote.destroyAsync.called.should.be.false()
         done()
       })
     })
@@ -866,8 +882,10 @@ function(doc) {
 
     beforeEach(() => {
       clock = sinon.useFakeTimers()
-      side = {trash: sinon.stub()}
+      side = {trashAsync: sinon.stub()}
       sync = new Sync(null, {}, {}, null, null)
+
+      side.trashAsync.returnsPromise().resolves()
     })
 
     afterEach(() => {
@@ -893,7 +911,7 @@ function(doc) {
         waitAndTrash(bar, qux, baz, foo)
 
         for (let doc of [foo, bar, baz, qux]) {
-          should(side.trash).have.been.calledWith(doc)
+          should(side.trashAsync).have.been.calledWith(doc)
         }
       })
 
@@ -905,9 +923,9 @@ function(doc) {
 
         waitAndTrash(qux, baz, bar, foo)
 
-        should(side.trash).have.been.calledWith(foo)
+        should(side.trashAsync).have.been.calledWith(foo)
         for (let doc of [bar, baz, qux]) {
-          should(side.trash).not.have.been.calledWith(doc)
+          should(side.trashAsync).not.have.been.calledWith(doc)
         }
       })
     })


### PR DESCRIPTION
Right now we only promisify `fileChanged()` and `folderChanged()` since this should allow us to progressively remove callback-based wrappers in `Sync`'s dependencies.