### PR TITLE
Bunyan

### DIFF
--- a/gui/app/main.js
+++ b/gui/app/main.js
@@ -17,7 +17,6 @@ const autoLauncher = new AutoLaunch({
 })
 const desktop = new Desktop(process.env.COZY_DESKTOP_DIR)
 const lastFilesPath = path.join(desktop.basePath, 'last-files')
-desktop.writeLogsTo(path.join(desktop.basePath, 'logs.txt'))
 
 app.locale = (() => {
   const env = process.env

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-polyfill": "^6.23.0",
     "bluebird": "^3.5.0",
     "btoa": "1.1.2",
+    "bunyan": "^1.8.10",
     "chalk": "^1.1.3",
     "chokidar": "1.6.1",
     "commander": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -56,17 +56,14 @@
     "watch": "npm run build -- --watch"
   },
   "dependencies": {
-    "@ava/pretty-format": "^1.1.0",
     "async": "^2.1.5",
     "babel-polyfill": "^6.23.0",
     "bluebird": "^3.5.0",
     "btoa": "1.1.2",
     "bunyan": "^1.8.10",
-    "chalk": "^1.1.3",
     "chokidar": "1.6.1",
     "commander": "2.9.0",
     "cozy-client-js": "^0.1.8",
-    "diff": "^3.2.0",
     "fs-extra": "^2.1.1",
     "isomorphic-fetch": "2.2.1",
     "lodash.clone": "4.5.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-// $FlowFixMe
-import { Console } from 'console'
 import EventEmitter from 'events'
 import fs from 'fs-extra'
 import os from 'os'
@@ -32,13 +30,7 @@ const log = logger({
 
 // App is the entry point for the CLI and GUI.
 // They both can do actions and be notified by events via an App instance.
-let MAX_LOG_SIZE
 class App {
-  static initClass () {
-    // When a log file weights more than 0.5Mo, rotate it
-    MAX_LOG_SIZE = 500000
-  }
-
   lang: string
   basePath: string
   config: Config
@@ -62,28 +54,6 @@ class App {
     this.config = new Config(this.basePath)
     this.pouch = new Pouch(this.config)
     this.events = new EventEmitter()
-  }
-
-  // Configure a file to write logs to
-  writeLogsTo (logfile: string) {
-    this.logfile = logfile
-    this.writeToLogfile()
-    if (this.logsInterval) { clearInterval(this.logsInterval) }
-    this.logsInterval = setInterval(this.rotateLogfile, 10000)
-  }
-
-  // Write logs in a file, by overriding the global console
-  writeToLogfile () {
-    let out = fs.createWriteStream(this.logfile, {flags: 'a+', mode: 0o0644})
-    logger.console = new Console(out, out)
-  }
-
-  // Rotate the log file if it's too heavy
-  rotateLogfile () {
-    fs.stat(this.logfile, (err, stats) => {
-      if (err || (stats.size < MAX_LOG_SIZE)) { return }
-      fs.rename(this.logfile, `${this.logfile}.old`, this.writeToLogfile)
-    })
   }
 
   // Parse the URL
@@ -307,6 +277,5 @@ class App {
     })
   }
 }
-App.initClass()
 
 export default App

--- a/src/app.js
+++ b/src/app.js
@@ -24,8 +24,7 @@ import type { Callback } from './utils/func'
 import type { SyncMode } from './sync'
 
 const log = logger({
-  prefix: 'Cozy Desktop  ',
-  date: true
+  component: 'App'
 })
 
 // App is the entry point for the CLI and GUI.

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -10,8 +10,7 @@ import App from '../app'
 import logger from '../logger'
 let app = new App(process.env.COZY_DESKTOP_DIR)
 const log = logger({
-  prefix: 'Cozy Desktop  ',
-  date: true
+  component: 'CLI'
 })
 
 let exit = function () {

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -32,9 +32,6 @@ const askConfirmation = (callback) => {
 
 let sync = function (mode, args) {
   log.info(`Cozy-desktop v${pkg.version} started (PID: ${process.pid})`)
-  if (args.logfile != null) {
-    app.writeLogsTo(args.logfile)
-  }
   if (!app.config.isValid()) {
     log.info('Your configuration file seems invalid.')
     log.info('Have you added a remote cozy?')
@@ -93,7 +90,6 @@ program
 program
   .command('sync')
   .description('Synchronize the local filesystem and the remote cozy')
-  .option('-l, --logfile [logfile]', 'Write logs to this file')
   .action(function (args) {
     try {
       return sync('full', args)
@@ -112,7 +108,6 @@ The README has more instructions about that.
 program
   .command('pull')
   .description('Pull files & folders from a remote cozy to local filesystem')
-  .option('-l, --logfile [logfile]', 'Write logs to this file')
   .action(function (args) {
     try {
       return sync('pull', args)
@@ -131,7 +126,6 @@ The README has more instructions about that.
 program
   .command('push')
   .description('Push files & folders from local filesystem to the remote cozy')
-  .option('-l, --logfile [logfile]', 'Write logs to this file')
   .action(function (args) {
     try {
       return sync('push', args)

--- a/src/local/index.js
+++ b/src/local/index.js
@@ -21,8 +21,7 @@ import type { Side } from '../side' // eslint-disable-line
 import type { Callback } from '../utils/func'
 
 const log = logger({
-  prefix: 'Local writer  ',
-  date: true
+  component: 'LocalWriter'
 })
 // Local is the class that interfaces cozy-desktop with the local filesystem.
 // It uses a watcher, based on chokidar, to listen for file and folder changes.

--- a/src/local/watcher.js
+++ b/src/local/watcher.js
@@ -208,8 +208,7 @@ class LocalWatcher {
 
   // New file detected
   onAddFile (filePath: string, stats: fs.Stats) {
-    log.chokidar.debug(`${filePath}: add`)
-    log.chokidar.inspect(stats)
+    log.chokidar.debug({event: 'add', filePath, stats})
     if (this.paths) { this.paths.push(filePath) }
     this.pending.executeIfAny(filePath)
     this.checksums++
@@ -250,8 +249,7 @@ class LocalWatcher {
 
   // New directory detected
   onAddDir (folderPath: string, stats: fs.Stats) {
-    log.chokidar.debug(`${folderPath}: addDir`)
-    log.chokidar.inspect(stats)
+    log.chokidar.debug({event: 'addDir', folderPath, stats})
     if (folderPath === '') return
 
     if (this.paths) { this.paths.push(folderPath) }
@@ -318,8 +316,7 @@ class LocalWatcher {
 
   // File update detected
   onChange (filePath: string, stats: fs.Stats) {
-    log.chokidar.debug(`${filePath}: change`)
-    log.chokidar.inspect(stats)
+    log.chokidar.debug({event: 'change', filePath, stats})
     log.info(`${filePath}: changed`)
     this.createDoc(filePath, stats, (err, doc) => {
       if (err) {

--- a/src/local/watcher.js
+++ b/src/local/watcher.js
@@ -18,12 +18,10 @@ import type { Callback } from '../utils/func'
 import type { Pending } from '../utils/pending' // eslint-disable-line
 
 const log = logger({
-  prefix: 'Local watcher ',
-  date: true
+  component: 'LocalWatcher'
 })
-log.chokidar = logger({
-  prefix: 'Chokidar      ',
-  date: true
+log.chokidar = log.child({
+  component: 'Chokidar'
 })
 
 // This file contains the filesystem watcher that will trigger operations when

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,197 +1,27 @@
 /* @flow weak */
 
-import prettyFormat from '@ava/pretty-format'
-import {
-  blue,
-  dim,
-  gray,
-  green,
-  magenta,
-  red,
-  yellow
-} from 'chalk'
-import * as diff from 'diff'
+import bunyan from 'bunyan'
+import os from 'os'
+import path from 'path'
 
-let printit = options => new Logger(options)
-if (printit.console == null) { printit.console = global.console }
+export const defaultLogger = bunyan.createLogger({
+  name: 'Cozy Desktop',
+  level: 'debug',
+  serializers: {
+    err: bunyan.stdSerializers.err
+  },
+  streams: [
+    {
+      type: 'rotating-file',
+      path: path.join(process.env.COZY_DESKTOP_DIR || os.homedir(), '.cozy-desktop', 'logs.txt'),
+      period: '1d',
+      count: 7
+    }
+  ]
+})
 
-const theme = {
-  boolean: 'dim',
-  content: 'dim',
-  date: 'dim',
-  function: 'dim',
-  label: 'dim',
-  misc: 'dim',
-  number: 'dim',
-  prop: 'dim',
-  value: 'dim',
-  regex: 'dim',
-  string: 'dim',
-  tag: 'dim',
-
-  key: 'italic',
-
-  bracket: 'reset',
-  comma: 'reset',
-  symbol: 'reset',
-
-  error: 'red'
+function logger (options) {
+  return defaultLogger.child(options)
 }
 
-function highlight (obj) {
-  return prettyFormat(obj, {highlight: true, theme, min: true})
-}
-
-class Logger {
-  options: Object
-
-  constructor (options) {
-    this.options = options
-    if (this.options == null) { this.options = {} }
-    if (this.options.date && (this.options.dateFormat == null)) {
-      this.options.dateFormat = 'YYYY-MM-DD hh:mm:ss:S'
-    }
-  }
-
-  colorify (text, color) {
-    return `${color[0]}${text}${color[1]}`
-  }
-
-  stringify (text) {
-    if (text instanceof Error && text.stack) {
-      text = text.stack
-    } else if (text instanceof Object) {
-      text = JSON.stringify(text)
-    }
-    return text
-  }
-
-  getFileAndLine () {
-    let stacklist = (new Error()).stack.split('\n').slice(4)
-    let nodeReg = /at\s+(.*)\s+\((.*):(\d*):(\d*)\)/gi
-    let browserReg = /at\s+()(.*):(\d*):(\d*)/gi
-
-    let firstLineStack = stacklist[0]
-    let fileAndLineInfos =
-            nodeReg.exec(firstLineStack) || browserReg.exec(firstLineStack)
-
-    let filePath = fileAndLineInfos[2].substr(process.cwd().length)
-    let line = fileAndLineInfos[3]
-    return `.${filePath}:${line} |`
-  }
-
-  format (level, texts) {
-    var text = ((() => {
-      let result = []
-      for (text of Array.from(texts)) {
-        if (typeof text === 'string') {
-          result.push(this.stringify(text))
-        } else if (text.stack) {
-          result.push(text.stack)
-        } else {
-          result.push(highlight(text))
-        }
-      }
-      return result
-    })()).join(' ')
-
-    if (level === 'success') { text = green(text) }
-    if (level === 'error') { text = red(text) }
-    if (level === 'debug') { text = dim(text) }
-
-    let prefix = this.options.prefix
-    if (prefix != null) {
-      if (prefix.startsWith('Local')) prefix = magenta(prefix)
-      if (prefix.startsWith('Remote')) prefix = blue(prefix)
-      if (prefix.startsWith('Pouch')) prefix = yellow(prefix)
-      if (level === 'debug') prefix = dim(prefix)
-
-      text = `${prefix} | ${text}`
-    }
-
-    if (this.options.date) {
-      const date = new Date()
-      let ms = date.getMilliseconds().toString()
-      ms = '000'.substring(0, 3 - ms.length) + ms
-      const timestamp = gray(`[${date.toLocaleString()} ${ms}]`)
-      text = `${timestamp} ${text}`
-    }
-    return text
-  }
-
-  info (...texts) {
-    if (process.env.DEBUG || (process.env.NODE_ENV !== 'test')) {
-      return printit.console.info(this.format('info', texts))
-    }
-  }
-
-  success (...texts) {
-    if (process.env.DEBUG || (process.env.NODE_ENV !== 'test')) {
-      return printit.console.info(this.format('success', texts))
-    }
-  }
-
-  warn (...texts) {
-    if (process.env.DEBUG || (process.env.NODE_ENV !== 'test')) {
-      if (this.options.duplicateToStdout) {
-        printit.console.info(this.format('warn', texts))
-      }
-      return printit.console.warn(this.format('warn', texts))
-    }
-  }
-
-  error (...texts) {
-    if (process.env.DEBUG || (process.env.NODE_ENV !== 'test')) {
-      if (this.options.duplicateToStdout) {
-        printit.console.info(this.format('error', texts))
-      }
-      return printit.console.error(this.format('error', texts))
-    }
-  }
-
-  errorIfAny (err) {
-    if (err) {
-      this.error(err)
-    }
-  }
-
-  debug (...texts) {
-    if (process.env.DEBUG) {
-      return printit.console.info(this.format('debug', texts))
-    }
-  }
-
-  inspect (obj) {
-    if (process.env.DEBUG) {
-      this.raw(highlight(obj))
-    }
-  }
-
-  diff (was, obj) {
-    if (process.env.DEBUG) {
-      const lines = diff.diffJson(was, obj)
-
-      this.raw(lines.map(line => {
-        if (line.added) {
-          return green(line.value)
-        } else if (line.removed) {
-          return red(line.value)
-        } else {
-          return ''
-        }
-      }).join(''))
-    }
-  }
-
-  raw (...texts) {
-    if (process.env.DEBUG) {
-      return printit.console.log(...texts)
-    }
-  }
-
-  lineBreak (text) {
-    return this.raw(Array(80).join('*'))
-  }
-}
-
-export default printit
+export default logger

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,8 +1,14 @@
 /* @flow weak */
 
 import bunyan from 'bunyan'
+import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
+
+const LOG_DIR = path.join(process.env.COZY_DESKTOP_DIR || os.homedir(), '.cozy-desktop')
+const LOG_FILE = path.join(LOG_DIR, 'logs.txt')
+
+fs.ensureDirSync(LOG_DIR)
 
 export const defaultLogger = bunyan.createLogger({
   name: 'Cozy Desktop',
@@ -13,7 +19,7 @@ export const defaultLogger = bunyan.createLogger({
   streams: [
     {
       type: 'rotating-file',
-      path: path.join(process.env.COZY_DESKTOP_DIR || os.homedir(), '.cozy-desktop', 'logs.txt'),
+      path: LOG_FILE,
       period: '1d',
       count: 7
     }

--- a/src/merge.js
+++ b/src/merge.js
@@ -210,7 +210,7 @@ class Merge {
         if (doc.mime == null) { doc.mime = file.mime }
       }
       if (sameFile(file, doc)) {
-        log.success(`${doc.path}: up to date`)
+        log.info({doc}, 'up to date')
         return null
       } else {
         return this.pouch.put(doc)
@@ -245,7 +245,7 @@ class Merge {
       if (doc.creationDate == null) { doc.creationDate = folder.creationDate }
       if (doc.remote == null) { doc.remote = folder.remote }
       if (sameFolder(folder, doc)) {
-        log.success(`${doc.path}: up to date`)
+        log.info({doc}, 'up to date')
         return null
       } else {
         return this.pouch.put(doc)

--- a/src/merge.js
+++ b/src/merge.js
@@ -14,8 +14,7 @@ import type { SideName } from './side'
 import type { Callback } from './utils/func'
 
 const log = logger({
-  prefix: 'Merge         ',
-  date: true
+  component: 'Merge'
 })
 
 // When the local filesystem or the remote cozy detects a change, it calls this

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -10,8 +10,7 @@ import { TRASH_DIR_NAME } from './remote/constants'
 import { sameDate } from './timestamp'
 
 const log = logger({
-  prefix: 'Metadata',
-  date: true
+  component: 'Metadata'
 })
 
 export type MetadataRemoteInfo = {

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -160,7 +160,7 @@ export function sameFolder (one: Metadata, two: Metadata) {
   one = pick(one, fields)
   two = pick(two, fields)
   const same = isEqual(one, two)
-  if (!same) log.diff(one, two)
+  if (!same) log.debug({diff: {one, two}})
   return same
 }
 
@@ -176,7 +176,7 @@ export function sameFile (one: Metadata, two: Metadata) {
   one = {...pick(one, fields), executable: !!one.executable}
   two = {...pick(two, fields), executable: !!two.executable}
   const same = isEqual(one, two)
-  if (!same) log.diff(one, two)
+  if (!same) log.debug({diff: {one, two}})
   return same
 }
 

--- a/src/pouch.js
+++ b/src/pouch.js
@@ -13,8 +13,7 @@ import type { Metadata } from './metadata'
 import type { Callback } from './utils/func'
 
 const log = logger({
-  prefix: 'Pouch         ',
-  date: true
+  component: 'Pouch'
 })
 
 // Pouchdb is used to store all the metadata about files and folders.

--- a/src/pouch.js
+++ b/src/pouch.js
@@ -67,15 +67,13 @@ class Pouch {
   /* Mini ODM */
 
   put (doc: Metadata, callback?: Callback) {
-    log.debug(`${doc.path}: Saving metadata:`)
-    log.inspect(doc)
+    log.debug({doc})
     return this.db.put(doc).asCallback(callback)
   }
 
   bulkDocs (docs: Metadata[], callback?: Callback) {
     for (const doc of docs) {
-      log.debug(`${doc.path}: Saving bulk metadata:`)
-      log.inspect(doc)
+      log.debug({doc, bulk: true})
     }
     return this.db.bulkDocs(docs).asCallback(callback)
   }

--- a/src/prep.js
+++ b/src/prep.js
@@ -10,8 +10,7 @@ import type { SideName } from './side'
 import type { Callback } from './utils/func'
 
 const log = logger({
-  prefix: 'Prep          ',
-  date: true
+  component: 'Prep'
 })
 
 // When the local filesystem or the remote cozy detects a change, it calls this

--- a/src/remote/index.js
+++ b/src/remote/index.js
@@ -17,8 +17,7 @@ import type { Side } from '../side' // eslint-disable-line
 import type { Callback } from '../utils/func'
 
 const log = logger({
-  prefix: 'Remote writer ',
-  date: true
+  component: 'RemoteWriter'
 })
 
 export default class Remote implements Side {

--- a/src/remote/watcher.js
+++ b/src/remote/watcher.js
@@ -70,7 +70,7 @@ export default class RemoteWatcher {
 
       await this.pullMany(changes.ids)
       await this.pouch.setRemoteSeqAsync(changes.last_seq)
-      log.lineBreak()
+      log.debug({event: 'end'}, 'No more remote changes for now')
     } catch (err) {
       if (err.message === REVOKED) {
         throw err
@@ -109,12 +109,10 @@ export default class RemoteWatcher {
   }
 
   async onChange (doc: RemoteDoc) {
-    log.debug(`${doc.path}: change detected`)
-    log.inspect(doc)
+    log.debug({event: 'change', doc})
 
     const was: ?Metadata = await this.pouch.byRemoteIdMaybeAsync(doc._id)
-    log.debug(`${doc.path}: was:`)
-    log.inspect(was)
+    log.debug({doc, was})
 
     if (['directory', 'file'].includes(doc.type)) {
       return this.putDoc(doc, was)

--- a/src/remote/watcher.js
+++ b/src/remote/watcher.js
@@ -11,8 +11,7 @@ import type { Metadata } from '../metadata'
 import type { RemoteDoc } from './document'
 
 const log = logger({
-  prefix: 'Remote watcher',
-  date: true
+  component: 'RemoteWatcher'
 })
 
 export const DEFAULT_HEARTBEAT: number = 1000 * 60 * 3 // 3 minutes

--- a/src/sync.js
+++ b/src/sync.js
@@ -157,8 +157,7 @@ class Sync {
         .on('complete', info => {
           if (info.results && info.results.length) { return }
           this.events.emit('up-to-date')
-          log.debug('No more metadata changes for now')
-          log.lineBreak()
+          log.debug({event: 'end'}, 'No more metadata changes for now')
           opts.live = true
           opts.returnDocs = false
           this.changes = this.pouch.db.changes(opts)
@@ -184,8 +183,7 @@ class Sync {
   // In some cases, both sides have the change
   apply (change: Change, callback: Callback) {
     let { doc } = change
-    log.info(`${doc.path}: Applying change ${change.seq}...`)
-    log.inspect(change)
+    log.info({change})
 
     if (this.ignore.isIgnored(doc)) {
       this.pouch.setLocalSeq(change.seq, _ => callback())
@@ -226,7 +224,7 @@ class Sync {
     } else if (remoteRev > localRev) {
       return [this.local, 'local', localRev]
     } else {
-      log.success(`${doc.path}: Nothing to do (rev ${localRev})`)
+      log.info({doc}, 'up to date')
       return []
     }
   }

--- a/src/sync.js
+++ b/src/sync.js
@@ -18,8 +18,7 @@ import type { Side, SideName } from './side' // eslint-disable-line
 import type { Callback } from './utils/func'
 
 const log = logger({
-  prefix: 'Synchronize   ',
-  date: true
+  component: 'Sync'
 })
 
 export const TRASHING_DELAY = 1000

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,6 +915,15 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bunyan@^1.8.10:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.10.tgz#201fedd26c7080b632f416072f53a90b9a52981c"
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
+
 bytes@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"
@@ -1416,6 +1425,12 @@ doctrine@^2.0.0:
 double-ended-queue@2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+
+dtrace-provider@~0.8:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.1.tgz#cd4d174a233bea1bcf4a1fbfa5798f44f48cda9f"
+  dependencies:
+    nan "^2.3.3"
 
 duplexer2@~0.0.2:
   version "0.0.2"
@@ -2202,6 +2217,16 @@ glob@7.0.5:
 glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -3182,7 +3207,7 @@ minimist@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3203,6 +3228,10 @@ mocha@^3.2.0:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
+
+moment@^2.10.6:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 ms@0.7.1:
   version "0.7.1"
@@ -3226,7 +3255,15 @@ mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.3.0, nan@^2.3.3:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
 
@@ -3241,6 +3278,10 @@ native-promise-only@^0.8.1:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -4577,6 +4618,12 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  dependencies:
+    glob "^6.0.1"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -4594,6 +4641,10 @@ rx-lite@^3.1.2:
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+safe-json-stringify@~1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz#81a098f447e4bbc3ff3312a243521bc060ef5911"
 
 samsam@1.x, samsam@^1.1.3:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@ava/pretty-format@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ava/pretty-format/-/pretty-format-1.1.0.tgz#d0a57d25eb9aeab9643bdd1a030642b91c123e28"
-  dependencies:
-    ansi-styles "^2.2.1"
-    esutils "^2.0.2"
-
 "@jkroso/type@1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@jkroso/type/-/type-1.1.1.tgz#22903a346f633f2c65c0f6a938caafc43f181f17"
@@ -1404,7 +1397,7 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 


### PR DESCRIPTION
- Replace our custom logger with Bunyan
- Logs are now lines of json records
- The `bunyan` command allows us to format/filter them (by piping the command / logfile into it)
- The way we log things could still be improved (by adding fields, e.g. `side`), but this is a working 1st version
- We cannot chose a custom log location from the CLI anymore, we know always use the `.cozy-desktop/logs.txt` path as it was already done in the GUI.