### PR TITLE
build: Try not to cache node_modules on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ services:
     - docker
 cache:
     directories:
-        - node_modules
         - /Library/Caches/Homebrew
 addons:
     apt:


### PR DESCRIPTION
To make sure dtrace-provider is recompiled.
See: https://travis-ci.org/cozy-labs/cozy-desktop/jobs/223061506