### PR TITLE
Use Windows personal certificate store

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -5,6 +5,9 @@
   "build": {
     "appId": "io.cozy.desktop",
     "productName": "Cozy Desktop",
+    "win": {
+      "certificateSubjectName": "Cozy Cloud SAS"
+    },
     "linux": {
       "target": [
         "deb"


### PR DESCRIPTION
So we don't need to export the certificate and use some password env var.
We can still follow the standard way later, would it be more convenient.