### PR TITLE
Fix for renaming in local a file from the remote

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -239,6 +239,9 @@ class Merge {
       if (doc.class == null) { doc.class = was.class }
       if (doc.mime == null) { doc.mime = was.mime }
       if (doc.tags == null) { doc.tags = was.tags || [] }
+      const wasUpdatedAt = new Date(was.updated_at)
+      const docUpdatedAt = new Date(doc.updated_at)
+      if (docUpdatedAt < wasUpdatedAt) { doc.updated_at = was.updated_at }
       delete doc.trashed
       was.moveTo = doc._id
       was._deleted = true


### PR DESCRIPTION
The `updated_at` field on a local filesystem can have a worse precision,
and be ceiled to the second. It was then rejected by the cozy-stack.