### PR TITLE
Trash fixes

### DIFF
--- a/cli/src/local/index.js
+++ b/cli/src/local/index.js
@@ -358,7 +358,6 @@ class Local implements Side {
       this.events.emit('delete-file', doc)
       return
     } catch (err) {
-      if (err.code === 'ENOENT') return
       if (err.code !== 'ENOTEMPTY') throw err
     }
     log.warn({path: doc.path}, 'Folder is not empty!')

--- a/cli/src/local/index.js
+++ b/cli/src/local/index.js
@@ -23,6 +23,8 @@ import type { Metadata } from '../metadata'
 import type { Side } from '../side' // eslint-disable-line
 import type { Callback } from '../utils/func'
 
+Promise.promisifyAll(fs)
+
 const log = logger({
   component: 'LocalWriter'
 })
@@ -344,6 +346,23 @@ class Local implements Side {
     this.events.emit('delete-file', doc)
     let fullpath = path.join(this.syncPath, doc.path)
     return this._trash([fullpath])
+  }
+
+  async deleteFolderAsync (doc: Metadata): Promise<*> {
+    if (doc.docType !== 'folder') throw new Error(`Not folder metadata: ${doc.path}`)
+    const fullpath = path.join(this.syncPath, doc.path)
+
+    try {
+      log.info({path: doc.path}, 'Deleting empty folder...')
+      await fs.rmdirAsync(fullpath)
+      this.events.emit('delete-file', doc)
+      return
+    } catch (err) {
+      if (err.code === 'ENOENT') return
+      if (err.code !== 'ENOTEMPTY') throw err
+    }
+    log.warn({path: doc.path}, 'Folder is not empty!')
+    return this.trashAsync(doc)
   }
 
   // Rename a file/folder to resolve a conflict

--- a/cli/src/merge.js
+++ b/cli/src/merge.js
@@ -376,12 +376,16 @@ class Merge {
     delete oldMetadata.errors
     const newMetadata = clone(oldMetadata)
     markSide(side, newMetadata, oldMetadata)
+    newMetadata._id = doc._id
+    newMetadata._rev = doc._rev
+    newMetadata.path = oldMetadata.path
     newMetadata.trashed = true
     if (oldMetadata.sides && oldMetadata.sides[side]) {
       markSide(side, oldMetadata, oldMetadata)
       oldMetadata._deleted = true
       try {
         await this.pouch.put(oldMetadata)
+        return
       } catch (err) {
         log.warn({path, err})
       }

--- a/cli/src/remote/cozy.js
+++ b/cli/src/remote/cozy.js
@@ -47,6 +47,7 @@ export default class RemoteCozy {
     this.updateFileById = composeAsync(this.client.files.updateById, this.toRemoteDoc)
     this.updateAttributesById = composeAsync(this.client.files.updateAttributesById, this.toRemoteDoc)
     this.trashById = this.client.files.trashById
+    this.destroyById = this.client.files.destroyById
   }
 
   createJob: (workerType: string, args: any) => Promise<*>
@@ -73,6 +74,7 @@ export default class RemoteCozy {
                          options?: {ifMatch?: string}) => Promise<RemoteDoc>
 
   trashById: (id: string, options?: {ifMatch: string}) => Promise<RemoteDoc>
+  destroyById: (id: string) => Promise<void>
 
   async changes (since: string = '0'): Promise<{last_seq: string, docs: Array<RemoteDoc|RemoteDeletion>}> {
     const options = {since, include_docs: true}

--- a/cli/src/remote/index.js
+++ b/cli/src/remote/index.js
@@ -239,9 +239,28 @@ export default class Remote implements Side {
         ifMatch: doc.remote._rev
       })
     } catch (err) {
+      // FIXME: Don't complain when file/dir is already trashed/deleted?
       throw err
     }
     doc.remote._rev = newRemoteDoc._rev
+  }
+
+  async deleteFolderAsync (doc: Metadata): Promise<void> {
+    await this.trashAsync(doc)
+    const {path} = doc
+
+    // FIXME: We use cozy-client-js directly instead of RemoteCozy because we
+    // want the dir contents.
+    // FIXME: Couldn't we reuse RemoteDoc from trashAsync()
+    const folder = await this.remoteCozy.client.files.statById(doc.remote._id)
+    if (folder.relations('contents').length === 0) {
+      log.info({path}, 'Deleting folder from the Cozy trash...')
+      // FIXME: Would it make sense to have an ifMatch option in destroyById()?
+      // FIXME: Don't complain when user cleared the trash? (race condition)
+      await this.remoteCozy.destroyById(folder._id)
+    } else {
+      log.warn({path}, 'Folder is not empty and cannot be deleted!')
+    }
   }
 
   moveFolderAsync (doc: Metadata, from: Metadata): Promise<*> {

--- a/cli/src/side.js
+++ b/cli/src/side.js
@@ -12,6 +12,7 @@ export interface Side {
   moveFileAsync (doc: Metadata, from: Metadata): Promise<*>;
   moveFolderAsync (doc: Metadata, from: Metadata): Promise<*>;
   trashAsync (doc: Metadata): Promise<*>;
+  deleteFolderAsync (doc: Metadata): Promise<*>;
   resolveConflictAsync (doc: Metadata, from: Metadata): Promise<*>;
 }
 

--- a/cli/src/sync.js
+++ b/cli/src/sync.js
@@ -386,7 +386,7 @@ class Sync {
         this.moveFrom = doc
         return
       case doc._deleted:
-        return side.trashAsync(doc)
+        return side.deleteFolderAsync(doc)
       case rev === 0:
         return side.addFolderAsync(doc)
       default:

--- a/cli/test/builders/metadata/dir.js
+++ b/cli/test/builders/metadata/dir.js
@@ -16,7 +16,7 @@ export default class DirMetadataBuilder {
   constructor (pouch?: Pouch) {
     this.pouch = pouch
     this.opts = {
-      path: ''
+      path: 'foo'
     }
   }
 

--- a/cli/test/integration/v3/move.js
+++ b/cli/test/integration/v3/move.js
@@ -131,9 +131,9 @@ suite('Move', () => {
         ...pick(oldFile, ['docType', 'md5sum', 'mime', 'class', 'size'])
       }, oldFile)
       // FIXME: PouchDB 409 conflict errors
-      await should(prep.trashFolderAsync('local', {path: 'parent/src/dir/subdir'})).be.rejectedWith({status: 409})
-      await should(prep.trashFolderAsync('local', {path: 'parent/src/dir/empty-subdir'})).be.rejectedWith({status: 409})
-      await should(prep.trashFolderAsync('local', {path: 'parent/src/dir'})).be.rejectedWith({status: 409})
+      await prep.trashFolderAsync('local', {path: 'parent/src/dir/subdir'})
+      await prep.trashFolderAsync('local', {path: 'parent/src/dir/empty-subdir'})
+      await prep.trashFolderAsync('local', {path: 'parent/src/dir'})
 
       should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
         // Moved file
@@ -145,11 +145,8 @@ suite('Move', () => {
         {path: path.normalize('parent/dst/dir/subdir')},
         // Deleted dirs
         {path: path.normalize('parent/src/dir/subdir'), _deleted: true},
-        {path: path.normalize('parent/src/dir/subdir'), trashed: true},
         {path: path.normalize('parent/src/dir/empty-subdir'), _deleted: true},
-        {path: path.normalize('parent/src/dir/empty-subdir'), trashed: true},
-        {path: path.normalize('parent/src/dir'), _deleted: true},
-        {path: path.normalize('parent/src/dir'), trashed: true}
+        {path: path.normalize('parent/src/dir'), _deleted: true}
       ])
 
       await helpers.syncAll()

--- a/cli/test/integration/v3/trash.js
+++ b/cli/test/integration/v3/trash.js
@@ -50,11 +50,10 @@ suite('Trash', () => {
     })
 
     test('local', async () => {
-      await should(prep.trashFileAsync('local', {path: 'parent/file'})).be.rejectedWith({status: 409})
+      await prep.trashFileAsync('local', {path: 'parent/file'})
 
       should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        {path: path.normalize('parent/file'), _deleted: true},
-        {path: path.normalize('parent/file'), trashed: true}
+        {path: path.normalize('parent/file'), _deleted: true}
       ])
       await should(pouch.db.get(file._id)).be.rejectedWith({status: 404})
 
@@ -73,8 +72,7 @@ suite('Trash', () => {
       await helpers.remote.pullChanges()
 
       should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        {path: path.normalize('parent/file'), _deleted: true},
-        {path: path.normalize('parent/file'), trashed: true}
+        {path: path.normalize('parent/file'), _deleted: true}
       ])
       await should(pouch.db.get(file._id)).be.rejectedWith({status: 404})
 
@@ -104,14 +102,13 @@ suite('Trash', () => {
     })
 
     test('local', async () => {
-      await should(prep.trashFolderAsync('local', {path: path.normalize('parent/dir')})).be.rejectedWith({status: 409})
+      await prep.trashFolderAsync('local', {path: path.normalize('parent/dir')})
 
       should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
         // XXX: Why isn't file deleted? (it works anyway)
         {path: path.normalize('parent/dir/subdir'), _deleted: true},
         {path: path.normalize('parent/dir/empty-subdir'), _deleted: true},
-        {path: path.normalize('parent/dir'), _deleted: true},
-        {path: path.normalize('parent/dir'), trashed: true}
+        {path: path.normalize('parent/dir'), _deleted: true}
       ])
 
       await helpers.syncAll()
@@ -128,14 +125,13 @@ suite('Trash', () => {
 
     test('remote', async() => {
       // FIXME: should pass a remote doc, or trash from Cozy
-      await should(prep.trashFolderAsync('remote', {path: 'parent/dir'})).be.rejectedWith({status: 409})
+      await prep.trashFolderAsync('remote', {path: 'parent/dir'})
 
       should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
         // XXX: Why isn't file deleted? (it works anyway)
         {path: path.normalize('parent/dir/subdir'), _deleted: true},
         {path: path.normalize('parent/dir/empty-subdir'), _deleted: true},
-        {path: path.normalize('parent/dir'), _deleted: true},
-        {path: path.normalize('parent/dir'), trashed: true}
+        {path: path.normalize('parent/dir'), _deleted: true}
       ])
 
       await helpers.syncAll()

--- a/cli/test/unit/local/index.js
+++ b/cli/test/unit/local/index.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import Promise from 'bluebird'
 import crypto from 'crypto'
 import fs from 'fs-extra'
 import path from 'path'
@@ -11,8 +12,11 @@ import Local from '../../../src/local'
 import { TMP_DIR_NAME } from '../../../src/local/constants'
 import { PendingMap } from '../../../src/utils/pending'
 
+import MetadataBuilders from '../../builders/metadata'
 import configHelpers from '../../helpers/config'
 import pouchHelpers from '../../helpers/pouch'
+
+Promise.promisifyAll(fs)
 
 describe('Local', function () {
   before('instanciate config', configHelpers.createConfig)
@@ -634,6 +638,70 @@ describe('Local', function () {
           })
         })
       })
+    })
+  })
+
+  describe('deleteFolderAsync', () => {
+    let builders, fullPath
+
+    beforeEach(function () {
+      builders = new MetadataBuilders(this.pouch)
+      fullPath = (doc) => path.join(this.syncPath, doc.path)
+
+      this.events.emit = sinon.spy()
+      sinon.spy(this.local, 'trashAsync')
+    })
+
+    afterEach(function () {
+      this.local.trashAsync.restore()
+    })
+
+    it('deletes an empty folder', async function () {
+      const doc = builders.dirMetadata().build()
+      await fs.emptyDirAsync(fullPath(doc))
+
+      await this.local.deleteFolderAsync(doc)
+
+      should(await fs.pathExistsAsync(fullPath(doc))).be.false()
+      should(this.events.emit.args).deepEqual([
+        ['delete-file', doc]
+      ])
+    })
+
+    it('trashes a non-empty folder (ENOTEMPTY)', async function () {
+      const doc = builders.dirMetadata().build()
+      await fs.ensureDirAsync(path.join(fullPath(doc), 'something-inside'))
+
+      await this.local.deleteFolderAsync(doc)
+
+      should(await fs.pathExistsAsync(fullPath(doc))).be.false()
+      should(this.local.trashAsync.args).deepEqual([
+        [doc]
+      ])
+    })
+
+    it('does not complain when folder was already deleted (ENOENT)', async function () {
+      const doc = builders.dirMetadata().build()
+
+      await should(this.local.deleteFolderAsync(doc))
+        .be.fulfilled()
+    })
+
+    it('does not swallow other fs errors', async function () {
+      const doc = builders.dirMetadata().build()
+      await fs.ensureFileAsync(fullPath(doc))
+
+      await should(this.local.deleteFolderAsync(doc))
+        .be.rejectedWith(/ENOTDIR/)
+    })
+
+    it('throws when given non-folder metadata', async function () {
+      // TODO: FileMetadataBuilder
+      const doc = {path: 'FILE-TO-DELETE', docType: 'file'}
+      await fs.ensureFileAsync(fullPath(doc))
+
+      await should(this.local.deleteFolderAsync(doc))
+        .be.rejectedWith(/metadata/)
     })
   })
 

--- a/cli/test/unit/local/index.js
+++ b/cli/test/unit/local/index.js
@@ -680,19 +680,11 @@ describe('Local', function () {
       ])
     })
 
-    it('does not complain when folder was already deleted (ENOENT)', async function () {
+    it('does not swallow fs errors', async function () {
       const doc = builders.dirMetadata().build()
 
       await should(this.local.deleteFolderAsync(doc))
-        .be.fulfilled()
-    })
-
-    it('does not swallow other fs errors', async function () {
-      const doc = builders.dirMetadata().build()
-      await fs.ensureFileAsync(fullPath(doc))
-
-      await should(this.local.deleteFolderAsync(doc))
-        .be.rejectedWith(/ENOTDIR/)
+        .be.rejectedWith(/ENOENT/)
     })
 
     it('throws when given non-folder metadata', async function () {

--- a/cli/test/unit/sync.js
+++ b/cli/test/unit/sync.js
@@ -613,8 +613,10 @@ function(doc) {
           remote: 2
         }
       }
+      this.local.deleteFolderAsync = sinon.stub()
+      this.local.deleteFolderAsync.returnsPromise().resolves()
       this.sync.folderChangedAsync(doc, this.local, 1).then(() => {
-        this.local.trashAsync.calledWith(doc).should.be.true()
+        this.local.deleteFolderAsync.calledWith(doc).should.be.true()
         done()
       })
     })


### PR DESCRIPTION
- Prevent PouchDB 409 conflict errors (while preserving behavior)
- Delete empty folders in local/remote trash after move/rename
- In remote client move test, a file may sometimes remain in the local trash (it was already an issue before this fix, to be fixed in another PR)