### PR TITLE
Disable remote instance bootstrap on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - cmd: appveyor-retry powershell Install-Product node $env:nodejs_version
   - cd cli
   - cmd: appveyor-retry yarn
-  - cmd: appveyor-retry yarn bootstrap:remote
+  - ps: Add-Content .\.env.test "NODE_ENV=test`nCOZY_STACK_TOKEN=whatever"
   - cd ..
 
 build: off


### PR DESCRIPTION
We don't run remote unit/integration tests on AppVeyor anyway.