### PR TITLE
Properly transmit error to renderer

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -672,10 +672,14 @@ ipcMain.on('unlink-cozy', () => {
   })
 })
 
+function serializeError (err) {
+  return {message: err.message, name: err.name, stack: err.stack}
+}
+
 ipcMain.on('send-mail', (event, body) => {
   desktop.sendMailToSupport(body).then(
     () => { event.sender.send('mail-sent') },
-    (err) => { event.sender.send('mail-sent', err) }
+    (err) => { event.sender.send('mail-sent', serializeError(err)) }
   )
 })
 


### PR DESCRIPTION
This fix the [object Objet] error by properly serializing the renderer. Most probable error is Host Not Found, which is properly handled in renderer.