### PR TITLE
Use new electron-builder install-app-deps subcommand

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -92,7 +92,7 @@
     "lint": "standard --verbose main.js ports.js",
     "pack": "cross-env DEBUG=electron-builder build --dir",
     "postinstall": "yarn postinstall:electron && yarn postinstall:elm",
-    "postinstall:electron": "cross-env DEBUG=electron-builder install-app-deps",
+    "postinstall:electron": "cross-env DEBUG=electron-builder electron-builder install-app-deps",
     "postinstall:elm": "elm-package install -y",
     "reinstall": "bash -c 'rm -rf node_modules/' && yarn",
     "release:build": "yarn release:check:node-6 && yarn release:build:cli && yarn reinstall && yarn run clean && yarn build && yarn dist && yarn release:fix",


### PR DESCRIPTION
So we don't get a warning anymore.