### PR TITLE
Get rid of fswin

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -64,7 +64,6 @@
     "commander": "2.9.0",
     "cozy-client-js": "^0.3.9",
     "fs-extra": "^3.0.0",
-    "fswin": "sebn/node-fswin#electron",
     "isomorphic-fetch": "2.2.1",
     "lodash.clone": "4.5.0",
     "lodash.find": "4.6.0",

--- a/cli/src/utils/fs.js
+++ b/cli/src/utils/fs.js
@@ -1,23 +1,22 @@
+import Promise from 'bluebird'
+import childProcess from 'child_process'
+
 import logger from '../logger'
+
+Promise.promisifyAll(childProcess)
 
 const log = logger({
   component: 'FS'
 })
 
-// The fswin module can only be loaded on Windows
-let fswin
-if (process.platform === 'win32') {
-  fswin = require('fswin')
-}
-
-// Hides a file or directory on Windows.
-// Async so it doesn't block more useful operations.
-// No failure handling because we can't / don't want to do anything anyway.
-export function hideOnWindows (path: string): void {
-  if (!fswin) return
-  fswin.setAttributes(path, {IS_HIDDEN: true}, (succeeded) => {
-    if (!succeeded) log.warn(`Could not set IS_HIDDEN flag on ${path}`)
-  })
+// Hides a directory on Windows.
+// Errors are logged, not thrown.
+export async function hideOnWindows (path: string): Promise<void> {
+  try {
+    await childProcess.execAsync(`attrib +h "${path}"`)
+  } catch (err) {
+    log.error(err)
+  }
 }
 
 const ILLEGAL_CHARACTERS = '/?<>\\:*|"'

--- a/cli/test/unit/utils/fs.js
+++ b/cli/test/unit/utils/fs.js
@@ -1,0 +1,51 @@
+/* @flow */
+/* eslint-env mocha */
+
+import Promise from 'bluebird'
+import childProcess from 'child_process'
+import fs from 'fs-extra'
+import path from 'path'
+import should from 'should'
+
+import { hideOnWindows } from '../../../src/utils/fs'
+
+import configHelpers from '../../helpers/config'
+
+Promise.promisifyAll(childProcess)
+Promise.promisifyAll(fs)
+
+describe('utils/fs', () => {
+  before('instanciate config', configHelpers.createConfig)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  describe('hideOnWindows', () => {
+    const { platform } = process
+    const dirName = '.dir-to-hide'
+    let parentPath, dirPath, missingPath
+
+    before(async function () {
+      parentPath = this.syncPath
+      dirPath = path.join(parentPath, dirName)
+      missingPath = path.join(parentPath, 'missing')
+
+      await fs.ensureDirAsync(dirPath)
+    })
+
+    if (platform === 'win32') {
+      it('sets the hidden attribute of the given dir on Windows', async () => {
+        await should(hideOnWindows(dirPath)).be.fulfilled()
+        // $FlowFixMe
+        const output = await childProcess.execAsync(`dir ${parentPath}`, {encoding: 'utf8'})
+        should(output).not.match(dirName)
+      })
+    } else {
+      it(`does nothing on ${platform}`, () =>
+        should(hideOnWindows(dirPath)).be.fulfilled()
+      )
+    }
+
+    it('never throws any error', async () =>
+      should(hideOnWindows(missingPath)).be.fulfilled()
+    )
+  })
+})

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -860,7 +860,7 @@ binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
-bindings@^1.2.1, bindings@~1.2.1:
+bindings@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
 
@@ -2358,12 +2358,6 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
-
-fswin@sebn/node-fswin#electron:
-  version "2.16.501"
-  resolved "https://codeload.github.com/sebn/node-fswin/tar.gz/99c7f27f1d7bfd00c03fa616ac76d6fc1cba5a2a"
-  dependencies:
-    bindings "^1.2.1"
 
 function-bind@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
Better hide directories with a simple Windows command.
1 dependency less.
No need to depend on a fork anymore.
And we won't need to recompile it for electron everytime we run yarn.