### PR TITLE
Promisify checksumer

### DIFF
--- a/cli/src/local/index.js
+++ b/cli/src/local/index.js
@@ -202,7 +202,7 @@ class Local implements Side {
       next => {
         if (doc.md5sum != null) {
           // TODO: Share checksumer instead of chaining properties
-          this.watcher.checksumer.push(tmpFile, function (err, md5sum) {
+          this.watcher.checksumer.push(tmpFile).asCallback(function (err, md5sum) {
             if (err) {
               next(err)
             } else if (md5sum === doc.md5sum) {

--- a/cli/src/local/watcher.js
+++ b/cli/src/local/watcher.js
@@ -218,7 +218,7 @@ class LocalWatcher {
 
   checksum (filePath: string, callback: Callback) {
     const absPath = path.join(this.syncPath, filePath)
-    this.checksumer.push(absPath, callback)
+    this.checksumer.push(absPath).asCallback(callback)
   }
 
   /* Actions */

--- a/cli/test/unit/local/checksumer.js
+++ b/cli/test/unit/local/checksumer.js
@@ -17,22 +17,14 @@ describe('local/checksumer', () => {
   })
 
   describe('push', () => {
-    it('returns the checksum of an existing file', function (done) {
-      let filePath = 'test/fixtures/chat-mignon.jpg'
-      checksumer.push(filePath, function (err, sum) {
-        should.not.exist(err)
-        sum.should.equal('+HBGS7uN4XdB0blqLv5tFQ==')
-        done()
-      })
+    it('resolves with the checksum of an existing file', async () => {
+      await should(checksumer.push('test/fixtures/chat-mignon.jpg'))
+        .be.fulfilledWith('+HBGS7uN4XdB0blqLv5tFQ==')
     })
 
-    it('returns an error for a missing file', function (done) {
-      let filePath = 'no/such/file'
-      checksumer.push(filePath, function (err, sum) {
-        should.exist(err)
-        should(err).have.property('code', 'ENOENT')
-        done()
-      })
+    it('rejects for a missing file', async () => {
+      await should(checksumer.push('no/such/file'))
+        .be.rejectedWith({code: 'ENOENT'})
     })
   })
 })

--- a/cli/test/unit/local/watcher.js
+++ b/cli/test/unit/local/watcher.js
@@ -173,6 +173,7 @@ describe('LocalWatcher Tests', function () {
             size: 29865
           })
           done()
+          return Promise.resolve()
         }
         let src = path.join(__dirname, '../../fixtures/chat-mignon.jpg')
         let dst = path.join(this.syncPath, 'aaa.jpg')


### PR DESCRIPTION
So we can await for multiple checksum promises at once.
Useful to process an event batch.