### PR TITLE
sync: Temporarily disable the remote Cozy overloading guard

### DIFF
--- a/cli/src/sync.js
+++ b/cli/src/sync.js
@@ -276,7 +276,7 @@ class Sync {
     try {
       // The sync error may be due to the remote cozy being overloaded.
       // So, it's better to wait a bit before trying the next operation.
-      await Promise.delay(HEARTBEAT)
+      // TODO: Wait for some increasing delay before saving errors
       await this.pouch.db.put(doc)
     } catch (err) {
       // If the doc can't be saved, it's because of a new revision.


### PR DESCRIPTION
So we can effectively test the new releases