### PR TITLE
gui: Make tray-running app not visible in macOS dock & cmd+tab

### DIFF
--- a/gui/src/main/tray.window.js
+++ b/gui/src/main/tray.window.js
@@ -38,6 +38,10 @@ module.exports = class TrayWM extends WindowManager {
 
   create () {
     let pReady = super.create()
+    // Once configured and running in the tray, the app doesn't need to be
+    // visible anymore in macOS dock (and cmd+tab), even when the tray popover
+    // is visible, until another window shows up.
+    if (process.platform === 'darwin') this.app.dock.hide()
     this.positioner = new Positioner(this.win)
     this.win.on('blur', this.onBlur.bind(this))
     return pReady

--- a/gui/src/main/window_manager.js
+++ b/gui/src/main/window_manager.js
@@ -79,7 +79,9 @@ module.exports = class WindowManager {
     this.win.setMenu(null)
     this.win.setAutoHideMenuBar(true)
 
-    // dockApple
+    // Most windows (e.g. onboarding, help...) make the app visible in macOS
+    // dock (and cmd+tab) by default. App is hidden when windows is closed to
+    // allow per-window visibility.
     if (process.platform === 'darwin') {
       this.app.dock.show()
       this.win.on('closed', () => { this.app.dock.hide() })


### PR DESCRIPTION
App is still not visible in dock or with cmd+tab when the tray popover
shows up. Only during auto-update, onboarding or when showing help form.