### PR TITLE
Add Arch Linux GLIBCXX version

### DIFF
--- a/doc/usage/linux.md
+++ b/doc/usage/linux.md
@@ -27,10 +27,11 @@ nightly builds for Debian and Ubuntu are already being tested internally).
 
 ## Supported distributions
 
-The AppImage needs a relatively recent version of `GLIBCXX >= 3.4.21`.
+The current AppImage needs a relatively recent version of `GLIBCXX >= 3.4.21`.
 
 | Distribution | supported | `GLIBCXX` | comment |
 | --- | --- | --- | --- |
+| Arch Linux | no | 3.4.20 | |
 | Debian 7 (Wheezy) | no | 3.4.17 | |
 | Debian 8 (Jessie) | no | 3.4.20 | |
 | **Debian 9 (Stretch)** | ? | 3.4.22 | **should work** |


### PR DESCRIPTION
Après avoir lancé la commande `strings $(locate -b '\libstdc++.so.6') | grep 'GLIBCXX_[0-9]' | tail -n 1` (il a fallut que j'installe locate et que je crée la DB (`pacman -S mlocate && sudo updatedb`)), je n'ai pas une version suffisante de GLIBCXX.

Comment on peut updater GLIBCXX ?