### PR TITLE
ci/travis: Don't cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ cache:
     yarn: true
     directories:
         - /Library/Caches/Homebrew
-        - node_modules
         - $HOME/.cache/electron
         - $HOME/.cache/electron-builder
 addons:


### PR DESCRIPTION
Looks like caching `node_modules` breaks `elm-package install` on macOS builds.