### PR TITLE
core/remote/watcher: Prevent infinite sync of corrupt file

### DIFF
--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -205,7 +205,18 @@ export default class RemoteWatcher {
       return remoteChange.restored(doc, was)
     }
     if (was._id === doc._id) {
-      return remoteChange.updated(doc)
+      if (doc.docType === 'file' && doc.md5sum === was.md5sum && doc.size !== was.size) {
+        return {
+          type: 'InvalidChange',
+          doc,
+          was,
+          error: new Error(
+            'File is corrupt on either side (md5sum matches but size does not)'
+          )
+        }
+      } else {
+        return remoteChange.updated(doc)
+      }
     }
     if ((doc.docType === 'file') && (was.md5sum === doc.md5sum)) {
       const change: FileMoved = {type: 'FileMoved', doc, was}

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -535,6 +535,23 @@ describe('RemoteWatcher', function () {
       should(dst).not.have.properties(['_rev', 'path', 'name'])
     })
 
+    it('is invalid when local or remote file is corrupt', async function () {
+      const doc: RemoteDoc = builders.remote.file().build()
+      const was: Metadata = createMetadata(doc)
+      metadata.ensureValidPath(was)
+      metadata.assignId(was)
+      should(doc.md5sum).equal(was.md5sum)
+      doc.size = '123'
+      was.size = 456
+      was.remote._rev = '0'
+
+      const change: Change = this.watcher.identifyChange(clone(doc), was, 0, [])
+
+      should(change).have.property('type', 'InvalidChange')
+      // $FlowFixMe
+      should(change.error).match(/corrupt/)
+    })
+
     xit('calls deleteDoc & addDoc when trashed', async function () {
       this.prep.deleteFolderAsync = sinon.stub()
       this.prep.deleteFolderAsync.returnsPromise().resolves(null)


### PR DESCRIPTION
Be it corrupted on local or remote (md5sum matches but size doesn't)