### PR TITLE
core: Support email improvements

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -29,6 +29,8 @@ const log = logger({
   component: 'App'
 })
 
+const SUPPORT_EMAIL = process.env.COZY_DESKTOP_SUPPORT_EMAIL || 'contact@cozycloud.cc'
+
 // App is the entry point for the CLI and GUI.
 // They both can do actions and be notified by events via an App instance.
 class App {
@@ -186,7 +188,7 @@ class App {
     const args = {
       mode: 'from',
       to: [
-        { name: 'Support', email: 'contact@cozycloud.cc' }
+        { name: 'Support', email: SUPPORT_EMAIL }
       ],
       subject: 'Ask support for cozy-desktop',
       parts: [

--- a/core/app.js
+++ b/core/app.js
@@ -260,17 +260,19 @@ class App {
   }
 
   debugInformations () {
+    const config = this.config || {}
+
     return {
       appVersion: pkg.version,
-      configPath: this.config && this.config.configPath,
-      configVersion: this.config && this.config.config.creds.client.softwareVersion,
-      cozyUrl: this.config && this.config.cozyUrl,
-      deviceName: this.config && this.config.deviceName,
+      configPath: config.configPath,
+      configVersion: config.version,
+      cozyUrl: config.cozyUrl,
+      deviceName: config.deviceName,
       osType: os.type(),
       osRelease: os.release(),
       osArch: os.arch(),
-      permissions: this.config && this.config.config.creds.token.scope.split(' '),
-      syncPath: this.config && this.config.syncPath
+      permissions: config.permissions,
+      syncPath: config.syncPath
     }
   }
 

--- a/core/app.js
+++ b/core/app.js
@@ -262,9 +262,15 @@ class App {
   debugInformations () {
     return {
       appVersion: pkg.version,
+      configPath: this.config && this.config.configPath,
+      configVersion: this.config && this.config.config.creds.client.softwareVersion,
+      cozyUrl: this.config && this.config.cozyUrl,
+      deviceName: this.config && this.config.deviceName,
       osType: os.type(),
       osRelease: os.release(),
-      osArch: os.arch()
+      osArch: os.arch(),
+      permissions: this.config && this.config.config.creds.token.scope.split(' '),
+      syncPath: this.config && this.config.syncPath
     }
   }
 

--- a/core/config.js
+++ b/core/config.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import _ from 'lodash'
 import path from 'path'
 
 import { hideOnWindows } from './utils/fs'
@@ -74,6 +75,15 @@ export default class Config {
       throw new Error(`Device not configured`)
     }
     return this.config.creds.client
+  }
+
+  get version () {
+    return _.get(this, 'config.creds.client.softwareVersion')
+  }
+
+  get permissions () {
+    const scope = _.get(this, 'config.creds.token.scope')
+    return scope ? scope.split(' ') : []
   }
 
   // Set the remote configuration

--- a/core/config.js
+++ b/core/config.js
@@ -66,7 +66,7 @@ export default class Config {
 
   // Return the name of the registered client
   get deviceName () {
-    return this.client ? this.client.clientName : ''
+    return _.get(this, 'config.creds.client.clientName', '')
   }
 
   // Return config related to the OAuth client

--- a/core/remote/registration.js
+++ b/core/remote/registration.js
@@ -58,6 +58,7 @@ export default class Registration {
       logoURI: pkg.logo,
       policyURI: 'https://files.cozycloud.cc/cgu.pdf',
       scopes: [
+        // TODO: Implement existing config update in case we change permissions
         'io.cozy.files',
         'io.cozy.settings:GET:io.cozy.settings.disk-usage',
         'io.cozy.jobs:POST:sendmail:worker'

--- a/gui/elm/Help.elm
+++ b/gui/elm/Help.elm
@@ -107,7 +107,7 @@ view helpers model =
                 [ case model.status of
                     Error error ->
                         p [ class "message--error" ]
-                            [ text ("Error: " ++ error) ]
+                            [ text (helpers.t error) ]
 
                     _ ->
                         p []

--- a/gui/js/help.window.js
+++ b/gui/js/help.window.js
@@ -2,6 +2,10 @@ const WindowManager = require('./window_manager')
 const HELP_SCREEN_WIDTH = 768
 const HELP_SCREEN_HEIGHT = 570
 
+const log = require('../../core-built/app.js').default.logger({
+  component: 'GUI'
+})
+
 module.exports = class TrayWM extends WindowManager {
   windowOptions () {
     return {
@@ -22,10 +26,9 @@ module.exports = class TrayWM extends WindowManager {
         that.desktop.sendMailToSupport(body).then(
           () => { event.sender.send('mail-sent') },
           (err) => {
+            log.error({err})
             event.sender.send('mail-sent', {
-              message: err.message,
-              name: err.name,
-              stack: err.stack
+              message: 'Help An error occured while sending your email'
             })
           }
         )

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -82,6 +82,7 @@
   "Help [ The more you can say about the issue, the better: do you have many files? Are they big? Is your cozy up-to-date? ]": "[ The more you can say about the issue, the better: do you have many files? Are they big? Is your cozy up-to-date? ]",
   "Help Take care!": "Take care!",
   "Help Your mail has been sent. We will try to respond to it really soon!": "Your mail has been sent. We will try to respond to it really soon!",
+  "Help An error occured while sending your email": "An error occured while sending your email. Please contact the support.",
   "Help You can send us feedback, report bugs and ask for assistance.": "You can send us feedback, report bugs and ask for assistance.",
   "Help We will get back to you as soon as possible.": "We will get back to you as soon as possible.",
   "Help Send us a message": "Send us a message",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -82,6 +82,7 @@
   "Help [ The more you can say about the issue, the better: do you have many files? Are they big? Is your cozy up-to-date? ]": "[ Donnez nous un maximum de détails : avez-vous beaucoup de fichiers ? Sont-ils gros ? Votre cozy est-il à jour ? ]",
   "Help Take care!": "À bientôt !",
   "Help Your mail has been sent. We will try to respond to it really soon!": "Votre courriel a été envoyé. Nous essayerons d'y répondre très rapidement !",
+  "Help An error occured while sending your email": "Une erreur est survenue pendant l'envoi de votre courriel. Veuillez contacter le support.",
   "Help You can send us feedback, report bugs and ask for assistance.": "Vous pouvez nous envoyer vos retours, nous remonter des bugs et demander de l'assistance.",
   "Help We will get back to you as soon as possible.": "Nous allons revenir vers vous aussi vite que possible.",
   "Help Send us a message": "Nous envoyer un message",

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -9,10 +9,10 @@ import { COZY_URL } from './cozy'
 export default {
   createConfig () {
     let parent = process.env.COZY_DESKTOP_DIR || 'tmp'
-    const basePath = path.resolve(`${parent}/test/${+new Date()}`)
-    this.syncPath = path.join(basePath, 'Cozy Drive')
+    this.basePath = path.resolve(`${parent}/test/${+new Date()}`)
+    this.syncPath = path.join(this.basePath, 'Cozy Drive')
     fs.ensureDirSync(this.syncPath)
-    this.config = new Config(path.join(basePath, '.cozy-desktop'))
+    this.config = new Config(path.join(this.basePath, '.cozy-desktop'))
     this.config.syncPath = this.syncPath
     this.config.cozyUrl = COZY_URL
   },

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -7,6 +7,7 @@ import should from 'should'
 
 import App from '../../core/app'
 import { LOG_FILENAME } from '../../core/logger'
+import { version } from '../../package.json'
 
 import configHelpers from '../support/helpers/config'
 
@@ -122,5 +123,42 @@ describe('App', function () {
         should(result).deepEqual({syncPath})
       })
     }
+  })
+
+  describe('debugInformations', () => {
+    it('works when app is not configured', () => {
+      const basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'base-dir-'))
+      const app = new App(basePath)
+
+      const info = app.debugInformations()
+
+      should(info.appVersion).equal(version)
+      should(info.configPath).startWith(basePath)
+      should.not.exist(info.configVersion)
+      should.not.exist(info.cozyUrl)
+      should(info.deviceName).equal('')
+      should.exist(info.osRelease)
+      should.exist(info.osType)
+      should(info.permissions).deepEqual([])
+      should.not.exist(info.syncPath)
+    })
+
+    it('works when app is configured', function () {
+      configHelpers.createConfig.call(this)
+      configHelpers.registerClient.call(this)
+      const app = new App(this.basePath)
+
+      const info = app.debugInformations()
+
+      should(info.appVersion).equal(version)
+      should(info.configPath).startWith(this.basePath)
+      should(info.configVersion).equal(this.config.version)
+      should(info.cozyUrl).equal(this.config.cozyUrl)
+      should(info.deviceName).equal(this.config.deviceName)
+      should.exist(info.osRelease)
+      should.exist(info.osType)
+      should(info.permissions).deepEqual(this.config.permissions)
+      should(info.syncPath).equal(this.syncPath)
+    })
   })
 })


### PR DESCRIPTION
So we can use our own email and stop polluting support in dev.
Defaults to the real one.