### PR TITLE
core: Standardize change types

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -172,13 +172,13 @@ function sortBeforeSquash (changes: LocalChange[]) {
   log.trace('Sort changes before squash...')
   const stopMeasure = measureTime('LocalWatcher#sortBeforeSquash')
   changes.sort((a, b) => {
-    if (a.type === 'LocalDirMove' || a.type === 'LocalFileMove') {
-      if (b.type === 'LocalDirMove' || b.type === 'LocalFileMove') {
+    if (a.type === 'DirMove' || a.type === 'FileMove') {
+      if (b.type === 'DirMove' || b.type === 'FileMove') {
         if (a.path < b.path) return -1
         else if (a.path > b.path) return 1
         else return 0
       } else return -1
-    } else if (b.type === 'LocalDirMove' || b.type === 'LocalFileMove') {
+    } else if (b.type === 'DirMove' || b.type === 'FileMove') {
       return 1
     } else {
       return 0
@@ -194,13 +194,13 @@ function squashMoves (changes: LocalChange[]) {
   for (let i = 0; i < changes.length; i++) {
     let a = changes[i]
 
-    if (a.type !== 'LocalDirMove' && a.type !== 'LocalFileMove') break
+    if (a.type !== 'DirMove' && a.type !== 'FileMove') break
     for (let j = i + 1; j < changes.length; j++) {
       let b = changes[j]
-      if (b.type !== 'LocalDirMove' && b.type !== 'LocalFileMove') break
+      if (b.type !== 'DirMove' && b.type !== 'FileMove') break
 
       // inline of LocalChange.isChildMove
-      if (a.type === 'LocalDirMove' &&
+      if (a.type === 'DirMove' &&
       b.path.indexOf(a.path + path.sep) === 0 &&
       a.old && b.old &&
       b.old.path.indexOf(a.old.path + path.sep) === 0) {
@@ -226,7 +226,7 @@ function separatePendingChanges (changes: LocalChange[], pendingChanges: LocalCh
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i]
     if (change.wip) {
-      if (change.type === 'LocalDirMove' || change.type === 'LocalFileMove') {
+      if (change.type === 'DirMove' || change.type === 'FileMove') {
         log.debug({
           change: change.type,
           oldpath: change.old.path,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -19,22 +19,22 @@ const log = logger({
   component: 'LocalWatcher'
 })
 
-export type LocalDirDeletion = {sideName: 'local', type: 'LocalDirDeletion', path: string, old: ?Metadata, ino: ?number}
-export type LocalFileDeletion = {sideName: 'local', type: 'LocalFileDeletion', path: string, old: ?Metadata, ino: ?number}
-export type LocalDirAddition = {sideName: 'local', type: 'LocalDirAddition', path: string, ino: number, stats: fs.Stats, wip?: true}
-export type LocalFileUpdate = {sideName: 'local', type: 'LocalFileUpdate', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
-export type LocalFileAddition = {sideName: 'local', type: 'LocalFileAddition', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
-export type LocalFileMove = {sideName: 'local', type: 'LocalFileMove', path: string, old: Metadata, ino: number, stats: fs.Stats, md5sum: string, wip?: true, needRefetch: boolean}
-export type LocalDirMove = {sideName: 'local', type: 'LocalDirMove', path: string, old: Metadata, ino: number, stats: fs.Stats, wip?: true, needRefetch: boolean}
+export type LocalDirAddition = {sideName: 'local', type: 'DirAddition', path: string, ino: number, stats: fs.Stats, wip?: true}
+export type LocalDirDeletion = {sideName: 'local', type: 'DirDeletion', path: string, old: ?Metadata, ino: ?number}
+export type LocalDirMove = {sideName: 'local', type: 'DirMove', path: string, old: Metadata, ino: number, stats: fs.Stats, wip?: true, needRefetch: boolean}
+export type LocalFileAddition = {sideName: 'local', type: 'FileAddition', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
+export type LocalFileDeletion = {sideName: 'local', type: 'FileDeletion', path: string, old: ?Metadata, ino: ?number}
+export type LocalFileMove = {sideName: 'local', type: 'FileMove', path: string, old: Metadata, ino: number, stats: fs.Stats, md5sum: string, wip?: true, needRefetch: boolean}
+export type LocalFileUpdate = {sideName: 'local', type: 'FileUpdate', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
 
 export type LocalChange =
-  | LocalDirDeletion
-  | LocalFileDeletion
-  | LocalFileAddition
   | LocalDirAddition
-  | LocalFileUpdate
-  | LocalFileMove
+  | LocalDirDeletion
   | LocalDirMove
+  | LocalFileAddition
+  | LocalFileDeletion
+  | LocalFileMove
+  | LocalFileUpdate
 
 const sideName = 'local'
 
@@ -46,12 +46,12 @@ export const build = (type: string, path: string, opts?: {stats?: fs.Stats, md5s
   return change
 }
 
-export const maybeAddFile = (a: ?LocalChange): ?LocalFileAddition => (a && a.type === 'LocalFileAddition') ? a : null
-export const maybePutFolder = (a: ?LocalChange): ?LocalDirAddition => (a && a.type === 'LocalDirAddition') ? a : null
-export const maybeMoveFile = (a: ?LocalChange): ?LocalFileMove => (a && a.type === 'LocalFileMove') ? a : null
-export const maybeMoveFolder = (a: ?LocalChange): ?LocalDirMove => (a && a.type === 'LocalDirMove') ? a : null
-export const maybeDeleteFile = (a: ?LocalChange): ?LocalFileDeletion => (a && a.type === 'LocalFileDeletion') ? a : null
-export const maybeDeleteFolder = (a: ?LocalChange): ?LocalDirDeletion => (a && a.type === 'LocalDirDeletion') ? a : null
+export const maybeAddFile = (a: ?LocalChange): ?LocalFileAddition => (a && a.type === 'FileAddition') ? a : null
+export const maybePutFolder = (a: ?LocalChange): ?LocalDirAddition => (a && a.type === 'DirAddition') ? a : null
+export const maybeMoveFile = (a: ?LocalChange): ?LocalFileMove => (a && a.type === 'FileMove') ? a : null
+export const maybeMoveFolder = (a: ?LocalChange): ?LocalDirMove => (a && a.type === 'DirMove') ? a : null
+export const maybeDeleteFile = (a: ?LocalChange): ?LocalFileDeletion => (a && a.type === 'FileDeletion') ? a : null
+export const maybeDeleteFolder = (a: ?LocalChange): ?LocalDirDeletion => (a && a.type === 'DirDeletion') ? a : null
 
 export const find = <T>(changes: LocalChange[], maybeRightType: (LocalChange) => ?T, predicate: (T) => boolean, remove?: true): ?T => {
   for (let i = 0; i < changes.length; i++) {
@@ -65,16 +65,16 @@ export const find = <T>(changes: LocalChange[], maybeRightType: (LocalChange) =>
 }
 
 export const isChildMove = (a: LocalChange, b: LocalChange): boolean %checks => {
-  return a.type === 'LocalDirMove' &&
-         (b.type === 'LocalDirMove' || b.type === 'LocalFileMove') &&
+  return a.type === 'DirMove' &&
+         (b.type === 'DirMove' || b.type === 'FileMove') &&
         b.path.indexOf(a.path + path.sep) === 0 &&
         a.old && b.old &&
         b.old.path.indexOf(a.old.path + path.sep) === 0
 }
 
-const isDelete = (a: LocalChange): boolean %checks => a.type === 'LocalDirDeletion' || a.type === 'LocalFileDeletion'
-const isAdd = (a: LocalChange): boolean %checks => a.type === 'LocalDirAddition' || a.type === 'LocalFileAddition'
-const isMove = (a: LocalChange): boolean %checks => a.type === 'LocalDirMove' || a.type === 'LocalFileMove'
+const isDelete = (a: LocalChange): boolean %checks => a.type === 'DirDeletion' || a.type === 'FileDeletion'
+const isAdd = (a: LocalChange): boolean %checks => a.type === 'DirAddition' || a.type === 'FileAddition'
+const isMove = (a: LocalChange): boolean %checks => a.type === 'DirMove' || a.type === 'FileMove'
 
 export const addPath = (a: LocalChange): ?string => isAdd(a) || isMove(a) ? a.path : null
 export const delPath = (a: LocalChange): ?string => isDelete(a) ? a.path : isMove(a) ? a.old.path : null
@@ -90,15 +90,15 @@ export const toString = (a: LocalChange): string => '(' + a.type + ': ' + (a.old
 export const fromEvent = (e: LocalEvent) : LocalChange => {
   switch (e.type) {
     case 'unlinkDir':
-      return {sideName, type: 'LocalDirDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
+      return {sideName, type: 'DirDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
     case 'unlink':
-      return {sideName, type: 'LocalFileDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
+      return {sideName, type: 'FileDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
     case 'addDir':
-      return {sideName, type: 'LocalDirAddition', path: e.path, stats: e.stats, ino: e.stats.ino}
+      return {sideName, type: 'DirAddition', path: e.path, stats: e.stats, ino: e.stats.ino}
     case 'change':
-      return {sideName, type: 'LocalFileUpdate', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
+      return {sideName, type: 'FileUpdate', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
     case 'add':
-      return {sideName, type: 'LocalFileAddition', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
+      return {sideName, type: 'FileAddition', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
     default:
       throw new TypeError(`wrong type ${e.type}`) // @TODO FlowFixMe
   }
@@ -106,7 +106,7 @@ export const fromEvent = (e: LocalEvent) : LocalChange => {
 
 export const fileMoveFromUnlinkAdd = (unlinkChange: LocalFileDeletion, e: LocalFileAdded): * => {
   log.debug({oldpath: unlinkChange.path, path: e.path, ino: unlinkChange.ino}, 'File moved')
-  return build('LocalFileMove', e.path, {
+  return build('FileMove', e.path, {
     stats: e.stats,
     md5sum: e.md5sum,
     old: unlinkChange.old,
@@ -117,7 +117,7 @@ export const fileMoveFromUnlinkAdd = (unlinkChange: LocalFileDeletion, e: LocalF
 
 export const dirMoveFromUnlinkAdd = (unlinkChange: LocalDirDeletion, e: LocalDirAdded): * => {
   log.debug({oldpath: unlinkChange.path, path: e.path}, 'moveFolder')
-  return build('LocalDirMove', e.path, {
+  return build('DirMove', e.path, {
     stats: e.stats,
     old: unlinkChange.old,
     ino: unlinkChange.ino,
@@ -127,7 +127,7 @@ export const dirMoveFromUnlinkAdd = (unlinkChange: LocalDirDeletion, e: LocalDir
 
 export const fileMoveFromAddUnlink = (addChange: LocalFileAddition, e: LocalFileUnlinked): * => {
   log.debug({oldpath: e.path, path: addChange.path, ino: addChange.ino}, 'File moved')
-  return build('LocalFileMove', addChange.path, {
+  return build('FileMove', addChange.path, {
     stats: addChange.stats,
     md5sum: addChange.md5sum,
     old: e.old,
@@ -138,7 +138,7 @@ export const fileMoveFromAddUnlink = (addChange: LocalFileAddition, e: LocalFile
 
 export const dirMoveFromAddUnlink = (addChange: LocalDirAddition, e: LocalDirUnlinked): * => {
   log.debug({oldpath: e.path, path: addChange.path}, 'moveFolder')
-  return build('LocalDirMove', addChange.path, {
+  return build('DirMove', addChange.path, {
     stats: addChange.stats,
     old: e.old,
     ino: addChange.ino,
@@ -189,7 +189,7 @@ export const convertFileMoveToDeletion = (change: LocalFileMove) => {
   log.debug({path: change.old.path, ino: change.ino},
     'File was moved then deleted. Deleting origin directly.')
   // $FlowFixMe
-  change.type = 'LocalFileDeletion'
+  change.type = 'FileDeletion'
   change.path = change.old.path
   delete change.stats
   delete change.wip

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -38,10 +38,10 @@ export type LocalChange =
 
 // TODO: Introduce specific builders?
 export const build = (type: string, path: string, opts?: {stats?: fs.Stats, md5sum?: string, old?: ?Metadata}): LocalChange => {
-  const event: Object = _.assign({type, path}, opts)
-  if (event.wip == null) delete event.wip
-  if (event.md5sum == null) delete event.md5sum
-  return event
+  const change: Object = _.assign({type, path}, opts)
+  if (change.wip == null) delete change.wip
+  if (change.md5sum == null) delete change.md5sum
+  return change
 }
 
 export const maybeAddFile = (a: ?LocalChange): ?LocalFileAddition => (a && a.type === 'LocalFileAddition') ? a : null

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -19,13 +19,13 @@ const log = logger({
   component: 'LocalWatcher'
 })
 
-export type LocalDirDeletion = {type: 'LocalDirDeletion', path: string, old: ?Metadata, ino: ?number}
-export type LocalFileDeletion = {type: 'LocalFileDeletion', path: string, old: ?Metadata, ino: ?number}
-export type LocalDirAddition = {type: 'LocalDirAddition', path: string, ino: number, stats: fs.Stats, wip?: true}
-export type LocalFileUpdate = {type: 'LocalFileUpdate', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
-export type LocalFileAddition = {type: 'LocalFileAddition', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
-export type LocalFileMove = {type: 'LocalFileMove', path: string, old: Metadata, ino: number, stats: fs.Stats, md5sum: string, wip?: true, needRefetch: boolean}
-export type LocalDirMove = {type: 'LocalDirMove', path: string, old: Metadata, ino: number, stats: fs.Stats, wip?: true, needRefetch: boolean}
+export type LocalDirDeletion = {sideName: 'local', type: 'LocalDirDeletion', path: string, old: ?Metadata, ino: ?number}
+export type LocalFileDeletion = {sideName: 'local', type: 'LocalFileDeletion', path: string, old: ?Metadata, ino: ?number}
+export type LocalDirAddition = {sideName: 'local', type: 'LocalDirAddition', path: string, ino: number, stats: fs.Stats, wip?: true}
+export type LocalFileUpdate = {sideName: 'local', type: 'LocalFileUpdate', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
+export type LocalFileAddition = {sideName: 'local', type: 'LocalFileAddition', path: string, ino: number, stats: fs.Stats, md5sum: string, wip?: true}
+export type LocalFileMove = {sideName: 'local', type: 'LocalFileMove', path: string, old: Metadata, ino: number, stats: fs.Stats, md5sum: string, wip?: true, needRefetch: boolean}
+export type LocalDirMove = {sideName: 'local', type: 'LocalDirMove', path: string, old: Metadata, ino: number, stats: fs.Stats, wip?: true, needRefetch: boolean}
 
 export type LocalChange =
   | LocalDirDeletion
@@ -36,9 +36,11 @@ export type LocalChange =
   | LocalFileMove
   | LocalDirMove
 
+const sideName = 'local'
+
 // TODO: Introduce specific builders?
 export const build = (type: string, path: string, opts?: {stats?: fs.Stats, md5sum?: string, old?: ?Metadata}): LocalChange => {
-  const change: Object = _.assign({type, path}, opts)
+  const change: Object = _.assign({sideName, type, path}, opts)
   if (change.wip == null) delete change.wip
   if (change.md5sum == null) delete change.md5sum
   return change
@@ -88,15 +90,15 @@ export const toString = (a: LocalChange): string => '(' + a.type + ': ' + (a.old
 export const fromEvent = (e: LocalEvent) : LocalChange => {
   switch (e.type) {
     case 'unlinkDir':
-      return {type: 'LocalDirDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
+      return {sideName, type: 'LocalDirDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
     case 'unlink':
-      return {type: 'LocalFileDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
+      return {sideName, type: 'LocalFileDeletion', path: e.path, old: e.old, ino: (e.old != null ? e.old.ino : null)}
     case 'addDir':
-      return {type: 'LocalDirAddition', path: e.path, stats: e.stats, ino: e.stats.ino}
+      return {sideName, type: 'LocalDirAddition', path: e.path, stats: e.stats, ino: e.stats.ino}
     case 'change':
-      return {type: 'LocalFileUpdate', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
+      return {sideName, type: 'LocalFileUpdate', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
     case 'add':
-      return {type: 'LocalFileAddition', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
+      return {sideName, type: 'LocalFileAddition', path: e.path, stats: e.stats, ino: e.stats.ino, md5sum: e.md5sum, wip: e.wip}
     default:
       throw new TypeError(`wrong type ${e.type}`) // @TODO FlowFixMe
   }

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -258,29 +258,29 @@ class LocalWatcher {
       try {
         switch (c.type) {
           // TODO: Inline old LocalWatcher methods
-          case 'LocalDirDeletion':
+          case 'DirDeletion':
             await this.onUnlinkDir(c.path)
             break
-          case 'LocalFileDeletion':
+          case 'FileDeletion':
             await this.onUnlinkFile(c.path)
             break
-          case 'LocalDirAddition':
+          case 'DirAddition':
             await this.onAddDir(c.path, c.stats)
             break
-          case 'LocalFileUpdate':
+          case 'FileUpdate':
             await this.onChange(c.path, c.stats, c.md5sum)
             break
-          case 'LocalFileAddition':
+          case 'FileAddition':
             await this.onAddFile(c.path, c.stats, c.md5sum)
             break
-          case 'LocalFileMove':
+          case 'FileMove':
             if (c.needRefetch) {
               c.old = await this.pouch.db.get(metadata.id(c.old.path))
               c.old.childMove = false
             }
             await this.onMoveFile(c.path, c.stats, c.md5sum, c.old)
             break
-          case 'LocalDirMove':
+          case 'DirMove':
             await this.onMoveFolder(c.path, c.stats, c.old)
             break
           default:

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -7,40 +7,38 @@ import { isFile } from '../metadata'
 import type { RemoteDoc, RemoteDeletion } from './document'
 import type { Metadata } from '../metadata'
 
-// TODO: Introduce UnidentifiedChange type with doc/was properties?
-// TODO: Merge with local/prep_action?
-export type RemoteFileAdded = {sideName: 'remote', type: 'RemoteFileAdded', doc: Metadata}
-export type RemoteFileDeleted = {sideName: 'remote', type: 'RemoteFileDeleted', doc: Metadata}
-export type RemoteFileDissociated = {sideName: 'remote', type: 'RemoteFileDissociated', doc: Metadata, was: Metadata}
-export type RemoteFileMoved = {sideName: 'remote', type: 'RemoteFileMoved', doc: Metadata, was: Metadata, needRefetch?: true}
-export type RemoteFileRestored = {sideName: 'remote', type: 'RemoteFileRestored', doc: Metadata, was: Metadata}
-export type RemoteFileTrashed = {sideName: 'remote', type: 'RemoteFileTrashed', doc: Metadata, was: Metadata}
-export type RemoteFileUpdated = {sideName: 'remote', type: 'RemoteFileUpdated', doc: Metadata}
-export type RemoteFolderAdded = {sideName: 'remote', type: 'RemoteFolderAdded', doc: Metadata, was: Metadata}
-export type RemoteFolderDeleted = {sideName: 'remote', type: 'RemoteFolderDeleted', doc: Metadata}
-export type RemoteFolderDissociated = {sideName: 'remote', type: 'RemoteFolderDissociated', doc: Metadata, was: Metadata}
-export type RemoteFolderMoved = {sideName: 'remote', type: 'RemoteFolderMoved', doc: Metadata, was: Metadata, needRefetch?: true}
-export type RemoteFolderRestored = {sideName: 'remote', type: 'RemoteFolderRestored', doc: Metadata, was: Metadata}
-export type RemoteFolderTrashed = {sideName: 'remote', type: 'RemoteFolderTrashed', doc: Metadata, was: Metadata}
+export type RemoteFileAddition = {sideName: 'remote', type: 'FileAddition', doc: Metadata}
+export type RemoteFileDeletion = {sideName: 'remote', type: 'FileDeletion', doc: Metadata}
+export type RemoteFileDissociation = {sideName: 'remote', type: 'FileDissociation', doc: Metadata, was: Metadata}
+export type RemoteFileMove = {sideName: 'remote', type: 'FileMove', doc: Metadata, was: Metadata, needRefetch?: true}
+export type RemoteFileRestoration = {sideName: 'remote', type: 'FileRestoration', doc: Metadata, was: Metadata}
+export type RemoteFileTrashing = {sideName: 'remote', type: 'FileTrashing', doc: Metadata, was: Metadata}
+export type RemoteFileUpdate = {sideName: 'remote', type: 'FileUpdate', doc: Metadata}
+export type RemoteDirAddition = {sideName: 'remote', type: 'DirAddition', doc: Metadata, was: Metadata}
+export type RemoteDirDeletion = {sideName: 'remote', type: 'DirDeletion', doc: Metadata}
+export type RemoteDirDissociation = {sideName: 'remote', type: 'DirDissociation', doc: Metadata, was: Metadata}
+export type RemoteDirMove = {sideName: 'remote', type: 'DirMove', doc: Metadata, was: Metadata, needRefetch?: true}
+export type RemoteDirRestoration = {sideName: 'remote', type: 'DirRestoration', doc: Metadata, was: Metadata}
+export type RemoteDirTrashing = {sideName: 'remote', type: 'DirTrashing', doc: Metadata, was: Metadata}
+
+export type RemoteChange =
+  | RemoteDirAddition
+  | RemoteDirDeletion
+  | RemoteDirDissociation
+  | RemoteDirMove
+  | RemoteDirRestoration
+  | RemoteDirTrashing
+  | RemoteFileAddition
+  | RemoteFileDeletion
+  | RemoteFileDissociation
+  | RemoteFileMove
+  | RemoteFileRestoration
+  | RemoteFileTrashing
+  | RemoteFileUpdate
 
 export type RemoteIgnoredChange = {type: 'RemoteIgnoredChange', doc: Metadata|RemoteDoc|RemoteDeletion, detail: string}
 export type RemoteInvalidChange = {type: 'RemoteInvalidChange', doc: *, error: Error}
 export type RemoteUpToDate = {type: 'RemoteUpToDate', doc: Metadata, was: Metadata}
-
-export type RemoteChange =
-  | RemoteFileAdded
-  | RemoteFileDeleted
-  | RemoteFileDissociated
-  | RemoteFileMoved
-  | RemoteFileRestored
-  | RemoteFileTrashed
-  | RemoteFileUpdated
-  | RemoteFolderAdded
-  | RemoteFolderDeleted
-  | RemoteFolderDissociated
-  | RemoteFolderMoved
-  | RemoteFolderRestored
-  | RemoteFolderTrashed
 
 export type RemoteNoise =
   | RemoteIgnoredChange
@@ -51,55 +49,55 @@ const sideName = 'remote'
 
 // FIXME: return types
 export const added = (doc: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'RemoteFileAdded' : 'RemoteFolderAdded'), doc})
+  ({sideName, type: (isFile(doc) ? 'FileAddition' : 'DirAddition'), doc})
 
 export const trashed = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'RemoteFileTrashed' : 'RemoteFolderTrashed'), doc, was})
+  ({sideName, type: (isFile(doc) ? 'FileTrashing' : 'DirTrashing'), doc, was})
 
 export const deleted = (doc: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'RemoteFileDeleted' : 'RemoteFolderDeleted'), doc})
+  ({sideName, type: (isFile(doc) ? 'FileDeletion' : 'DirDeletion'), doc})
 
 export const restored = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'RemoteFileRestored' : 'RemoteFolderRestored'), doc, was})
+  ({sideName, type: (isFile(doc) ? 'FileRestoration' : 'DirRestoration'), doc, was})
 
 export const upToDate = (doc: Metadata, was: Metadata): * =>
   ({sideName, type: 'RemoteUpToDate', doc, was})
 
 export const updated = (doc: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'RemoteFileUpdated' : 'RemoteFolderAdded'), doc})
+  ({sideName, type: (isFile(doc) ? 'FileUpdate' : 'DirAddition'), doc})
 
 export const dissociated = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'RemoteFileDissociated' : 'RemoteFolderDissociated'), doc, was})
+  ({sideName, type: (isFile(doc) ? 'FileDissociation' : 'DirDissociation'), doc, was})
 
 // TODO: Rename args
 export const isChildMove = (a: RemoteChange|RemoteNoise, b: RemoteChange|RemoteNoise): boolean %checks => {
-  return a.type === 'RemoteFolderMoved' &&
-        (b.type === 'RemoteFolderMoved' || b.type === 'RemoteFileMoved') &&
+  return a.type === 'DirMove' &&
+        (b.type === 'DirMove' || b.type === 'FileMove') &&
         (b.doc.path.indexOf(a.doc.path + path.sep) === 0) &&
         a.was && b.was &&
         (b.was.path.indexOf(a.was.path + path.sep) === 0) &&
-        a.type === 'RemoteFolderMoved' &&
-        (b.type === 'RemoteFolderMoved' || b.type === 'RemoteFileMoved')
+        a.type === 'DirMove' &&
+        (b.type === 'DirMove' || b.type === 'FileMove')
 }
 
 /*     was           doc
  a    /a     ->    /a2
  b    /a/b   ->    /a2/b
 */
-export const isOnlyChildMove = (a: RemoteFolderMoved, b: RemoteFileMoved|RemoteFolderMoved): boolean %checks => {
+export const isOnlyChildMove = (a: RemoteDirMove, b: RemoteFileMove|RemoteDirMove): boolean %checks => {
   return isChildMove(a, b) && b.doc.path.replace(a.doc.path, '') === b.was.path.replace(a.was.path, '')
 }
 
-export const applyMoveToPath = (a: RemoteFolderMoved, p: string): string => {
+export const applyMoveToPath = (a: RemoteDirMove, p: string): string => {
   return p.replace(a.was.path, a.doc.path)
 }
 
-const isDelete = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'RemoteFolderDeleted' || a.type === 'RemoteFileDeleted'
-const isAdd = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'RemoteFolderAdded' || a.type === 'RemoteFileAdded'
-const isMove = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'RemoteFolderMoved' || a.type === 'RemoteFileMoved'
-const isTrash = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'RemoteFolderTrashed' || a.type === 'RemoteFileTrashed'
-const isRestore = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'RemoteFolderRestored' || a.type === 'RemoteFileRestored'
-const isDissociate = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'RemoteFolderDissociated' || a.type === 'RemoteFileDissociated'
+const isDelete = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'DirDeletion' || a.type === 'FileDeletion'
+const isAdd = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'DirAddition' || a.type === 'FileAddition'
+const isMove = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'DirMove' || a.type === 'FileMove'
+const isTrash = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'DirTrashing' || a.type === 'FileTrashing'
+const isRestore = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'DirRestoration' || a.type === 'FileRestoration'
+const isDissociate = (a: RemoteChange|RemoteNoise): boolean %checks => a.type === 'DirDissociation' || a.type === 'FileDissociation'
 
 const addPath = (a: RemoteChange|RemoteNoise): ?string => isAdd(a) || isMove(a) || isRestore(a) || isDissociate(a) ? a.doc.path : null
 const delPath = (a: RemoteChange|RemoteNoise): ?string => isDelete(a) ? a.doc.path : isMove(a) || isTrash(a) ? a.was.path : null

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -9,20 +9,19 @@ import type { Metadata } from '../metadata'
 
 // TODO: Introduce UnidentifiedChange type with doc/was properties?
 // TODO: Merge with local/prep_action?
-export type RemoteFileAdded = {type: 'RemoteFileAdded', doc: Metadata}
-export type RemoteFileDeleted = {type: 'RemoteFileDeleted', doc: Metadata}
-export type RemoteFileDissociated = {type: 'RemoteFileDissociated', doc: Metadata, was: Metadata}
-export type RemoteFileMoved = {type: 'RemoteFileMoved', doc: Metadata, was: Metadata, needRefetch?: true}
-export type RemoteFileRestored = {type: 'RemoteFileRestored', doc: Metadata, was: Metadata}
-export type RemoteFileTrashed = {type: 'RemoteFileTrashed', doc: Metadata, was: Metadata}
-export type RemoteFileUpdated = {type: 'RemoteFileUpdated', doc: Metadata}
-
-export type RemoteFolderAdded = {type: 'RemoteFolderAdded', doc: Metadata, was: Metadata}
-export type RemoteFolderDeleted = {type: 'RemoteFolderDeleted', doc: Metadata}
-export type RemoteFolderDissociated = {type: 'RemoteFolderDissociated', doc: Metadata, was: Metadata}
-export type RemoteFolderMoved = {type: 'RemoteFolderMoved', doc: Metadata, was: Metadata, needRefetch?: true}
-export type RemoteFolderRestored = {type: 'RemoteFolderRestored', doc: Metadata, was: Metadata}
-export type RemoteFolderTrashed = {type: 'RemoteFolderTrashed', doc: Metadata, was: Metadata}
+export type RemoteFileAdded = {sideName: 'remote', type: 'RemoteFileAdded', doc: Metadata}
+export type RemoteFileDeleted = {sideName: 'remote', type: 'RemoteFileDeleted', doc: Metadata}
+export type RemoteFileDissociated = {sideName: 'remote', type: 'RemoteFileDissociated', doc: Metadata, was: Metadata}
+export type RemoteFileMoved = {sideName: 'remote', type: 'RemoteFileMoved', doc: Metadata, was: Metadata, needRefetch?: true}
+export type RemoteFileRestored = {sideName: 'remote', type: 'RemoteFileRestored', doc: Metadata, was: Metadata}
+export type RemoteFileTrashed = {sideName: 'remote', type: 'RemoteFileTrashed', doc: Metadata, was: Metadata}
+export type RemoteFileUpdated = {sideName: 'remote', type: 'RemoteFileUpdated', doc: Metadata}
+export type RemoteFolderAdded = {sideName: 'remote', type: 'RemoteFolderAdded', doc: Metadata, was: Metadata}
+export type RemoteFolderDeleted = {sideName: 'remote', type: 'RemoteFolderDeleted', doc: Metadata}
+export type RemoteFolderDissociated = {sideName: 'remote', type: 'RemoteFolderDissociated', doc: Metadata, was: Metadata}
+export type RemoteFolderMoved = {sideName: 'remote', type: 'RemoteFolderMoved', doc: Metadata, was: Metadata, needRefetch?: true}
+export type RemoteFolderRestored = {sideName: 'remote', type: 'RemoteFolderRestored', doc: Metadata, was: Metadata}
+export type RemoteFolderTrashed = {sideName: 'remote', type: 'RemoteFolderTrashed', doc: Metadata, was: Metadata}
 
 export type RemoteIgnoredChange = {type: 'RemoteIgnoredChange', doc: Metadata|RemoteDoc|RemoteDeletion, detail: string}
 export type RemoteInvalidChange = {type: 'RemoteInvalidChange', doc: *, error: Error}
@@ -48,27 +47,29 @@ export type RemoteNoise =
   | RemoteInvalidChange
   | RemoteUpToDate
 
+const sideName = 'remote'
+
 // FIXME: return types
 export const added = (doc: Metadata): * =>
-  ({type: (isFile(doc) ? 'RemoteFileAdded' : 'RemoteFolderAdded'), doc})
+  ({sideName, type: (isFile(doc) ? 'RemoteFileAdded' : 'RemoteFolderAdded'), doc})
 
 export const trashed = (doc: Metadata, was: Metadata): * =>
-  ({type: (isFile(doc) ? 'RemoteFileTrashed' : 'RemoteFolderTrashed'), doc, was})
+  ({sideName, type: (isFile(doc) ? 'RemoteFileTrashed' : 'RemoteFolderTrashed'), doc, was})
 
 export const deleted = (doc: Metadata): * =>
-  ({type: (isFile(doc) ? 'RemoteFileDeleted' : 'RemoteFolderDeleted'), doc})
+  ({sideName, type: (isFile(doc) ? 'RemoteFileDeleted' : 'RemoteFolderDeleted'), doc})
 
 export const restored = (doc: Metadata, was: Metadata): * =>
-  ({type: (isFile(doc) ? 'RemoteFileRestored' : 'RemoteFolderRestored'), doc, was})
+  ({sideName, type: (isFile(doc) ? 'RemoteFileRestored' : 'RemoteFolderRestored'), doc, was})
 
 export const upToDate = (doc: Metadata, was: Metadata): * =>
-  ({type: 'RemoteUpToDate', doc, was})
+  ({sideName, type: 'RemoteUpToDate', doc, was})
 
 export const updated = (doc: Metadata): * =>
-  ({type: (isFile(doc) ? 'RemoteFileUpdated' : 'RemoteFolderAdded'), doc})
+  ({sideName, type: (isFile(doc) ? 'RemoteFileUpdated' : 'RemoteFolderAdded'), doc})
 
 export const dissociated = (doc: Metadata, was: Metadata): * =>
-  ({type: (isFile(doc) ? 'RemoteFileDissociated' : 'RemoteFolderDissociated'), doc, was})
+  ({sideName, type: (isFile(doc) ? 'RemoteFileDissociated' : 'RemoteFolderDissociated'), doc, was})
 
 // TODO: Rename args
 export const isChildMove = (a: RemoteChange|RemoteNoise, b: RemoteChange|RemoteNoise): boolean %checks => {

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -26,8 +26,6 @@ export type RemoteFolderTrashed = {type: 'RemoteFolderTrashed', doc: Metadata, w
 
 export type RemoteIgnoredChange = {type: 'RemoteIgnoredChange', doc: Metadata|RemoteDoc|RemoteDeletion, detail: string}
 export type RemoteInvalidChange = {type: 'RemoteInvalidChange', doc: *, error: Error}
-// FIXME: use PlatformIncompatibility type
-export type RemotePlatformIncompatibleChange = {type: 'RemotePlatformIncompatibleChange', doc: Metadata, incompatibilities: *}
 export type RemoteUpToDate = {type: 'RemoteUpToDate', doc: Metadata, was: Metadata}
 
 export type RemoteChange =
@@ -46,7 +44,6 @@ export type RemoteChange =
   | RemoteFolderTrashed
   | RemoteIgnoredChange
   | RemoteInvalidChange
-  | RemotePlatformIncompatibleChange
   | RemoteUpToDate
 
 // FIXME: return types

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -182,7 +182,11 @@ export default class RemoteWatcher {
         doc,
         this.prep.config.syncPath
       )
-      if (incompatibilities.length > 0) doc.incompatibilities = incompatibilities
+      if (incompatibilities.length > 0) {
+        log.warn({path, incompatibilities})
+        this.events.emit('platform-incompatibilities', incompatibilities)
+        doc.incompatibilities = incompatibilities
+      }
     } else {
       if (!was) {
         return {

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -221,7 +221,7 @@ export default class RemoteWatcher {
       }
     }
     if ((doc.docType === 'file') && (was.md5sum === doc.md5sum)) {
-      const change: RemoteFileMoved = {type: 'RemoteFileMoved', doc, was}
+      const change: RemoteFileMoved = {sideName, type: 'RemoteFileMoved', doc, was}
       // Squash moves
       for (let previousChangeIndex = 0; previousChangeIndex < changeIndex; previousChangeIndex++) {
         const previousChange: RemoteChange|RemoteNoise = previousChanges[previousChangeIndex]
@@ -245,7 +245,7 @@ export default class RemoteWatcher {
       return change
     }
     if (doc.docType === 'folder') {
-      const change = {type: 'RemoteFolderMoved', doc, was}
+      const change = {sideName, type: 'RemoteFolderMoved', doc, was}
       // Squash moves
       for (let previousChangeIndex = 0; previousChangeIndex < changeIndex; previousChangeIndex++) {
         const previousChange: RemoteChange|RemoteNoise = previousChanges[previousChangeIndex]

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -23,7 +23,7 @@ const log = logger({
 export const DEFAULT_HEARTBEAT: number = 1000 * 60 // 1 minute
 export const HEARTBEAT: number = parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || DEFAULT_HEARTBEAT
 
-const SIDE = 'remote'
+const sideName = 'remote'
 
 // Get changes from the remote Cozy and prepare them for merge
 export default class RemoteWatcher {
@@ -310,39 +310,39 @@ export default class RemoteWatcher {
         break
       case 'RemoteFileTrashed':
         log.info({path}, 'file was trashed remotely')
-        await this.prep.trashFileAsync(SIDE, change.was, change.doc)
+        await this.prep.trashFileAsync(sideName, change.was, change.doc)
         break
       case 'RemoteFolderTrashed':
         log.info({path}, 'folder was trashed remotely')
-        await this.prep.trashFolderAsync(SIDE, change.was, change.doc)
+        await this.prep.trashFolderAsync(sideName, change.was, change.doc)
         break
       case 'RemoteFileDeleted':
         log.info({path}, 'file was deleted permanently')
-        await this.prep.deleteFileAsync(SIDE, change.doc)
+        await this.prep.deleteFileAsync(sideName, change.doc)
         break
       case 'RemoteFolderDeleted':
         log.info({path}, 'folder was deleted permanently')
-        await this.prep.deleteFolderAsync(SIDE, change.doc)
+        await this.prep.deleteFolderAsync(sideName, change.doc)
         break
       case 'RemoteFileAdded':
         log.info({path}, 'file was added remotely')
-        await this.prep.addFileAsync(SIDE, change.doc)
+        await this.prep.addFileAsync(sideName, change.doc)
         break
       case 'RemoteFolderAdded':
         log.info({path}, 'folder was added remotely')
-        await this.prep.putFolderAsync(SIDE, change.doc)
+        await this.prep.putFolderAsync(sideName, change.doc)
         break
       case 'RemoteFileRestored':
         log.info({path}, 'file was restored remotely')
-        await this.prep.restoreFileAsync(SIDE, change.doc, change.was)
+        await this.prep.restoreFileAsync(sideName, change.doc, change.was)
         break
       case 'RemoteFolderRestored':
         log.info({path}, 'folder was restored remotely')
-        await this.prep.restoreFolderAsync(SIDE, change.doc, change.was)
+        await this.prep.restoreFolderAsync(sideName, change.doc, change.was)
         break
       case 'RemoteFileUpdated':
         log.info({path}, 'file was updated remotely')
-        await this.prep.updateFileAsync(SIDE, change.doc)
+        await this.prep.updateFileAsync(sideName, change.doc)
         break
       case 'RemoteFileMoved':
         log.info({path, oldpath: change.was.path}, 'file was moved or renamed remotely')
@@ -350,21 +350,21 @@ export default class RemoteWatcher {
           change.was = await this.pouch.byRemoteIdMaybeAsync(change.was.remote._id)
           change.was.childMove = false
         }
-        await this.prep.moveFileAsync(SIDE, change.doc, change.was)
+        await this.prep.moveFileAsync(sideName, change.doc, change.was)
         break
       case 'RemoteFolderMoved':
         log.info({path}, 'folder was moved or renamed remotely')
-        await this.prep.moveFolderAsync(SIDE, change.doc, change.was)
+        await this.prep.moveFolderAsync(sideName, change.doc, change.was)
         break
       case 'RemoteFileDissociated':
         log.info({path}, 'file was possibly renamed remotely while updated locally')
         await this.dissociateFromRemote(change.was)
-        await this.prep.addFileAsync(SIDE, change.doc)
+        await this.prep.addFileAsync(sideName, change.doc)
         break
       case 'RemoteFolderDissociated':
         log.info({path}, 'folder was possibly renamed remotely while updated locally')
         await this.dissociateFromRemote(change.was)
-        await this.prep.putFolderAsync(SIDE, change.doc)
+        await this.prep.putFolderAsync(sideName, change.doc)
         break
       case 'RemoteUpToDate':
         log.info({path}, `${docType} is up-to-date`)

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -301,11 +301,6 @@ export default class RemoteWatcher {
     switch (change.type) {
       case 'RemoteInvalidChange':
         throw change.error
-      case 'RemotePlatformIncompatibleChange':
-        const { incompatibilities } = change
-        log.warn({path, incompatibilities})
-        this.events.emit('platform-incompatibilities', incompatibilities)
-        break
       case 'RemoteIgnoredChange':
         log.debug({path, remoteId: change.doc._id}, change.detail)
         break

--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -11,6 +11,7 @@ import type { LocalChange } from '../../../core/local/change'
 import type { Metadata } from '../../../core/metadata'
 
 describe('core/local/analysis', function () {
+  const sideName = 'local'
   let metadataBuilders
 
   before(() => { metadataBuilders = new MetadataBuilders() })
@@ -33,6 +34,7 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
       type: 'LocalFileMove',
       path: 'dst2',
       ino: 1,
@@ -59,6 +61,7 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
       type: 'LocalFileMove',
       path: 'dst',
       md5sum: 'yolo',
@@ -79,6 +82,7 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
       type: 'LocalDirMove',
       path: 'dst',
       ino: 1,
@@ -99,6 +103,7 @@ describe('core/local/analysis', function () {
 
     should(analysis(events, pendingChanges)).deepEqual([])
     should(pendingChanges).deepEqual([{
+      sideName,
       type: 'LocalFileMove',
       path: 'dst1',
       ino: 1,
@@ -111,6 +116,7 @@ describe('core/local/analysis', function () {
       {type: 'unlink', path: 'dst1'}
     ]
     should(analysis(nextEvents, pendingChanges)).deepEqual([{
+      sideName,
       type: 'LocalFileDeletion',
       ino: 1,
       path: 'src',
@@ -127,6 +133,7 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
       type: 'LocalDirAddition',
       path: 'foo',
       ino: 1,
@@ -145,6 +152,7 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
       type: 'LocalDirMove',
       path: 'dst',
       ino: 1,
@@ -179,12 +187,12 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([
-      {type: 'LocalFileUpdate', path: 'other-file', stats: otherFileStats, ino: otherFileStats.ino, md5sum: 'yolo', /* FIXME: */ wip: undefined},
-      {type: 'LocalDirMove', path: 'dst', stats: dirStats, ino: dirStats.ino, old: dirMetadata},
+      {sideName, type: 'LocalFileUpdate', path: 'other-file', stats: otherFileStats, ino: otherFileStats.ino, md5sum: 'yolo', /* FIXME: */ wip: undefined},
+      {sideName, type: 'LocalDirMove', path: 'dst', stats: dirStats, ino: dirStats.ino, old: dirMetadata},
       // FIXME: Move should have been squashed
-      {type: 'LocalFileMove', path: 'dst/file', stats: fileStats, ino: fileStats.ino, old: fileMetadata},
-      {type: 'LocalDirMove', path: 'dst/subdir', stats: subdirStats, ino: subdirStats.ino, old: subdirMetadata},
-      {type: 'LocalDirMove', path: 'other-dir-dst', stats: otherDirStats, ino: otherDirStats.ino, old: otherDirMetadata}
+      {sideName, type: 'LocalFileMove', path: 'dst/file', stats: fileStats, ino: fileStats.ino, old: fileMetadata},
+      {sideName, type: 'LocalDirMove', path: 'dst/subdir', stats: subdirStats, ino: subdirStats.ino, old: subdirMetadata},
+      {sideName, type: 'LocalDirMove', path: 'other-dir-dst', stats: otherDirStats, ino: otherDirStats.ino, old: otherDirMetadata}
     ])
   })
 })

--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -35,7 +35,7 @@ describe('core/local/analysis', function () {
 
     should(analysis(events, pendingChanges)).deepEqual([{
       sideName,
-      type: 'LocalFileMove',
+      type: 'FileMove',
       path: 'dst2',
       ino: 1,
       md5sum: 'yolo',
@@ -62,7 +62,7 @@ describe('core/local/analysis', function () {
 
     should(analysis(events, pendingChanges)).deepEqual([{
       sideName,
-      type: 'LocalFileMove',
+      type: 'FileMove',
       path: 'dst',
       md5sum: 'yolo',
       ino: 1,
@@ -83,7 +83,7 @@ describe('core/local/analysis', function () {
 
     should(analysis(events, pendingChanges)).deepEqual([{
       sideName,
-      type: 'LocalDirMove',
+      type: 'DirMove',
       path: 'dst',
       ino: 1,
       stats,
@@ -104,7 +104,7 @@ describe('core/local/analysis', function () {
     should(analysis(events, pendingChanges)).deepEqual([])
     should(pendingChanges).deepEqual([{
       sideName,
-      type: 'LocalFileMove',
+      type: 'FileMove',
       path: 'dst1',
       ino: 1,
       stats,
@@ -117,7 +117,7 @@ describe('core/local/analysis', function () {
     ]
     should(analysis(nextEvents, pendingChanges)).deepEqual([{
       sideName,
-      type: 'LocalFileDeletion',
+      type: 'FileDeletion',
       ino: 1,
       path: 'src',
       old
@@ -134,7 +134,7 @@ describe('core/local/analysis', function () {
 
     should(analysis(events, pendingChanges)).deepEqual([{
       sideName,
-      type: 'LocalDirAddition',
+      type: 'DirAddition',
       path: 'foo',
       ino: 1,
       stats
@@ -153,7 +153,7 @@ describe('core/local/analysis', function () {
 
     should(analysis(events, pendingChanges)).deepEqual([{
       sideName,
-      type: 'LocalDirMove',
+      type: 'DirMove',
       path: 'dst',
       ino: 1,
       stats,
@@ -187,12 +187,12 @@ describe('core/local/analysis', function () {
     const pendingChanges: LocalChange[] = []
 
     should(analysis(events, pendingChanges)).deepEqual([
-      {sideName, type: 'LocalFileUpdate', path: 'other-file', stats: otherFileStats, ino: otherFileStats.ino, md5sum: 'yolo', /* FIXME: */ wip: undefined},
-      {sideName, type: 'LocalDirMove', path: 'dst', stats: dirStats, ino: dirStats.ino, old: dirMetadata},
+      {sideName, type: 'FileUpdate', path: 'other-file', stats: otherFileStats, ino: otherFileStats.ino, md5sum: 'yolo', /* FIXME: */ wip: undefined},
+      {sideName, type: 'DirMove', path: 'dst', stats: dirStats, ino: dirStats.ino, old: dirMetadata},
       // FIXME: Move should have been squashed
-      {sideName, type: 'LocalFileMove', path: 'dst/file', stats: fileStats, ino: fileStats.ino, old: fileMetadata},
-      {sideName, type: 'LocalDirMove', path: 'dst/subdir', stats: subdirStats, ino: subdirStats.ino, old: subdirMetadata},
-      {sideName, type: 'LocalDirMove', path: 'other-dir-dst', stats: otherDirStats, ino: otherDirStats.ino, old: otherDirMetadata}
+      {sideName, type: 'FileMove', path: 'dst/file', stats: fileStats, ino: fileStats.ino, old: fileMetadata},
+      {sideName, type: 'DirMove', path: 'dst/subdir', stats: subdirStats, ino: subdirStats.ino, old: subdirMetadata},
+      {sideName, type: 'DirMove', path: 'other-dir-dst', stats: otherDirStats, ino: otherDirStats.ino, old: otherDirMetadata}
     ])
   })
 })

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -181,7 +181,7 @@ describe('RemoteWatcher', function () {
     context('when apply() rejects some file/dir', function () {
       beforeEach(function () {
         apply.callsFake(async (change: RemoteChange): Promise<void> => {
-          if (change.type === 'RemoteFileAdded') throw new Error('oops')
+          if (change.type === 'FileAddition') throw new Error('oops')
         })
       })
 
@@ -195,7 +195,7 @@ describe('RemoteWatcher', function () {
         should(apply).have.been.calledTwice()
         // Changes are sorted before applying (FileAdded was the first one)
         should(apply.args[0][0]).have.properties({type: 'RemoteIgnoredChange', doc: docs[1]})
-        should(apply.args[1][0]).have.properties({type: 'RemoteFileAdded', doc: validMetadata(docs[0])})
+        should(apply.args[1][0]).have.properties({type: 'FileAddition', doc: validMetadata(docs[0])})
       })
 
       it('releases the Pouch lock', async function () {
@@ -297,7 +297,7 @@ describe('RemoteWatcher', function () {
         }
         const change: RemoteChange = this.watcher.identifyChange(doc, null, 0, [])
         const platform = process.platform
-        should(change.type).equal('RemoteFileAdded')
+        should(change.type).equal('FileAddition')
         should(change.doc).have.property('incompatibilities', [
           {
             type: 'reservedChars',
@@ -339,7 +339,7 @@ describe('RemoteWatcher', function () {
         }
         const change: RemoteChange = this.watcher.identifyChange(doc, null, 0, [])
         const platform = process.platform
-        should(change.type).equal('RemoteFileAdded')
+        should(change.type).equal('FileAddition')
         should((change: any).doc.incompatibilities).deepEqual([
           {
             type: 'reservedChars',
@@ -377,7 +377,7 @@ describe('RemoteWatcher', function () {
 
       const change: RemoteChange = this.watcher.identifyChange(clone(doc), null, 0, [])
 
-      should(change.type).equal('RemoteFileAdded')
+      should(change.type).equal('FileAddition')
       should(change.doc).have.properties({
         path: 'my-folder',
         docType: 'file',
@@ -416,7 +416,7 @@ describe('RemoteWatcher', function () {
 
       const change: RemoteChange = this.watcher.identifyChange(clone(doc), was, 0, [])
 
-      should(change.type).equal('RemoteFileUpdated')
+      should(change.type).equal('FileUpdate')
       should(change.doc).have.properties({
         path: path.normalize('my-folder/file-1'),
         docType: 'file',
@@ -448,7 +448,7 @@ describe('RemoteWatcher', function () {
 
       const change: RemoteChange = this.watcher.identifyChange(clone(doc), was, 0, [])
 
-      should(change.type).equal('RemoteFileUpdated')
+      should(change.type).equal('FileUpdate')
       should(change.doc).have.properties({
         path: path.normalize('my-folder/file-1'),
         docType: 'file',
@@ -481,7 +481,7 @@ describe('RemoteWatcher', function () {
       const was = await this.pouch.byRemoteIdMaybeAsync(doc._id)
       const change: RemoteChange = this.watcher.identifyChange(clone(doc), was, 0, [])
 
-      should(change.type).equal('RemoteFileMoved')
+      should(change.type).equal('FileMove')
       // $FlowFixMe
       const src = change.was
       should(src).have.properties({
@@ -533,7 +533,7 @@ describe('RemoteWatcher', function () {
 
       const change: RemoteChange = this.watcher.identifyChange(clone(doc), was, 0, [])
 
-      should(change.type).equal('RemoteFileMoved')
+      should(change.type).equal('FileMove')
       // $FlowFixMe
       const src = change.was
       should(src).have.properties({


### PR DESCRIPTION
- Give them a `sideName` property
- Standardize their names
- Shorten their `type` value (no need to prefix with the new `sideName`)

Also fixed incompatibilities that were not emitted anymore.