### PR TITLE
all: Replace es6 modules with node ones

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -1,33 +1,34 @@
 /* @flow */
 
-import EventEmitter from 'events'
-import fs from 'fs-extra'
-import _ from 'lodash'
-import os from 'os'
-import path from 'path'
-import readdirp from 'readdirp'
-import url from 'url'
-import uuid from 'uuid/v4'
-import https from 'https'
-import stream from 'stream'
-import {createGzip} from 'zlib'
-
-import './globals' // FIXME Use bluebird promises as long as we need asCallback
-import pkg from '../package.json'
-import Config from './config'
-import logger, { LOG_FILE, LOG_FILENAME } from './logger'
-import Pouch from './pouch'
-import Ignore from './ignore'
-import Merge from './merge'
-import Prep from './prep'
-import Local from './local'
-import Remote from './remote'
-import Sync from './sync'
-import SyncState from './syncstate'
-import Registration from './remote/registration'
-
 import type { Callback } from './utils/func'
 import type { SyncMode } from './sync'
+
+const EventEmitter = require('events')
+const fs = require('fs-extra')
+const _ = require('lodash')
+const os = require('os')
+const path = require('path')
+const readdirp = require('readdirp')
+const url = require('url')
+const uuid = require('uuid/v4')
+const https = require('https')
+const stream = require('stream')
+const {createGzip} = require('zlib')
+
+require('./globals') // FIXME Use bluebird promises as long as we need asCallback
+const pkg = require('../package.json')
+const Config = require('./config')
+const logger = require('./logger')
+const { LOG_FILE, LOG_FILENAME } = logger
+const Pouch = require('./pouch')
+const Ignore = require('./ignore')
+const Merge = require('./merge')
+const Prep = require('./prep')
+const Local = require('./local')
+const Remote = require('./remote')
+const Sync = require('./sync')
+const SyncState = require('./syncstate')
+const Registration = require('./remote/registration')
 
 const log = logger({
   component: 'App'
@@ -37,7 +38,7 @@ const SUPPORT_EMAIL = process.env.COZY_DESKTOP_SUPPORT_EMAIL || 'contact@cozyclo
 
 // App is the entry point for the CLI and GUI.
 // They both can do actions and be notified by events via an App instance.
-class App {
+module.exports = class App {
   lang: string
   basePath: string
   config: Config
@@ -50,7 +51,7 @@ class App {
   remote: Remote
   sync: Sync
 
-  static logger: Function
+  static logger = logger
 
   // basePath is the directory where the config and pouch are saved
   constructor (basePath: string) {
@@ -363,7 +364,3 @@ class App {
     return this.remote.diskUsage()
   }
 }
-
-App.logger = logger
-
-export default App

--- a/core/config.js
+++ b/core/config.js
@@ -1,12 +1,12 @@
-import fs from 'fs-extra'
-import _ from 'lodash'
-import path from 'path'
+const fs = require('fs-extra')
+const _ = require('lodash')
+const path = require('path')
 
-import { hideOnWindows } from './utils/fs'
+const { hideOnWindows } = require('./utils/fs')
 
 // Config can keep some configuration parameters in a JSON file,
 // like the devices credentials or the mount path
-export default class Config {
+module.exports = class Config {
   // Create config file if it doesn't exist.
   constructor (basePath) {
     this.configPath = path.join(basePath, 'config.json')

--- a/core/conversion.js
+++ b/core/conversion.js
@@ -1,13 +1,19 @@
 /* @flow */
 
-import path from 'path'
-
-import { DIR_TYPE, FILE_TYPE } from './remote/constants'
-
 import type { RemoteDoc } from './remote/document'
 import type { Metadata } from './metadata'
 
-export function localDocType (remote: string): string {
+const path = require('path')
+
+const { DIR_TYPE, FILE_TYPE } = require('./remote/constants')
+
+module.exports = {
+  localDocType,
+  createMetadata,
+  extractDirAndName
+}
+
+function localDocType (remote: string): string {
   switch (remote) {
     case FILE_TYPE: return 'file'
     case DIR_TYPE: return 'folder'
@@ -18,7 +24,7 @@ export function localDocType (remote: string): string {
 // Transform a remote document into metadata, as stored in Pouch.
 // Please note the path is not normalized yet!
 // Normalization is done as a side effect of metadata.invalidPath() :/
-export function createMetadata (remote: RemoteDoc): Metadata {
+function createMetadata (remote: RemoteDoc): Metadata {
   const doc: Object = {
     path: remote.path.substring(1),
     docType: localDocType(remote.type),
@@ -41,7 +47,7 @@ export function createMetadata (remote: RemoteDoc): Metadata {
 }
 
 // Extract the remote path and name from a local id
-export function extractDirAndName (id: string): [string, string] {
+function extractDirAndName (id: string): [string, string] {
   const dir = '/' + id.split(path.sep).slice(0, -1).join('/')
   const name = path.basename(id)
   return [dir, name]

--- a/core/file_stream_provider.js
+++ b/core/file_stream_provider.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import * as stream from 'stream'
-
 import type { Metadata } from './metadata'
 
-export class ReadableWithContentLength extends stream.Readable {contentLength: ?number}
+const stream = require('stream')
 
-export function withContentLength (s: stream.Readable, contentLength: ?number): ReadableWithContentLength {
+class ReadableWithContentLength extends stream.Readable {contentLength: ?number}
+
+function withContentLength (s: stream.Readable, contentLength: ?number): ReadableWithContentLength {
   const s2: ReadableWithContentLength = (s: any)
   s2.contentLength = contentLength
   return s2
@@ -16,4 +16,9 @@ export function withContentLength (s: stream.Readable, contentLength: ?number): 
 // given metadata.
 export type FileStreamProvider = {
   createReadStreamAsync: (Metadata) => Promise<ReadableWithContentLength>;
+}
+
+module.exports = {
+  ReadableWithContentLength,
+  withContentLength
 }

--- a/core/globals.js
+++ b/core/globals.js
@@ -1,4 +1,4 @@
-import Promise from 'bluebird'
+const Promise = require('bluebird')
 
 global.Promise = Promise
 Promise.longStackTraces()

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 
-import { basename, dirname } from 'path'
-import { matcher, makeRe } from 'micromatch'
+const { basename, dirname } = require('path')
+const { matcher, makeRe } = require('micromatch')
 
 export type IgnorePattern = {
   match: (string) => boolean,
@@ -152,4 +152,4 @@ class Ignore {
 }
 Ignore.initClass()
 
-export default Ignore
+module.exports = Ignore

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -1,12 +1,5 @@
 /* @flow */
 
-import path from 'path'
-
-import { getInode } from './event'
-import * as localChange from './change'
-import logger from '../logger'
-import measureTime from '../perftools'
-
 import type { LocalEvent } from './event'
 import type {
   LocalChange,
@@ -18,6 +11,13 @@ import type {
   LocalFileMove
 } from './change'
 
+const path = require('path')
+
+const { getInode } = require('./event')
+const localChange = require('./change')
+const logger = require('../logger')
+const measureTime = require('../perftools')
+
 const log = logger({
   component: 'LocalWatcher'
 })
@@ -25,7 +25,7 @@ log.chokidar = log.child({
   component: 'Chokidar'
 })
 
-export default function analysis (events: LocalEvent[], pendingChanges: LocalChange[]): LocalChange[] {
+module.exports = function analysis (events: LocalEvent[], pendingChanges: LocalChange[]): LocalChange[] {
   const changes: LocalChange[] = analyseEvents(events, pendingChanges)
   sortBeforeSquash(changes)
   squashMoves(changes)

--- a/core/local/checksumer.js
+++ b/core/local/checksumer.js
@@ -1,12 +1,16 @@
 /* @flow */
 
-import Promise from 'bluebird'
-import async from 'async'
-import crypto from 'crypto'
-import fs from 'fs'
-import measureTime from '../perftools'
-
 import type { Callback } from '../utils/func'
+
+const Promise = require('bluebird')
+const async = require('async')
+const crypto = require('crypto')
+const fs = require('fs')
+const measureTime = require('../perftools')
+
+module.exports = {
+  init
+}
 
 // Get checksum for given file
 const computeChecksum = (filePath: string, callback: Callback) => {
@@ -41,7 +45,7 @@ export type Checksumer = {
   kill: () => void
 }
 
-export const init = (): Checksumer => {
+function init (): Checksumer {
   // Use a queue for checksums to avoid computing many checksums at the
   // same time. It's better for performance (hard disk are faster with
   // linear readings).

--- a/core/local/chokidar_event.js
+++ b/core/local/chokidar_event.js
@@ -15,7 +15,11 @@ export type ChokidarEvent =
   | ChokidarUnlink
   | ChokidarUnlinkDir
 
-export const build = (type: string, path?: string, stats?: fs.Stats): ChokidarEvent => {
+module.exports = {
+  build
+}
+
+function build (type: string, path?: string, stats?: fs.Stats): ChokidarEvent {
   const event: Object = {type}
   if (path != null) event.path = path
   if (stats != null) event.stats = stats

--- a/core/local/constants.js
+++ b/core/local/constants.js
@@ -1,1 +1,3 @@
-export const TMP_DIR_NAME = '.system-tmp-cozy-drive'
+module.exports = {
+  TMP_DIR_NAME: '.system-tmp-cozy-drive'
+}

--- a/core/local/event.js
+++ b/core/local/event.js
@@ -22,7 +22,11 @@ export type LocalEvent =
   | LocalFileUnlinked
   | LocalFileUpdated
 
-export const getInode = (e: LocalEvent): ?number => {
+module.exports = {
+  getInode
+}
+
+function getInode (e: LocalEvent): ?number {
   switch (e.type) {
     case 'add':
     case 'addDir':

--- a/core/local/event_buffer.js
+++ b/core/local/event_buffer.js
@@ -16,7 +16,7 @@ type FlushCallback<EventType> = (EventType[]) => any
 //
 // Right now this class is in the local/ namespace because this is where it is
 // used, but it could be anywhere else since it doesn't have any dependency.
-export default class EventBuffer<EventType> {
+module.exports = class EventBuffer<EventType> {
   events: EventType[]
   mode: EventBufferMode
   timeoutInMs: number

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -1,28 +1,28 @@
 /* @flow */
 
-import async from 'async'
-import EventEmitter from 'events'
-import fs from 'fs-extra'
-import path from 'path'
-import trash from 'trash'
-
-import bluebird from 'bluebird'
-
-import Config from '../config'
-import { TMP_DIR_NAME } from './constants'
-import logger from '../logger'
-import { isUpToDate } from '../metadata'
-import Pouch from '../pouch'
-import Prep from '../prep'
-import { hideOnWindows } from '../utils/fs'
-import Watcher from './watcher'
-import measureTime from '../perftools'
-import { withContentLength } from '../file_stream_provider'
-
-import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider'
+import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider' // eslint-disable-line
 import type { Metadata } from '../metadata'
 import type { Side } from '../side' // eslint-disable-line
 import type { Callback } from '../utils/func'
+
+const async = require('async')
+const EventEmitter = require('events')
+const fs = require('fs-extra')
+const path = require('path')
+const trash = require('trash')
+
+const bluebird = require('bluebird')
+
+const Config = require('../config')
+const { TMP_DIR_NAME } = require('./constants')
+const logger = require('../logger')
+const { isUpToDate } = require('../metadata')
+const Pouch = require('../pouch')
+const Prep = require('../prep')
+const { hideOnWindows } = require('../utils/fs')
+const Watcher = require('./watcher')
+const measureTime = require('../perftools')
+const { withContentLength } = require('../file_stream_provider')
 
 bluebird.promisifyAll(fs)
 
@@ -32,7 +32,7 @@ const log = logger({
 // Local is the class that interfaces cozy-desktop with the local filesystem.
 // It uses a watcher, based on chokidar, to listen for file and folder changes.
 // It also applied changes from the remote cozy on the local filesystem.
-class Local implements Side {
+module.exports = class Local implements Side {
   prep: Prep
   pouch: Pouch
   events: EventEmitter
@@ -393,5 +393,3 @@ class Local implements Side {
 
   renameConflictingDocAsync: (doc: Metadata, newPath: string) => Promise<void>
 }
-
-export default Local

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -1,19 +1,5 @@
 /* @flow */
 
-import Promise from 'bluebird'
-import chokidar from 'chokidar'
-import fs from 'fs-extra'
-import path from 'path'
-
-import analysis from './analysis'
-import * as checksumer from './checksumer'
-import * as chokidarEvent from './chokidar_event'
-import LocalEventBuffer from './event_buffer'
-import logger from '../logger'
-import * as metadata from '../metadata'
-import Pouch from '../pouch'
-import Prep from '../prep'
-
 import type { Checksumer } from './checksumer'
 import type { ChokidarEvent } from './chokidar_event'
 import type { LocalEvent } from './event'
@@ -21,6 +7,20 @@ import type { LocalChange } from './change'
 import type { Metadata } from '../metadata'
 import type { Pending } from '../utils/pending' // eslint-disable-line
 import type EventEmitter from 'events'
+
+const Promise = require('bluebird')
+const chokidar = require('chokidar')
+const fs = require('fs-extra')
+const path = require('path')
+
+const analysis = require('./analysis')
+const checksumer = require('./checksumer')
+const chokidarEvent = require('./chokidar_event')
+const LocalEventBuffer = require('./event_buffer')
+const logger = require('../logger')
+const metadata = require('../metadata')
+const Pouch = require('../pouch')
+const Prep = require('../prep')
 
 const log = logger({
   component: 'LocalWatcher'
@@ -40,7 +40,7 @@ type InitialScan = {
 // a file or a folder is added/removed/changed locally.
 // Operations will be added to the a common operation queue along with the
 // remote operations triggered by the remoteEventWatcher.
-class LocalWatcher {
+module.exports = class LocalWatcher {
   syncPath: string
   prep: Prep
   pouch: Pouch
@@ -398,5 +398,3 @@ class LocalWatcher {
     return this.prep.updateFileAsync(SIDE, doc)
   }
 }
-
-export default LocalWatcher

--- a/core/logger.js
+++ b/core/logger.js
@@ -1,18 +1,18 @@
 /* @flow weak */
 
-import bunyan from 'bunyan'
-import fs from 'fs-extra'
-import os from 'os'
-import path from 'path'
-import _ from 'lodash'
+const bunyan = require('bunyan')
+const fs = require('fs-extra')
+const os = require('os')
+const path = require('path')
+const _ = require('lodash')
 
-export const LOG_DIR = path.join(process.env.COZY_DESKTOP_DIR || os.homedir(), '.cozy-desktop')
-export const LOG_FILENAME = 'logs.txt'
-export const LOG_FILE = path.join(LOG_DIR, LOG_FILENAME)
+const LOG_DIR = path.join(process.env.COZY_DESKTOP_DIR || os.homedir(), '.cozy-desktop')
+const LOG_FILENAME = 'logs.txt'
+const LOG_FILE = path.join(LOG_DIR, LOG_FILENAME)
 
 fs.ensureDirSync(LOG_DIR)
 
-export const defaultLogger = bunyan.createLogger({
+const defaultLogger = bunyan.createLogger({
   name: 'Cozy Desktop',
   level: 'trace',
   serializers: {
@@ -49,4 +49,8 @@ function logger (options) {
   return defaultLogger.child(options)
 }
 
-export default logger
+logger.defaultLogger = defaultLogger
+logger.LOG_DIR = LOG_DIR
+logger.LOG_FILENAME = LOG_FILENAME
+logger.LOG_FILE = LOG_FILE
+module.exports = logger

--- a/core/merge.js
+++ b/core/merge.js
@@ -1,17 +1,17 @@
 /* @flow */
 
-import { clone } from 'lodash'
-import { basename, dirname, extname, join } from 'path'
-
-import Local from './local'
-import logger from './logger'
-import { isUpToDate, markSide, sameBinary, sameFile, sameFolder, detectPlatformIncompatibilities } from './metadata'
-import Pouch from './pouch'
-import Remote from './remote'
-import { otherSide } from './side'
-import * as fsutils from './utils/fs'
-
 import type { SideName, Metadata } from './metadata'
+
+const { clone } = require('lodash')
+const { basename, dirname, extname, join } = require('path')
+
+const Local = require('./local')
+const logger = require('./logger')
+const { isUpToDate, markSide, sameBinary, sameFile, sameFolder, detectPlatformIncompatibilities } = require('./metadata')
+const Pouch = require('./pouch')
+const Remote = require('./remote')
+const { otherSide } = require('./side')
+const fsutils = require('./utils/fs')
 
 const log = logger({
   component: 'Merge'
@@ -533,4 +533,4 @@ class Merge {
   }
 }
 
-export default Merge
+module.exports = Merge

--- a/core/path_restrictions.js
+++ b/core/path_restrictions.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import path, { sep } from 'path'
+const path = require('path')
+const { sep } = path
 
 type SingleCharString = string
 
@@ -84,7 +85,14 @@ const linux = pathRestrictions({
   reservedChars: new Set('/')
 })
 
-export default { win, mac, linux }
+module.exports = {
+  win,
+  mac,
+  linux,
+  detectNameIssues,
+  detectPathIssues,
+  detectPathLengthIssue
+}
 
 function restrictionsByPlatform (platform: string) {
   switch (platform) {
@@ -128,7 +136,7 @@ function detectDirNameLengthIssue (name: string, restrictions: PathRestrictions)
 }
 
 // Identifies file/dir name issues that will prevent local synchronization
-export function detectNameIssues (name: string, type: string, platform: string): NameIssue[] {
+function detectNameIssues (name: string, type: string, platform: string): NameIssue[] {
   const restrictions = restrictionsByPlatform(platform)
   const issues = []
 
@@ -163,7 +171,7 @@ export function detectNameIssues (name: string, type: string, platform: string):
 }
 
 // Identifies issues in every path item that will prevent local synchronization
-export function detectPathIssues (path: string, type: string): Array<PathIssue> {
+function detectPathIssues (path: string, type: string): Array<PathIssue> {
   const platform = process.platform
   const ancestorNames = path.split(sep)
   const basename = ancestorNames.pop()
@@ -187,7 +195,7 @@ export function detectPathIssues (path: string, type: string): Array<PathIssue> 
   return recursivePathIssues.filter(issue => issue != null)
 }
 
-export function detectPathLengthIssue (path: string, platform: string): ?PathLengthIssue {
+function detectPathLengthIssue (path: string, platform: string): ?PathLengthIssue {
   const { pathMaxBytes } = restrictionsByPlatform(platform)
   const pathBytes = Buffer.byteLength(path) // TODO: utf16?
   if (pathBytes > pathMaxBytes) {

--- a/core/perftools.js
+++ b/core/perftools.js
@@ -1,9 +1,11 @@
 /* @flow */
 
-import logger from './logger'
+const logger = require('./logger')
 const log = logger({
   component: 'PerfReports'
 })
+
+module.exports = measureTime
 
 var store = {}
 
@@ -12,7 +14,7 @@ function ellapsedMillis (startHRTime: [number, number]) {
   return (sec * 1000) + (nano / 1000000)
 }
 
-export default function measureTime (key: string): () => void {
+function measureTime (key: string): () => void {
   if (!process.env.MEASURE_PERF) return () => {}
   store[key] = store[key] || {nb: 0, time: 0}
   const startTime = process.hrtime()

--- a/core/pouch.js
+++ b/core/pouch.js
@@ -1,17 +1,17 @@
 /* @flow weak */
 
-import Promise from 'bluebird'
-import PouchDB from 'pouchdb'
-import async from 'async'
-import fs from 'fs-extra'
-import { isEqual } from 'lodash'
-import path from 'path'
-
-import Config from './config'
-import logger from './logger'
-
 import type { Metadata } from './metadata'
 import type { Callback } from './utils/func'
+
+const Promise = require('bluebird')
+const PouchDB = require('pouchdb')
+const async = require('async')
+const fs = require('fs-extra')
+const { isEqual } = require('lodash')
+const path = require('path')
+
+const Config = require('./config')
+const logger = require('./logger')
 
 const log = logger({
   component: 'Pouch'
@@ -371,4 +371,4 @@ class Pouch {
   treeAsync: () => Promise<Array<string>>
 }
 
-export default Pouch
+module.exports = Pouch

--- a/core/prep.js
+++ b/core/prep.js
@@ -1,17 +1,17 @@
 /* @flow */
 
-import { clone } from 'lodash'
-import { join } from 'path'
-
-import Config from './config'
-import Ignore from './ignore'
-import logger from './logger'
-import Merge from './merge'
-import { assignId, ensureValidChecksum, ensureValidPath } from './metadata'
-import { TRASH_DIR_NAME } from './remote/constants'
-
 import type { SideName, Metadata } from './metadata'
 import type { PathObject } from './utils/path'
+
+const { clone } = require('lodash')
+const { join } = require('path')
+
+const Config = require('./config')
+const Ignore = require('./ignore')
+const logger = require('./logger')
+const Merge = require('./merge')
+const { assignId, ensureValidChecksum, ensureValidPath } = require('./metadata')
+const { TRASH_DIR_NAME } = require('./remote/constants')
 
 const log = logger({
   component: 'Prep'
@@ -257,4 +257,4 @@ class Prep {
   }
 }
 
-export default Prep
+module.exports = Prep

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import path from 'path'
-
-import { isFile } from '../metadata'
-
 import type { RemoteDoc, RemoteDeletion } from './document'
 import type { Metadata } from '../metadata'
+
+const path = require('path')
+
+const { isFile } = require('../metadata')
 
 export type RemoteFileAddition = {sideName: 'remote', type: 'FileAddition', doc: Metadata}
 export type RemoteFileDeletion = {sideName: 'remote', type: 'FileDeletion', doc: Metadata}
@@ -45,32 +45,53 @@ export type RemoteNoise =
   | RemoteInvalidChange
   | RemoteUpToDate
 
+module.exports = {
+  added,
+  trashed,
+  deleted,
+  restored,
+  upToDate,
+  updated,
+  dissociated,
+  isChildMove,
+  isOnlyChildMove,
+  applyMoveToPath,
+  sort
+}
+
 const sideName = 'remote'
 
 // FIXME: return types
-export const added = (doc: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'FileAddition' : 'DirAddition'), doc})
+function added (doc: Metadata): * {
+  return {sideName, type: (isFile(doc) ? 'FileAddition' : 'DirAddition'), doc}
+}
 
-export const trashed = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'FileTrashing' : 'DirTrashing'), doc, was})
+function trashed (doc: Metadata, was: Metadata): * {
+  return {sideName, type: (isFile(doc) ? 'FileTrashing' : 'DirTrashing'), doc, was}
+}
 
-export const deleted = (doc: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'FileDeletion' : 'DirDeletion'), doc})
+function deleted (doc: Metadata): * {
+  return {sideName, type: (isFile(doc) ? 'FileDeletion' : 'DirDeletion'), doc}
+}
 
-export const restored = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'FileRestoration' : 'DirRestoration'), doc, was})
+function restored (doc: Metadata, was: Metadata): * {
+  return {sideName, type: (isFile(doc) ? 'FileRestoration' : 'DirRestoration'), doc, was}
+}
 
-export const upToDate = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: 'RemoteUpToDate', doc, was})
+function upToDate (doc: Metadata, was: Metadata): * {
+  return {sideName, type: 'RemoteUpToDate', doc, was}
+}
 
-export const updated = (doc: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'FileUpdate' : 'DirAddition'), doc})
+function updated (doc: Metadata): * {
+  return {sideName, type: (isFile(doc) ? 'FileUpdate' : 'DirAddition'), doc}
+}
 
-export const dissociated = (doc: Metadata, was: Metadata): * =>
-  ({sideName, type: (isFile(doc) ? 'FileDissociation' : 'DirDissociation'), doc, was})
+function dissociated (doc: Metadata, was: Metadata): * {
+  return {sideName, type: (isFile(doc) ? 'FileDissociation' : 'DirDissociation'), doc, was}
+}
 
 // TODO: Rename args
-export const isChildMove = (a: RemoteChange|RemoteNoise, b: RemoteChange|RemoteNoise): boolean %checks => {
+function isChildMove (a: RemoteChange|RemoteNoise, b: RemoteChange|RemoteNoise): boolean %checks {
   return a.type === 'DirMove' &&
         (b.type === 'DirMove' || b.type === 'FileMove') &&
         (b.doc.path.indexOf(a.doc.path + path.sep) === 0) &&
@@ -84,11 +105,11 @@ export const isChildMove = (a: RemoteChange|RemoteNoise, b: RemoteChange|RemoteN
  a    /a     ->    /a2
  b    /a/b   ->    /a2/b
 */
-export const isOnlyChildMove = (a: RemoteDirMove, b: RemoteFileMove|RemoteDirMove): boolean %checks => {
+function isOnlyChildMove (a: RemoteDirMove, b: RemoteFileMove|RemoteDirMove): boolean %checks {
   return isChildMove(a, b) && b.doc.path.replace(a.doc.path, '') === b.was.path.replace(a.was.path, '')
 }
 
-export const applyMoveToPath = (a: RemoteDirMove, p: string): string => {
+function applyMoveToPath (a: RemoteDirMove, p: string): string {
   return p.replace(a.was.path, a.doc.path)
 }
 
@@ -127,6 +148,6 @@ const sorter = (a, b) => {
   return 1
 }
 
-export const sort = (changes: Array<RemoteChange|RemoteNoise>): void => {
+function sort (changes: Array<RemoteChange|RemoteNoise>): void {
   changes.sort(sorter)
 }

--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -1,14 +1,16 @@
 // https://github.com/cozy/cozy-stack/blob/master/pkg/consts/consts.go
 
-// Doctypes
-export const FILES_DOCTYPE = 'io.cozy.files'
+module.exports = {
+  // Doctypes
+  FILES_DOCTYPE: 'io.cozy.files',
 
-// Files document type
-export const DIR_TYPE = 'directory'
-export const FILE_TYPE = 'file'
+  // Files document type
+  DIR_TYPE: 'directory',
+  FILE_TYPE: 'file',
 
-// Special document ids
-export const ROOT_DIR_ID = 'io.cozy.files.root-dir'
-export const TRASH_DIR_ID = 'io.cozy.files.trash-dir'
+  // Special document ids
+  ROOT_DIR_ID: 'io.cozy.files.root-dir',
+  TRASH_DIR_ID: 'io.cozy.files.trash-dir',
 
-export const TRASH_DIR_NAME = '.cozy_trash'
+  TRASH_DIR_NAME: '.cozy_trash'
+}

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -1,16 +1,16 @@
 /* @flow */
 
-import { Client as CozyClient } from 'cozy-client-js'
-import path from 'path'
-import { Readable } from 'stream'
-
-import Config from '../config'
-import { FILES_DOCTYPE, FILE_TYPE } from './constants'
-import { dropSpecialDocs, jsonApiToRemoteDoc, keepFiles, parentDirIds } from './document'
-import logger from '../logger'
-import { composeAsync } from '../utils/func'
-
 import type { RemoteDoc, RemoteDeletion } from './document'
+
+const CozyClient = require('cozy-client-js').Client
+const path = require('path')
+const { Readable } = require('stream')
+
+const Config = require('../config')
+const { FILES_DOCTYPE, FILE_TYPE } = require('./constants')
+const { dropSpecialDocs, jsonApiToRemoteDoc, keepFiles, parentDirIds } = require('./document')
+const logger = require('../logger')
+const { composeAsync } = require('../utils/func')
 
 const { posix } = path
 
@@ -18,7 +18,7 @@ const log = logger({
   component: 'RemoteCozy'
 })
 
-export function DirectoryNotFound (path: string, cozyURL: string) {
+function DirectoryNotFound (path: string, cozyURL: string) {
   this.name = 'DirectoryNotFound'
   this.message = `Directory ${path} was not found on Cozy ${cozyURL}`
   this.stack = (new Error()).stack
@@ -31,9 +31,11 @@ export function DirectoryNotFound (path: string, cozyURL: string) {
 // - deal with parsing and errors
 // - provide custom functions (that may eventually be merged into the lib)
 //
-export default class RemoteCozy {
+class RemoteCozy {
   url: string
   client: CozyClient
+
+  static DirectoryNotFound = DirectoryNotFound
 
   constructor (config: Config) {
     this.url = config.cozyUrl
@@ -185,3 +187,5 @@ export default class RemoteCozy {
     doc.path = path.posix.join(parentDir.path, doc.name)
   }
 }
+
+module.exports = RemoteCozy

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -1,12 +1,21 @@
 /* @flow */
 
-import { uniq } from 'lodash'
+const { uniq } = require('lodash')
 
-import {
+const {
   DIR_TYPE, FILE_TYPE, ROOT_DIR_ID, TRASH_DIR_ID, TRASH_DIR_NAME
-} from './constants'
+} = require('./constants')
 
-export function specialId (id: string) {
+module.exports = {
+  specialId,
+  dropSpecialDocs,
+  keepFiles,
+  parentDirIds,
+  inRemoteTrash,
+  jsonApiToRemoteDoc
+}
+
+function specialId (id: string) {
   return (
     id === ROOT_DIR_ID ||
     id === TRASH_DIR_ID ||
@@ -41,19 +50,19 @@ export type RemoteDeletion = {
   _deleted: true
 }
 
-export function dropSpecialDocs (docs: RemoteDoc[]) {
+function dropSpecialDocs (docs: RemoteDoc[]) {
   return docs.filter(doc => !specialId(doc._id))
 }
 
-export function keepFiles (docs: RemoteDoc[]) {
+function keepFiles (docs: RemoteDoc[]) {
   return docs.filter(doc => doc.type === FILE_TYPE)
 }
 
-export function parentDirIds (docs: RemoteDoc[]) {
+function parentDirIds (docs: RemoteDoc[]) {
   return uniq(docs.map(doc => doc.dir_id))
 }
 
-export function inRemoteTrash (doc: RemoteDoc): boolean {
+function inRemoteTrash (doc: RemoteDoc): boolean {
   return doc.trashed || doc.path.startsWith(`/${TRASH_DIR_NAME}/`)
 }
 
@@ -78,7 +87,7 @@ export type JsonApiDoc = {
   attributes: JsonApiAttributes,
 }
 
-export function jsonApiToRemoteDoc (json: JsonApiDoc): RemoteDoc {
+function jsonApiToRemoteDoc (json: JsonApiDoc): RemoteDoc {
   let metadata = {}
 
   Object.assign(metadata, {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -1,28 +1,28 @@
 /* @flow */
 
-import EventEmitter from 'events'
-import { posix, sep } from 'path'
-
-import Config from '../config'
-import * as conversion from '../conversion'
-import RemoteCozy from './cozy'
-import logger from '../logger'
-import Pouch from '../pouch'
-import Prep from '../prep'
-import Watcher from './watcher'
-import measureTime from '../perftools'
-import { withContentLength } from '../file_stream_provider'
-
 import type { RemoteDoc } from './document'
-import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider'
+import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider' // eslint-disable-line
 import type { Metadata } from '../metadata'
 import type { Side } from '../side' // eslint-disable-line
+
+const EventEmitter = require('events')
+const { posix, sep } = require('path')
+
+const Config = require('../config')
+const conversion = require('../conversion')
+const RemoteCozy = require('./cozy')
+const logger = require('../logger')
+const Pouch = require('../pouch')
+const Prep = require('../prep')
+const Watcher = require('./watcher')
+const measureTime = require('../perftools')
+const { withContentLength } = require('../file_stream_provider')
 
 const log = logger({
   component: 'RemoteWriter'
 })
 
-export default class Remote implements Side {
+module.exports = class Remote implements Side {
   other: FileStreamProvider
   pouch: Pouch
   events: EventEmitter

--- a/core/remote/registration.js
+++ b/core/remote/registration.js
@@ -1,12 +1,12 @@
-import os from 'os'
-import http from 'http'
-import opn from 'opn'
+const os = require('os')
+const http = require('http')
+const opn = require('opn')
 
-import { Client as CozyClient } from 'cozy-client-js'
+const CozyClient = require('cozy-client-js').Client
 
 const PORT_NUMBER = 3344
 
-export default class Registration {
+module.exports = class Registration {
   constructor (url, config, onReady = null) {
     this.url = url
     this.config = config

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -1,38 +1,41 @@
 /* @flow */
 
-import * as conversion from '../conversion'
-import EventEmitter from 'events'
-import _ from 'lodash'
-
-import logger from '../logger'
-import { assignId, ensureValidPath, detectPlatformIncompatibilities } from '../metadata'
-import Pouch from '../pouch'
-import Prep from '../prep'
-import RemoteCozy from './cozy'
-import * as remoteChange from './change'
-import { inRemoteTrash } from './document'
-
 import type { Metadata } from '../metadata'
 import type { RemoteChange, RemoteNoise, RemoteFileMove } from './change'
 import type { RemoteDoc, RemoteDeletion } from './document'
+
+const conversion = require('../conversion')
+const EventEmitter = require('events')
+const _ = require('lodash')
+
+const logger = require('../logger')
+const { assignId, ensureValidPath, detectPlatformIncompatibilities } = require('../metadata')
+const Pouch = require('../pouch')
+const Prep = require('../prep')
+const RemoteCozy = require('./cozy')
+const remoteChange = require('./change')
+const { inRemoteTrash } = require('./document')
 
 const log = logger({
   component: 'RemoteWatcher'
 })
 
-export const DEFAULT_HEARTBEAT: number = 1000 * 60 // 1 minute
-export const HEARTBEAT: number = parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || DEFAULT_HEARTBEAT
+const DEFAULT_HEARTBEAT: number = 1000 * 60 // 1 minute
+const HEARTBEAT: number = parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || DEFAULT_HEARTBEAT
 
 const sideName = 'remote'
 
 // Get changes from the remote Cozy and prepare them for merge
-export default class RemoteWatcher {
+class RemoteWatcher {
   pouch: Pouch
   prep: Prep
   remoteCozy: RemoteCozy
   events: EventEmitter
   intervalID: *
   runningResolve: ?() => void
+
+  static DEFAULT_HEARTBEAT = DEFAULT_HEARTBEAT
+  static HEARTBEAT = HEARTBEAT
 
   constructor (pouch: Pouch, prep: Prep, remoteCozy: RemoteCozy, events: EventEmitter) {
     this.pouch = pouch
@@ -385,3 +388,5 @@ export default class RemoteWatcher {
     await this.pouch.put(doc)
   }
 }
+
+module.exports = RemoteWatcher

--- a/core/side.js
+++ b/core/side.js
@@ -17,7 +17,11 @@ export interface Side {
   renameConflictingDocAsync (doc: Metadata, newPath: string): Promise<void>;
 }
 
-export function otherSide (side: SideName): SideName {
+module.exports = {
+  otherSide
+}
+
+function otherSide (side: SideName): SideName {
   switch (side) {
     case 'local': return 'remote'
     case 'remote': return 'local'

--- a/core/sync.js
+++ b/core/sync.js
@@ -1,27 +1,27 @@
 /* @flow */
 
-import Promise from 'bluebird'
-import EventEmitter from 'events'
-import { dirname } from 'path'
-
-import Ignore from './ignore'
-import Local from './local'
-import logger from './logger'
-import { extractRevNumber, isUpToDate } from './metadata'
-import Pouch from './pouch'
-import Remote from './remote'
-import { HEARTBEAT } from './remote/watcher'
-import { PendingMap } from './utils/pending'
-import measureTime from './perftools'
-
 import type { SideName, Metadata } from './metadata'
 import type { Side } from './side' // eslint-disable-line
+
+const Promise = require('bluebird')
+const EventEmitter = require('events')
+const { dirname } = require('path')
+
+const Ignore = require('./ignore')
+const Local = require('./local')
+const logger = require('./logger')
+const { extractRevNumber, isUpToDate } = require('./metadata')
+const Pouch = require('./pouch')
+const Remote = require('./remote')
+const { HEARTBEAT } = require('./remote/watcher')
+const { PendingMap } = require('./utils/pending')
+const measureTime = require('./perftools')
 
 const log = logger({
   component: 'Sync'
 })
 
-export const TRASHING_DELAY = 1000
+const TRASHING_DELAY = 1000
 
 type MetadataChange = {
   changes: {rev: string}[],
@@ -49,6 +49,8 @@ class Sync {
   stopped: ?boolean
   moveFrom: ?Metadata
   moveTo: ?string
+
+  static TRASHING_DELAY = TRASHING_DELAY
 
   diskUsage: () => Promise<*>
 
@@ -521,4 +523,4 @@ class Sync {
   }
 }
 
-export default Sync
+module.exports = Sync

--- a/core/syncstate.js
+++ b/core/syncstate.js
@@ -1,6 +1,6 @@
-import EventEmitter from 'events'
+const EventEmitter = require('events')
 
-export default class SyncState extends EventEmitter {
+module.exports = class SyncState extends EventEmitter {
   syncLastSeq: number
   syncCurrentSeq: number
   buffering: boolean

--- a/core/timestamp.js
+++ b/core/timestamp.js
@@ -2,7 +2,20 @@
 
 export type Timestamp = Date
 
-export function InvalidTimestampError (obj: any) {
+module.exports = {
+  InvalidTimestampError,
+  valid,
+  ensureValid,
+  build,
+  current,
+  fromDate,
+  same,
+  sameDate,
+  maxDate,
+  stringify
+}
+
+function InvalidTimestampError (obj: any) {
   this.name = 'InvalidTimestampError'
 
   this.message = `
@@ -46,13 +59,13 @@ function same (t1: Timestamp, t2: Timestamp): boolean {
 }
 
 // Return true if the two dates are the same, +/- 3 seconds
-export function sameDate (one: any, two: any) {
+function sameDate (one: any, two: any) {
   one = +new Date(one)
   two = +new Date(two)
   return Math.abs(two - one) < 3000
 }
 
-export function maxDate (d1: Date, d2: Date): Date {
+function maxDate (d1: Date, d2: Date): Date {
   return (d1.getTime() > d2.getTime()) ? d1 : d2
 }
 
@@ -60,14 +73,4 @@ function stringify (t: Timestamp) {
   ensureValid(t)
 
   return t.toISOString().substring(0, 19) + 'Z'
-}
-
-export default {
-  valid,
-  ensureValid,
-  build,
-  current,
-  fromDate,
-  same,
-  stringify
 }

--- a/core/utils/fs.js
+++ b/core/utils/fs.js
@@ -1,9 +1,14 @@
-import Promise from 'bluebird'
-import childProcess from 'child_process'
+const Promise = require('bluebird')
+const childProcess = require('child_process')
 
-import logger from '../logger'
+const logger = require('../logger')
 
 Promise.promisifyAll(childProcess)
+
+module.exports = {
+  hideOnWindows,
+  validName
+}
 
 const log = logger({
   component: 'FS'
@@ -11,7 +16,7 @@ const log = logger({
 
 // Hides a directory on Windows.
 // Errors are logged, not thrown.
-export async function hideOnWindows (path: string): Promise<void> {
+async function hideOnWindows (path: string): Promise<void> {
   if (process.platform !== 'win32') return
   try {
     await childProcess.execAsync(`attrib +h "${path}"`)
@@ -26,6 +31,6 @@ const REPLACEMENT_CHARACTER = '_'
 
 // Return a new name compatible with target filesystems by replacing invalid
 // characters from the given file/dir name.
-export function validName (name: string) {
+function validName (name: string) {
   return name.replace(ILLEGAL_CHARACTERS_REGEXP, REPLACEMENT_CHARACTER)
 }

--- a/core/utils/func.js
+++ b/core/utils/func.js
@@ -5,7 +5,11 @@
 //        signatures.
 export type Callback = (?Error, any) => void;
 
-export function composeAsync (f1: (...args: Array<*>) => Promise<*>,
+module.exports = {
+  composeAsync
+}
+
+function composeAsync (f1: (...args: Array<*>) => Promise<*>,
                        f2: (*) => Promise<*>):
                       (...args: Array<*>) => Promise<*> {
   return function composed (...args: Array<*>): Promise<*> {

--- a/core/utils/path.js
+++ b/core/utils/path.js
@@ -4,6 +4,10 @@ export type PathObject = {
   path: string
 }
 
-export function getPath (target: string|PathObject) {
+module.exports = {
+  getPath
+}
+
+function getPath (target: string|PathObject) {
   return typeof target === 'string' ? target : target.path
 }

--- a/core/utils/pending.js
+++ b/core/utils/pending.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import path from 'path'
+const path = require('path')
 
 // A pending operation e.g. on a file or a folder.
 export interface Pending { // eslint-disable-line no-undef
@@ -9,7 +9,7 @@ export interface Pending { // eslint-disable-line no-undef
 }
 
 // A map of pending operations
-export class PendingMap {
+class PendingMap {
   map: Map<string, Pending>; // eslint-disable-line no-undef
 
   constructor () {
@@ -69,4 +69,8 @@ export class PendingMap {
       this.clear(path)
     }
   }
+}
+
+module.exports = {
+  PendingMap
 }

--- a/dev/capture.js
+++ b/dev/capture.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env babel-node
 
-import program from 'commander'
-import path from 'path'
+const program = require('commander')
+const path = require('path')
 
-import local from './capture/local'
-import remote from './capture/remote'
-import scenarioHelpers from '../test/support/helpers/scenarios'
+const local = require('./capture/local')
+const remote = require('./capture/remote')
+const scenarioHelpers = require('../test/support/helpers/scenarios')
 
 program
   .description('Capture FS events')

--- a/dev/capture/local.js
+++ b/dev/capture/local.js
@@ -1,9 +1,9 @@
-import Promise from 'bluebird'
-import chokidar from 'chokidar'
-import fs from 'fs-extra'
-import _ from 'lodash'
-import path from 'path'
-import fixturesHelpers from '../../test/support/helpers/scenarios'
+const Promise = require('bluebird')
+const chokidar = require('chokidar')
+const fs = require('fs-extra')
+const _ = require('lodash')
+const path = require('path')
+const fixturesHelpers = require('../../test/support/helpers/scenarios')
 
 const cliDir = path.resolve(path.join(__dirname, '..', '..'))
 const syncPath = path.join(cliDir, 'tmp', 'local_watcher', 'synced_dir')
@@ -141,7 +141,7 @@ const captureScenario = (scenario) => {
     .then(() => runAndRecordFSEvents(scenario))
 }
 
-export default {
+module.exports = {
   name: 'local',
   captureScenario
 }

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -1,16 +1,16 @@
 /* @flow */
 
-import Promise from 'bluebird'
-import fs from 'fs-extra'
-import _ from 'lodash'
-import path from 'path'
+const Promise = require('bluebird')
+const fs = require('fs-extra')
+const _ = require('lodash')
+const path = require('path')
 
-import * as metadata from '../../core/metadata'
-import Pouch from '../../core/pouch'
-import RemoteCozy from '../../core/remote/cozy'
+const metadata = require('../../core/metadata')
+const Pouch = require('../../core/pouch')
+const RemoteCozy = require('../../core/remote/cozy')
 
-import configHelpers from '../../test/support/helpers/config'
-import * as cozyHelpers from '../../test/support/helpers/cozy'
+const configHelpers = require('../../test/support/helpers/config')
+const cozyHelpers = require('../../test/support/helpers/cozy')
 
 const debug = process.env.DEBUG != null ? console.log : (...args) => {}
 
@@ -171,7 +171,7 @@ const captureScenario = async (scenario: *) => {
   return path.basename(changesFile)
 }
 
-export default {
+module.exports = {
   name: 'remote',
   createInitialTree,
   runActions,

--- a/dev/remote/generate-test-env.js
+++ b/dev/remote/generate-test-env.js
@@ -1,11 +1,11 @@
-import cheerio from 'cheerio'
-import cozy from 'cozy-client-js'
-import fs from 'fs'
-import request from 'request'
-import url from 'url'
+const cheerio = require('cheerio')
+const cozy = require('cozy-client-js')
+const fs = require('fs')
+const request = require('request')
+const url = require('url')
 
-import pkg from '../../package.json'
-import Registration from '../../core/remote/registration'
+const pkg = require('../../package.json')
+const Registration = require('../../core/remote/registration')
 
 const cozyUrl = process.env.COZY_URL
 const passphrase = process.env.COZY_PASSPHRASE

--- a/dev/repl.js
+++ b/dev/repl.js
@@ -1,10 +1,10 @@
-import 'source-map-support/register'
+require('source-map-support/register')
 
-import { start } from 'repl'
+const { start } = require('repl')
 
-import '../core/globals'
-import App from '../core/app'
-import { IntegrationTestHelpers } from '../test/support/helpers/integration'
+require('../core/globals')
+const App = require('../core/app')
+const { IntegrationTestHelpers } = require('../test/support/helpers/integration')
 
 const app = new App(process.env.COZY_DESKTOP_DIR)
 const config = app.config

--- a/gui/js/help.window.js
+++ b/gui/js/help.window.js
@@ -2,7 +2,7 @@ const WindowManager = require('./window_manager')
 const HELP_SCREEN_WIDTH = 768
 const HELP_SCREEN_HEIGHT = 570
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI'
 })
 

--- a/gui/js/lastfiles.js
+++ b/gui/js/lastfiles.js
@@ -4,7 +4,7 @@ const path = require('path')
 let lastFilesPath = ''
 let lastFiles = []
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI'
 })
 

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -4,7 +4,7 @@ const autoLaunch = require('./autolaunch')
 const defaults = require('./defaults')
 const {translate} = require('./i18n')
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI'
 })
 

--- a/gui/js/proxy.js
+++ b/gui/js/proxy.js
@@ -5,7 +5,7 @@ const url = require('url')
 const http = require('http')
 const https = require('https')
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI:proxy'
 })
 

--- a/gui/js/shortcut.js
+++ b/gui/js/shortcut.js
@@ -4,7 +4,7 @@ const path = require('path')
 const url = require('url')
 const childProcess = require('child_process')
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI'
 })
 

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -7,7 +7,7 @@ const DASHBOARD_SCREEN_HEIGHT = 830
 
 const {translate} = require('./i18n')
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI'
 })
 

--- a/gui/js/updater.window.js
+++ b/gui/js/updater.window.js
@@ -1,7 +1,7 @@
 const WindowManager = require('./window_manager')
 const {autoUpdater} = require('electron-updater')
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'GUI:autoupdater'
 })
 

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -5,7 +5,7 @@ const electron = require('electron')
 
 const ELMSTARTUP = 400
 
-const log = require('../../core-built/app.js').default.logger({
+const log = require('../../core-built/app').logger({
   component: 'windows'
 })
 
@@ -14,7 +14,7 @@ module.exports = class WindowManager {
     this.win = null
     this.app = app
     this.desktop = desktop
-    this.log = require('../../core-built/app.js').default.logger({
+    this.log = require('../../core-built/app').logger({
       component: 'GUI/' + this.windowOptions().title
     })
 

--- a/gui/main.js
+++ b/gui/main.js
@@ -2,7 +2,7 @@
 
 require('babel-polyfill')
 
-const Desktop = require('../core-built/app.js').default
+const Desktop = require('../core-built/app.js')
 const pkg = require('../package.json')
 
 const debounce = require('lodash').debounce

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -1,20 +1,20 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import path from 'path'
-import should from 'should'
+} = require('mocha')
+const path = require('path')
+const should = require('should')
 
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 const cozy = cozyHelpers.cozy
 

--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -1,19 +1,19 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import should from 'should'
+} = require('mocha')
+const should = require('should')
 
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 suite('Case or encoding change', () => {
   if (process.env.TRAVIS && (process.platform === 'darwin')) {

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -1,21 +1,21 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import should from 'should'
-import sinon from 'sinon'
+} = require('mocha')
+const should = require('should')
+const sinon = require('sinon')
 
-import Builders from '../support/builders'
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const Builders = require('../support/builders')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 suite('Conflict resolution', () => {
   let builders, cozy, helpers

--- a/test/integration/full_loop.js
+++ b/test/integration/full_loop.js
@@ -1,21 +1,21 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import should from 'should'
+} = require('mocha')
+const should = require('should')
 
-import * as metadata from '../../core/metadata'
+const metadata = require('../../core/metadata')
 
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 const cozy = cozyHelpers.cozy
 

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -1,23 +1,23 @@
 /* @flow */
 
-import { pick } from 'lodash'
-import {
+const { pick } = require('lodash')
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import path from 'path'
-import should from 'should'
+} = require('mocha')
+const path = require('path')
+const should = require('should')
 
-import Builders from '../support/builders'
-import pouchdbBuilders from '../support/builders/pouchdb'
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const Builders = require('../support/builders')
+const pouchdbBuilders = require('../support/builders/pouchdb')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 suite('Move', () => {
   if (process.env.APPVEYOR) {

--- a/test/integration/permanent_deletion.js
+++ b/test/integration/permanent_deletion.js
@@ -1,19 +1,19 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import should from 'should'
+} = require('mocha')
+const should = require('should')
 
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 const cozy = cozyHelpers.cozy
 

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -1,22 +1,22 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import should from 'should'
+} = require('mocha')
+const should = require('should')
 
-import * as metadata from '../../core/metadata'
+const metadata = require('../../core/metadata')
 
-import Builders from '../support/builders'
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const Builders = require('../support/builders')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 suite('Platform incompatibilities', () => {
   let builders, cozy, helpers

--- a/test/integration/sync_state.js
+++ b/test/integration/sync_state.js
@@ -1,21 +1,21 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import should from 'should'
-import sinon from 'sinon'
+} = require('mocha')
+const should = require('should')
+const sinon = require('sinon')
 
-import Builders from '../support/builders'
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const Builders = require('../support/builders')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 suite('Sync state', () => {
   before(configHelpers.createConfig)

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -1,20 +1,20 @@
 /* @flow */
 
-import {
+const {
   after,
   afterEach,
   before,
   beforeEach,
   suite,
   test
-} from 'mocha'
-import path from 'path'
-import should from 'should'
+} = require('mocha')
+const path = require('path')
+const should = require('should')
 
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import pouchHelpers from '../support/helpers/pouch'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
 
 suite('Trash', () => {
   let cozy, helpers, pouch, prep

--- a/test/performance/local/watcher.js
+++ b/test/performance/local/watcher.js
@@ -1,15 +1,15 @@
 /* eslint-env mocha */
 /* @flow */
 
-import Promise from 'bluebird'
-import fs from 'fs-extra'
-import path from 'path'
+const Promise = require('bluebird')
+const fs = require('fs-extra')
+const path = require('path')
 
-import Watcher from '../../../core/local/watcher'
-import * as metadata from '../../../core/metadata'
+const Watcher = require('../../../core/local/watcher')
+const metadata = require('../../../core/metadata')
 
-import configHelpers from '../../support/helpers/config'
-import pouchHelpers from '../../support/helpers/pouch'
+const configHelpers = require('../../support/helpers/config')
+const pouchHelpers = require('../../support/helpers/pouch')
 
 class SpyPrep {
   calls: *

--- a/test/regression/TRELLO_484_local_sort_before_squash.js
+++ b/test/regression/TRELLO_484_local_sort_before_squash.js
@@ -1,16 +1,16 @@
 /* eslint-env mocha */
 /* @flow */
 
-import fs from 'fs-extra'
-import _ from 'lodash'
-import should from 'should'
-import sinon from 'sinon'
+const fs = require('fs-extra')
+const _ = require('lodash')
+const should = require('should')
+const sinon = require('sinon')
 
-import { runActions, init } from '../support/helpers/scenarios'
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
-import pouchHelpers from '../support/helpers/pouch'
+const { runActions, init } = require('../support/helpers/scenarios')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const pouchHelpers = require('../support/helpers/pouch')
 
 let helpers
 

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -1,19 +1,19 @@
 /* eslint-env mocha */
 /* @flow */
 
-import Promise from 'bluebird'
-import fs from 'fs-extra'
-import _ from 'lodash'
-import path from 'path'
-import should from 'should'
-import sinon from 'sinon'
+const Promise = require('bluebird')
+const fs = require('fs-extra')
+const _ = require('lodash')
+const path = require('path')
+const should = require('should')
+const sinon = require('sinon')
 
-import { scenarios, loadFSEventFiles, runActions, init } from '../support/helpers/scenarios'
-import configHelpers from '../support/helpers/config'
-import * as cozyHelpers from '../support/helpers/cozy'
-import { IntegrationTestHelpers } from '../support/helpers/integration'
-import pouchHelpers from '../support/helpers/pouch'
-import remoteCaptureHelpers from '../../dev/capture/remote'
+const { scenarios, loadFSEventFiles, runActions, init } = require('../support/helpers/scenarios')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const pouchHelpers = require('../support/helpers/pouch')
+const remoteCaptureHelpers = require('../../dev/capture/remote')
 
 let helpers
 

--- a/test/support/assertions/timestamp.js
+++ b/test/support/assertions/timestamp.js
@@ -1,6 +1,6 @@
-import should from 'should'
+const should = require('should')
 
-import timestamp from '../../../core/timestamp'
+const timestamp = require('../../../core/timestamp')
 
 should.use(function (should, Assertion) {
   Assertion.add('sameTimestamp', function (expected, message) {

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -2,12 +2,12 @@
 
 import type { Cozy } from 'cozy-client-js'
 
-import type Pouch from '../../../core/pouch'
+const Pouch = require('../../../core/pouch')
 
-import MetadataBuilders from './metadata'
-import RemoteDirBuilder from './remote/dir'
-import RemoteFileBuilder from './remote/file'
-import StreamBuilder from './stream'
+const MetadataBuilders = require('./metadata')
+const RemoteDirBuilder = require('./remote/dir')
+const RemoteFileBuilder = require('./remote/file')
+const StreamBuilder = require('./stream')
 
 // Test data builders facade.
 //
@@ -15,7 +15,7 @@ import StreamBuilder from './stream'
 //     builders.remote.dir()...
 //     builders.stream()...
 //
-export default class Builders {
+module.exports = class Builders {
   cozy: Cozy
   metadata: MetadataBuilders
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import Pouch from '../../../../core/pouch'
-
 import type { Metadata, MetadataSidesInfo } from '../../../../core/metadata'
 
-export default class BaseMetadataBuilder {
+const Pouch = require('../../../../core/pouch')
+
+module.exports = class BaseMetadataBuilder {
   pouch: ?Pouch
   opts: {
     path: string,

--- a/test/support/builders/metadata/dir.js
+++ b/test/support/builders/metadata/dir.js
@@ -1,13 +1,13 @@
 // @flow
 
-import { assignId } from '../../../../core/metadata'
-import BaseMetadataBuilder from './base'
-
 import type { Metadata } from '../../../../core/metadata'
 
-import pouchdbBuilders from '../pouchdb'
+const { assignId } = require('../../../../core/metadata')
+const BaseMetadataBuilder = require('./base')
 
-export default class DirMetadataBuilder extends BaseMetadataBuilder {
+const pouchdbBuilders = require('../pouchdb')
+
+module.exports = class DirMetadataBuilder extends BaseMetadataBuilder {
   build (): Metadata {
     const doc = {
       ...this.opts,

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import BaseMetadataBuilder from './base'
-import { assignId } from '../../../../core/metadata'
-
 import type { Metadata } from '../../../../core/metadata'
 
-import pouchdbBuilders from '../pouchdb'
+const BaseMetadataBuilder = require('./base')
+const { assignId } = require('../../../../core/metadata')
 
-export default class FileMetadataBuilder extends BaseMetadataBuilder {
+const pouchdbBuilders = require('../pouchdb')
+
+module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   build (): Metadata {
     const doc = {
       ...this.opts,

--- a/test/support/builders/metadata/index.js
+++ b/test/support/builders/metadata/index.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import Pouch from '../../../../core/pouch'
+const Pouch = require('../../../../core/pouch')
 
-import DirMetadataBuilder from './dir'
-import FileMetadataBuilder from './file'
+const DirMetadataBuilder = require('./dir')
+const FileMetadataBuilder = require('./file')
 
-export default class MetadataBuilders {
+module.exports = class MetadataBuilders {
   pouch: ?Pouch
 
   constructor (pouch: ?Pouch) {

--- a/test/support/builders/pouchdb.js
+++ b/test/support/builders/pouchdb.js
@@ -1,6 +1,6 @@
-import uuid from 'uuid/v4'
+const uuid = require('uuid/v4')
 
-export default {
+module.exports = {
   id () {
     return uuid().replace(/-/g, '')
   },

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import { Cozy } from 'cozy-client-js'
-import uuid from 'uuid/v4'
-
-import { FILES_DOCTYPE, ROOT_DIR_ID, TRASH_DIR_ID, TRASH_DIR_NAME } from '../../../../core/remote/constants'
-import timestamp from '../../../../core/timestamp'
-
 import type { RemoteDoc } from '../../../../core/remote/document'
+
+const { Cozy } = require('cozy-client-js')
+const uuid = require('uuid/v4')
+
+const { FILES_DOCTYPE, ROOT_DIR_ID, TRASH_DIR_ID, TRASH_DIR_NAME } = require('../../../../core/remote/constants')
+const timestamp = require('../../../../core/timestamp')
 
 const ROOT_DIR_PROPERTIES = {
   _id: ROOT_DIR_ID,
@@ -18,7 +18,7 @@ const TRASH_DIR_PROPERTIES = {
   path: `/${TRASH_DIR_NAME}`
 }
 
-export default class RemoteBaseBuilder {
+module.exports = class RemoteBaseBuilder {
   cozy: Cozy
   options: {
     contentType?: string,

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import { Cozy } from 'cozy-client-js'
-
-import RemoteBaseBuilder from './base'
-import { jsonApiToRemoteDoc } from '../../../../core/remote/document'
-
 import type { RemoteDoc } from '../../../../core/remote/document'
+
+const { Cozy } = require('cozy-client-js')
+
+const RemoteBaseBuilder = require('./base')
+const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
 
 // Used to generate readable unique dirnames
 var dirNumber = 1
@@ -19,7 +19,7 @@ var dirNumber = 1
 //
 //     const dir: RemoteDoc = await builders.remote.dir().inDir(...).create()
 //
-export default class RemoteDirBuilder extends RemoteBaseBuilder {
+module.exports = class RemoteDirBuilder extends RemoteBaseBuilder {
   constructor (cozy: Cozy) {
     super(cozy)
 

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -1,15 +1,15 @@
 /* @flow */
 
-import fs from 'fs'
-import path from 'path'
-import * as stream from 'stream'
-import { Cozy } from 'cozy-client-js'
-
-import RemoteBaseBuilder from './base'
-
-import { jsonApiToRemoteDoc } from '../../../../core/remote/document'
-
 import type { RemoteDoc } from '../../../../core/remote/document'
+
+const fs = require('fs')
+const path = require('path')
+const stream = require('stream')
+const { Cozy } = require('cozy-client-js')
+
+const RemoteBaseBuilder = require('./base')
+
+const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
 
 // Used to generate readable unique filenames
 var fileNumber = 1
@@ -23,7 +23,7 @@ var fileNumber = 1
 //
 //     const file: RemoteDoc = await builders.remote.file().inDir(...).create()
 //
-export default class RemoteFileBuilder extends RemoteBaseBuilder {
+module.exports = class RemoteFileBuilder extends RemoteBaseBuilder {
   _data: string | stream.Readable
 
   constructor (cozy: Cozy) {

--- a/test/support/builders/stream.js
+++ b/test/support/builders/stream.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import * as stream from 'stream'
+const stream = require('stream')
 
-export default class StreamBuilder {
+module.exports = class StreamBuilder {
   data: string
 
   constructor () {

--- a/test/support/coverage.js
+++ b/test/support/coverage.js
@@ -1,6 +1,6 @@
 // See: https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/blob/1b2055b286f1f296c0d48dec714224c14acb3c34/test/electron/util/coverage.js
 
-import Module from 'module'
+const Module = require('module')
 
 const originalRequire = Module.prototype.require
 

--- a/test/support/doubles/cozy_stack.js
+++ b/test/support/doubles/cozy_stack.js
@@ -1,8 +1,8 @@
-import http from 'http'
+const http = require('http')
 
 // A fake HTTP server, to be used in place of the cozy-stack for integration
 // testing purpose (e.g. to simulate failures).
-export default class CozyStackDouble {
+module.exports = class CozyStackDouble {
   constructor () {
     this.clearStub()
 

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import sinon from 'sinon'
-
 import type { Side } from '../../../core/side'
+
+const sinon = require('sinon')
 
 const METHODS = [
   'addFileAsync',
@@ -18,7 +18,7 @@ const METHODS = [
   'renameConflictingDocAsync'
 ]
 
-export default function stubSide (): Side {
+module.exports = function stubSide (): Side {
   const double = {}
   for (let method of METHODS) {
     double[method] = sinon.stub().resolves()

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -1,12 +1,12 @@
-import fs from 'fs-extra'
-import del from 'del'
-import path from 'path'
+const fs = require('fs-extra')
+const del = require('del')
+const path = require('path')
 
-import Config from '../../../core/config'
+const Config = require('../../../core/config')
 
-import { COZY_URL } from './cozy'
+const { COZY_URL } = require('./cozy')
 
-export default {
+module.exports = {
   createConfig () {
     let parent = process.env.COZY_DESKTOP_DIR || 'tmp'
     this.basePath = path.resolve(`${parent}/test/${+new Date()}`)

--- a/test/support/helpers/conflict.js
+++ b/test/support/helpers/conflict.js
@@ -1,7 +1,11 @@
 /* @flow */
 
+module.exports = {
+  ellipsizeDate
+}
+
 // Replace the date with an ellipsis in a conflict file name.
 // Useful to write test assertions checking the local/remote filesystem.
-export function ellipsizeDate (path: string): string {
+function ellipsizeDate (path: string): string {
   return path.replace(/-conflict-[^/]+/, '-conflict-...')
 }

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -1,13 +1,13 @@
 /* @flow */
 /* eslint-env mocha */
 
-import { Client as CozyClient } from 'cozy-client-js'
+const CozyClient = require('cozy-client-js').Client
 
-import { FILES_DOCTYPE, ROOT_DIR_ID, TRASH_DIR_ID } from '../../../core/remote/constants'
-import Builders from '../builders'
+const { FILES_DOCTYPE, ROOT_DIR_ID, TRASH_DIR_ID } = require('../../../core/remote/constants')
+const Builders = require('../builders')
 
 // The URL of the Cozy instance used for tests
-export const COZY_URL = process.env.COZY_URL || 'http://cozy.tools:8080'
+const COZY_URL = process.env.COZY_URL || 'http://cozy.tools:8080'
 
 if (!process.env.COZY_STACK_TOKEN) {
   const domain = COZY_URL.replace('http://', '')
@@ -19,13 +19,21 @@ if (!process.env.COZY_STACK_TOKEN) {
 }
 
 // A cozy-client-js instance
-export const cozy = new CozyClient({
+const cozy = new CozyClient({
   cozyURL: COZY_URL,
   token: process.env.COZY_STACK_TOKEN
 })
 
 // Facade for all the test data builders
-export const builders = new Builders(cozy)
+const builders = new Builders(cozy)
+
+module.exports = {
+  COZY_URL,
+  cozy,
+  builders,
+  deleteAll,
+  createTheCouchdbFolder
+}
 
 // List files and directories in the root directory
 async function rootDirContents () {
@@ -42,7 +50,7 @@ async function rootDirContents () {
 }
 
 // Delete all files and directories
-export async function deleteAll () {
+async function deleteAll () {
   const docs = await rootDirContents()
 
   await Promise.all(docs.map(async doc => {
@@ -60,7 +68,7 @@ export async function deleteAll () {
 // Creates a root directory named 'couchdb-folder', used in a lot of v2 tests.
 //
 // TODO: Use test data builders instead
-export async function createTheCouchdbFolder () {
+async function createTheCouchdbFolder () {
   await builders.remote.dir()
     .named('couchdb-folder')
     .inRootDir()

--- a/test/support/helpers/integration.js
+++ b/test/support/helpers/integration.js
@@ -1,23 +1,23 @@
 /* @flow */
 
-import cozy from 'cozy-client-js'
-import { pick } from 'lodash'
-import sinon from 'sinon'
+const cozy = require('cozy-client-js')
+const { pick } = require('lodash')
+const sinon = require('sinon')
 
-import Config from '../../../core/config'
-import Ignore from '../../../core/ignore'
-import Local from '../../../core/local'
-import Merge from '../../../core/merge'
-import Pouch from '../../../core/pouch'
-import Prep from '../../../core/prep'
-import Remote from '../../../core/remote'
-import Sync from '../../../core/sync'
-import SyncState from '../../../core/syncstate'
+const Config = require('../../../core/config')
+const Ignore = require('../../../core/ignore')
+const Local = require('../../../core/local')
+const Merge = require('../../../core/merge')
+const Pouch = require('../../../core/pouch')
+const Prep = require('../../../core/prep')
+const Remote = require('../../../core/remote')
+const Sync = require('../../../core/sync')
+const SyncState = require('../../../core/syncstate')
 
-import { LocalTestHelpers } from './local'
-import { RemoteTestHelpers } from './remote'
+const { LocalTestHelpers } = require('./local')
+const { RemoteTestHelpers } = require('./remote')
 
-export class IntegrationTestHelpers {
+class IntegrationTestHelpers {
   local: LocalTestHelpers
   remote: RemoteTestHelpers
   prep: Prep
@@ -74,4 +74,8 @@ export class IntegrationTestHelpers {
 
     return results
   }
+}
+
+module.exports = {
+  IntegrationTestHelpers
 }

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -1,22 +1,22 @@
 /* @flow */
 
-import Promise from 'bluebird'
-import fs from 'fs-extra'
-import path from 'path'
-import rimraf from 'rimraf'
-
-import * as conflictHelpers from './conflict'
-import { SyncDirTestHelpers } from './sync_dir'
-
-import { TMP_DIR_NAME } from '../../../core/local/constants'
-import Local from '../../../core/local'
-
 import type { ChokidarEvent } from '../../../core/local/chokidar_event'
+
+const Promise = require('bluebird')
+const fs = require('fs-extra')
+const path = require('path')
+const rimraf = require('rimraf')
+
+const conflictHelpers = require('./conflict')
+const { SyncDirTestHelpers } = require('./sync_dir')
+
+const { TMP_DIR_NAME } = require('../../../core/local/constants')
+const Local = require('../../../core/local')
 
 Promise.promisifyAll(fs)
 const rimrafAsync = Promise.promisify(rimraf)
 
-export function posixifyPath (localPath: string): string {
+function posixifyPath (localPath: string): string {
   return localPath.split(path.sep).join(path.posix.sep)
 }
 
@@ -48,7 +48,7 @@ async function tree (rootPath: string): Promise<string[]> {
   return relPaths.sort((a, b) => a.localeCompare(b))
 }
 
-export class LocalTestHelpers {
+class LocalTestHelpers {
   local: Local
   syncDir: SyncDirTestHelpers
 
@@ -112,4 +112,9 @@ export class LocalTestHelpers {
   async simulateEvents (events: ChokidarEvent[]) {
     return this.local.watcher.onFlush(events)
   }
+}
+
+module.exports = {
+  posixifyPath,
+  LocalTestHelpers
 }

--- a/test/support/helpers/platform.js
+++ b/test/support/helpers/platform.js
@@ -1,6 +1,11 @@
-import mocha from 'mocha'
+const mocha = require('mocha')
 
-export function onPlatforms (...platformsAndSpec) {
+module.exports = {
+  onPlatforms,
+  onPlatform
+}
+
+function onPlatforms (...platformsAndSpec) {
   const spec = platformsAndSpec.pop()
   const platforms = platformsAndSpec
 
@@ -9,6 +14,6 @@ export function onPlatforms (...platformsAndSpec) {
   }
 }
 
-export function onPlatform (platform, spec) {
+function onPlatform (platform, spec) {
   onPlatforms(platform, spec)
 }

--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -1,9 +1,9 @@
-import path from 'path'
+const path = require('path')
 
-import { assignId } from '../../../core/metadata'
-import Pouch from '../../../core/pouch'
+const { assignId } = require('../../../core/metadata')
+const Pouch = require('../../../core/pouch')
 
-export default {
+module.exports = {
   createDatabase (done) {
     this.pouch = new Pouch(this.config)
     return this.pouch.addAllViews(done)

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -1,18 +1,18 @@
 /* @flow */
 
-import cozy from 'cozy-client-js'
-import _ from 'lodash'
-import path from 'path'
-
-import * as conflictHelpers from './conflict'
-
-import Pouch from '../../../core/pouch'
-import Remote from '../../../core/remote'
-import { TRASH_DIR_NAME } from '../../../core/remote/constants'
-
 import type { RemoteDoc } from '../../../core/remote/document'
 
-export class RemoteTestHelpers {
+const cozy = require('cozy-client-js')
+const _ = require('lodash')
+const path = require('path')
+
+const conflictHelpers = require('./conflict')
+
+const Pouch = require('../../../core/pouch')
+const Remote = require('../../../core/remote')
+const { TRASH_DIR_NAME } = require('../../../core/remote/constants')
+
+class RemoteTestHelpers {
   remote: Remote
 
   constructor (remote: Remote) {
@@ -102,4 +102,8 @@ export class RemoteTestHelpers {
   async simulateChanges (docs: *) {
     await this.remote.watcher.pullMany(docs)
   }
+}
+
+module.exports = {
+  RemoteTestHelpers
 }

--- a/test/support/helpers/sync_dir.js
+++ b/test/support/helpers/sync_dir.js
@@ -1,16 +1,16 @@
 /* @flow */
 
-import Promise from 'bluebird'
-import fs from 'fs-extra'
-import path from 'path'
-
-import { getPath } from '../../../core/utils/path'
-
 import type { PathObject } from '../../../core/utils/path'
+
+const Promise = require('bluebird')
+const fs = require('fs-extra')
+const path = require('path')
+
+const { getPath } = require('../../../core/utils/path')
 
 Promise.promisifyAll(fs)
 
-export class SyncDirTestHelpers {
+class SyncDirTestHelpers {
   root: string
 
   constructor (root: string) {
@@ -36,4 +36,8 @@ export class SyncDirTestHelpers {
   async rmdir (target: string|PathObject) {
     await fs.rmdirSync(this.abspath(target))
   }
+}
+
+module.exports = {
+  SyncDirTestHelpers
 }

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1,15 +1,15 @@
 /* eslint-env mocha */
 
-import fs from 'fs-extra'
-import os from 'os'
-import path from 'path'
-import should from 'should'
+const fs = require('fs-extra')
+const os = require('os')
+const path = require('path')
+const should = require('should')
 
-import App from '../../core/app'
-import { LOG_FILENAME } from '../../core/logger'
-import { version } from '../../package.json'
+const App = require('../../core/app')
+const { LOG_FILENAME } = require('../../core/logger')
+const { version } = require('../../package.json')
 
-import configHelpers from '../support/helpers/config'
+const configHelpers = require('../support/helpers/config')
 
 describe('App', function () {
   describe('parseCozyUrl', function () {

--- a/test/unit/case_and_encoding.js
+++ b/test/unit/case_and_encoding.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import fs from 'fs-extra'
-import { setup, suite, test } from 'mocha'
-import path from 'path'
-import should from 'should'
+const fs = require('fs-extra')
+const { setup, suite, test } = require('mocha')
+const path = require('path')
+const should = require('should')
 
 should.Assertion.add('hex', function (expectedPretty) {
   const expected = expectedPretty.trim().split(/\s+/)

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 
-import path from 'path'
-import should from 'should'
+const path = require('path')
+const should = require('should')
 
-import configHelpers from '../support/helpers/config'
+const configHelpers = require('../support/helpers/config')
 
-import Config from '../../core/config'
+const Config = require('../../core/config')
 
 describe('Config', function () {
   before('instanciate config', configHelpers.createConfig)

--- a/test/unit/conversion.js
+++ b/test/unit/conversion.js
@@ -1,15 +1,15 @@
 /* @flow */
 /* eslint-env mocha */
 
-import should from 'should'
-import path from 'path'
-
-import * as conversion from '../../core/conversion'
-import { FILES_DOCTYPE } from '../../core/remote/constants'
-import timestamp from '../../core/timestamp'
-
 import type { Metadata } from '../../core/metadata'
 import type { RemoteDoc } from '../../core/remote/document'
+
+const should = require('should')
+const path = require('path')
+
+const conversion = require('../../core/conversion')
+const { FILES_DOCTYPE } = require('../../core/remote/constants')
+const timestamp = require('../../core/timestamp')
 
 describe('conversion', function () {
   describe('createMetadata', () => {

--- a/test/unit/gui/tray.window.js
+++ b/test/unit/gui/tray.window.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 
-import should from 'should'
+const should = require('should')
 
-import { popoverBounds } from '../../../gui/js/tray.window'
+const { popoverBounds } = require('../../../gui/js/tray.window')
 
 describe('tray.window', () => {
   describe('popoverBounds', () => {

--- a/test/unit/helpers_merge.js
+++ b/test/unit/helpers_merge.js
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
 
-import path from 'path'
-import sinon from 'sinon'
-import should from 'should'
+const path = require('path')
+const sinon = require('sinon')
+const should = require('should')
 
-import Merge from '../../core/merge'
+const Merge = require('../../core/merge')
 
-import configHelpers from '../support/helpers/config'
-import pouchHelpers from '../support/helpers/pouch'
+const configHelpers = require('../support/helpers/config')
+const pouchHelpers = require('../support/helpers/pouch')
 
 describe('Merge Helpers', function () {
   before('instanciate config', configHelpers.createConfig)

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import Ignore from '../../core/ignore'
+const Ignore = require('../../core/ignore')
 
 describe('Ignore', function () {
   it('rejects blank lines for patterns', function () {

--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 
-import should from 'should'
-
-import analysis from '../../../core/local/analysis'
-
-import MetadataBuilders from '../../support/builders/metadata'
-
 import type { LocalEvent } from '../../../core/local/event'
 import type { LocalChange } from '../../../core/local/change'
 import type { Metadata } from '../../../core/metadata'
+
+const should = require('should')
+
+const analysis = require('../../../core/local/analysis')
+
+const MetadataBuilders = require('../../support/builders/metadata')
 
 describe('core/local/analysis', function () {
   const sideName = 'local'

--- a/test/unit/local/checksumer.js
+++ b/test/unit/local/checksumer.js
@@ -1,12 +1,12 @@
 /* eslint-env mocha */
 /* @flow */
 
-import fs from 'fs'
-import should from 'should'
-import sinon from 'sinon'
-import { Readable } from 'stream'
+const fs = require('fs')
+const should = require('should')
+const sinon = require('sinon')
+const { Readable } = require('stream')
 
-import { init } from '../../../core/local/checksumer'
+const { init } = require('../../../core/local/checksumer')
 
 describe('local/checksumer', () => {
   let checksumer

--- a/test/unit/local/chokidar_event.js
+++ b/test/unit/local/chokidar_event.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 /* @flow */
 
-import * as faker from 'faker'
-import fs from 'fs'
-import should from 'should'
+const faker = require('faker')
+const fs = require('fs')
+const should = require('should')
 
-import * as chokidarEvent from '../../../core/local/chokidar_event'
+const chokidarEvent = require('../../../core/local/chokidar_event')
 
 describe('local/chokidar_event', () => {
   describe('build', () => {

--- a/test/unit/local/event_buffer.js
+++ b/test/unit/local/event_buffer.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 /* @flow */
 
-import should from 'should'
-import sinon from 'sinon'
+const should = require('should')
+const sinon = require('sinon')
 
-import LocalEventBuffer from '../../../core/local/event_buffer'
+const LocalEventBuffer = require('../../../core/local/event_buffer')
 
 describe('EventBuffer', () => {
   const TIMEOUT_IN_MS = 2000

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -1,21 +1,21 @@
 /* eslint-env mocha */
 
-import Promise from 'bluebird'
-import crypto from 'crypto'
-import fs from 'fs-extra'
-import path from 'path'
-import sinon from 'sinon'
-import should from 'should'
-import { Readable } from 'stream'
+const Promise = require('bluebird')
+const crypto = require('crypto')
+const fs = require('fs-extra')
+const path = require('path')
+const sinon = require('sinon')
+const should = require('should')
+const { Readable } = require('stream')
 
-import Local from '../../../core/local'
-import { TMP_DIR_NAME } from '../../../core/local/constants'
-import { PendingMap } from '../../../core/utils/pending'
+const Local = require('../../../core/local')
+const { TMP_DIR_NAME } = require('../../../core/local/constants')
+const { PendingMap } = require('../../../core/utils/pending')
 
-import MetadataBuilders from '../../support/builders/metadata'
-import configHelpers from '../../support/helpers/config'
-import { SyncDirTestHelpers } from '../../support/helpers/sync_dir'
-import pouchHelpers from '../../support/helpers/pouch'
+const MetadataBuilders = require('../../support/builders/metadata')
+const configHelpers = require('../../support/helpers/config')
+const { SyncDirTestHelpers } = require('../../support/helpers/sync_dir')
+const pouchHelpers = require('../../support/helpers/pouch')
 
 Promise.promisifyAll(fs)
 

--- a/test/unit/local/watcher.js
+++ b/test/unit/local/watcher.js
@@ -1,16 +1,16 @@
 /* eslint-env mocha */
 
-import fs from 'fs-extra'
-import path from 'path'
-import sinon from 'sinon'
-import should from 'should'
+const fs = require('fs-extra')
+const path = require('path')
+const sinon = require('sinon')
+const should = require('should')
 
-import { TMP_DIR_NAME } from '../../../core/local/constants'
-import Watcher from '../../../core/local/watcher'
-import * as metadata from '../../../core/metadata'
+const { TMP_DIR_NAME } = require('../../../core/local/constants')
+const Watcher = require('../../../core/local/watcher')
+const metadata = require('../../../core/metadata')
 
-import configHelpers from '../../support/helpers/config'
-import pouchHelpers from '../../support/helpers/pouch'
+const configHelpers = require('../../support/helpers/config')
+const pouchHelpers = require('../../support/helpers/pouch')
 
 describe('LocalWatcher Tests', function () {
   before('instanciate config', configHelpers.createConfig)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
-import async from 'async'
-import { clone, pick } from 'lodash'
-import path from 'path'
-import sinon from 'sinon'
-import should from 'should'
+const async = require('async')
+const { clone, pick } = require('lodash')
+const path = require('path')
+const sinon = require('sinon')
+const should = require('should')
 
-import Merge from '../../core/merge'
-import * as metadata from '../../core/metadata'
+const Merge = require('../../core/merge')
+const metadata = require('../../core/metadata')
 
-import configHelpers from '../support/helpers/config'
-import pouchHelpers from '../support/helpers/pouch'
-import MetadataBuilders from '../support/builders/metadata'
+const configHelpers = require('../support/helpers/config')
+const pouchHelpers = require('../support/helpers/pouch')
+const MetadataBuilders = require('../support/builders/metadata')
 
 describe('Merge', function () {
   let builders

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
-import _, { clone } from 'lodash'
-import fs from 'fs-extra'
-import should from 'should'
-import path from 'path'
+const _ = require('lodash')
+const fs = require('fs-extra')
+const should = require('should')
+const path = require('path')
 
-import { onPlatform } from '../support/helpers/platform'
+const { onPlatform } = require('../support/helpers/platform')
 
-import {
+const {
   assignId, extractRevNumber, invalidChecksum, invalidPath, markSide,
   detectPlatformIncompatibilities, sameBinary, sameFile, sameFolder, buildDir,
   buildFile
-} from '../../core/metadata'
+} = require('../../core/metadata')
 
 describe('metadata', function () {
   describe('assignId', function () {
@@ -372,11 +372,11 @@ describe('metadata', function () {
           rev: '4-567'
         }
       }
-      let b = clone(a)
+      let b = _.clone(a)
       b.executable = undefined
-      let c = clone(a)
+      let c = _.clone(a)
       c.executable = false
-      let d = clone(a)
+      let d = _.clone(a)
       d.executable = true
       sameFile(a, b).should.be.true()
       sameFile(a, c).should.be.true()

--- a/test/unit/path_restrictions.js
+++ b/test/unit/path_restrictions.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
 
-import should from 'should'
+const should = require('should')
 
-import pathRestrictions, {
-  detectNameIssues, detectPathLengthIssue
-} from '../../core/path_restrictions'
+const pathRestrictions = require('../../core/path_restrictions')
+const { detectNameIssues, detectPathLengthIssue } = pathRestrictions
 
 describe('path_restrictions', () => {
   describe('detectNameIssues', () => {

--- a/test/unit/pouch.js
+++ b/test/unit/pouch.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
-import async from 'async'
-import Promise from 'bluebird'
-import jsv from 'jsverify'
-import path from 'path'
-import should from 'should'
-import sinon from 'sinon'
-import { uniq } from 'lodash'
+const async = require('async')
+const Promise = require('bluebird')
+const jsv = require('jsverify')
+const path = require('path')
+const should = require('should')
+const sinon = require('sinon')
+const { uniq } = require('lodash')
 
-import * as metadata from '../../core/metadata'
+const metadata = require('../../core/metadata')
 
-import configHelpers from '../support/helpers/config'
-import pouchHelpers from '../support/helpers/pouch'
+const configHelpers = require('../support/helpers/config')
+const pouchHelpers = require('../support/helpers/pouch')
 
 describe('Pouch', function () {
   before('instanciate config', configHelpers.createConfig)

--- a/test/unit/prep.js
+++ b/test/unit/prep.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
-import sinon from 'sinon'
-import should from 'should'
+const sinon = require('sinon')
+const should = require('should')
 
-import Ignore from '../../core/ignore'
-import Prep from '../../core/prep'
+const Ignore = require('../../core/ignore')
+const Prep = require('../../core/prep')
 
 describe('Prep', function () {
   beforeEach('instanciate prep', function () {

--- a/test/unit/regressions/850.js
+++ b/test/unit/regressions/850.js
@@ -1,22 +1,22 @@
 /* eslint-env mocha */
 
-import fs from 'fs-extra'
-import path from 'path'
-import sinon from 'sinon'
+const fs = require('fs-extra')
+const path = require('path')
+const sinon = require('sinon')
 // import should from 'should'
 
 // import { TMP_DIR_NAME } from '../../../core/local/constants'
-import * as ChokidarEvent from '../../../core/local/chokidar_event'
-import Watcher from '../../../core/local/watcher'
-import Merge from '../../../core/merge'
-import Prep from '../../../core/prep'
-import Ignore from '../../../core/ignore'
-import Sync from '../../../core/sync'
-import * as metadata from '../../../core/metadata'
-import * as conversion from '../../../core/conversion'
+const ChokidarEvent = require('../../../core/local/chokidar_event')
+const Watcher = require('../../../core/local/watcher')
+const Merge = require('../../../core/merge')
+const Prep = require('../../../core/prep')
+const Ignore = require('../../../core/ignore')
+const Sync = require('../../../core/sync')
+const metadata = require('../../../core/metadata')
+const conversion = require('../../../core/conversion')
 
-import configHelpers from '../../support/helpers/config'
-import pouchHelpers from '../../support/helpers/pouch'
+const configHelpers = require('../../support/helpers/config')
+const pouchHelpers = require('../../support/helpers/pouch')
 
 describe('issue 850', function () {
   this.timeout(10000)

--- a/test/unit/remote/change.js
+++ b/test/unit/remote/change.js
@@ -1,5 +1,5 @@
-import {describe, it} from 'mocha'
-import * as remoteChange from '../../../core/remote/change'
+const {describe, it} = require('mocha')
+const remoteChange = require('../../../core/remote/change')
 
 describe('remote change sort', () => {
   it('sort correctly move inside move', () => {

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -1,13 +1,14 @@
 /* eslint-env mocha */
 /* @flow weak */
 
-import should from 'should'
+const should = require('should')
 
-import RemoteCozy, { DirectoryNotFound } from '../../../core/remote/cozy'
+const RemoteCozy = require('../../../core/remote/cozy')
+const { DirectoryNotFound } = RemoteCozy
 
-import configHelpers from '../../support/helpers/config'
-import { COZY_URL, builders, deleteAll } from '../../support/helpers/cozy'
-import CozyStackDouble from '../../support/doubles/cozy_stack'
+const configHelpers = require('../../support/helpers/config')
+const { COZY_URL, builders, deleteAll } = require('../../support/helpers/cozy')
+const CozyStackDouble = require('../../support/doubles/cozy_stack')
 
 const cozyStackDouble = new CozyStackDouble()
 

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -1,30 +1,30 @@
 /* @flow */
 /* eslint-env mocha */
 
-import crypto from 'crypto'
-import EventEmitter from 'events'
-import fs from 'fs-extra'
-import { pick } from 'lodash'
-import path from 'path'
-import sinon from 'sinon'
-import should from 'should'
-
-import * as conversion from '../../../core/conversion'
-import { ensureValidPath } from '../../../core/metadata'
-import Prep from '../../../core/prep'
-import Remote from '../../../core/remote'
-import { TRASH_DIR_ID } from '../../../core/remote/constants'
-import timestamp from '../../../core/timestamp'
-
 import type { Metadata } from '../../../core/metadata'
 import type { RemoteDoc, JsonApiDoc } from '../../../core/remote/document'
 
-import MetadataBuilders from '../../support/builders/metadata'
-import configHelpers from '../../support/helpers/config'
-import pouchHelpers from '../../support/helpers/pouch'
-import {
+const crypto = require('crypto')
+const EventEmitter = require('events')
+const fs = require('fs-extra')
+const { pick } = require('lodash')
+const path = require('path')
+const sinon = require('sinon')
+const should = require('should')
+
+const conversion = require('../../../core/conversion')
+const { ensureValidPath } = require('../../../core/metadata')
+const Prep = require('../../../core/prep')
+const Remote = require('../../../core/remote')
+const { TRASH_DIR_ID } = require('../../../core/remote/constants')
+const timestamp = require('../../../core/timestamp')
+
+const MetadataBuilders = require('../../support/builders/metadata')
+const configHelpers = require('../../support/helpers/config')
+const pouchHelpers = require('../../support/helpers/pouch')
+const {
   cozy, builders, deleteAll, createTheCouchdbFolder
-} from '../../support/helpers/cozy'
+} = require('../../support/helpers/cozy')
 
 const metadataBuilders = new MetadataBuilders()
 

--- a/test/unit/remote/registration.js
+++ b/test/unit/remote/registration.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
-import should from 'should'
+const should = require('should')
 
-import Registration from '../../../core/remote/registration'
+const Registration = require('../../../core/remote/registration')
 
-import configHelpers from '../../support/helpers/config'
+const configHelpers = require('../../support/helpers/config')
 
 describe('Registration', function () {
   before('instanciate config', configHelpers.createConfig)

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -1,30 +1,30 @@
 /* @flow */
 /* eslint-env mocha */
 
-import async from 'async'
-import EventEmitter from 'events'
-import { clone } from 'lodash'
-import path from 'path'
-import sinon from 'sinon'
-import should from 'should'
-import { Client as CozyClient } from 'cozy-client-js'
-
-import pouchdbBuilders from '../../support/builders/pouchdb'
-import configHelpers from '../../support/helpers/config'
-import { onPlatform } from '../../support/helpers/platform'
-import pouchHelpers from '../../support/helpers/pouch'
-import { builders } from '../../support/helpers/cozy'
-
-import { createMetadata } from '../../../core/conversion'
-import * as metadata from '../../../core/metadata'
-import { FILES_DOCTYPE, ROOT_DIR_ID, TRASH_DIR_ID } from '../../../core/remote/constants'
-import Prep from '../../../core/prep'
-import RemoteCozy from '../../../core/remote/cozy'
-import RemoteWatcher from '../../../core/remote/watcher'
-
 import type { RemoteChange } from '../../../core/remote/change'
 import type { RemoteDoc, RemoteDeletion } from '../../../core/remote/document'
 import type { Metadata } from '../../../core/metadata'
+
+const async = require('async')
+const EventEmitter = require('events')
+const { clone } = require('lodash')
+const path = require('path')
+const sinon = require('sinon')
+const should = require('should')
+const CozyClient = require('cozy-client-js').Client
+
+const pouchdbBuilders = require('../../support/builders/pouchdb')
+const configHelpers = require('../../support/helpers/config')
+const { onPlatform } = require('../../support/helpers/platform')
+const pouchHelpers = require('../../support/helpers/pouch')
+const { builders } = require('../../support/helpers/cozy')
+
+const { createMetadata } = require('../../../core/conversion')
+const metadata = require('../../../core/metadata')
+const { FILES_DOCTYPE, ROOT_DIR_ID, TRASH_DIR_ID } = require('../../../core/remote/constants')
+const Prep = require('../../../core/prep')
+const RemoteCozy = require('../../../core/remote/cozy')
+const RemoteWatcher = require('../../../core/remote/watcher')
 
 const { assignId, ensureValidPath } = metadata
 

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 
-import sinon from 'sinon'
-import should from 'should'
+const sinon = require('sinon')
+const should = require('should')
 
-import Ignore from '../../core/ignore'
-import Sync from '../../core/sync'
+const Ignore = require('../../core/ignore')
+const Sync = require('../../core/sync')
 
-import stubSide from '../support/doubles/side'
-import configHelpers from '../support/helpers/config'
-import pouchHelpers from '../support/helpers/pouch'
+const stubSide = require('../support/doubles/side')
+const configHelpers = require('../support/helpers/config')
+const pouchHelpers = require('../support/helpers/pouch')
 
 describe('Sync', function () {
   before('instanciate config', configHelpers.createConfig)

--- a/test/unit/timestamp.js
+++ b/test/unit/timestamp.js
@@ -1,9 +1,10 @@
 /* eslint-env mocha */
 
-import should from 'should'
-import sinon from 'sinon'
+const should = require('should')
+const sinon = require('sinon')
 
-import timestamp, { InvalidTimestampError, maxDate, sameDate } from '../../core/timestamp'
+const timestamp = require('../../core/timestamp')
+const { InvalidTimestampError, maxDate, sameDate } = timestamp
 
 // XXX: Pass strings to javascript's Date constructor everywhere, so the tests
 //      don't depend on the current timezone.

--- a/test/unit/utils/fs.js
+++ b/test/unit/utils/fs.js
@@ -1,15 +1,15 @@
 /* @flow */
 /* eslint-env mocha */
 
-import Promise from 'bluebird'
-import childProcess from 'child_process'
-import fs from 'fs-extra'
-import path from 'path'
-import should from 'should'
+const Promise = require('bluebird')
+const childProcess = require('child_process')
+const fs = require('fs-extra')
+const path = require('path')
+const should = require('should')
 
-import { hideOnWindows } from '../../../core/utils/fs'
+const { hideOnWindows } = require('../../../core/utils/fs')
 
-import configHelpers from '../../support/helpers/config'
+const configHelpers = require('../../support/helpers/config')
 
 Promise.promisifyAll(childProcess)
 Promise.promisifyAll(fs)

--- a/test/unit/utils/func.js
+++ b/test/unit/utils/func.js
@@ -1,9 +1,9 @@
 /* @flow */
 /* eslint-env mocha */
 
-import should from 'should'
+const should = require('should')
 
-import { composeAsync } from '../../../core/utils/func'
+const { composeAsync } = require('../../../core/utils/func')
 
 describe('utils', () => {
   describe('composeAsync', () => {

--- a/test/unit/utils/pending.js
+++ b/test/unit/utils/pending.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* @flow */
 
-import should from 'should'
+const should = require('should')
 
-import { PendingMap } from '../../../core/utils/pending'
+const { PendingMap } = require('../../../core/utils/pending')
 
 import type { Pending } from '../../../core/utils/pending' // eslint-disable-line
 


### PR DESCRIPTION
Another step to get rid of babel.
Moved type imports to the top so eslint doesn't complain.
Not sure why I get errors regarding ReadableWithContentLength type import, though.