### PR TITLE
core/app: Ensure logs archive extension matches the actual format

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -216,7 +216,7 @@ module.exports = class App {
     const pouchdbTree = await this.pouch.treeAsync()
 
     const logsSent = Promise.all([
-      this.uploadFileToSupport(incidentID, 'logs.zip', logs.pipe(zipper)),
+      this.uploadFileToSupport(incidentID, 'logs.gz', logs.pipe(zipper)),
       this.uploadFileToSupport(incidentID, 'pouchdtree.json', JSON.stringify(pouchdbTree))
     ]).catch((err) => {
       log.error({err}, 'FAILED TO SEND LOGS')


### PR DESCRIPTION
So we don't:
- get an error with `unzip logs.zip` because file is not a zip
- get an error with `gunzip logs.zip` because it doesn't like the filename
- need to `mv logs.zip logs.gz && gunzip logz.gz`