### PR TITLE
core/sync: Stop logging already synced seq

### DIFF
--- a/core/sync.js
+++ b/core/sync.js
@@ -130,14 +130,10 @@ class Sync {
   // sync
   async syncBatch () {
     let seq = null
-    let lastSeq = null
     while (true) {
       if (this.stopped) break
       seq = await this.pouch.getLocalSeqAsync()
-      // TODO: if (seq === lastSeq) throw new Error('Infinite loop!')
-      if (seq === lastSeq) log.warn({seq}, 'Seq was already synced!')
-      else lastSeq = seq
-
+      // TODO: Prevent infinite loop
       let change = await this.getNextChange(seq)
       if (change == null) break
       this.events.emit('sync-current', change.seq)


### PR DESCRIPTION
It always happens, it's normal, and generates a lot of noise in logs.
We still need to figure out a way to prevent infinite loops though.