### PR TITLE
Dump failed test logs in console

### DIFF
--- a/test/support/logging.js
+++ b/test/support/logging.js
@@ -3,11 +3,31 @@
 
 import logger from '../../core/logger'
 
+const { defaultLogger } = logger
 const log = logger({component: 'mocha'})
 
+const lines = []
+
+defaultLogger.addStream({
+  type: 'raw',
+  level: 'trace',
+  stream: {
+    write: function (msg) {
+      lines.push(msg)
+    }
+  }
+})
+
 beforeEach(function () {
+  lines.length = 0
   // FIXME: this.currentTest is undefined on AppVeyor, not sure why
   if (process.env.APPVEYOR == null) {
     log.info('\n\n---------- ' + this.currentTest.title + ' ----------\n\n')
+  }
+})
+
+afterEach(function () {
+  if (this.currentTest.state === 'failed') {
+    console.log(lines.map(l => JSON.stringify(l)).join('\n'))
   }
 })


### PR DESCRIPTION
Dump logs (JSON lines format) in console for failing test, so we can debug failures occurring only on CI.

Failing build examples:
- [Travis](https://travis-ci.org/cozy-labs/cozy-desktop/jobs/362697020#L3448)
- [AppVeyor](https://ci.appveyor.com/project/cozy/cozy-desktop/build/1.0.517#L860)

I assume it should not be an issue on the security level, since we don't log credentials anyway.