### PR TITLE
chore: Introduce yarn stack:update script

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "release:check:branch": "node ./dev/check-release-branch.js",
     "release:check:node8": "node -e \"(process.versions.node.split('.')[0] !== '8') && process.exit(1)\"",
     "repl": "env-cmd .env.dev babel-node ./dev/repl.js",
+    "stack:update": "docker pull cozy/cozy-app-dev:2.0.0 && docker rm cozy-desktop-stack",
     "start": "env-cmd .env.dev electron .",
     "test": "yarn test:unit && yarn test:elm && yarn test:integration && yarn test:scenarios",
     "test:coverage": "yarn test:unit:coverage && yarn test:integration",


### PR DESCRIPTION
So we don't need to remember how to do this.
Use docker tag `2.0.0`, not `latest`, because:

> “Latest” simply means “the last build/tag that ran without a specific tag/version specified”.

https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375