### PR TITLE
core/merge: Keep unapplied move source

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -271,7 +271,7 @@ class Merge {
       was.moveTo = doc._id
       was._deleted = true
       delete was.errors
-      doc.moveFrom = was
+      doc.moveFrom = was.moveFrom || was
       if (file && sameFile(file, doc)) {
         log.info({path}, 'up to date (move)')
         return null
@@ -308,7 +308,7 @@ class Merge {
       // FIXME: Shouldn't we compare doc/was updated_at & set doc accordingly
       // as in moveFileAsync?
       delete doc.trashed
-      doc.moveFrom = was
+      doc.moveFrom = was.moveFrom || was
       if (folder) {
         const dst = await this.resolveConflictAsync(side, doc, folder)
         dst.sides = {}
@@ -349,7 +349,7 @@ class Merge {
       markSide(side, dst, src)
       dst._id = src.moveTo
       dst.path = doc.path.replace(was.path, folder.path)
-      dst.moveFrom = src
+      dst.moveFrom = src.moveFrom || src
       delete dst._rev
       delete dst.errors
       // FIXME: Find a cleaner way to pass the syncPath to the Merge


### PR DESCRIPTION
So we don't end up with doc.moveFrom.moveFrom... in Pouch