### PR TITLE
test/support: Don't swallow skipped test in platform helpers

### DIFF
--- a/test/support/helpers/platform.js
+++ b/test/support/helpers/platform.js
@@ -7,11 +7,14 @@ module.exports = {
 
 function onPlatforms (...platformsAndSpec) {
   const spec = platformsAndSpec.pop()
-  const platforms = platformsAndSpec
+  const expectedPlatforms = platformsAndSpec
+  const currentPlatform = process.platform
 
-  if (platforms.indexOf(process.platform) > -1) {
-    mocha.describe(`on ${platforms.join(' / ')}`, spec)
-  }
+  const describe = expectedPlatforms.indexOf(currentPlatform) > -1
+    ? mocha.describe
+    : mocha.describe.skip
+
+  describe(`on ${expectedPlatforms.join(' / ')}`, spec)
 }
 
 function onPlatform (platform, spec) {


### PR DESCRIPTION
So developers don't end up wondering why some test doesn't run.