### PR TITLE
test/support: Rename SyncDirTestHelpers to ContextDir including #tree()

### DIFF
--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -13,7 +13,8 @@ Promise.promisifyAll(checksumer)
 
 /*:: import type { PathObject } from '../../../core/utils/path' */
 
-class SyncDirTestHelpers {
+// A directory in the context of which we want to perform many FS operations.
+class ContextDir {
   /*::
   root: string
   */
@@ -58,5 +59,5 @@ class SyncDirTestHelpers {
 }
 
 module.exports = {
-  SyncDirTestHelpers
+  ContextDir
 }

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -19,42 +19,11 @@ import type Local from '../../../core/local'
 import type { ChokidarEvent } from '../../../core/local/chokidar_event'
 */
 
-function posixifyPath (localPath /*: string */) /*: string */ {
-  return localPath.split(path.sep).join(path.posix.sep)
-}
-
-async function tree (rootPath /*: string */) /*: Promise<string[]> */ {
-  const dirsToRead = [rootPath]
-  const relPaths = []
-  const makeRelative = (absPath /*: string */) => posixifyPath(absPath.slice(rootPath.length + path.sep.length))
-
-  while (true) {
-    const dir = dirsToRead.shift()
-    if (dir == null) break
-
-    for (const name of await fs.readdirAsync(dir)) {
-      if (name === TMP_DIR_NAME) continue
-
-      const absPath = path.join(dir, name)
-      const stat = await fs.statAsync(absPath)
-      let relPath = makeRelative(absPath)
-
-      if (stat.isDirectory()) {
-        dirsToRead.push(absPath)
-        relPath = relPath + path.posix.sep
-      }
-
-      relPaths.push(relPath)
-    }
-  }
-
-  return relPaths.sort((a, b) => a.localeCompare(b))
-}
-
 class LocalTestHelpers {
   /*::
   local: Local
   syncDir: ContextDir
+  trashDir: ContextDir
   */
 
   constructor (local /*: Local */) {
@@ -90,13 +59,14 @@ class LocalTestHelpers {
 
   async setupTrash () {
     await fs.emptyDir(this.trashPath)
+    this.trashDir = new ContextDir(this.trashPath)
     this.local._trash = this.trashFunc
   }
 
   async tree () /*: Promise<string[]> */ {
     let trashContents
     try {
-      trashContents = await tree(this.trashPath)
+      trashContents = await this.trashDir.tree()
     } catch (err) {
       if (err.code !== 'ENOENT') throw err
       throw new Error(
@@ -106,8 +76,9 @@ class LocalTestHelpers {
     }
     return trashContents
       .map(relPath => path.posix.join('/Trash', relPath))
-      .concat(await tree(this.syncPath))
+      .concat(await this.syncDir.tree())
       .map(conflictHelpers.ellipsizeDate)
+      .filter(relpath => !relpath.match(TMP_DIR_NAME))
   }
 
   async treeWithoutTrash () {
@@ -125,6 +96,5 @@ class LocalTestHelpers {
 }
 
 module.exports = {
-  posixifyPath,
   LocalTestHelpers
 }

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -7,7 +7,7 @@ const path = require('path')
 const rimraf = require('rimraf')
 
 const conflictHelpers = require('./conflict')
-const { SyncDirTestHelpers } = require('./sync_dir')
+const { ContextDir } = require('./context_dir')
 
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 
@@ -54,12 +54,12 @@ async function tree (rootPath /*: string */) /*: Promise<string[]> */ {
 class LocalTestHelpers {
   /*::
   local: Local
-  syncDir: SyncDirTestHelpers
+  syncDir: ContextDir
   */
 
   constructor (local /*: Local */) {
     this.local = local
-    this.syncDir = new SyncDirTestHelpers(local.syncPath)
+    this.syncDir = new ContextDir(local.syncPath)
     autoBind(this)
   }
 

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -15,7 +15,7 @@ const { PendingMap } = require('../../../core/utils/pending')
 const MetadataBuilders = require('../../support/builders/metadata')
 const StreamBuilder = require('../../support/builders/stream')
 const configHelpers = require('../../support/helpers/config')
-const { SyncDirTestHelpers } = require('../../support/helpers/sync_dir')
+const { ContextDir } = require('../../support/helpers/context_dir')
 const pouchHelpers = require('../../support/helpers/pouch')
 
 Promise.promisifyAll(fs)
@@ -31,7 +31,7 @@ describe('Local', function () {
     this.local = new Local(this.config, this.prep, this.pouch, this.events)
     this.local.watcher.pending = new PendingMap()
 
-    syncDir = new SyncDirTestHelpers(this.syncPath)
+    syncDir = new ContextDir(this.syncPath)
   })
   after('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)


### PR DESCRIPTION
Its API is in no way specific to the sync dir.
This will help testing other directory-relative behaviors.
Also moved `#tree()` there because we'll probably always want to get the tree of some context dir.
Which also means now we can handle the fake trash as any other `ContextDir` (e.g. for *treeing* or *clearing*).