### PR TITLE
ci/macos: Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,12 @@ before_install:
     - export COZY_STACK_TOKEN=$($GOPATH/bin/cozy-stack instances token-oauth localhost:8080 "$COZY_CLIENT_ID" io.cozy.files io.cozy.settings)
 
     # COZY_DESKTOP_DIR
-    - mkdir -p "$COZY_DESKTOP_DIR"
+    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+        hdiutil create -megabytes 10 -fs APFS -volname cozy-desktop "$COZY_DESKTOP_DIR";
+        hdiutil attach "${COZY_DESKTOP_DIR}.dmg" -mountpoint "$COZY_DESKTOP_DIR";
+      else
+        mkdir -p "$COZY_DESKTOP_DIR";
+      fi
 
     # Dummy .env.test (all variables are already set)
     # env-cmd ignores the file when empty

--- a/test/world/case_and_encoding.js
+++ b/test/world/case_and_encoding.js
@@ -7,6 +7,8 @@ const should = require('should')
 
 const MacOSRelease = require('../support/helpers/MacOSRelease')
 
+const { TRAVIS } = process.env
+
 should.Assertion.add('hex', function (expectedPretty) {
   const expected = expectedPretty.trim().split(/\s+/)
   const actual = Buffer.from(this.obj).toString('hex').match(/.{1,2}/g)
@@ -40,7 +42,7 @@ suite('Case and encoding basics', () => {
         should(await listFiles()).deepEqual(['\u00e9'])
         break
       case 'darwin':
-        if (MacOSRelease.isAtLeast(MacOSRelease.HIGH_SIERRA_10_13)) {
+        if (MacOSRelease.isAtLeast(MacOSRelease.HIGH_SIERRA_10_13) && !TRAVIS) {
           should(await listFiles()).deepEqual(['\u00e9'])
         } else {
           should(await listFiles()).deepEqual(['\u0065\u0301'])
@@ -101,7 +103,7 @@ suite('Case and encoding basics', () => {
         should(await listFiles()).deepEqual(['\u00e9'])
         break
       case 'darwin':
-        if (MacOSRelease.isAtLeast(MacOSRelease.HIGH_SIERRA_10_13)) {
+        if (MacOSRelease.isAtLeast(MacOSRelease.HIGH_SIERRA_10_13) && !TRAVIS) {
           should(await listFiles()).deepEqual(['\u00e9'])
         } else {
           should(await listFiles()).deepEqual(['\u0065\u0301'])


### PR DESCRIPTION
Travis macOS workers switched to 10.13/HFS+:
https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce

We don't handle this combination in tests yet, although it does work in production.
Using an APFS disk image should fix the macOS builds.
