### PR TITLE
Make local tree expectations clearer and more reliable

### DIFF
--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -77,8 +77,8 @@ suite('Case or encoding change', () => {
       switch (process.platform) {
         case 'win32':
           should(tree).deepEqual([
-            '\u00e9/',
-            'foo/'
+            'foo/',
+            '\u00e9/'
           ])
           break
 
@@ -91,8 +91,8 @@ suite('Case or encoding change', () => {
 
         case 'linux':
           should(tree).deepEqual([
-            '\u00e9/',
-            'FOO/'
+            'FOO/',
+            '\u00e9/'
           ])
       }
     })

--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -52,19 +52,19 @@ suite('Case or encoding change', () => {
     beforeEach(async () => {
       // This will fail with a 409 conflict error when cozy-stack runs directly
       // on macOS & HFS+ because a file with an equivalent name already exists.
-      dir = await cozy.files.createDirectory({name: '\u0065\u0301'})
+      dir = await cozy.files.createDirectory({name: 'e\u0301'}) // 'é'
       dir2 = await cozy.files.createDirectory({name: 'foo'})
       await helpers.remote.pullChanges()
       await helpers.syncAll()
       helpers.spyPouch()
       should(await helpers.local.tree()).deepEqual([
-        '\u0065\u0301/',
+        'e\u0301/', // 'é/'
         'foo/'
       ])
     })
 
     test('remote', async () => {
-      await cozy.files.updateAttributesById(dir._id, {name: '\u00e9'})
+      await cozy.files.updateAttributesById(dir._id, {name: '\u00e9'}) // 'é'
       await cozy.files.updateAttributesById(dir2._id, {name: 'FOO'})
       await helpers.remote.pullChanges()
 
@@ -78,13 +78,13 @@ suite('Case or encoding change', () => {
         case 'win32':
           should(tree).deepEqual([
             'foo/',
-            '\u00e9/'
+            '\u00e9/' // 'é/'
           ])
           break
 
         case 'darwin':
           should(tree).deepEqual([
-            '\u0065\u0301/',
+            'e\u0301/', // 'é/'
             'foo/'
           ])
           break
@@ -92,7 +92,7 @@ suite('Case or encoding change', () => {
         case 'linux':
           should(tree).deepEqual([
             'FOO/',
-            '\u00e9/'
+            '\u00e9/' // 'é/'
           ])
       }
     })

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -79,6 +79,7 @@ class LocalTestHelpers {
       .concat(await this.syncDir.tree())
       .map(conflictHelpers.ellipsizeDate)
       .filter(relpath => !relpath.match(TMP_DIR_NAME))
+      .sort()
   }
 
   async scan () {


### PR DESCRIPTION
So we don't end up with hard-to-debug test failures.
