### PR TITLE
ci/travis: Run brew [cask] doctor on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,3 +118,5 @@ after_success:
 after_failure:
     - $CXX --version
     - netstat -lntp
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew doctor; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask doctor; fi


### PR DESCRIPTION
To help debugging when things get bad.
Separated both commands to make it easier to know which output belongs
to which one.
