### PR TITLE
test/unit/merge: Fix random moveFolder() failure

### DIFF
--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -325,14 +325,14 @@ describe('Merge', function () {
         _id: 'FOOBAR/NEW',
         path: 'FOOBAR/NEW',
         docType: 'folder',
-        updated_at: new Date(),
+        updated_at: new Date('2018-09-02T00:00:00.000Z'),
         tags: ['courge', 'quux']
       }
       let was = {
         _id: 'FOOBAR/OLD',
         path: 'FOOBAR/OLD',
         docType: 'folder',
-        updated_at: new Date(),
+        updated_at: new Date('2018-09-01T00:00:00.000Z'),
         tags: ['courge', 'quux'],
         sides: {
           local: 1,


### PR DESCRIPTION
At least try to fix it.
Assuming was.updated_at can differ from 1 ms in which case Merge will
actually use it as it's the most recent one.
