### PR TITLE
core,jq: Unify logging & filters

### DIFF
--- a/.jq
+++ b/.jq
@@ -34,14 +34,25 @@ def is_debug: .level >= debug_level;
 def debug: clean | select(is_debug);
 
 # Components:
-def chokidar: select(.component == "Chokidar");
-def LocalChange: select(.component == "local/change");
-def LocalWatcher: select(.component == "LocalWatcher");
-def Prep: select(.component == "Prep");
-def Merge: select(.component == "Merge");
-def Metadata: select(.component == "Metadata");
-def Pouch: select(.component == "Pouch");
-def Sync: select(.component == "Sync");
+def component(pattern): select(.component | test(pattern));
+def App: component("^App$");
+def Chokidar: component("^Chokidar|chokidar$");
+def Fs: component("^Fs|FS$");
+def LocalAnalysis: component("^LocalAnalysis|local/analysis$");
+def LocalChange: component("^LocalChange|local/change$");
+def LocalWatcher: component("^LocalWatcher$");
+def LocalWriter: component("^LocalWriter$");
+def Merge: component("^Merge$");
+def Metadata: component("^Metadata$");
+def Perfs: component("^Perfs|PerfReports$");
+def Pouch: component("^Pouch$");
+def Prep: component("^Prep$");
+def RemoteCozy: component("^RemoteCozy$");
+def RemoteUserActionRequired: component("^RemoteUserActionRequired|remote/user_action_required$");
+def RemoteWarningPoller: component("^RemoteWarningPoller$");
+def RemoteWatcher: component("^RemoteWatcher$");
+def RemoteWriter: component("^RemoteWriter$");
+def Sync: component("^Sync$");
 
 # Find conflicts:
 #

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -21,7 +21,7 @@ import type {
 */
 
 const log = logger({
-  component: 'local/analysis'
+  component: 'LocalAnalysis'
 })
 log.chokidar = log.child({
   component: 'chokidar'

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -49,7 +49,7 @@ module.exports = {
 }
 
 const log = logger({
-  component: 'local/change'
+  component: 'LocalChange'
 })
 
 /*::

--- a/core/perftools.js
+++ b/core/perftools.js
@@ -2,7 +2,7 @@
 
 const logger = require('./logger')
 const log = logger({
-  component: 'PerfReports'
+  component: 'Perfs'
 })
 
 module.exports = measureTime

--- a/core/remote/user_action_required.js
+++ b/core/remote/user_action_required.js
@@ -3,7 +3,7 @@
 const logger = require('../logger')
 
 const log = logger({
-  component: 'remote/user_action_required'
+  component: 'RemoteUserActionRequired'
 })
 
 module.exports = {

--- a/core/utils/fs.js
+++ b/core/utils/fs.js
@@ -11,7 +11,7 @@ module.exports = {
 }
 
 const log = logger({
-  component: 'FS'
+  component: 'Fs'
 })
 
 // Hides a directory on Windows.


### PR DESCRIPTION
- Unify logger names (upper camel case)
- Add missing filters (so we stop adding them one at a time)
- Still support old logger names
