### PR TITLE
WIP: test/support/builders/metadata: Fix up-to-date sides

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -108,7 +108,7 @@ module.exports = class BaseMetadataBuilder {
   }
 
   upToDate () /*: this */ {
-    this.opts.sides = {local: 1, remote: 1}
+    this.opts.sides = {local: 2, remote: 2}
     return this
   }
 


### PR DESCRIPTION
Up-to-date metadata always had its sides incremented at least 2 times:

- Once on Merge (on the side from which the change is coming from), e.g.
1-N/A or 2-3
- Once on Sync (on both sides), e.g. 2-2 or 4-4
