### PR TITLE
ci/travis/linux: Fix docker --env-file error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ script:
     - |
       if [ "$TRAVIS_OS_NAME" == "linux" ]; then
         docker run --rm \
-          --env-file <(env -u TRAVIS_COMMIT_MESSAGE | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_') \
+          --env-file <(env | grep -v '\r' | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_') \
           -v ${PWD}:/project \
           -v ~/.cache/electron:/root/.cache/electron \
           -v ~/.cache/electron-builder:/root/.cache/electron-builder \


### PR DESCRIPTION
So we stop wondering about multiline env vars occasionnally breaking the build.
I can't think of any multiline one that would be useful anyway... (please correct me if I'm wrong).
Courtesy of @aenario :)