### PR TITLE
dev: Use latest cozy-app-dev:2018M3S6 [ci skip]

### DIFF
--- a/dev/cozy-stack/Dockerfile
+++ b/dev/cozy-stack/Dockerfile
@@ -1,6 +1,6 @@
 # Use explicit tag (not latest which doesn't necessarily mean the last stable
 # version of the image)
-FROM cozy/cozy-app-dev:2018M2S5
+FROM cozy/cozy-app-dev:2018M3S6
 
 # Bring back git so we can install Cozy apps later
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Tag was force-pushed with development version of the stack, so it works now thanks to @aeris :heart: 