### PR TITLE
Update onboarding procedure

### DIFF
--- a/doc/developer/requirements.md
+++ b/doc/developer/requirements.md
@@ -79,13 +79,13 @@ parameters below):
     docker-machine create default
     eval $(docker-machine env default)
 
-### Fedora 27
+### Fedora 28
 
-    sudo dnf install docker gcc-c++ git nodejs
-    cd /etc/yum.repos.d/
-    sudo wget https://dl.yarnpkg.com/rpm/yarn.repo
-    cd -
-    sudo dnf install yarn
+    sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
+    sudo dnf install docker gcc-c++ git nodejs yarn transifex-client python3-pip
+    sudo pip install docker-compose
+    sudo groupadd docker
+    sudo usermod -aG docker $USER # Restart your session so this takes effect
 
 ### Ubuntu
 
@@ -95,22 +95,17 @@ parameters below):
     sudo add-apt-repository \
      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     sudo apt update
-    sudo apt install git nodejs build-essential gcc transifex-client icnsutils graphicsmagick python-pip docker-ce yarn
+    sudo apt install git nodejs build-essential gcc transifex-client icnsutils graphicsmagick python3-pip docker-ce yarn
     sudo pip install docker-compose
     sudo groupadd docker
-    sudo usermod -aG docker $USER
+    sudo usermod -aG docker $USER # Restart your session so this takes effect
 
 ## Set up a Cozy stack
 
 If you don't already have a [running Cozy stack](https://github.com/cozy/cozy-stack/blob/master/docs/INSTALL.md), the easiest way to get started is to use Docker:
 
-    cd cli
     docker-compose up
     yarn bootstrap
-
-Otherwise, please refer to the
-[../../cli/dev/docker/bootstrap-cozy-desktop.sh]()
-script to create the appropriate instances, token, etc...
 
 ## Cozy Stack
 
@@ -127,3 +122,7 @@ You can also run any cozy-stack command with the `yarn cozy-stack` script, e.g.:
 ```
 yarn cozy-stack apps install --domain cozy.tools:8080 drive 'git://github.com/cozy/cozy-drive.git#build-drive'
 ```
+
+## Complete your setup
+
+See [./setup.md]()

--- a/doc/developer/setup.md
+++ b/doc/developer/setup.md
@@ -30,17 +30,33 @@ cd cozy-desktop
 **Warning**: The path to your local repository should not include any space,
 otherwise [installing dependencies will fail](https://github.com/cozy-labs/cozy-desktop/issues/1097).
 
-### Install dependencies
+## Install dependencies
 
 ```
 yarn install
 ```
 
-### Build everything
+## Build everything
 
 ```
 yarn build
 ```
+
+### Transifex (optional)
+
+If you need to update translations, you'll need a Transifex API token at this step (requested automatically if `transifex` is in your $PATH)
+
+- Create an account on http://www.transifex.com
+- Join the Cozy team
+- Get your API token from the account settings page
+
+## Start development version
+
+```
+yarn start
+```
+
+N.B.: the address of the development cozy-stack is http://cozy.tools:8080. Don't forget the protocol part when creating the connection in cozy-desktop for the first time or it won't find the server.
 
 ## Run tests
 

--- a/doc/developer/test.md
+++ b/doc/developer/test.md
@@ -19,7 +19,14 @@ We use [`mocha`][1] for testing cozy-desktop, the options are in
 Integration tests and some unit tests require that you have a Cozy stack up.
 It's also expected that you have an instance registered for
 `test.cozy-desktop.tools:8080` with the
-[test passphrase](../test/helpers/passphrase.js).
+[test passphrase](../../test/support/helpers/passphrase.js).
+You can start a cozy-stack via the provided docker-compose file:
+
+```
+docker-compose up
+```
+
+See [requirements](./requirements.md) for details on how to setup docker and docker-compose.
 
 Unit tests
 ----------

--- a/doc/developer/test.md
+++ b/doc/developer/test.md
@@ -34,7 +34,7 @@ Unit tests
 For testing a class in isolation, method per method:
 
 ```bash
-yarn test-unit
+yarn test:unit
 ```
 
 
@@ -49,7 +49,7 @@ You can run the integration suite to test the communication between
 cozy-desktop and a remote cozy stack:
 
 ```bash
-COZY_DESKTOP_DIR=tmp yarn test-integration
+COZY_DESKTOP_DIR=tmp yarn test:integration
 ```
 
 
@@ -95,7 +95,7 @@ COZY_DESKTOP_DIR=tmp yarn test
 To run a specific set of tests (here testing pouch)
 
 ```bash
-NODE_ENV=test node_modules/.bin/mocha test/unit/pouch.js
+yarn mocha test/unit/pouch.js
 ```
 
 For more logs you can activate debug logs:


### PR DESCRIPTION
  For Fedora 28:
  - add transifex-client, docker and docker-compose dependencies

  Add build and run steps, including the creation of a Transifex
  account (i.e. to get an API token).

  Add command to start the included development cozy-stack via docker in
  the testing procedure.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [x] it includes relevant documentation
