### PR TITLE
core/analysis: multiple adds for same path is not move

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -119,7 +119,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               break
             }
             const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByInode(e))
-            if (addChange) {
+            if (addChange && addChange.path !== e.path) {
               changeFound(localChange.dirRenamingCaseOnlyFromAddAdd(addChange, e))
               break
             }

--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -261,6 +261,25 @@ describe('core/local/analysis', function () {
     }])
   })
 
+  it('identifies addDir({path: foo, ino: 1}) + addDir({path: foo, ino: 1}) as only DirAddition(foo)', () => {
+    const old /*: Metadata */ = metadataBuilders.dir().path('foo').ino(1).build()
+    const stats = {ino: 1}
+    const events /*: LocalEvent[] */ = [
+      {type: 'addDir', path: 'foo', stats, old},
+      {type: 'addDir', path: 'foo', stats, old}
+    ]
+    const pendingChanges = []
+
+    should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
+      type: 'DirAddition',
+      path: 'foo',
+      ino: 1,
+      stats,
+      old
+    }])
+  })
+
   it('identifies addDir({path: FOO, stats: {ino}, old: {path: foo, ino}}) as offline DirMove(foo, FOO)', () => {
     const ino = 456
     const stats = {ino}


### PR DESCRIPTION
Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
