### PR TITLE
core/config: Reset corrupted config file on start

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -4,6 +4,11 @@ const _ = require('lodash')
 const path = require('path')
 
 const { hideOnWindows } = require('./utils/fs')
+const logger = require('./logger')
+
+const log = logger({
+  component: 'Config'
+})
 
 // Config can keep some configuration parameters in a JSON file,
 // like the devices credentials or the mount path
@@ -20,7 +25,17 @@ module.exports = class Config {
       this.reset()
     }
 
-    this.config = require(this.configPath)
+    try {
+      this.config = require(this.configPath)
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        log.error(`Could not read config file at ${this.configPath}:`, e)
+        this.reset()
+        this.config = require(this.configPath)
+      } else {
+        throw e
+      }
+    }
 
     // FIXME: autoBind(this)
   }

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const should = require('should')
+const fs = require('fs-extra')
 
 const configHelpers = require('../support/helpers/config')
 
@@ -10,6 +11,19 @@ const Config = require('../../core/config')
 describe('Config', function () {
   before('instanciate config', configHelpers.createConfig)
   after('clean config directory', configHelpers.cleanConfig)
+
+  describe('constructor', function () {
+    it('resets corrupted config', function () {
+      const corruptedContent = '\0'
+      fs.writeFileSync(this.config.configPath, corruptedContent)
+
+      let conf
+      (() => {
+        conf = new Config(path.dirname(this.config.configPath))
+      }).should.not.throw()
+      conf.should.be.an.Object()
+    })
+  })
 
   describe('persist', function () {
     it('saves last changes made on the config', function () {


### PR DESCRIPTION
  A corrupted config.json file is not parsable and requiring it throws
  an uncaught error, preventing the app to start.
  Since we couldn't figure out how this file gets corrupted and since it
  can get corrupted by any other software, we catch this error and reset
  the file so the app can start in any case.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
