### PR TITLE
core/merge: Fix move conflicting destination id

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -7,6 +7,7 @@ const { basename, dirname, extname, join } = require('path')
 const IdConflict = require('./IdConflict')
 const logger = require('./logger')
 const {
+  assignId,
   assignMaxDate,
   detectPlatformIncompatibilities,
   isUpToDate,
@@ -109,6 +110,7 @@ class Merge {
       base = base.slice(0, 180)
     }
     dst.path = `${join(dir, base)}-conflict-${date}${ext}`
+    assignId(dst)
     try {
       // $FlowFixMe
       await this[side].renameConflictingDocAsync(doc, dst.path)

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -57,6 +57,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  noRev () /*: this */ {
+    delete this.doc._rev
+    return this
+  }
+
   incompatible () /*: this */ {
     const { platform } = process
 

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -12,12 +12,13 @@ const BaseMetadataBuilder = require('./base')
 
 /*::
 import type Pouch from '../../../../core/pouch'
+import type { Metadata } from '../../../../core/metadata'
 import type { RemoteDoc } from '../../../../core/remote/document'
 */
 
 module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
-  constructor (pouch /*: ?Pouch */) {
-    super(pouch)
+  constructor (pouch /*: ?Pouch */, old /*: ?Metadata */) {
+    super(pouch, old)
     this.doc.docType = 'file'
     this.data('')
   }

--- a/test/support/builders/metadata/index.js
+++ b/test/support/builders/metadata/index.js
@@ -22,8 +22,8 @@ module.exports = class MetadataBuilders {
     return new DirMetadataBuilder(this.pouch, old)
   }
 
-  file () /*: FileMetadataBuilder */ {
-    return new FileMetadataBuilder(this.pouch)
+  file (old /*: ?Metadata */) /*: FileMetadataBuilder */ {
+    return new FileMetadataBuilder(this.pouch, old)
   }
 
   whatever () /*: BaseMetadataBuilder */ {


### PR DESCRIPTION
Conflicting file/dir move destination id was not matching its path (it was missing the conflict suffix).