### PR TITLE
core/config: Replace require with fs.readJSON

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -26,7 +26,7 @@ module.exports = class Config {
     }
 
     try {
-      this.config = require(this.configPath)
+      this.config = fs.readJSONSync(this.configPath)
     } catch (e) {
       if (e instanceof SyntaxError) {
         log.error(`Could not read config file at ${this.configPath}:`, e)

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -179,8 +179,9 @@ describe('App', function () {
     it('works when app is configured', function () {
       configHelpers.createConfig.call(this)
       configHelpers.registerClient.call(this)
-      const app = new App(this.basePath)
+      this.config.persist() // the config helper does not persist it
 
+      const app = new App(this.basePath)
       const info = app.clientInfo()
 
       should(info.appVersion).equal(version)


### PR DESCRIPTION
  NodeJS' require maintains a cache of imported modules or, in our case,
  configurations.
  This is an issue in tests where loading an empty config results in a
  complete config object.

  In our situation, we can easily replace require with fs.readJSON
  which does not maintain any cache.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
