### PR TITLE
test/scenarios: log to console with TESTDEBUG, not DEBUG

### DIFF
--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -12,7 +12,7 @@ const { RemoteCozy } = require('../../core/remote/cozy')
 const configHelpers = require('../../test/support/helpers/config')
 const cozyHelpers = require('../../test/support/helpers/cozy')
 
-const debug = process.env.DEBUG != null ? console.log : (...args) => {}
+const debug = process.env.TESTDEBUG != null ? console.log : (...args) => {}
 
 const createInitialTree = async function (scenario /*: * */, cozy /*: * */, pouch /*: Pouch */) {
   if (!scenario.init) return

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -10,7 +10,7 @@ const metadata = require('../../../core/metadata')
 
 const { cozy } = require('./cozy')
 
-const debug = process.env.DEBUG ? console.log : () => {}
+const debug = process.env.TESTDEBUG ? console.log : () => {}
 
 const disabledExtension = '.DISABLED'
 


### PR DESCRIPTION
So we get a readable output when all we want is to analyse the log file.
