### PR TITLE
WIP: core/local: Fix harmless file/dir identical renaming loopback issues

### DIFF
--- a/core/local/change.js
+++ b/core/local/change.js
@@ -156,6 +156,7 @@ function _fromEvent (e/*: LocalEvent */) /*: LocalChange */ {
 }
 
 function fileMoveFromUnlinkAdd (unlinkChange /*: LocalFileDeletion */, e /*: LocalFileAdded */) /*: * */ {
+  if (_.get(unlinkChange, 'old.path') === e.path) return fromEvent(e)
   log.debug({oldpath: unlinkChange.path, path: e.path, ino: unlinkChange.ino}, 'unlink + add = FileMove')
   return build('FileMove', e.path, {
     stats: e.stats,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -167,6 +167,7 @@ function fileMoveFromUnlinkAdd (unlinkChange /*: LocalFileDeletion */, e /*: Loc
 }
 
 function dirMoveFromUnlinkAdd (unlinkChange /*: LocalDirDeletion */, e /*: LocalDirAdded */) /*: * */ {
+  if (_.get(unlinkChange, 'old.path') === e.path) return fromEvent(e)
   log.debug({oldpath: unlinkChange.path, path: e.path}, 'unlinkDir + addDir = DirMove')
   return build('DirMove', e.path, {
     stats: e.stats,

--- a/test/scenarios/rename_identical/local/win32.json
+++ b/test/scenarios/rename_identical/local/win32.json
@@ -1,0 +1,61 @@
+[
+  {
+    "breakpoints": [0]
+  },
+  {
+    "type": "unlinkDir",
+    "path": "dir-case"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "dir-nfc-to-nfd-é"
+  },
+  {
+    "type": "addDir",
+    "path": "DIR-CASE",
+    "stats": {
+      "ino": 1,
+      "size": 0,
+      "mtime": "2018-10-18T14:36:22.899Z",
+      "ctime": "2018-10-18T14:36:25.927Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "dir-nfc-to-nfd-é",
+    "stats": {
+      "ino": 3,
+      "size": 0,
+      "mtime": "2018-10-18T14:36:22.954Z",
+      "ctime": "2018-10-18T14:36:25.931Z"
+    }
+  },
+  {
+    "type": "unlink",
+    "path": "file-nfc-to-nfd-é"
+  },
+  {
+    "type": "unlink",
+    "path": "file-case"
+  },
+  {
+    "type": "add",
+    "path": "FILE-CASE",
+    "stats": {
+      "ino": 2,
+      "size": 8,
+      "mtime": "2018-10-18T14:36:22.953Z",
+      "ctime": "2018-10-18T14:36:25.929Z"
+    }
+  },
+  {
+    "type": "add",
+    "path": "file-nfc-to-nfd-é",
+    "stats": {
+      "ino": 4,
+      "size": 8,
+      "mtime": "2018-10-18T14:36:22.958Z",
+      "ctime": "2018-10-18T14:36:25.932Z"
+    }
+  }
+]

--- a/test/scenarios/rename_identical_local_loopback/local/win32_faked.json
+++ b/test/scenarios/rename_identical_local_loopback/local/win32_faked.json
@@ -1,0 +1,33 @@
+[
+  {
+    "breakpoints": [0]
+  },
+  {
+    "type": "unlinkDir",
+    "path": "dir_case"
+  },
+  {
+    "type": "addDir",
+    "path": "DIR_CASE",
+    "stats": {
+      "ino": 1,
+      "size": 0,
+      "mtime": "2018-10-18T14:36:22.899Z",
+      "ctime": "2018-10-18T14:36:25.927Z"
+    }
+  },
+  {
+    "type": "unlink",
+    "path": "file.case"
+  },
+  {
+    "type": "add",
+    "path": "FILE.CASE",
+    "stats": {
+      "ino": 2,
+      "size": 0,
+      "mtime": "2018-10-18T14:36:22.899Z",
+      "ctime": "2018-10-18T14:36:25.927Z"
+    }
+  }
+]

--- a/test/scenarios/rename_identical_local_loopback/scenario.js
+++ b/test/scenarios/rename_identical_local_loopback/scenario.js
@@ -7,14 +7,16 @@ module.exports = ({
   platforms: ['win32', 'darwin'],
   side: 'local',
   init: [
-    {ino: 1, path: 'DIR_CASE/'}
+    {ino: 1, path: 'DIR_CASE/'},
+    {ino: 2, path: 'FILE.CASE'}
   ],
   actions: [
     // No action, we're just simulating FS events after syncing remote to local.
   ],
   expected: {
     tree: [
-      'DIR_CASE/'
+      'DIR_CASE/',
+      'FILE.CASE'
     ],
     remoteTrash: []
   }

--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -74,6 +74,31 @@ describe('core/local/analysis', function () {
     should(pendingChanges).deepEqual([])
   })
 
+  it('handles unlink(x,old=X)+add(X,old=X) (identical renaming loopback) as FileAddition(X) because we lack an x doc to build FileMove(x → X)', () => {
+    const ino = 1
+    const oldPath = 'x'
+    const newPath = 'X'
+    const old /*: Metadata */ = metadataBuilders.file().path(newPath).ino(ino).build()
+    const { md5sum } = old
+    const stats = {ino}
+    const events /*: LocalEvent[] */ = [
+      {type: 'unlink', path: oldPath, old},
+      {type: 'add', path: newPath, stats, md5sum, old}
+    ]
+    const pendingChanges = []
+
+    should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
+      type: 'FileAddition',
+      path: newPath,
+      ino,
+      md5sum,
+      stats,
+      old,
+      wip: undefined
+    }])
+  })
+
   it('handles unlink+add+change', () => {
     const old /*: Metadata */ = metadataBuilders.file().ino(1).build()
     const stats = {ino: 1}

--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -150,6 +150,28 @@ describe('core/local/analysis', function () {
     should(pendingChanges).deepEqual([])
   })
 
+  it('handles unlinkDir(x,old=X)+addDir(X,old=X) (identical renaming loopback) as DirAddition(X) because we lack an x doc to build DirMove(x → X)', () => {
+    const ino = 1
+    const oldPath = 'x'
+    const newPath = 'X'
+    const old /*: Metadata */ = metadataBuilders.dir().path(newPath).ino(ino).build()
+    const stats = {ino}
+    const events /*: LocalEvent[] */ = [
+      {type: 'unlinkDir', path: oldPath, old},
+      {type: 'addDir', path: newPath, stats, old}
+    ]
+    const pendingChanges = []
+
+    should(analysis(events, pendingChanges)).deepEqual([{
+      sideName,
+      type: 'DirAddition',
+      path: newPath,
+      ino,
+      stats,
+      old
+    }])
+  })
+
   it('handles partial successive moves (add+unlink+add, then unlink later)', () => {
     const old /*: Metadata */ = metadataBuilders.file().path('src').ino(1).build()
     const stats = {ino: 1}


### PR DESCRIPTION
The fixes in `core/loca/change` are quite ugly.
This is due to the fact that we have no simple way to turn the deletion into a move because this would require a source doc while we only have the destination one in case of an identical renaming.
Which brings us to the fact that a few things have misleading names (e.g. `old`) and some legitimate cases are currently not possible to represent when getting some events + doc combinations (e.g. identical renaming loopback).

The scenario cases actually pass without the fix even with the new captures, because we don't fail on error, but the *Invalid move* messages are still visible in logs.
So those are only fixed according to unit tests for now.