### PR TITLE
travis: Make built artifacts available in each PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,10 @@ after_failure: ./dev/ci/after_failure.sh
 branches:
     only:
         - master
+stages:
+    - test
+    - name: notify
+      if: type = pull_request
 jobs:
     fast_finish: true
     include:
@@ -119,3 +123,10 @@ jobs:
           os: linux
           after_failure: skip
           script: ./dev/ci/coverage.sh
+        - stage: notify
+          name: artifacts built
+          services: false
+          cache: false
+          before_install: skip
+          install: skip
+          script: ./dev/ci/notify.sh

--- a/dev/ci/dist.sh
+++ b/dev/ci/dist.sh
@@ -19,3 +19,18 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
 else
   yarn dist:all
 fi
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    version=$(git rev-parse --short HEAD);
+    bintray_version="PR-$TRAVIS_PULL_REQUEST";
+    dist_files=$(ls -p dist/ | grep -v /);
+
+    IFS=$'\n'
+    for file in $dist_files; do
+      bintray_path="$version-${file/ /%20}";
+      curl -u "$BINTRAY_USER:$BINTRAY_API_TOKEN" \
+           -T "dist/$file" \
+           "https://api.bintray.com/content/$BINTRAY_ORG/$BINTRAY_REPO/$BINTRAY_PACKAGE/$bintray_version/$bintray_path?publish=1&override=1";
+    done
+    unset IFS
+fi

--- a/dev/ci/notify.sh
+++ b/dev/ci/notify.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    version=$(git rev-parse --short HEAD);
+
+    comment_body="Available development artifacts for commit $version:\n";
+    comment_body+=$(curl -s -u "$BINTRAY_USER:$BINTRAY_API_TOKEN" \
+            "https://api.bintray.com/search/file?name=$version-*&subject=$BINTRAY_ORG&repo=$BINTRAY_REPO" \
+            | jq -r "map([\"- [\(.name)](\",@uri \"https://dl.bintray.com/$BINTRAY_ORG/$BINTRAY_REPO/\(.path)\",\")\"] | join(\"\")) | join(\"\\\n\")");
+
+    echo "Comment body: $comment_body";
+
+    curl -X POST "https://api.github.com/repos/$TRAVIS_PULL_REQUEST_SLUG/issues/$TRAVIS_PULL_REQUEST/comments" \
+         -H "Authorization: token $GH_TOKEN" \
+         -H "Content-Type: application/json" \
+         -d "{\"body\":\"$comment_body\"}";
+fi


### PR DESCRIPTION
Each time we build a Pull Request on travis, we build the binary
  artifacts for linux and mac OSX.

  We upload those binaries to bintray.com and add a comment on the PR so
  we can easily find them and test the Pull Request before merging it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
