### PR TITLE
travis: Build master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 ---
 dist: trusty
 language: node_js
+branches:
+    only:
+        - master
 matrix:
     fast_finish: true
     include:


### PR DESCRIPTION
  Enabling builds of Pull Requests will help us in adding a comment to
  them with links to the built artifacts.
  However, this means we'll build twice the same commits: once for the
  push to the remote branch and once for the creation of the pull
  request.

  We can avoid this by disabling builds on branches but we'll keep
  builds for the master branch since there won't be any pull request for
  this branch.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
