### PR TITLE
feat: Enhance Ignore files and folders feature

### DIFF
--- a/core/config/.cozyignore
+++ b/core/config/.cozyignore
@@ -42,3 +42,4 @@ Icon
 # Windows
 Thumbs.db
 ehthumbs.db
+$Recycle.bin

--- a/core/config/.cozyignore
+++ b/core/config/.cozyignore
@@ -1,0 +1,44 @@
+# See https://github.com/github/gitignore/tree/master/Global
+
+# all hidden files
+.*
+
+# Dropbox
+.dropbox
+.dropbox.attr
+.dropbox.cache
+
+# Eclipse, SublimeText and many others
+*.tmp
+*.bak
+
+# Emacs
+*~
+\\#*\\#
+
+# LibreOffice
+.~lock.*#
+
+# Linux
+.fuse_hidden*
+.Trash-*
+
+# Microsoft Office
+~$*.{doc,xls,ppt}*
+
+# OSX
+.DS_Store
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+Icon
+
+# Vim
+*.sw[px]
+
+# Windows
+Thumbs.db
+ehthumbs.db

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -1,8 +1,21 @@
-/* @flow weak */
+// @flow
 
 const { basename, dirname, resolve } = require('path')
 const { matcher, makeRe } = require('micromatch')
 const fs = require('fs')
+
+/*::
+export type IgnorePattern = {
+  match: (string) => boolean,
+  basename: boolean,
+  folder: boolean,
+  negate: boolean
+}
+*/
+
+/* ::
+import type {Metadata} from './metadata.js'
+*/
 
 // Parse a line and build the corresponding pattern
 function buildPattern (line) {
@@ -42,11 +55,11 @@ function buildPattern (line) {
   return pattern
 }
 
-function isNotBlankOrComment (line) {
+function isNotBlankOrComment (line /*: string */) /*: boolean */ {
   return line !== '' && line[0] !== '#'
 }
 
-function match (path, isFolder, pattern) {
+function match (path, isFolder, pattern /*: IgnorePattern */) {
   if (pattern.basename) {
     if (pattern.match(basename(path))) {
       return true
@@ -69,8 +82,13 @@ function match (path, isFolder, pattern) {
 //
 // See https://git-scm.com/docs/gitignore/#_pattern_format
 class Ignore {
+  /*::
+  patterns: IgnorePattern[]
+  match: (string, boolean, IgnorePattern) => boolean
+  */
+
   // Load patterns for detecting ignored files and folders
-  constructor (lines) {
+  constructor (lines /*: string[] */) {
     this.patterns = Array.from(lines)
       .filter(isNotBlankOrComment)
       .map(buildPattern)
@@ -90,7 +108,7 @@ class Ignore {
   }
 
   // Return true if the given file/folder path should be ignored
-  isIgnored (doc) {
+  isIgnored (doc /*: Metadata */) {
     let result = false
     for (let pattern of Array.from(this.patterns)) {
       if (pattern.negate) {

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -33,7 +33,7 @@ function buildPattern (line) {
     line = makeRe(line, { nocase: true })
   }
   let pattern = {
-    match: matcher(line, MicromatchOptions),
+    match: matcher(line, {}),
     basename: noslash, // The pattern can match only the basename
     folder, // The pattern will only match a folder
     negate // The pattern is negated
@@ -62,9 +62,6 @@ function match (path, isFolder, pattern) {
   }
   return match(parent, true, pattern)
 }
-
-// See https://github.com/jonschlinkert/micromatch#options
-const MicromatchOptions = { noextglob: true }
 
 // See https://github.com/github/gitignore/tree/master/Global
 const DefaultRules = [

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -1,149 +1,140 @@
 /* @flow weak */
 
-const autoBind = require('auto-bind')
 const { basename, dirname } = require('path')
 const { matcher, makeRe } = require('micromatch')
 
-/*::
-export type IgnorePattern = {
-  match: (string) => boolean,
-  basename: boolean,
-  folder: boolean,
-  negate: boolean
+// Parse a line and build the corresponding pattern
+function buildPattern (line) {
+  let folder = false
+  let negate = false
+  let noslash = line.indexOf('/') === -1
+  if (line.indexOf('**') !== -1) {
+    // Detect two asterisks
+    noslash = false
+  }
+  if (line[0] === '!') {
+    // Detect bang prefix
+    line = line.slice(1)
+    negate = true
+  }
+  if (line[0] === '/') {
+    // Detect leading slash
+    line = line.slice(1)
+  }
+  if (line[line.length - 1] === '/') {
+    // Detect trailing slash
+    line = line.slice(0, line.length - 1)
+    folder = true
+  }
+  line = line.replace(/^\\/, '') // Remove leading escaping char
+  line = line.replace(/( |\t)*$/, '') // Remove trailing spaces
+  // Ignore case for case insensitive file-systems
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    line = makeRe(line, { nocase: true })
+  }
+  let pattern = {
+    match: matcher(line, MicromatchOptions),
+    basename: noslash, // The pattern can match only the basename
+    folder, // The pattern will only match a folder
+    negate // The pattern is negated
+  }
+  return pattern
 }
-*/
+
+function isNotBlankOrComment (line) {
+  return line !== '' && line[0] !== '#'
+}
+
+function match (path, isFolder, pattern) {
+  if (pattern.basename) {
+    if (pattern.match(basename(path))) {
+      return true
+    }
+  }
+  if (isFolder || !pattern.folder) {
+    if (pattern.match(path)) {
+      return true
+    }
+  }
+  let parent = dirname(path)
+  if (parent === '.') {
+    return false
+  }
+  return match(parent, true, pattern)
+}
+
+// See https://github.com/jonschlinkert/micromatch#options
+const MicromatchOptions = { noextglob: true }
+
+// See https://github.com/github/gitignore/tree/master/Global
+const DefaultRules = [
+  // all hidden files
+  '.*',
+
+  // Dropbox
+  '.dropbox',
+  '.dropbox.attr',
+  '.dropbox.cache',
+
+  // Eclipse, SublimeText and many others
+  '*.tmp',
+  '*.bak',
+
+  // Emacs
+  '*~',
+  '\\#*\\#',
+
+  // LibreOffice
+  '.~lock.*#',
+
+  // Linux
+  '.fuse_hidden*',
+  '.Trash-*',
+
+  // Microsoft Office
+  '~$*.{doc,xls,ppt}*',
+
+  // OSX
+  '.DS_Store',
+  '.DocumentRevisions-V100',
+  '.fseventsd',
+  '.Spotlight-V100',
+  '.TemporaryItems',
+  '.Trashes',
+  '.VolumeIcon.icns',
+  // Pattern must be escaped twice on case-insensitive plateforms in order
+  // for makeRe() to work
+  process.platform === 'darwin' || process.platform === 'win32'
+    ? 'Icon\\r'
+    : 'Icon\r',
+
+  // Vim
+  '*.sw[px]',
+
+  // Windows
+  'Thumbs.db',
+  'ehthumbs.db'
+]
 
 // Cozy-desktop can ignore some files and folders from a list of patterns in the
 // cozyignore file. This class can be used to know if a file/folder is ignored.
 //
 // See https://git-scm.com/docs/gitignore/#_pattern_format
-let DefaultRules
-let MicromatchOptions
 class Ignore {
-  static initClass () {
-    // See https://github.com/github/gitignore/tree/master/Global
-    DefaultRules = [
-      // all hidden files
-      '.*',
-
-      // Dropbox
-      '.dropbox',
-      '.dropbox.attr',
-      '.dropbox.cache',
-
-      // Eclipse, SublimeText and many others
-      '*.tmp',
-      '*.bak',
-
-      // Emacs
-      '*~',
-      '\\#*\\#',
-
-      // LibreOffice
-      '.~lock.*#',
-
-      // Linux
-      '.fuse_hidden*',
-      '.Trash-*',
-
-      // Microsoft Office
-      '~$*.{doc,xls,ppt}*',
-
-      // OSX
-      '.DS_Store',
-      '.DocumentRevisions-V100',
-      '.fseventsd',
-      '.Spotlight-V100',
-      '.TemporaryItems',
-      '.Trashes',
-      '.VolumeIcon.icns',
-      // Pattern must be escaped twice on case-insensitive plateforms in order
-      // for makeRe() to work
-      process.platform === 'darwin' || process.platform === 'win32'
-        ? 'Icon\\r'
-        : 'Icon\r',
-
-      // Vim
-      '*.sw[px]',
-
-      // Windows
-      'Thumbs.db',
-      'ehthumbs.db'
-    ]
-
-    // See https://github.com/jonschlinkert/micromatch#options
-    MicromatchOptions =
-            {noextglob: true}
-  }
-
-  /*::
-  patterns: IgnorePattern[]
-  */
-
   // Load patterns for detecting ignored files and folders
   constructor (lines) {
-    this.patterns = []
-    for (let line of Array.from(lines)) {
-      if (line === '') { continue }          // Blank line
-      if (line[0] === '#') { continue }      // Comments
-      this.patterns.push(this.buildPattern(line))
-    }
-    autoBind(this)
-  }
-
-  // Parse a line and build the corresponding pattern
-  buildPattern (line) {
-    let folder = false
-    let negate = false
-    let noslash = line.indexOf('/') === -1
-    if (line.indexOf('**') !== -1) {   // Detect two asterisks
-      noslash = false
-    }
-    if (line[0] === '!') {               // Detect bang prefix
-      line = line.slice(1)
-      negate = true
-    }
-    if (line[0] === '/') {               // Detect leading slash
-      line = line.slice(1)
-    }
-    if (line[line.length - 1] === '/') {   // Detect trailing slash
-      line = line.slice(0, line.length - 1)
-      folder = true
-    }
-    line = line.replace(/^\\/, '')   // Remove leading escaping char
-    line = line.replace(/( |\t)*$/, '')  // Remove trailing spaces
-    // Ignore case for case insensitive file-systems
-    if (process.platform === 'darwin' || process.platform === 'win32') {
-      line = makeRe(line, {nocase: true})
-    }
-    let pattern = {
-      match: matcher(line, MicromatchOptions),
-      basename: noslash,   // The pattern can match only the basename
-      folder,    // The pattern will only match a folder
-      negate    // The pattern is negated
-    }
-    return pattern
+    this.patterns = Array.from(lines)
+      .filter(isNotBlankOrComment)
+      .map(buildPattern)
+    this.match = match
   }
 
   // Add some rules for things that should be always ignored (temporary
   // files, thumbnails db, trash, etc.)
   addDefaultRules () {
-    let morePatterns = (Array.from(DefaultRules).map((rule) => this.buildPattern(rule)))
+    let morePatterns = Array.from(DefaultRules).map(buildPattern)
     this.patterns = morePatterns.concat(this.patterns)
     return this
-  }
-
-  // Return true if the doc matches the pattern
-  match (path, isFolder, pattern) {
-    if (pattern.basename) {
-      if (pattern.match(basename(path))) { return true }
-    }
-    if (isFolder || !pattern.folder) {
-      if (pattern.match(path)) { return true }
-    }
-    let parent = dirname(path)
-    if (parent === '.') { return false }
-    return this.match(parent, true, pattern)
   }
 
   // Return true if the given file/folder path should be ignored
@@ -151,14 +142,17 @@ class Ignore {
     let result = false
     for (let pattern of Array.from(this.patterns)) {
       if (pattern.negate) {
-        if (result) { result = !this.match(doc._id, doc.docType === 'folder', pattern) }
+        if (result) {
+          result = !this.match(doc._id, doc.docType === 'folder', pattern)
+        }
       } else {
-        if (!result) { result = this.match(doc._id, doc.docType === 'folder', pattern) }
+        if (!result) {
+          result = this.match(doc._id, doc.docType === 'folder', pattern)
+        }
       }
     }
     return result
   }
 }
-Ignore.initClass()
 
 module.exports = Ignore

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -1,7 +1,8 @@
 /* @flow weak */
 
-const { basename, dirname } = require('path')
+const { basename, dirname, resolve } = require('path')
 const { matcher, makeRe } = require('micromatch')
+const fs = require('fs')
 
 // Parse a line and build the corresponding pattern
 function buildPattern (line) {
@@ -63,56 +64,6 @@ function match (path, isFolder, pattern) {
   return match(parent, true, pattern)
 }
 
-// See https://github.com/github/gitignore/tree/master/Global
-const DefaultRules = [
-  // all hidden files
-  '.*',
-
-  // Dropbox
-  '.dropbox',
-  '.dropbox.attr',
-  '.dropbox.cache',
-
-  // Eclipse, SublimeText and many others
-  '*.tmp',
-  '*.bak',
-
-  // Emacs
-  '*~',
-  '\\#*\\#',
-
-  // LibreOffice
-  '.~lock.*#',
-
-  // Linux
-  '.fuse_hidden*',
-  '.Trash-*',
-
-  // Microsoft Office
-  '~$*.{doc,xls,ppt}*',
-
-  // OSX
-  '.DS_Store',
-  '.DocumentRevisions-V100',
-  '.fseventsd',
-  '.Spotlight-V100',
-  '.TemporaryItems',
-  '.Trashes',
-  '.VolumeIcon.icns',
-  // Pattern must be escaped twice on case-insensitive plateforms in order
-  // for makeRe() to work
-  process.platform === 'darwin' || process.platform === 'win32'
-    ? 'Icon\\r'
-    : 'Icon\r',
-
-  // Vim
-  '*.sw[px]',
-
-  // Windows
-  'Thumbs.db',
-  'ehthumbs.db'
-]
-
 // Cozy-desktop can ignore some files and folders from a list of patterns in the
 // cozyignore file. This class can be used to know if a file/folder is ignored.
 //
@@ -129,6 +80,10 @@ class Ignore {
   // Add some rules for things that should be always ignored (temporary
   // files, thumbnails db, trash, etc.)
   addDefaultRules () {
+    // TODO: split on return char depending on the OS
+    const DefaultRules = fs
+      .readFileSync(resolve(__dirname, './config/.cozyignore'), 'utf8')
+      .split('\n')
     let morePatterns = Array.from(DefaultRules).map(buildPattern)
     this.patterns = morePatterns.concat(this.patterns)
     return this

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -5,335 +5,342 @@ const metadata = require('../../core/metadata')
 
 describe('Ignore', function () {
   it('rejects blank lines for patterns', function () {
-    this.ignore = new Ignore(['foo', '', 'bar'])
-    this.ignore.patterns.length.should.equal(2)
+    const ignore = new Ignore(['foo', '', 'bar'])
+    ignore.patterns.length.should.equal(2)
   })
 
   it('rejects comments for patterns', function () {
-    this.ignore = new Ignore(['# Blah', 'foo', 'bar'])
-    this.ignore.patterns.length.should.equal(2)
+    const ignore = new Ignore(['# Blah', 'foo', 'bar'])
+    ignore.patterns.length.should.equal(2)
   })
 
   it('does not keep trailing spaces in patterns', function () {
-    this.ignore = new Ignore(['foo  '])
-    this.ignore.patterns[0].match('foo').should.be.true()
+    const ignore = new Ignore(['foo  '])
+    ignore.patterns[0].match('foo').should.be.true()
   })
 
   it('does not match a file when path and pattern are different', function () {
-    this.ignore = new Ignore(['foo'])
-    let doc = {
+    const ignore = new Ignore(['foo'])
+    const doc = {
       _id: 'bar',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('matches a file when its path is the pattern description', function () {
-    this.ignore = new Ignore(['foo'])
-    let doc = {
+    const ignore = new Ignore(['foo'])
+    const doc = {
       _id: 'foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('matches a folder when its path is the pattern description', function () {
-    this.ignore = new Ignore(['foo'])
-    let doc = {
+    const ignore = new Ignore(['foo'])
+    const doc = {
       _id: 'foo',
       docType: 'folder'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('does not match a file when the pattern is for folders only', function () {
-    this.ignore = new Ignore(['foo/'])
-    let doc = {
+    const ignore = new Ignore(['foo/'])
+    const doc = {
       _id: 'foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('matches a folder, even with a folders only pattern', function () {
-    this.ignore = new Ignore(['foo/'])
-    let doc = {
+    const ignore = new Ignore(['foo/'])
+    const doc = {
       _id: 'foo',
       docType: 'folder'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('matches dotfiles', function () {
-    this.ignore = new Ignore(['.foo'])
-    let doc = {
+    const ignore = new Ignore(['.foo'])
+    const doc = {
       _id: '.foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts glob', function () {
-    this.ignore = new Ignore(['*.txt'])
-    let doc = {
+    const ignore = new Ignore(['*.txt'])
+    const doc = {
       _id: 'foo.txt',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts wild card', function () {
-    this.ignore = new Ignore(['fo?'])
-    let doc = {
+    const ignore = new Ignore(['fo?'])
+    const doc = {
       _id: 'foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts wild card (bis)', function () {
-    let doc = {
+    const ignore = new Ignore(['fo?'])
+    const doc = {
       _id: 'foobar',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('accepts braces', function () {
-    this.ignore = new Ignore(['foo.{md,txt}'])
-    let doc = {
+    const ignore = new Ignore(['foo.{md,txt}'])
+    const doc = {
       _id: 'foo.txt',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts brackets', function () {
-    this.ignore = new Ignore(['[a-f]oo'])
-    let doc = {
+    const ignore = new Ignore(['[a-f]oo'])
+    const doc = {
       _id: 'foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('ignores files only on basename', function () {
-    this.ignore = new Ignore(['foo'])
-    let doc = {
+    const ignore = new Ignore(['foo'])
+    const doc = {
       _id: 'abc/foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('ignores files only on basename (bis)', function () {
-    this.ignore = new Ignore(['/foo'])
-    let doc = {
+    const ignore = new Ignore(['/foo'])
+    const doc = {
       _id: 'abc/foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('ignores files in a ignored directory', function () {
-    this.ignore = new Ignore(['foo'])
-    let doc = {
+    const ignore = new Ignore(['foo'])
+    const doc = {
       _id: 'foo/bar',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('ignores files in a ignored directory (bis)', function () {
-    this.ignore = new Ignore(['foo/'])
-    let doc = {
+    const ignore = new Ignore(['foo/'])
+    const doc = {
       _id: 'foo/bar',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('ignores directories in a ignored directory', function () {
-    this.ignore = new Ignore(['foo'])
-    let doc = {
+    const ignore = new Ignore(['foo'])
+    const doc = {
       _id: 'foo/baz',
       docType: 'folder'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('restricts ignore rules with a leading slash to a full path', function () {
-    this.ignore = new Ignore(['/foo'])
-    let doc = {
+    const ignore = new Ignore(['/foo'])
+    const doc = {
       _id: 'foo',
       docType: 'folder'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('restricts ignore rules with a leading slash to a full path (bis)', function () {
-    this.ignore = new Ignore(['/foo'])
-    let doc = {
+    const ignore = new Ignore(['/foo'])
+    const doc = {
       _id: 'bar/foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('accepts two asterisks at the start', function () {
-    this.ignore = new Ignore(['**/foo'])
-    let doc = {
+    const ignore = new Ignore(['**/foo'])
+    const doc = {
       _id: 'abc/def/foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts two asterisks at the end', function () {
-    this.ignore = new Ignore(['foo/**'])
-    let doc = {
+    const ignore = new Ignore(['foo/**'])
+    const doc = {
       _id: 'foo/abc/def',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts two asterisks at the middle', function () {
-    this.ignore = new Ignore(['a/**/b'])
-    let doc = {
+    const ignore = new Ignore(['a/**/b'])
+    const doc = {
       _id: 'a/foo/bar/b',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts two asterisks at the middle (bis)', function () {
-    this.ignore = new Ignore(['a/**/b'])
-    let doc = {
+    const ignore = new Ignore(['a/**/b'])
+    const doc = {
       _id: 'a/b',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts two asterisks at the middle (ter)', function () {
-    this.ignore = new Ignore(['a/**/b'])
-    let doc = {
+    const ignore = new Ignore(['a/**/b'])
+    const doc = {
       _id: 'foo/a/b',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('accepts escaping char', function () {
-    this.ignore = new Ignore(['\\#foo'])
-    let doc = {
+    const ignore = new Ignore(['\\#foo'])
+    const doc = {
       _id: '#foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('accepts escaping char', function () {
-    this.ignore = new Ignore(['\\!foo'])
-    let doc = {
+    const ignore = new Ignore(['\\!foo'])
+    const doc = {
       _id: '!foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('can negate a previous rule', function () {
-    this.ignore = new Ignore(['*.foo', '!important.foo'])
-    let doc = {
+    const ignore = new Ignore(['*.foo', '!important.foo'])
+    const doc = {
       _id: 'important.foo',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('can negate a previous rule (bis)', function () {
-    this.ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
-    let doc = {
+    const ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
+    const doc = {
       _id: 'foo/bar/abc/def',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('can negate a previous rule (ter)', function () {
-    this.ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
-    let doc = {
+    const ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
+    const doc = {
       _id: 'a/foo/bar',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('can negate a previous rule (quater)', function () {
-    this.ignore = new Ignore(['bar*', '!/foo/bar*'])
-    let doc = {
+    const ignore = new Ignore(['bar*', '!/foo/bar*'])
+    const doc = {
       _id: 'foo/bar',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.false()
+    ignore.isIgnored(doc).should.be.false()
   })
 
   it('has some defaults rules for dropbox', function () {
-    this.ignore = new Ignore([])
-    this.ignore.addDefaultRules()
-    let doc = {
+    const ignore = new Ignore([])
+    ignore.addDefaultRules()
+    const doc = {
       _id: '.dropbox',
       docType: 'folder'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('has some defaults rules for editors', function () {
-    this.ignore = new Ignore([])
-    this.ignore.addDefaultRules()
-    let doc = {
+    const ignore = new Ignore([])
+    ignore.addDefaultRules()
+    const doc = {
       _id: 'foo.c.swp~',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('has some defaults rules for OSes', function () {
-    this.ignore = new Ignore([])
-    this.ignore.addDefaultRules()
-    let doc = {
+    const ignore = new Ignore([])
+    ignore.addDefaultRules()
+    const doc = {
       _id: 'Thumbs.db',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('does ignore Icon\\r', function () {
-    this.ignore = new Ignore([])
-    this.ignore.addDefaultRules()
-    let doc = {
+    const ignore = new Ignore([])
+    ignore.addDefaultRules()
+    const doc = {
       _id: 'path/to/Icon\r',
       docType: 'file'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('does ignore any hidden file or directory', function () {
-    this.ignore = new Ignore([])
-    this.ignore.addDefaultRules()
-    let doc = {
+    const ignore = new Ignore([])
+    ignore.addDefaultRules()
+    const doc = {
       _id: '.eclipse',
       docType: 'folder'
     }
-    this.ignore.isIgnored(doc).should.be.true()
+    ignore.isIgnored(doc).should.be.true()
   })
 
   it('ignores Microsoft Office temporary files', function () {
-    this.ignore = new Ignore([])
-    this.ignore.addDefaultRules()
-    this.ignore.isIgnored({_id: metadata.id('~$whatever.docx'), docType: 'file'}).should.be.true()
-    this.ignore.isIgnored({_id: metadata.id('~$whatever.xlsx'), docType: 'file'}).should.be.true()
-    this.ignore.isIgnored({_id: metadata.id('~$whatever.pptx'), docType: 'file'}).should.be.true()
+    const ignore = new Ignore([])
+    ignore.addDefaultRules()
+    ignore
+      .isIgnored({ _id: metadata.id('~$whatever.docx'), docType: 'file' })
+      .should.be.true()
+    ignore
+      .isIgnored({ _id: metadata.id('~$whatever.xlsx'), docType: 'file' })
+      .should.be.true()
+    ignore
+      .isIgnored({ _id: metadata.id('~$whatever.pptx'), docType: 'file' })
+      .should.be.true()
   })
 })

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -308,11 +308,11 @@ describe('Ignore', function () {
       ignore.isIgnored(doc).should.be.true()
     })
 
-    it('does ignore Icon\\r', function () {
+    it('does ignore Icon', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
       const doc = {
-        _id: 'path/to/Icon\r',
+        _id: 'path/to/Icon',
         docType: 'file'
       }
       ignore.isIgnored(doc).should.be.true()

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -341,5 +341,22 @@ describe('Ignore', function () {
         .isIgnored({ _id: metadata.id('~$whatever.pptx'), docType: 'file' })
         .should.be.true()
     })
+
+    it('ignores hidden folder $Recycle.bin', () => {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      ignore
+        .isIgnored({
+          _id: '$Recycle.bin/foo',
+          type: 'file'
+        })
+        .should.be.true()
+      ignore
+        .isIgnored({
+          _id: '$Recycle.bin',
+          type: 'folder'
+        })
+        .should.be.true()
+    })
   })
 })

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -4,343 +4,342 @@ const Ignore = require('../../core/ignore')
 const metadata = require('../../core/metadata')
 
 describe('Ignore', function () {
-  it('rejects blank lines for patterns', function () {
-    const ignore = new Ignore(['foo', '', 'bar'])
-    ignore.patterns.length.should.equal(2)
+  describe('Removal of unnecessary lines', () => {
+    it('remove blank lines or comments', function () {
+      const ignore = new Ignore([
+        'foo',
+        '', // removed
+        'bar',
+        '# foo', // removed
+        '\\#bar'
+      ])
+      ignore.patterns.length.should.equal(3)
+    })
   })
 
-  it('rejects comments for patterns', function () {
-    const ignore = new Ignore(['# Blah', 'foo', 'bar'])
-    ignore.patterns.length.should.equal(2)
+  describe('Ignored patterns', () => {
+    it("don't ignore file name not matching to the pattern", function () {
+      const ignore = new Ignore(['foo'])
+      const doc = {
+        _id: 'bar',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.false()
+    })
+
+    it('ignore file name matching to the pattern', function () {
+      const ignore = new Ignore(['foo'])
+      const doc = {
+        _id: 'foo',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it('ignore folder name matching to the pattern', function () {
+      const ignore = new Ignore(['foo'])
+      const doc = {
+        _id: 'foo',
+        docType: 'folder'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it("don't ignore file name when the pattern match folders", function () {
+      const ignore = new Ignore(['foo/'])
+      const file = {
+        _id: 'foo',
+        docType: 'file'
+      }
+      const folder = {
+        _id: 'foo',
+        docType: 'folder'
+      }
+      ignore.isIgnored(file).should.be.false()
+      ignore.isIgnored(folder).should.be.true()
+    })
   })
 
-  it('does not keep trailing spaces in patterns', function () {
-    const ignore = new Ignore(['foo  '])
-    ignore.patterns[0].match('foo').should.be.true()
+  describe('Patterns operators', () => {
+    it('match to the glob with *', function () {
+      const ignore = new Ignore(['*.txt'])
+      const doc = {
+        _id: 'foo.txt',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it('match to the glob with ?', function () {
+      const ignore = new Ignore(['ba?'])
+      const bar = {
+        _id: 'bar',
+        docType: 'file'
+      }
+      const baz = {
+        _id: 'baz',
+        docType: 'file'
+      }
+      const foo = {
+        _id: 'foo',
+        docType: 'file'
+      }
+      const barbaz = {
+        _id: 'barbaz',
+        docType: 'file'
+      }
+      ignore.isIgnored(bar).should.be.true()
+      ignore.isIgnored(baz).should.be.true()
+      ignore.isIgnored(foo).should.be.false()
+      ignore.isIgnored(barbaz).should.be.false()
+    })
+
+    it('match braces {p1,p2}', function () {
+      const ignore = new Ignore(['{bar,baz}.txt'])
+      const foo = {
+        _id: 'foo.txt',
+        docType: 'file'
+      }
+      const bar = {
+        _id: 'bar.txt',
+        docType: 'file'
+      }
+      const baz = {
+        _id: 'baz.txt',
+        docType: 'file'
+      }
+      ignore.isIgnored(bar).should.be.true()
+      ignore.isIgnored(baz).should.be.true()
+      ignore.isIgnored(foo).should.be.false()
+    })
+
+    it('match to the glob with range [a-c]', function () {
+      const ignore = new Ignore(['foo[a-c]'])
+      const fooa = {
+        _id: 'fooa',
+        docType: 'file'
+      }
+      const foob = {
+        _id: 'foob',
+        docType: 'file'
+      }
+      const fooc = {
+        _id: 'fooc',
+        docType: 'file'
+      }
+      const food = {
+        _id: 'food',
+        docType: 'file'
+      }
+      ignore.isIgnored(fooa).should.be.true()
+      ignore.isIgnored(foob).should.be.true()
+      ignore.isIgnored(fooc).should.be.true()
+      ignore.isIgnored(food).should.be.false()
+    })
   })
 
-  it('does not match a file when path and pattern are different', function () {
-    const ignore = new Ignore(['foo'])
-    const doc = {
-      _id: 'bar',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
+  describe('Path patterns', () => {
+    it('ignore files in subdirectory', function () {
+      const doc = {
+        _id: 'bar/foo',
+        docType: 'file'
+      }
+      new Ignore(['foo']).isIgnored(doc).should.be.true()
+      new Ignore(['/foo']).isIgnored(doc).should.be.false()
+    })
+
+    it('ignore files in a ignored directory', function () {
+      const doc = {
+        _id: 'foo/bar',
+        docType: 'file'
+      }
+      new Ignore(['foo']).isIgnored(doc).should.be.true()
+      new Ignore(['foo/']).isIgnored(doc).should.be.true()
+    })
+
+    it('ignore folders in a ignored directory', function () {
+      const ignore = new Ignore(['foo'])
+      const doc = {
+        _id: 'foo/bar',
+        docType: 'folder'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it('match leading slash pattern', function () {
+      const ignore = new Ignore(['/foo'])
+      const file = {
+        _id: 'foo',
+        docType: 'folder'
+      }
+      const subfile = {
+        _id: 'bar/foo',
+        docType: 'file'
+      }
+      ignore.isIgnored(file).should.be.true()
+      ignore.isIgnored(subfile).should.be.false()
+    })
+
+    it('match nested file with leading **', function () {
+      const ignore = new Ignore(['**/baz'])
+      const doc = {
+        _id: 'foo/bar/baz',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it('match nested files with trailing **', function () {
+      const ignore = new Ignore(['foo/**'])
+      const doc = {
+        _id: 'foo/bar/baz',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it('match nested files with middle **', function () {
+      const ignore = new Ignore(['a/**/b'])
+      const nestedFile = {
+        _id: 'a/foo/bar/b',
+        docType: 'file'
+      }
+      const unnestedFile = {
+        _id: 'a/b',
+        docType: 'file'
+      }
+      ignore.isIgnored(nestedFile).should.be.true()
+      ignore.isIgnored(unnestedFile).should.be.true()
+    })
+
+    it("doen't match misnested file with middle **", function () {
+      const ignore = new Ignore(['a/**/b'])
+      const doc = {
+        _id: 'foo/a/b',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.false()
+    })
   })
 
-  it('matches a file when its path is the pattern description', function () {
-    const ignore = new Ignore(['foo'])
-    const doc = {
-      _id: 'foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
+  describe('Escaping', () => {
+    it('escapes the comment character', function () {
+      const ignore = new Ignore(['\\#foo'])
+      const doc = {
+        _id: '#foo',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
+
+    it('escapes the negation character', function () {
+      const ignore = new Ignore(['\\!foo'])
+      const doc = {
+        _id: '!foo',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
   })
 
-  it('matches a folder when its path is the pattern description', function () {
-    const ignore = new Ignore(['foo'])
-    const doc = {
-      _id: 'foo',
-      docType: 'folder'
-    }
-    ignore.isIgnored(doc).should.be.true()
+  describe('Negate rules', () => {
+    it('can negate a previous rule', function () {
+      const ignore = new Ignore(['*.foo', '!bar.foo'])
+      const bar = {
+        _id: 'bar.foo',
+        docType: 'file'
+      }
+      const baz = {
+        _id: 'baz.foo',
+        docType: 'file'
+      }
+      ignore.isIgnored(bar).should.be.false()
+      ignore.isIgnored(baz).should.be.true()
+    })
+
+    it('can negate a more complex previous rules organization', function () {
+      const ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
+      const foobar = {
+        _id: 'foo/bar',
+        docType: 'file'
+      }
+      const foobaz = {
+        _id: 'foo/baz',
+        docType: 'file'
+      }
+      const bazbar = {
+        _id: 'baz/bar',
+        docType: 'file'
+      }
+      ignore.isIgnored(foobar).should.be.false()
+      ignore.isIgnored(foobaz).should.be.true()
+      ignore.isIgnored(bazbar).should.be.true()
+    })
   })
 
-  it('does not match a file when the pattern is for folders only', function () {
-    const ignore = new Ignore(['foo/'])
-    const doc = {
-      _id: 'foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
+  describe('Default rules', () => {
+    it('has some defaults rules for dropbox', function () {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      const doc = {
+        _id: '.dropbox',
+        docType: 'folder'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
 
-  it('matches a folder, even with a folders only pattern', function () {
-    const ignore = new Ignore(['foo/'])
-    const doc = {
-      _id: 'foo',
-      docType: 'folder'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
+    it('has some defaults rules for editors', function () {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      const doc = {
+        _id: 'foo.c.swp~',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
 
-  it('matches dotfiles', function () {
-    const ignore = new Ignore(['.foo'])
-    const doc = {
-      _id: '.foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
+    it('has some defaults rules for OSes', function () {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      const doc = {
+        _id: 'Thumbs.db',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
 
-  it('accepts glob', function () {
-    const ignore = new Ignore(['*.txt'])
-    const doc = {
-      _id: 'foo.txt',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
+    it('does ignore Icon\\r', function () {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      const doc = {
+        _id: 'path/to/Icon\r',
+        docType: 'file'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
 
-  it('accepts wild card', function () {
-    const ignore = new Ignore(['fo?'])
-    const doc = {
-      _id: 'foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
+    it('does ignore any hidden file or directory', function () {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      const doc = {
+        _id: '.eclipse',
+        docType: 'folder'
+      }
+      ignore.isIgnored(doc).should.be.true()
+    })
 
-  it('accepts wild card (bis)', function () {
-    const ignore = new Ignore(['fo?'])
-    const doc = {
-      _id: 'foobar',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('accepts braces', function () {
-    const ignore = new Ignore(['foo.{md,txt}'])
-    const doc = {
-      _id: 'foo.txt',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('accepts brackets', function () {
-    const ignore = new Ignore(['[a-f]oo'])
-    const doc = {
-      _id: 'foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('ignores files only on basename', function () {
-    const ignore = new Ignore(['foo'])
-    const doc = {
-      _id: 'abc/foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('ignores files only on basename (bis)', function () {
-    const ignore = new Ignore(['/foo'])
-    const doc = {
-      _id: 'abc/foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('ignores files in a ignored directory', function () {
-    const ignore = new Ignore(['foo'])
-    const doc = {
-      _id: 'foo/bar',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('ignores files in a ignored directory (bis)', function () {
-    const ignore = new Ignore(['foo/'])
-    const doc = {
-      _id: 'foo/bar',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('ignores directories in a ignored directory', function () {
-    const ignore = new Ignore(['foo'])
-    const doc = {
-      _id: 'foo/baz',
-      docType: 'folder'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('restricts ignore rules with a leading slash to a full path', function () {
-    const ignore = new Ignore(['/foo'])
-    const doc = {
-      _id: 'foo',
-      docType: 'folder'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('restricts ignore rules with a leading slash to a full path (bis)', function () {
-    const ignore = new Ignore(['/foo'])
-    const doc = {
-      _id: 'bar/foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('accepts two asterisks at the start', function () {
-    const ignore = new Ignore(['**/foo'])
-    const doc = {
-      _id: 'abc/def/foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('accepts two asterisks at the end', function () {
-    const ignore = new Ignore(['foo/**'])
-    const doc = {
-      _id: 'foo/abc/def',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('accepts two asterisks at the middle', function () {
-    const ignore = new Ignore(['a/**/b'])
-    const doc = {
-      _id: 'a/foo/bar/b',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('accepts two asterisks at the middle (bis)', function () {
-    const ignore = new Ignore(['a/**/b'])
-    const doc = {
-      _id: 'a/b',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('accepts two asterisks at the middle (ter)', function () {
-    const ignore = new Ignore(['a/**/b'])
-    const doc = {
-      _id: 'foo/a/b',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('accepts escaping char', function () {
-    const ignore = new Ignore(['\\#foo'])
-    const doc = {
-      _id: '#foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('accepts escaping char', function () {
-    const ignore = new Ignore(['\\!foo'])
-    const doc = {
-      _id: '!foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('can negate a previous rule', function () {
-    const ignore = new Ignore(['*.foo', '!important.foo'])
-    const doc = {
-      _id: 'important.foo',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('can negate a previous rule (bis)', function () {
-    const ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
-    const doc = {
-      _id: 'foo/bar/abc/def',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('can negate a previous rule (ter)', function () {
-    const ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
-    const doc = {
-      _id: 'a/foo/bar',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('can negate a previous rule (quater)', function () {
-    const ignore = new Ignore(['bar*', '!/foo/bar*'])
-    const doc = {
-      _id: 'foo/bar',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.false()
-  })
-
-  it('has some defaults rules for dropbox', function () {
-    const ignore = new Ignore([])
-    ignore.addDefaultRules()
-    const doc = {
-      _id: '.dropbox',
-      docType: 'folder'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('has some defaults rules for editors', function () {
-    const ignore = new Ignore([])
-    ignore.addDefaultRules()
-    const doc = {
-      _id: 'foo.c.swp~',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('has some defaults rules for OSes', function () {
-    const ignore = new Ignore([])
-    ignore.addDefaultRules()
-    const doc = {
-      _id: 'Thumbs.db',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('does ignore Icon\\r', function () {
-    const ignore = new Ignore([])
-    ignore.addDefaultRules()
-    const doc = {
-      _id: 'path/to/Icon\r',
-      docType: 'file'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('does ignore any hidden file or directory', function () {
-    const ignore = new Ignore([])
-    ignore.addDefaultRules()
-    const doc = {
-      _id: '.eclipse',
-      docType: 'folder'
-    }
-    ignore.isIgnored(doc).should.be.true()
-  })
-
-  it('ignores Microsoft Office temporary files', function () {
-    const ignore = new Ignore([])
-    ignore.addDefaultRules()
-    ignore
-      .isIgnored({ _id: metadata.id('~$whatever.docx'), docType: 'file' })
-      .should.be.true()
-    ignore
-      .isIgnored({ _id: metadata.id('~$whatever.xlsx'), docType: 'file' })
-      .should.be.true()
-    ignore
-      .isIgnored({ _id: metadata.id('~$whatever.pptx'), docType: 'file' })
-      .should.be.true()
+    it('ignores Microsoft Office temporary files', function () {
+      const ignore = new Ignore([])
+      ignore.addDefaultRules()
+      ignore
+        .isIgnored({ _id: metadata.id('~$whatever.docx'), docType: 'file' })
+        .should.be.true()
+      ignore
+        .isIgnored({ _id: metadata.id('~$whatever.xlsx'), docType: 'file' })
+        .should.be.true()
+      ignore
+        .isIgnored({ _id: metadata.id('~$whatever.pptx'), docType: 'file' })
+        .should.be.true()
+    })
   })
 })

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -381,6 +381,9 @@ describe('Ignore', function () {
       Object.defineProperty(process, 'platform', this.originalPlatform)
     })
     it('does not match files if case does not match', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux'
+      })
       const ignore = new Ignore(['Foo'])
       ignore
         .isIgnored({

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -243,6 +243,15 @@ describe('Ignore', function () {
   })
 
   describe('Negate rules', () => {
+    it('can negate a rule', () => {
+      const ignore = new Ignore(['!foo'])
+      const foo = {
+        _id: 'foo',
+        docType: 'file'
+      }
+      ignore.isIgnored(foo).should.be.false()
+    })
+
     it('can negate a previous rule', function () {
       const ignore = new Ignore(['*.foo', '!bar.foo'])
       const bar = {
@@ -355,6 +364,54 @@ describe('Ignore', function () {
         .isIgnored({
           _id: '$Recycle.bin',
           type: 'folder'
+        })
+        .should.be.true()
+    })
+  })
+
+  describe('OS specific rules', () => {
+    before(() => {
+      this.originalPlatform = Object.getOwnPropertyDescriptor(
+        process,
+        'platform'
+      )
+    })
+
+    after(() => {
+      Object.defineProperty(process, 'platform', this.originalPlatform)
+    })
+    it('does not match files if case does not match', () => {
+      const ignore = new Ignore(['Foo'])
+      ignore
+        .isIgnored({
+          _id: 'foo',
+          type: 'file'
+        })
+        .should.be.false()
+    })
+
+    it('match files even if case does not match on darwin', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin'
+      })
+      const ignore = new Ignore(['Foo'])
+      ignore
+        .isIgnored({
+          _id: 'foo',
+          type: 'file'
+        })
+        .should.be.true()
+    })
+
+    it('match files even if case does not match on darwin', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32'
+      })
+      const ignore = new Ignore(['Foo'])
+      ignore
+        .isIgnored({
+          _id: 'foo',
+          type: 'file'
         })
         .should.be.true()
     })


### PR DESCRIPTION
I extracted some code from the class as they can be standalone
functions: easier to test, better insulation.

I reorganized tests by creating categories: easier to maintain,
faster to read.

I extracted default patterns to a standalone configuration file:
easier to patch, better SRP.

Let me know if every thing looks great to maintainers.