### PR TITLE
core: DRY electron hack

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -11,7 +11,7 @@ const uuid = require('uuid/v4')
 const https = require('https')
 const {createGzip} = require('zlib')
 
-require('./globals') // FIXME Use bluebird promises as long as we need asCallback
+require('./globals')
 const pkg = require('../package.json')
 const Config = require('./config')
 const logger = require('./logger')

--- a/core/globals.js
+++ b/core/globals.js
@@ -1,4 +1,12 @@
+// FIXME: Use bluebird promises as long as we need asCallback
 const Promise = require('bluebird')
-
 global.Promise = Promise
 Promise.longStackTraces()
+
+// Network requests can be stuck with Electron on Linux inside the event loop.
+// A hack to deblock them is push some events in the event loop.
+// See https://github.com/electron/electron/issues/7083#issuecomment-262038387
+// And https://github.com/electron/electron/issues/1833
+if (process.platform === 'linux' && !process.env.NO_ELECTRON) {
+  setInterval(() => {}, 1000)
+}

--- a/gui/main.js
+++ b/gui/main.js
@@ -374,11 +374,3 @@ if (process.env.WATCH === 'true') {
       }
     })
 }
-
-// Network requests can be stuck with Electron on Linux inside the event loop.
-// A hack to deblock them is push some events in the event loop.
-// See https://github.com/electron/electron/issues/7083#issuecomment-262038387
-// And https://github.com/electron/electron/issues/1833
-if (process.platform === 'linux') {
-  setInterval(() => {}, 1000)
-}

--- a/test/support/stacktraces.js
+++ b/test/support/stacktraces.js
@@ -3,11 +3,3 @@
 if (!process.env.DEBUG && !process.env.CI) {
   require('mocha-clean')
 }
-
-// Network requests can be stuck with Electron on Linux inside the event loop.
-// A hack to deblock them is push some events in the event loop.
-// See https://github.com/electron/electron/issues/7083#issuecomment-262038387
-// And https://github.com/electron/electron/issues/1833
-if (process.platform === 'linux' && !process.env.NO_ELECTRON) {
-  setInterval(() => {}, 1000)
-}


### PR DESCRIPTION
- It was repeated in to places
- It is global to the app/runtime (not GUI specific)
- It has nothing to do with test stacktraces support