### PR TITLE
travis: Run tests and other jobs in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 ---
 dist: trusty
 language: node_js
-branches:
-    only:
-        - master
-matrix:
-    fast_finish: true
-    include:
-        - os: linux
-          node_js: 8
-          env: CXX=g++-4.8
-          # @TODO macOS build is much slower
-        - os: osx
-          node_js: 8
+node_js: 8
+addons:
+  apt:
+      sources:
+          - ubuntu-toolchain-r-test
+      packages:
+          - gcc-8
+          - g++-8
+          - jq
+services:
+  - docker
+cache:
+  yarn: true
+  directories:
+      - $HOME/.cache/electron
+      - $HOME/.cache/electron-builder
+      - $HOME/bin
 env:
     global:
         - COZY_DESKTOP_DIR=/tmp/cozy-desktop
@@ -26,117 +31,91 @@ env:
         - NODE_ENV=test
         - NPM_CONFIG_PROGRESS=false
         - COZY_DESKTOP_HEARTBEAT=1000
-services:
-    - docker
-cache:
-    yarn: true
-    directories:
-        - $HOME/.cache/electron
-        - $HOME/.cache/electron-builder
-        - $HOME/bin
-addons:
-    apt:
-        sources:
-            - ubuntu-toolchain-r-test
-        packages:
-            - gcc-4.8
-            - g++-4.8
 
-# install cozy stack for integration test
-before_install:
+before_install: | # install cozy stack for integration test
     # FIXME: Homebrew 1.7.3 fails to install cask apache-couchdb
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew update;
-        cd /usr/local/Homebrew;
-        git reset --hard 1.7.2;
-        cd -;
-      fi
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update;
+      cd /usr/local/Homebrew;
+      git reset --hard 1.7.2;
+      cd -;
+    fi
 
     # CouchDB
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        travis_retry docker run -d -p 5984:5984 --name couch apache/couchdb:2.2;
-      fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        travis_retry brew cask install apache-couchdb;
-        printf "\n[log]\nlevel = warn\n" >> /Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/etc/local.ini;
-        ulimit -S -n 1024;
-        (/Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/bin/couchdb >couchdb.log 2>&1 &);
-      fi
-    - sleep 5
-    - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      travis_retry docker run -d -p 5984:5984 --name couch apache/couchdb:2.2;
+    fi
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      travis_retry brew cask install apache-couchdb;
+      printf "\n[log]\nlevel = warn\n" >> /Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/etc/local.ini;
+      ulimit -S -n 1024;
+      (/Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/bin/couchdb >couchdb.log 2>&1 &);
+    fi
+    sleep 5
+    curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
 
     # Cozy-stack
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        travis_retry brew install gimme;
-        travis_retry brew install imagemagick;
-      fi
-    - if [[ ! -f $GOPATH/bin/cozy-stack ]]; then
-        travis_retry gimme 1.11;
-        source ~/.gimme/envs/go1.11.env;
-        travis_retry go get -u github.com/cozy/cozy-stack;
-      fi
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      travis_retry brew install gimme;
+      travis_retry brew install imagemagick;
+    fi
+    if [[ ! -f $GOPATH/bin/cozy-stack ]]; then
+      travis_retry gimme 1.11;
+      source ~/.gimme/envs/go1.11.env;
+      travis_retry go get -u github.com/cozy/cozy-stack;
+    fi
 
     # Create a local instance and an OAuth client
-    - mkdir -p "$COZY_STACK_STORAGE"
-    - $GOPATH/bin/cozy-stack serve --fs-url "file://$COZY_STACK_STORAGE" --log-level warning >/dev/null &
-    - sleep 1
-    - $GOPATH/bin/cozy-stack instances add --dev --passphrase "$COZY_PASSPHRASE" localhost:8080
-    - export COZY_CLIENT_ID=$($GOPATH/bin/cozy-stack instances client-oauth localhost:8080 http://localhost/ test github.com/cozy-labs/cozy-desktop)
-    - export COZY_STACK_TOKEN=$($GOPATH/bin/cozy-stack instances token-oauth localhost:8080 "$COZY_CLIENT_ID" io.cozy.files io.cozy.settings)
+    mkdir -p "$COZY_STACK_STORAGE"
+    $GOPATH/bin/cozy-stack serve --fs-url "file://$COZY_STACK_STORAGE" --log-level warning >/dev/null &
+    sleep 1
+    $GOPATH/bin/cozy-stack instances add --dev --passphrase "$COZY_PASSPHRASE" localhost:8080
+    export COZY_CLIENT_ID=$($GOPATH/bin/cozy-stack instances client-oauth localhost:8080 http://localhost/ test github.com/cozy-labs/cozy-desktop)
+    export COZY_STACK_TOKEN=$($GOPATH/bin/cozy-stack instances token-oauth localhost:8080 "$COZY_CLIENT_ID" io.cozy.files io.cozy.settings)
 
     # COZY_DESKTOP_DIR
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-        hdiutil create -megabytes 10 -fs APFS -volname cozy-desktop "$COZY_DESKTOP_DIR";
-        hdiutil attach "${COZY_DESKTOP_DIR}.dmg" -mountpoint "$COZY_DESKTOP_DIR";
-      else
-        mkdir -p "$COZY_DESKTOP_DIR";
-      fi
+    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      hdiutil create -megabytes 10 -fs APFS -volname cozy-desktop "$COZY_DESKTOP_DIR";
+      hdiutil attach "${COZY_DESKTOP_DIR}.dmg" -mountpoint "$COZY_DESKTOP_DIR";
+    else
+      mkdir -p "$COZY_DESKTOP_DIR";
+    fi
 
     # Dummy .env.test (all variables are already set)
     # env-cmd ignores the file when empty
-    - echo "NODE_ENV=test" > "${TRAVIS_BUILD_DIR}/.env.test"
+    echo "NODE_ENV=test" > "${TRAVIS_BUILD_DIR}/.env.test"
 
-before_script:
-    # Set up display for electron-mocha
-    - export DISPLAY=:99.0
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-        ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )&
-      else
-        sh -e /etc/init.d/xvfb start;
-      fi
-    - sleep 3 # give xvfb some time to start
+after_failure: ./dev/ci/after_failure.sh
 
-script:
-    - yarn build
-    - yarn lint
-    - yarn test:world --timeout $MOCHA_TIMEOUT --forbid-only
-    - yarn test:unit:coverage --timeout $MOCHA_TIMEOUT --forbid-only
-    - yarn test:elm
-    - yarn test:integration --timeout $MOCHA_TIMEOUT --forbid-only
-    - yarn test:scenarios --timeout $MOCHA_TIMEOUT --forbid-only
-    - |
-      if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-        docker run --rm \
-          $(env | \
-            grep -Eo '^[^\s=]*(DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_)[^\s=]*' | \
-            sed 's/^/-e /;/^$/d' | \
-            paste -sd ' ' \
-          ) \
-          -v ${PWD}:/project \
-          -v ~/.cache/electron:/root/.cache/electron \
-          -v ~/.cache/electron-builder:/root/.cache/electron-builder \
-          electronuserland/builder:8 \
-          /bin/bash -c "yarn dist:all"
-      else
-        yarn dist:all
-      fi
-
-after_success:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        bash <(curl -s https://codecov.io/bash);
-      fi
-
-after_failure:
-    - $CXX --version
-    - netstat -lntp
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat couchdb.log; fi
+branches:
+    only:
+        - master
+jobs:
+    fast_finish: true
+    include:
+        - &test_unit
+          stage: test
+          script: ./dev/ci/tests.sh
+          name: unit and integration tests
+          os: linux
+        - <<: *test_unit
+          os: osx
+        - &test_scenarios
+          stage: test
+          script: ./dev/ci/scenarios.sh
+          name: real life scenarios
+          os: linux
+        - <<: *test_scenarios
+          os: osx
+        - &dist
+          stage: test
+          script: ./dev/ci/dist.sh
+          name: artifacts build
+          os: linux
+        - <<: *dist
+          os: osx
+        - stage: test
+          name: code coverage
+          os: linux
+          after_failure: skip
+          script: ./dev/ci/coverage.sh

--- a/dev/ci/after_failure.sh
+++ b/dev/ci/after_failure.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+netstat -lntp
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat couchdb.log; fi

--- a/dev/ci/coverage.sh
+++ b/dev/ci/coverage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+. "./dev/ci/start_xvfb.sh"
+
+yarn test:unit:coverage --timeout $MOCHA_TIMEOUT --forbid-only
+bash <(curl -s https://codecov.io/bash)

--- a/dev/ci/dist.sh
+++ b/dev/ci/dist.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+yarn build
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  docker run --rm \
+    $(env | \
+      grep -Eo '^[^\s=]*(DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_)[^\s=]*' | \
+      sed 's/^/-e /;/^$/d' | \
+      paste -sd ' ' \
+    ) \
+    -v ${PWD}:/project \
+    -v ~/.cache/electron:/root/.cache/electron \
+    -v ~/.cache/electron-builder:/root/.cache/electron-builder \
+    electronuserland/builder:8 \
+    /bin/bash -c "yarn dist:all"
+else
+  yarn dist:all
+fi

--- a/dev/ci/scenarios.sh
+++ b/dev/ci/scenarios.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+. "./dev/ci/start_xvfb.sh"
+
+yarn test:scenarios --timeout $MOCHA_TIMEOUT --forbid-only

--- a/dev/ci/start_xvfb.sh
+++ b/dev/ci/start_xvfb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+export DISPLAY=:99.0
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+  ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )&
+else
+  sh -e /etc/init.d/xvfb start;
+fi
+sleep 3 # give xvfb some time to start

--- a/dev/ci/tests.sh
+++ b/dev/ci/tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+. "./dev/ci/start_xvfb.sh"
+
+yarn build:elm
+yarn lint
+yarn test:unit
+yarn test:world --timeout $MOCHA_TIMEOUT --forbid-only
+yarn test:elm
+yarn test:integration --timeout $MOCHA_TIMEOUT --forbid-only


### PR DESCRIPTION
  Travis offers running different jobs in parallel to speed up builds.
  If we can run more than 2 jobs in parallel (it depends on load) then
  we can get the final results of our builds much more quickly.

  This commit separates unit & integration tests, real life scenarios,
  building the binaries and running codecov.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
