### PR TITLE
Make travis/macOS builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,20 +33,12 @@ env:
         - COZY_DESKTOP_HEARTBEAT=1000
 
 before_install: | # install cozy stack for integration test
-    # FIXME: Homebrew 1.7.3 fails to install cask apache-couchdb
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update;
-      cd /usr/local/Homebrew;
-      git reset --hard 1.7.2;
-      cd -;
-    fi
-
     # CouchDB
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       travis_retry docker run -d -p 5984:5984 --name couch apache/couchdb:2.2;
     fi
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      travis_retry brew cask install apache-couchdb;
+      travis_retry brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/apache-couchdb.rb;
       printf "\n[log]\nlevel = warn\n" >> /Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/etc/local.ini;
       ulimit -S -n 1024;
       (/Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/bin/couchdb >couchdb.log 2>&1 &);


### PR DESCRIPTION
We can avoid the slow brew update by installing CouchDB via an URL

