### PR TITLE
fix: Fetch changesFeed with recursive paginated call

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -281,11 +281,14 @@ async function getChangesFeed (since, client) {
     return response
   }
   const nextResponse = await getChangesFeed(last_seq, client)
-  return {
-    ...nextResponse,
-    results: [
-      ...results,
-      ...nextResponse.results
-    ]
-  }
+  return Object.assign(
+    {},
+    nextResponse,
+    {
+      results: [
+        ...results,
+        ...nextResponse.results
+      ]
+    }
+  )
 }

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -274,7 +274,7 @@ module.exports = {
   RemoteCozy
 }
 
-async function getChangesFeed (since, client) {
+async function getChangesFeed (since /*: string */, client /*: CozyClient */) /*: Promise<{pending: number, last_seq: string, results: Array<any> }> */ {
   const response = await client.data.changesFeed(FILES_DOCTYPE, { since, include_docs: true, limit: 10000 })
   const {last_seq, pending, results} = response
   if (pending === 0) {


### PR DESCRIPTION
When changesFeed `_changes` are very big, the request fails with timeout.
The idea of this PR is to fetch changesFeed by chunks of 10k items.
Implementation is recursive.

What do you think?