### PR TITLE
fix: Fetch changesFeed with recursive paginated call

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -125,8 +125,7 @@ class RemoteCozy {
   }
 
   async changes (since/*: string */ = '0') /*: Promise<{last_seq: string, docs: Array<RemoteDoc|RemoteDeletion>}> */ {
-    const {last_seq, results} = await this.client.data.changesFeed(
-      FILES_DOCTYPE, {since, include_docs: true})
+    const {last_seq, results} = await getChangesFeed(since, this.client)
 
     // The stack docs: dirs, files (without a path), deletions
     const rawDocs = dropSpecialDocs(results.map(r => r.doc))
@@ -273,4 +272,23 @@ module.exports = {
   DirectoryNotFound,
   FSCK_PATH,
   RemoteCozy
+}
+
+async function getChangesFeed (since /*: string */, client /*: CozyClient */) /*: Promise<{pending: number, last_seq: string, results: Array<any> }> */ {
+  const response = await client.data.changesFeed(FILES_DOCTYPE, { since, include_docs: true, limit: 10000 })
+  const {last_seq, pending, results} = response
+  if (pending === 0) {
+    return response
+  }
+  const nextResponse = await getChangesFeed(last_seq, client)
+  return Object.assign(
+    {},
+    nextResponse,
+    {
+      results: [
+        ...results,
+        ...nextResponse.results
+      ]
+    }
+  )
 }

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -75,6 +75,42 @@ describe('RemoteCozy', function () {
 
       return should(remoteCozy.changes()).be.rejected()
     })
+
+    it('makes several calls to get changesfeed aka pagination', async () => {
+      const fakeChangesFeed = sinon.stub(remoteCozy.client.data, 'changesFeed')
+      const docsOnServer = [{
+        doc: {
+          _id: 'a'
+        }
+      }, {
+        doc: {
+          _id: 'b'
+        }
+      }, {
+        doc: {
+          _id: 'c'
+        }
+      },
+      {
+        doc: {
+          _id: 'd'
+        }
+      }]
+      fakeChangesFeed
+        .onFirstCall().resolves({
+          last_seq: 'abc',
+          pending: 1,
+          results: docsOnServer.slice(0, 3)
+        })
+      .onSecondCall().resolves({
+        last_seq: 'd',
+        pending: 0,
+        results: docsOnServer.slice(3)
+      })
+
+      const { docs } = await remoteCozy.changes()
+      should(docs.map(doc => ({ doc }))).eql(docsOnServer)
+    })
   })
 
   describe('find', function () {


### PR DESCRIPTION
When changesFeed `_changes` are very big, the request fails with timeout.
The idea of this PR is to fetch changesFeed by chunks of 10k items.
Implementation is recursive.

What do you think?