### PR TITLE
repl: Use electron embedded node

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "release:check": "yarn release:check:node8 && yarn release:check:branch",
     "release:check:branch": "node ./dev/check-release-branch.js",
     "release:check:node8": "node -e \"(process.versions.node.split('.')[0] !== '8') && process.exit(1)\"",
-    "repl": "env-cmd .env.dev node ./dev/repl.js",
+    "repl": "env-cmd .env.dev electron ./dev/repl.js",
     "stack:reset": "sudo ./node_modules/.bin/rimraf tmp/couchdb tmp/cozy-storage",
     "start": "env-cmd .env.dev electron .",
     "test": "yarn test:world && yarn test:unit && yarn test:elm && yarn test:integration && yarn test:scenarios",


### PR DESCRIPTION
So the runtime actually matches the production one.