### PR TITLE
Handle doctype mismatch on doTrash

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -394,7 +394,7 @@ class Merge {
       return
     }
     if (doc.docType !== oldMetadata.docType) {
-      await this.resolveConflictAsync(side, doc, oldMetadata)
+      log.error({doc, oldMetadata, sentry: true}, 'Mismatch on doctype for doTrash')
       return
     }
     if (side === 'remote' && !sameBinary(oldMetadata, doc)) {

--- a/core/prep.js
+++ b/core/prep.js
@@ -204,7 +204,6 @@ class Prep {
     }
 
     ensureValidPath(doc)
-    ensureValidChecksum(doc)
 
     doc.trashed = true
     doc.docType = 'file'


### PR DESCRIPTION
The conflict resolution can't work here, as it will try to move a deleted file/folder.
