### PR TITLE
core: Fix ignore rules CRLF issue

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -253,7 +253,7 @@ class App {
     try {
       let syncPath = this.config.syncPath
       ignored = fs.readFileSync(path.join(syncPath, '.cozyignore'))
-      ignored = ignored.toString().split('\n')
+      ignored = ignored.toString().split(/\r?\n/)
     } catch (error) {
       ignored = []
     }

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -101,7 +101,7 @@ class Ignore {
     // TODO: split on return char depending on the OS
     const DefaultRules = fs
       .readFileSync(resolve(__dirname, './config/.cozyignore'), 'utf8')
-      .split('\n')
+      .split(/\r?\n/)
     let morePatterns = Array.from(DefaultRules).map(buildPattern)
     this.patterns = morePatterns.concat(this.patterns)
     return this

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -158,6 +158,23 @@ describe('App', function () {
     }
   })
 
+  describe('#loadIgnore()', () => {
+    beforeEach(configHelpers.createConfig)
+    afterEach(configHelpers.cleanConfig)
+
+    it('can load user-defined rules from file with CRLF', function () {
+      const app = new App(this.basePath)
+      app.config = this.config
+      fs.writeFileSync(
+        path.join(this.syncPath, '.cozyignore'),
+        'foo\r\nbar\r\n\r\n'
+      )
+      should(() => app.loadIgnore()).not.throwError()
+      should(app.ignore.isIgnored({_id: 'foo'})).be.true()
+      should(app.ignore.isIgnored({_id: 'bar'})).be.true()
+    })
+  })
+
   describe('clientInfo', () => {
     it('works when app is not configured', () => {
       const basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'base-dir-'))

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -1,5 +1,9 @@
 /* eslint-env mocha */
 
+const fs = require('fs')
+const should = require('should')
+const sinon = require('sinon')
+
 const Ignore = require('../../core/ignore')
 const metadata = require('../../core/metadata')
 
@@ -366,6 +370,19 @@ describe('Ignore', function () {
           type: 'folder'
         })
         .should.be.true()
+    })
+
+    it('can be loaded from file with CRLF', () => {
+      const ignore = new Ignore([])
+      const readFileSync = sinon.stub(fs, 'readFileSync')
+      try {
+        readFileSync.returns('foo\r\nbar\r\n\r\n')
+        should(() => ignore.addDefaultRules()).not.throwError()
+        should(ignore.isIgnored({_id: 'foo'})).be.true()
+        should(ignore.isIgnored({_id: 'bar'})).be.true()
+      } finally {
+        readFileSync.restore()
+      }
     })
   })
 


### PR DESCRIPTION
- User-defined rules with CRLF inside were not loaded
- Default rules could not be loaded on Windows development workstation depending on git config