### PR TITLE
core/merge: Treat move before upload as addition 

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -103,7 +103,8 @@ module.exports = {
   sameBinary,
   markSide,
   buildDir,
-  buildFile
+  buildFile,
+  upToDate
 }
 
 function isFile (doc /*: Metadata */) /*: bool */ {
@@ -179,6 +180,8 @@ function invariants (doc /*: Metadata */) {
   let err
   if (!doc.sides) {
     err = new Error(`${doc._id} has no sides`)
+  } else if (doc._deleted && isUpToDate('local', doc) && isUpToDate('remote', doc)) {
+    err = null
   } else if (doc.sides.remote && !doc.remote) {
     err = new Error(`${doc._id} has 'sides.remote' but no remote`)
   } else if (doc.docType === 'file' && doc.md5sum == null) {
@@ -260,6 +263,13 @@ function markAsUpToDate (doc /*: Metadata */) {
   }
   delete doc.errors
   return rev
+}
+
+function upToDate (doc /*: Metadata */) /*: Metadata */ {
+  const clone = _.clone(doc)
+  const rev = Math.max(clone.sides.local, clone.sides.remote)
+
+  return _.assign(clone, { errors: undefined, sides: { local: rev, remote: rev } })
 }
 
 // Ensure new timestamp is never older than the previous one

--- a/core/pouch.js
+++ b/core/pouch.js
@@ -5,7 +5,8 @@ const Promise = require('bluebird')
 const PouchDB = require('pouchdb')
 const async = require('async')
 const fs = require('fs-extra')
-const { isEqual } = require('lodash')
+const _ = require('lodash')
+const { isEqual } = _
 const path = require('path')
 
 const logger = require('./logger')
@@ -113,6 +114,10 @@ class Pouch {
     const {local, remote} = doc.sides
     log.debug({path: doc.path, local, remote, _deleted: doc._deleted, doc}, 'Saving metadata...')
     return this.db.put(doc).asCallback(callback)
+  }
+
+  async remove (doc /*: Metadata */) /*: Promise<*> */ {
+    return this.put(_.defaults({ _deleted: true }, doc))
   }
 
   // WARNING: bulkDocs is not a transaction, some updates can be applied while

--- a/core/sync.js
+++ b/core/sync.js
@@ -194,6 +194,7 @@ class Sync {
         })
         .on('error', err => {
           if (this.changes) {
+            // FIXME: pas de cancel ici ??
             this.changes = null
             reject(err)
           }

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -125,7 +125,7 @@ describe('Move', () => {
       await helpers.local.scan()
     })
 
-    it.only('local', async () => {
+    it('local', async () => {
       should(await helpers.local.tree()).deepEqual([
         'dst/',
         'src/',
@@ -139,12 +139,18 @@ describe('Move', () => {
       await helpers.local.scan()
       await helpers.syncAll()
 
-      should(await helpers.remote.tree()).deepEqual([
-        '.cozy_trash/',
-        'dst/',
-        'dst/file',
-        'src/'
-      ])
+      should(await helpers.trees('metadata', 'remote')).deepEqual({
+        remote: [
+          'dst/',
+          'dst/file',
+          'src/'
+        ],
+        metadata: [
+          'dst/',
+          'dst/file',
+          'src/'
+        ]
+      })
     })
   })
 


### PR DESCRIPTION
  If a new file is moved after we've detected the addition but before we
  could upload it, we should not try to apply the following move as the
  source file does not exist on the filesystem anymore but instead treat
  it as an addition of the destition file and remove the source file in
  Pouch.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
