### PR TITLE
Fix missing COZY_STACK_TOKEN on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install: | # install cozy stack for integration test
       ulimit -S -n 1024;
       (/Applications/Apache\ CouchDB.app/Contents/Resources/couchdbx-core/bin/couchdb >couchdb.log 2>&1 &);
     fi
-    sleep 5
+    sleep 8
     curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
 
     # Cozy-stack


### PR DESCRIPTION
When CouchDB is too slow to start, the generation of the COZY_STACK_TOKEN fails. With this commit, we will wait longer that CouchDB has started.
