### PR TITLE
Handle unapplied remote move - initialScan - sync

### DIFF
--- a/core/local/chokidar_event.js
+++ b/core/local/chokidar_event.js
@@ -19,7 +19,8 @@ export type ChokidarEvent =
 */
 
 module.exports = {
-  build
+  build,
+  pretendUnlinkFromMetadata
 }
 
 function build (type /*: string */, path /*: ?string */, stats /*: ?fs.Stats */) /*: ChokidarEvent */ {
@@ -27,4 +28,11 @@ function build (type /*: string */, path /*: ?string */, stats /*: ?fs.Stats */)
   if (path != null) event.path = path
   if (stats != null) event.stats = stats
   return event
+}
+
+function pretendUnlinkFromMetadata (doc /*: Metadata */) /*: ChokidarUnlink|ChokidarUnlinkDir */ {
+  const type = doc.docType === 'file' ? 'unlink' : 'unlinkDir'
+  const path = doc.path
+  // $FlowFixMe
+  return { type, path, old: doc }
 }

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -1,0 +1,77 @@
+/* @flow */
+
+const {
+  after,
+  afterEach,
+  before,
+  beforeEach,
+  suite,
+  test
+} = require('mocha')
+const should = require('should')
+
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+const { IntegrationTestHelpers } = require('../support/helpers/integration')
+
+const cozy = cozyHelpers.cozy
+
+suite('Sync gets interrupted, initialScan occurs', () => {
+  let helpers
+
+  before(configHelpers.createConfig)
+  before(configHelpers.registerClient)
+  beforeEach(pouchHelpers.createDatabase)
+  beforeEach(cozyHelpers.deleteAll)
+
+  afterEach(() => helpers.local.clean())
+  afterEach(pouchHelpers.cleanDatabase)
+  after(configHelpers.cleanConfig)
+
+  beforeEach(async function () {
+    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers.local.setupTrash()
+    await helpers.remote.ignorePreviousChanges()
+
+    await helpers.remote.pullChanges()
+    await helpers.syncAll()
+
+    helpers.spyPouch()
+  })
+
+  test('move Folder', async () => {
+    const docs = await helpers.remote.createTree([
+      '/a/',
+      '/b/'
+    ])
+
+    await helpers.remote.pullChanges()
+    await helpers.syncAll()
+
+    await cozy.files.updateAttributesById(docs['/b/']._id, {dir_id: docs['/a/']._id})
+
+    await helpers.remote.pullChanges() // Merge
+
+    // but not sync (client restart)
+
+    await helpers.local.scan()
+    await helpers.syncAll()
+
+    const expected = [ 'a/', 'a/b/' ]
+
+    should(await helpers.trees()).deepEqual({
+      remote: expected,
+      local: expected
+    })
+
+    await helpers.local.scan()
+    await helpers.remote.pullChanges()
+    await helpers.syncAll()
+
+    should(await helpers.trees()).deepEqual({
+      remote: expected,
+      local: expected
+    })
+  })
+})


### PR DESCRIPTION
This PR includes and fix the test from #1235 
