### PR TITLE
[WIP] core/metadata: Assume up to date when current rev >= last one

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -293,7 +293,7 @@ function extractRevNumber (doc /*: Metadata|{_rev: string} */) {
 function isUpToDate (side /*: SideName */, doc /*: Metadata */) {
   let currentRev = doc.sides[side] || 0
   let lastRev = extractRevNumber(doc)
-  return currentRev === lastRev
+  return currentRev >= lastRev
 }
 
 function markAsUpToDate (doc /*: Metadata */) {


### PR DESCRIPTION
- Doesn't break existing tests
- May prevent unexpected conflicts

Courtesy of @aenario 