### PR TITLE
core/merge: Synchronize childs of moved directory

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -104,6 +104,8 @@ module.exports = {
   extractRevNumber,
   isUpToDate,
   isAtLeastUpToDate,
+  markAsNeverSynced,
+  markAsNew,
   markAsUpToDate,
   sameFolder,
   sameFile,
@@ -301,6 +303,16 @@ function isAtLeastUpToDate (side /*: SideName */, doc /*: Metadata */) {
   let currentRev = doc.sides[side] || 0
   let lastRev = extractRevNumber(doc)
   return currentRev >= lastRev
+}
+
+function markAsNeverSynced (doc /*: Metadata */) {
+  doc._deleted = true
+  doc.sides = { local: 1, remote: 1 }
+}
+
+function markAsNew (doc /*: Metadata */) {
+  delete doc._rev
+  delete doc.sides
 }
 
 function markAsUpToDate (doc /*: Metadata */) {


### PR DESCRIPTION
  When we move a directory during a synchronization phase, right after
  adding some new files to it, those files don't get uploaded while they
  remain in the renamed directory on the filesystem.

  We mark the source file as never synchronized and its destination as new
  so we don't try to move the source file and upload the destination
  file instead.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
