### PR TITLE
core: Rename all RemoteDoc/Metadata vars

### DIFF
--- a/core/conversion.js
+++ b/core/conversion.js
@@ -15,34 +15,34 @@ module.exports = {
   extractDirAndName
 }
 
-function localDocType (remote /*: string */) /*: string */ {
-  switch (remote) {
+function localDocType (remoteDocType /*: string */) /*: string */ {
+  switch (remoteDocType) {
     case FILE_TYPE: return 'file'
     case DIR_TYPE: return 'folder'
-    default: throw new Error(`Unexpected Cozy Files type: ${remote}`)
+    default: throw new Error(`Unexpected Cozy Files type: ${remoteDocType}`)
   }
 }
 
 // Transform a remote document into metadata, as stored in Pouch.
 // Please note the path is not normalized yet!
 // Normalization is done as a side effect of metadata.invalidPath() :/
-function createMetadata (remote /*: RemoteDoc */) /*: Metadata */ {
+function createMetadata (remoteDoc /*: RemoteDoc */) /*: Metadata */ {
   const doc /*: Object */ = {
-    path: remote.path.substring(1),
-    docType: localDocType(remote.type),
-    updated_at: remote.updated_at,
+    path: remoteDoc.path.substring(1),
+    docType: localDocType(remoteDoc.type),
+    updated_at: remoteDoc.updated_at,
     remote: {
-      _id: remote._id,
-      _rev: remote._rev
+      _id: remoteDoc._id,
+      _rev: remoteDoc._rev
     }
   }
 
-  if (remote.size) {
-    doc.size = parseInt(remote.size, 10)
+  if (remoteDoc.size) {
+    doc.size = parseInt(remoteDoc.size, 10)
   }
 
   for (let field of ['md5sum', 'executable', 'class', 'mime', 'tags']) {
-    if (remote[field]) { doc[field] = remote[field] }
+    if (remoteDoc[field]) { doc[field] = remoteDoc[field] }
   }
 
   return doc

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -135,29 +135,30 @@ class RemoteCozy {
       parentDirIds(keepFiles(rawDocs)))
 
     // The final docs with their paths (except for deletions)
-    let docs /*: Array<RemoteDoc|RemoteDeletion> */ = []
+    let remoteDocs /*: Array<RemoteDoc|RemoteDeletion> */ = []
 
-    for (const doc of rawDocs) {
-      if (doc.type === FILE_TYPE) {
+    for (const remoteDoc of rawDocs) {
+      if (remoteDoc.type === FILE_TYPE) {
         // File docs returned by the cozy-stack don't have a path
-        const parent = fileParentsById[doc.dir_id]
+        const parent = fileParentsById[remoteDoc.dir_id]
 
         if (parent.error || parent.doc == null || parent.doc.path == null) {
-          log.error({doc, parent}, 'Could not compute doc path from parent')
+          log.error({remoteDoc, parent}, 'Could not compute doc path from parent')
           continue
         } else {
-          doc.path = path.posix.join(parent.doc.path, doc.name)
+          remoteDoc.path = path.posix.join(parent.doc.path, remoteDoc.name)
         }
       }
-      docs.push(doc)
+      remoteDocs.push(remoteDoc)
     }
 
-    return {last_seq, docs}
+    return {last_seq, docs: remoteDocs}
   }
 
   async find (id/*: string */)/*: Promise<RemoteDoc> */ {
-    const doc = await this.client.files.statById(id)
-    return this.toRemoteDoc(doc)
+    return this.toRemoteDoc(
+      await this.client.files.statById(id)
+    )
   }
 
   async findMaybe (id/*: string */)/*: Promise<?RemoteDoc> */ {

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -92,9 +92,9 @@ export type JsonApiDoc = {
 */
 
 function jsonApiToRemoteDoc (json/*: JsonApiDoc */) /*: * */ {
-  let metadata = {}
+  let remoteDoc = {}
 
-  Object.assign(metadata, {
+  Object.assign(remoteDoc, {
     _id: json._id,
     _rev: json._rev,
     _type: json._type,
@@ -105,15 +105,15 @@ function jsonApiToRemoteDoc (json/*: JsonApiDoc */) /*: * */ {
     updated_at: json.attributes.updated_at
   })
 
-  switch (metadata.type) {
+  switch (remoteDoc.type) {
     case DIR_TYPE:
-      Object.assign(metadata, {
+      Object.assign(remoteDoc, {
         path: json.attributes.path
       })
       break
 
     case FILE_TYPE:
-      Object.assign(metadata, {
+      Object.assign(remoteDoc, {
         class: json.attributes.class,
         executable: json.attributes.executable,
         md5sum: json.attributes.md5sum,
@@ -123,5 +123,5 @@ function jsonApiToRemoteDoc (json/*: JsonApiDoc */) /*: * */ {
       break
   }
 
-  return metadata
+  return remoteDoc
 }

--- a/test/integration/corruption_fixer.js
+++ b/test/integration/corruption_fixer.js
@@ -158,8 +158,8 @@ describe('Re-Upload files when the stack report them as broken', () => {
     const prefix = rows[0].doc.prefix
     const fileURL = `${COUCHDB_URL}/${prefix}%2Fio-cozy-files/${remoteFile._id}`
     if (merge.size) merge.size = '' + merge.size // size is a string in couchdb
-    const doc = _.merge((await fetchJSON(fileURL)), merge)
-    return fetchJSON(fileURL, {method: 'PUT', body: JSON.stringify(doc)})
+    const remoteDoc = _.merge((await fetchJSON(fileURL)), merge)
+    return fetchJSON(fileURL, {method: 'PUT', body: JSON.stringify(remoteDoc)})
   }
 
   async function setupContentMismatchRemote (opts) {

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -101,19 +101,19 @@ describe('Platform incompatibilities', () => {
     ])
   })
   it('trash & restore incompatible', async () => {
-    const docs = await helpers.remote.createTree(['d:ir/', 'f:ile'])
+    const remoteDocs = await helpers.remote.createTree(['d:ir/', 'f:ile'])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.trashById(docs['d:ir/']._id)
-    await cozy.files.trashById(docs['f:ile']._id)
+    await cozy.files.trashById(remoteDocs['d:ir/']._id)
+    await cozy.files.trashById(remoteDocs['f:ile']._id)
     await helpers.pullAndSyncAll()
 
     should(await helpers.local.tree()).be.empty()
     should(await helpers.metadataTree()).be.empty()
     should(await helpers.incompatibleTree()).be.empty()
 
-    await cozy.files.restoreById(docs['d:ir/']._id)
-    await cozy.files.restoreById(docs['f:ile']._id)
+    await cozy.files.restoreById(remoteDocs['d:ir/']._id)
+    await cozy.files.restoreById(remoteDocs['f:ile']._id)
     await helpers.pullAndSyncAll()
 
     should(await helpers.local.tree()).be.empty()
@@ -124,13 +124,13 @@ describe('Platform incompatibilities', () => {
   })
 
   it('destroy & recreate incompatible', async () => {
-    const docs = await helpers.remote.createTree(['d:ir/', 'f:ile'])
+    const remoteDocs = await helpers.remote.createTree(['d:ir/', 'f:ile'])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.trashById(docs['d:ir/']._id)
-    await cozy.files.trashById(docs['f:ile']._id)
-    await cozy.files.destroyById(docs['d:ir/']._id)
-    await cozy.files.destroyById(docs['f:ile']._id)
+    await cozy.files.trashById(remoteDocs['d:ir/']._id)
+    await cozy.files.trashById(remoteDocs['f:ile']._id)
+    await cozy.files.destroyById(remoteDocs['d:ir/']._id)
+    await cozy.files.destroyById(remoteDocs['f:ile']._id)
     await helpers.pullAndSyncAll()
 
     should(await helpers.local.tree()).be.empty()
@@ -146,7 +146,7 @@ describe('Platform incompatibilities', () => {
   })
 
   it('make compatible bottom-up', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'd:ir/',
       'd:ir/sub:dir/',
       'd:ir/sub:dir/f:ile',
@@ -154,7 +154,7 @@ describe('Platform incompatibilities', () => {
     ])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.updateAttributesById(docs['d:ir/sub:dir/f:ile']._id, {name: 'file'})
+    await cozy.files.updateAttributesById(remoteDocs['d:ir/sub:dir/f:ile']._id, {name: 'file'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).be.empty()
     should(await helpers.incompatibleTree()).deepEqual([
@@ -164,7 +164,7 @@ describe('Platform incompatibilities', () => {
       'd:ir/sub:dir/subsubdir/'
     ])
 
-    await cozy.files.updateAttributesById(docs['d:ir/']._id, {name: 'dir'})
+    await cozy.files.updateAttributesById(remoteDocs['d:ir/']._id, {name: 'dir'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       'dir/'
@@ -175,7 +175,7 @@ describe('Platform incompatibilities', () => {
       'dir/sub:dir/subsubdir/'
     ])
 
-    await cozy.files.updateAttributesById(docs['d:ir/sub:dir/']._id, {name: 'subdir'})
+    await cozy.files.updateAttributesById(remoteDocs['d:ir/sub:dir/']._id, {name: 'subdir'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       'dir/',
@@ -187,14 +187,14 @@ describe('Platform incompatibilities', () => {
   })
 
   it('rename dir compatible -> incompatible', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'dir/',
       'dir/subdir/',
       'dir/subdir/file'
     ])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.updateAttributesById(docs['dir/']._id, {name: 'dir:'})
+    await cozy.files.updateAttributesById(remoteDocs['dir/']._id, {name: 'dir:'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       '/Trash/dir/',
@@ -209,14 +209,14 @@ describe('Platform incompatibilities', () => {
   })
 
   it('rename dir compatible -> incompatible with already incompatible content', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'dir/',
       'dir/sub:dir/',
       'dir/sub:dir/file'
     ])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.updateAttributesById(docs['dir/']._id, {name: 'dir:'})
+    await cozy.files.updateAttributesById(remoteDocs['dir/']._id, {name: 'dir:'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       '/Trash/dir/'
@@ -229,13 +229,13 @@ describe('Platform incompatibilities', () => {
   })
 
   it('rename file compatible -> incompatible', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'dir/',
       'dir/file'
     ])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.updateAttributesById(docs['dir/file']._id, {name: 'fi:le'})
+    await cozy.files.updateAttributesById(remoteDocs['dir/file']._id, {name: 'fi:le'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       '/Trash/file',
@@ -247,14 +247,14 @@ describe('Platform incompatibilities', () => {
   })
 
   it('rename dir compatible -> compatible with incompatible content', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'dir/',
       'dir/fi:le',
       'dir/sub:dir/'
     ])
     await helpers.pullAndSyncAll()
 
-    await cozy.files.updateAttributesById(docs['dir/']._id, {name: 'dir2'})
+    await cozy.files.updateAttributesById(remoteDocs['dir/']._id, {name: 'dir2'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       'dir2/'
@@ -266,7 +266,7 @@ describe('Platform incompatibilities', () => {
   })
 
   it('move local dir with incompatible metadata & remote content', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'dir/',
       'dir/sub:dir/',
       'dir/sub:dir/file'
@@ -274,7 +274,7 @@ describe('Platform incompatibilities', () => {
     await helpers.pullAndSyncAll()
 
     // Simulate local move
-    const dir = await helpers._pouch.byRemoteIdAsync(docs['dir/']._id)
+    const dir = await helpers._pouch.byRemoteIdAsync(remoteDocs['dir/']._id)
     const stats = {mtime: new Date(), ctime: new Date(), ino: dir.ino}
     // $FlowFixMe
     const dir2 = metadata.buildDir('dir2', stats)
@@ -294,7 +294,7 @@ describe('Platform incompatibilities', () => {
   })
 
   it('rename dir compatible -> incompatible -> compatible with compatible content', async () => {
-    const docs = await helpers.remote.createTree([
+    const remoteDocs = await helpers.remote.createTree([
       'dir/',
       'dir/file'
     ])
@@ -305,7 +305,7 @@ describe('Platform incompatibilities', () => {
     ])
     should(await helpers.incompatibleTree()).be.empty()
 
-    await cozy.files.updateAttributesById(docs['dir/']._id, {name: 'd:ir'})
+    await cozy.files.updateAttributesById(remoteDocs['dir/']._id, {name: 'd:ir'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       '/Trash/dir/',
@@ -316,7 +316,7 @@ describe('Platform incompatibilities', () => {
       'd:ir/file'
     ])
 
-    await cozy.files.updateAttributesById(docs['dir/']._id, {name: 'dir'})
+    await cozy.files.updateAttributesById(remoteDocs['dir/']._id, {name: 'dir'})
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual([
       // XXX: We don't restore from OS trash for now. Hence the copy.

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -23,13 +23,13 @@ const defaultTimestamp = timestamp.stringify(timestamp.current())
 module.exports = class RemoteBaseBuilder {
   /*::
   cozy: Cozy
-  doc: RemoteDoc
+  remoteDoc: RemoteDoc
   */
 
   constructor (cozy /*: Cozy */) {
     this.cozy = cozy
     const name = 'whatever'
-    this.doc = {
+    this.remoteDoc = {
       _id: dbBuilders.id(),
       _rev: dbBuilders.rev(1),
       _type: FILES_DOCTYPE,
@@ -44,8 +44,8 @@ module.exports = class RemoteBaseBuilder {
   }
 
   inDir (dir /*: RemoteDoc | {_id: string, path: string} */) /*: this */ {
-    this.doc.dir_id = dir._id
-    this.doc.path = posix.join(dir.path, this.doc.name)
+    this.remoteDoc.dir_id = dir._id
+    this.remoteDoc.path = posix.join(dir.path, this.remoteDoc.name)
     return this
   }
 
@@ -64,17 +64,17 @@ module.exports = class RemoteBaseBuilder {
   }
 
   timestamp (...args /*: number[] */) /*: this */ {
-    this.doc.updated_at = timestamp.stringify(timestamp.build(...args))
+    this.remoteDoc.updated_at = timestamp.stringify(timestamp.build(...args))
     return this
   }
 
   name (name /*: string */) /*: this */ {
-    this.doc.name = name
-    this.doc.path = posix.join(posix.dirname(this.doc.path), name)
+    this.remoteDoc.name = name
+    this.remoteDoc.path = posix.join(posix.dirname(this.remoteDoc.path), name)
     return this
   }
 
   build () /*: Object */ {
-    return _.clone(this.doc)
+    return _.clone(this.remoteDoc)
   }
 }

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -23,16 +23,16 @@ var dirNumber = 1
 module.exports = class RemoteDirBuilder extends RemoteBaseBuilder {
   constructor (cozy /*: Cozy */) {
     super(cozy)
-    this.doc.type = 'directory'
+    this.remoteDoc.type = 'directory'
     this.name(`directory-${dirNumber++}`)
   }
 
   async create () /*: Promise<RemoteDoc> */ {
     return jsonApiToRemoteDoc(
       await this.cozy.files.createDirectory({
-        name: this.doc.name,
-        dirID: this.doc.dir_id,
-        lastModifiedDate: this.doc.updated_at
+        name: this.remoteDoc.name,
+        dirID: this.remoteDoc.dir_id,
+        lastModifiedDate: this.remoteDoc.updated_at
       })
     )
   }

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -34,26 +34,26 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder {
   constructor (cozy /*: Cozy */) {
     super(cozy)
 
-    this.doc.type = 'file'
+    this.remoteDoc.type = 'file'
     this.name(`remote-file-${fileNumber}`)
     this.data(`Content of remote file ${fileNumber}`)
-    this.doc.class = 'application'
-    this.doc.mime = 'application/octet-stream'
-    this.doc.executable = true
+    this.remoteDoc.class = 'application'
+    this.remoteDoc.mime = 'application/octet-stream'
+    this.remoteDoc.executable = true
 
     fileNumber++
   }
 
   contentType (contentType /*: string */) /*: RemoteFileBuilder */ {
-    this.doc.mime = contentType
+    this.remoteDoc.mime = contentType
     return this
   }
 
   data (data /*: string | stream.Readable */) /*: RemoteFileBuilder */ {
     this._data = data
     if (typeof data === 'string') {
-      this.doc.size = Buffer.from(data).length.toString()
-      this.doc.md5sum =
+      this.remoteDoc.size = Buffer.from(data).length.toString()
+      this.remoteDoc.md5sum =
         crypto.createHash('md5').update(data).digest().toString('base64')
     }
     // FIXME: Assuming doc will be created with data stream
@@ -65,18 +65,18 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder {
   }
 
   executable (isExecutable /*: boolean */) /*: RemoteFileBuilder */ {
-    this.doc.executable = isExecutable
+    this.remoteDoc.executable = isExecutable
     return this
   }
 
   async create () /*: Promise<RemoteDoc> */ {
     const doc = jsonApiToRemoteDoc(
       await this.cozy.files.create(this._data, {
-        contentType: this.doc.mime,
-        dirID: this.doc.dir_id,
-        executable: this.doc.executable,
-        lastModifiedDate: this.doc.updated_at,
-        name: this.doc.name
+        contentType: this.remoteDoc.mime,
+        dirID: this.remoteDoc.dir_id,
+        executable: this.remoteDoc.executable,
+        lastModifiedDate: this.remoteDoc.updated_at,
+        name: this.remoteDoc.name
       })
     )
 

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -38,7 +38,7 @@ module.exports = {
 // List files and directories in the root directory
 async function rootDirContents () {
   const index = await cozy.data.defineIndex(FILES_DOCTYPE, ['dir_id'])
-  const docs = await cozy.data.query(index, {
+  const remoteDocs = await cozy.data.query(index, {
     selector: {
       dir_id: ROOT_DIR_ID,
       '$not': {_id: TRASH_DIR_ID}
@@ -46,14 +46,14 @@ async function rootDirContents () {
     fields: ['_id', 'dir_id']
   })
 
-  return docs
+  return remoteDocs
 }
 
 // Delete all files and directories
 async function deleteAll () {
-  const docs = await rootDirContents()
+  const remoteDocs = await rootDirContents()
 
-  await Promise.all(docs.map(doc => cozy.files.trashById(doc._id)))
+  await Promise.all(remoteDocs.map(doc => cozy.files.trashById(doc._id)))
 
   return cozy.files.clearTrash()
 }

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -38,21 +38,21 @@ class RemoteTestHelpers {
   }
 
   async createTree (paths /*: Array<string> */) /*: Promise<{ [string]: RemoteDoc}> */ {
-    const docsByPath = {}
+    const remoteDocsByPath = {}
     for (const p of paths) {
       const name = path.posix.basename(p)
       const parentPath = path.posix.dirname(p)
-      const dirID = (docsByPath[parentPath + '/'] || {})._id
+      const dirID = (remoteDocsByPath[parentPath + '/'] || {})._id
       if (p.endsWith('/')) {
-        docsByPath[p] = await this.cozy.files.createDirectory(
+        remoteDocsByPath[p] = await this.cozy.files.createDirectory(
           {name, dirID, lastModifiedDate: new Date()})
       } else {
-        docsByPath[p] = await this.cozy.files.create(`Content of file ${p}`,
+        remoteDocsByPath[p] = await this.cozy.files.create(`Content of file ${p}`,
           {name, dirID, lastModifiedDate: new Date()})
       }
     }
 
-    return docsByPath
+    return remoteDocsByPath
   }
 
   // TODO: Extract reusable #scan() method from tree*()

--- a/test/unit/conversion.js
+++ b/test/unit/conversion.js
@@ -32,9 +32,9 @@ describe('conversion', function () {
         type: 'file',
         updated_at: timestamp.stringify(timestamp.build(2017, 9, 8, 7, 6, 5))
       }
-      let metadata /*: Metadata */ = conversion.createMetadata(remoteDoc)
+      let doc /*: Metadata */ = conversion.createMetadata(remoteDoc)
 
-      should(metadata).deepEqual({
+      should(doc).deepEqual({
         md5sum: 'N7UdGUp1E+RbVvZSTy1R8g==',
         class: 'document',
         docType: 'file',
@@ -50,8 +50,8 @@ describe('conversion', function () {
       })
 
       remoteDoc.executable = true
-      metadata = conversion.createMetadata(remoteDoc)
-      should(metadata.executable).equal(true)
+      doc = conversion.createMetadata(remoteDoc)
+      should(doc.executable).equal(true)
     })
 
     it('builds the metadata for a remote dir', () => {
@@ -67,9 +67,9 @@ describe('conversion', function () {
         updated_at: timestamp.stringify(timestamp.build(2017, 9, 8, 7, 6, 5))
       }
 
-      const metadata = conversion.createMetadata(remoteDoc)
+      const doc = conversion.createMetadata(remoteDoc)
 
-      should(metadata).deepEqual({
+      should(doc).deepEqual({
         docType: 'folder',
         updated_at: '2017-09-08T07:06:05Z',
         path: 'foo/bar',

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -138,15 +138,15 @@ describe('metadata', function () {
     const syncPath = ';'
 
     it('is null when all names in the path are compatible', () => {
-      const metadata = {path: path.normalize('foo/bar'), docType: 'file'}
-      should(detectPlatformIncompatibilities(metadata, syncPath)).deepEqual([])
+      const doc = {path: path.normalize('foo/bar'), docType: 'file'}
+      should(detectPlatformIncompatibilities(doc, syncPath)).deepEqual([])
     })
 
     onPlatform('win32', () => {
       it('lists platform incompatibilities for all names in the path', () => {
         const path = 'f?o:o\\ba|r\\baz\\q"ux'
-        const metadata = {path, docType: 'file'}
-        should(detectPlatformIncompatibilities(metadata, syncPath)).deepEqual([
+        const doc = {path, docType: 'file'}
+        should(detectPlatformIncompatibilities(doc, syncPath)).deepEqual([
           {
             type: 'reservedChars',
             name: 'q"ux',
@@ -178,8 +178,8 @@ describe('metadata', function () {
     onPlatform('darwin', () => {
       it('lists platform incompatibilities for all names in the path', () => {
         const path = 'foo/b:ar/qux'
-        const metadata = {path, docType: 'folder'}
-        should(detectPlatformIncompatibilities(metadata, syncPath)).deepEqual([
+        const doc = {path, docType: 'folder'}
+        should(detectPlatformIncompatibilities(doc, syncPath)).deepEqual([
           {
             type: 'reservedChars',
             name: 'b:ar',

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -198,7 +198,7 @@ describe('Remote', function () {
     })
 
     it('creates the parent folder when missing', async function () {
-      const metadata /*: Metadata */ = metadataBuilders.file().path(path.join('foo', 'bar', 'qux')).build()
+      const doc /*: Metadata */ = metadataBuilders.file().path(path.join('foo', 'bar', 'qux')).build()
       this.remote.other = {
         createReadStreamAsync (localDoc) {
           const empty = withContentLength(new stream.Readable({
@@ -207,21 +207,21 @@ describe('Remote', function () {
           return empty
         }
       }
-      await this.remote.addFileAsync(metadata)
+      await this.remote.addFileAsync(doc)
       await should(cozy.files.statByPath('/foo/bar')).be.fulfilled()
     })
 
     it('does not throw if the file does not exists locally anymore', async function () {
-      const metadata /*: Metadata */ = metadataBuilders.file().path('foo').build()
+      const doc /*: Metadata */ = metadataBuilders.file().path('foo').build()
       this.remote.other = {
         createReadStreamAsync (localDoc) {
           return fs.readFile('/path/do/not/exists')
         }
       }
-      await this.remote.addFileAsync(metadata)
-      should.exist(metadata.remote._id)
-      should.exist(metadata.remote._rev)
-      should.exist(metadata._deleted)
+      await this.remote.addFileAsync(doc)
+      should.exist(doc.remote._id)
+      should.exist(doc.remote._rev)
+      should.exist(doc._deleted)
     })
   })
 
@@ -249,23 +249,23 @@ describe('Remote', function () {
     it('does nothing when the folder already exists', async function () {
       const parentDir /*: RemoteDoc */ = await builders.remote.dir().create()
       const remoteDir /*: RemoteDoc */ = await builders.remote.dir().inDir(parentDir).create()
-      const metadata /*: Metadata */ = _.merge({remote: undefined}, conversion.createMetadata(remoteDir))
-      ensureValidPath(metadata)
+      const doc /*: Metadata */ = _.merge({remote: undefined}, conversion.createMetadata(remoteDir))
+      ensureValidPath(doc)
 
-      await this.remote.addFolderAsync(metadata)
+      await this.remote.addFolderAsync(doc)
 
-      const folder /*: JsonApiDoc */ = await cozy.files.statById(metadata.remote._id)
+      const folder /*: JsonApiDoc */ = await cozy.files.statById(doc.remote._id)
       const {path, name, type, updated_at} = remoteDir
       should(folder.attributes).have.properties({path, name, type, updated_at})
-      should(metadata.remote).have.properties({
+      should(doc.remote).have.properties({
         _id: remoteDir._id,
         _rev: remoteDir._rev
       })
     })
 
     it('creates the parent folder when missing', async function () {
-      const metadata /*: Metadata */ = metadataBuilders.dir().path(path.join('foo', 'bar', 'qux')).build()
-      await this.remote.addFolderAsync(metadata)
+      const doc /*: Metadata */ = metadataBuilders.dir().path(path.join('foo', 'bar', 'qux')).build()
+      await this.remote.addFolderAsync(doc)
       await should(cozy.files.statByPath('/foo/bar')).be.fulfilled()
     })
   })
@@ -327,16 +327,16 @@ describe('Remote', function () {
       })
 
       it('does not throw if the file does not exists locally anymore', async function () {
-        const metadata /*: Metadata */ = metadataBuilders.file().path('foo').build()
+        const doc /*: Metadata */ = metadataBuilders.file().path('foo').build()
         this.remote.other = {
           createReadStreamAsync (localDoc) {
             return fs.readFile('/path/do/not/exists')
           }
         }
-        await this.remote.overwriteFileAsync(metadata)
-        should.exist(metadata.remote._id)
-        should.exist(metadata.remote._rev)
-        should.exist(metadata._deleted)
+        await this.remote.overwriteFileAsync(doc)
+        should.exist(doc.remote._id)
+        should.exist(doc.remote._rev)
+        should.exist(doc._deleted)
       })
     })
   }


### PR DESCRIPTION
Same convention everywhere:

- doc(s) for Metadata(s)
- remoteDoc(s) for RemoteDoc(s)

Motivations:

- Prevents confusion between doc (Metadata), remote (Side) or
  file/dir/folder (?)
- Makes it easier to grep
- Allows using metadata module prefix
