### PR TITLE
core/prep: Merge#doMoveFile() method into #moveFileAsync()

### DIFF
--- a/core/prep.js
+++ b/core/prep.js
@@ -104,12 +104,8 @@ class Prep {
       const msg = 'Missing rev'
       log.warn({path, doc, was}, msg)
       throw new Error(msg)
-    } else {
-      return this.doMoveFile(side, doc, was)
     }
-  }
 
-  doMoveFile (side /*: SideName */, doc /*: Metadata */, was /*: Metadata */) {
     doc.docType = 'file'
     assignId(doc)
     assignId(was)


### PR DESCRIPTION
Motivations:

- Keeps valid metadata construction in the same place
- It was not used anywhere else
