### PR TITLE
appveyor: Split builds between 2 Cozy instances

### DIFF
--- a/dev/remote/generate-test-env.js
+++ b/dev/remote/generate-test-env.js
@@ -5,9 +5,17 @@ const fse = require('fs-extra')
 const pkg = require('../../package.json')
 const automatedRegistration = require('./automated_registration')
 
-const cozyUrl = process.env.COZY_URL
+const cozyUrl = chooseCozyUrl(process.env.APPVEYOR_BUILD_NUMBER)
 const passphrase = process.env.COZY_PASSPHRASE
 const storage = new cozy.MemoryStorage()
+
+function chooseCozyUrl (buildNumber) {
+  if (!!buildNumber && buildNumber % 2 === 1) {
+    return process.env.COZY_URL_2
+  }
+
+  return process.env.COZY_URL_1
+}
 
 function readAccessToken () {
   console.log('Read access token...')
@@ -20,6 +28,7 @@ function generateTestEnv (accessToken) {
   return fse.writeFile('.env.test', `
 COZY_DESKTOP_HEARTBEAT=1000
 COZY_STACK_TOKEN=${accessToken}
+COZY_URL=${cozyUrl}
 NODE_ENV=test
   `)
 }


### PR DESCRIPTION
  Some tests can fail if they run concurrently on 2 builds and the same
  Cozy instance.
  We've created a second Cozy instance dedicated to the AppVeyor builds
  and we split those builds between the 2 to avoid these conflicts.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
