### PR TITLE
test/support/helpers: Add unellipsized trees support

### DIFF
--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -3,6 +3,7 @@
 const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const fs = require('fs-extra')
+const _ = require('lodash')
 const path = require('path')
 const rimraf = require('rimraf')
 
@@ -63,7 +64,7 @@ class LocalTestHelpers {
     this.local._trash = this.trashFunc
   }
 
-  async tree () /*: Promise<string[]> */ {
+  async tree (opts /*: {ellipsize: boolean} */ = {ellipsize: true}) /*: Promise<string[]> */ {
     let trashContents
     try {
       trashContents = await this.trashDir.tree()
@@ -74,10 +75,11 @@ class LocalTestHelpers {
         'beforeEach block) before calling helpers.local.tree() in a test'
       )
     }
+    const ellipsizeDate = opts.ellipsize ? conflictHelpers.ellipsizeDate : _.identity
     return trashContents
       .map(relPath => path.posix.join('/Trash', relPath))
       .concat(await this.syncDir.tree())
-      .map(conflictHelpers.ellipsizeDate)
+      .map(ellipsizeDate)
       .filter(relpath => !relpath.match(TMP_DIR_NAME))
       .sort()
   }

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -57,7 +57,7 @@ class RemoteTestHelpers {
 
   // TODO: Extract reusable #scan() method from tree*()
 
-  async tree () /*: Promise<string[]> */ {
+  async tree (opts /*: {ellipsize: boolean} */ = {ellipsize: true}) /*: Promise<string[]> */ {
     const pathsToScan = ['/', `/${TRASH_DIR_NAME}`]
     const relPaths = [`${TRASH_DIR_NAME}/`]
 
@@ -87,13 +87,14 @@ class RemoteTestHelpers {
       }
     }
 
+    const ellipsizeDate = opts.ellipsize ? conflictHelpers.ellipsizeDate : _.identity
     return relPaths
       .sort()
-      .map(conflictHelpers.ellipsizeDate)
+      .map(ellipsizeDate)
   }
 
-  async treeWithoutTrash () /*: Promise<string[]> */ {
-    return (await this.tree())
+  async treeWithoutTrash (opts /*: {ellipsize: boolean} */ = {ellipsize: true}) /*: Promise<string[]> */ {
+    return (await this.tree(opts))
       .filter(p => !p.startsWith(`${TRASH_DIR_NAME}/`))
   }
 


### PR DESCRIPTION
For cases where we didn't expect some conflicts in tests.
So we can see the actual conflict suffixes.

We tried to make the change minimal for other tests expecting
the original #tree() helper to be ellipsized.
