### PR TITLE
feat: Start a sync manually

### DIFF
--- a/gui/elm/Ports.elm
+++ b/gui/elm/Ports.elm
@@ -1,4 +1,4 @@
-port module Ports exposing (autoLauncher, autolaunch, buffering, cancelUnlink, chooseFolder, closeApp, diskSpace, focus, folder, folderError, gotocozy, gotofolder, gototab, mail, newRelease, offline, openFile, quitAndInstall, registerRemote, registrationDone, registrationError, remoteWarnings, remove, sendMail, showHelp, squashPrepMerge, startSync, syncError, synchonization, syncing, transfer, unlinkCozy, updateDownloading, updateError, updated, userActionInProgress, userActionRequired)
+port module Ports exposing (autoLauncher, autolaunch, buffering, cancelUnlink, chooseFolder, closeApp, diskSpace, focus, folder, folderError, gotocozy, gotofolder, gototab, mail, newRelease, offline, openFile, quitAndInstall, registerRemote, registrationDone, registrationError, remoteWarnings, remove, sendMail, showHelp, squashPrepMerge, startSync, syncError, synchonization, syncing, transfer, unlinkCozy, updateDownloading, updateError, updated, userActionInProgress, userActionRequired, manualStartSync)
 
 import Data.DiskSpace exposing (DiskSpace)
 import Data.File exposing (EncodedFile)
@@ -117,3 +117,5 @@ port userActionInProgress : () -> Cmd msg
 
 
 port userActionRequired : (UserActionRequiredError -> msg) -> Sub msg
+
+port manualStartSync : () -> Cmd msg

--- a/gui/elm/Window/Tray.elm
+++ b/gui/elm/Window/Tray.elm
@@ -230,7 +230,10 @@ viewTabsWithContent helpers model =
                 Html.map DashboardMsg (Dashboard.view helpers model.dashboard)
 
             SettingsPage ->
-                Html.map SettingsMsg (Settings.view helpers model.settings)
+                let
+                    settingsModel = model.settings
+                in
+                    Html.map SettingsMsg (Settings.view helpers { settingsModel | status = model.status } )
         ]
 
 

--- a/gui/elm/Window/Tray/Settings.elm
+++ b/gui/elm/Window/Tray/Settings.elm
@@ -95,7 +95,7 @@ update msg model =
             ( { model | busyQuitting = True }, Ports.closeApp () )
 
         Sync ->
-            ( model, Cmd.none )
+            ( model, Ports.manualStartSync () )
 
 
 

--- a/gui/elm/Window/Tray/Settings.elm
+++ b/gui/elm/Window/Tray/Settings.elm
@@ -7,6 +7,9 @@ import Html.Events exposing (..)
 import Locale exposing (Helpers)
 import Ports
 import View.ProgressBar as ProgressBar
+import Data.Status exposing (Status(..))
+import Window.Tray.StatusBar exposing (statusToString)
+
 
 
 
@@ -22,6 +25,7 @@ type alias Model =
     , disk : DiskSpace
     , busyUnlinking : Bool
     , busyQuitting : Bool
+    , status : Status
     }
 
 
@@ -38,6 +42,7 @@ init version =
         }
     , busyUnlinking = False
     , busyQuitting = False
+    , status = Starting
     }
 
 
@@ -161,12 +166,7 @@ view helpers model =
             , text (helpers.t "Settings Startup")
             ]
         , h2 [] [ text (helpers.t "Settings Synchronize manually") ]
-        , a
-            [ class "btn"
-            , href "#"
-            , onClick Sync
-            ]
-            [ text (helpers.t "Settings Sync") ]
+        , syncButton helpers model.status
         , h2 [] [ text (helpers.t "Account About") ]
         , p []
             [ strong [] [ text (helpers.t "Account Account" ++ " ") ]
@@ -215,3 +215,18 @@ view helpers model =
             ]
             [ text (helpers.t "Account Unlink this Cozy") ]
         ]
+
+
+syncButton: Helpers -> Status -> Html Msg
+syncButton helpers status =
+    case status of
+        UpToDate -> a [ class "btn"
+            , href "#"
+            , onClick Sync
+            ]
+            [ text (helpers.t "Settings Sync") ]
+        _ -> a [ class "btn"
+                , href "#"
+                , attribute "disabled" "true"
+                ]
+                [ text (statusToString helpers status) ]

--- a/gui/elm/Window/Tray/Settings.elm
+++ b/gui/elm/Window/Tray/Settings.elm
@@ -56,6 +56,7 @@ type Msg
     | CancelUnlink
     | ShowHelp
     | CloseApp
+    | Sync
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -92,6 +93,9 @@ update msg model =
 
         CloseApp ->
             ( { model | busyQuitting = True }, Ports.closeApp () )
+
+        Sync ->
+            ( model, Cmd.none )
 
 
 
@@ -156,6 +160,13 @@ view helpers model =
                 ]
             , text (helpers.t "Settings Startup")
             ]
+        , h2 [] [ text (helpers.t "Settings Synchronize manually") ]
+        , a
+            [ class "btn"
+            , href "#"
+            , onClick Sync
+            ]
+            [ text (helpers.t "Settings Sync") ]
         , h2 [] [ text (helpers.t "Account About") ]
         , p []
             [ strong [] [ text (helpers.t "Account Account" ++ " ") ]

--- a/gui/elm/Window/Tray/StatusBar.elm
+++ b/gui/elm/Window/Tray/StatusBar.elm
@@ -1,4 +1,4 @@
-module Window.Tray.StatusBar exposing (icon, imgIcon, view, viewMessage)
+module Window.Tray.StatusBar exposing (icon, imgIcon, view, viewMessage, statusToString)
 
 import Data.Platform exposing (Platform(..))
 import Data.Status exposing (Status(..))
@@ -58,41 +58,57 @@ icon status platform =
                     span [ class "status__icon spin" ] []
 
 
+statusToString : Helpers -> Status -> String
+statusToString helpers status =
+    case status of
+        UpToDate ->
+            helpers.t "Dashboard Your cozy is up to date!"
+
+        Offline ->
+            helpers.t "Dashboard Offline"
+
+        UserActionRequired ->
+            helpers.t "Dashboard Synchronization impossible"
+
+        Starting ->
+            helpers.t "Dashboard Analyze"
+
+        Buffering ->
+            helpers.t "Dashboard Analyze"
+
+        SquashPrepMerging ->
+            helpers.t "Dashboard Prepare"
+
+        Syncing _ ->
+            helpers.t "Dashboard Synchronize"
+
+
+        Error _ ->
+            helpers.t "Dashboard Error:"
+
+
+
 viewMessage : Helpers -> Status -> List (Html msg)
 viewMessage helpers status =
     case
         status
     of
-        UpToDate ->
-            [ text (helpers.t "Dashboard Your cozy is up to date!") ]
-
-        Offline ->
-            [ text (helpers.t "Dashboard Offline") ]
-
-        UserActionRequired ->
-            [ text (helpers.t "Dashboard Synchronization impossible") ]
-
-        Starting ->
-            [ text (helpers.t "Dashboard Analyze") ]
-
-        Buffering ->
-            [ text (helpers.t "Dashboard Analyze") ]
-
-        SquashPrepMerging ->
-            [ text (helpers.t "Dashboard Prepare") ]
 
         Syncing n ->
-            [ text (helpers.t "Dashboard Synchronize")
+            [ text (statusToString helpers status)
             , text " ("
             , text (helpers.pluralize n "Dashboard left SINGULAR" "Dashboard left PLURAL")
             , text ")"
             ]
 
         Error message ->
-            [ text (helpers.t "Dashboard Error:")
+            [ text (statusToString helpers status)
             , text " "
             , em [] [ text message ]
             ]
+
+        _ ->
+            [ text (statusToString helpers status) ]
 
 
 view : Helpers -> Status -> Platform -> Html msg

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -155,7 +155,8 @@ module.exports = class TrayWM extends WindowManager {
       'auto-launcher': (event, enabled) => autoLaunch.setEnabled(enabled),
       'close-app': () => this.desktop.stopSync().then(() => this.app.quit()),
       'open-file': (event, path) => this.openPath(path),
-      'unlink-cozy': this.onUnlink
+      'unlink-cozy': this.onUnlink,
+      'manual-start-sync': () => this.desktop.stopSync().then(() => { this.desktop.synchronize('full') })
     }
   }
 

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -133,6 +133,8 @@
   "Settings Settings": "Settings",
   "Settings Start Cozy Drive on system startup": "Start Cozy Drive on system startup",
   "Settings Startup": "Your Cozy will be automatically synchronized with your computer",
+  "Settings Sync": "Synchronize",
+  "Settings Synchronize manually": "Synchronize manually",
   "Settings Version": "Version",
   "SyncDirEmpty Detail": "To avoid losing your data, this will not be synchronized. If you really want to reset the synchronization, you can just remove your Cozy folder.",
   "SyncDirEmpty Message": "Look like you Cozy folder got emptied. May be it is on a hard-drive which is not plugged at the moment?",

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -133,6 +133,8 @@
   "Settings Settings": "Ajustes",
   "Settings Start Cozy Drive on system startup": "Activar Cozy Drive al iniciar el sistema.",
   "Settings Startup": "Su Cozy se sincronizará automáticamente con su ordenador",
+  "Settings Sync": "Sincronizar",
+  "Settings Synchronize manually": "Sincronizar manualmente",
   "Settings Version": "Versión",
   "SyncDirEmpty Detail": "To avoid losing your data, this will not be synchronized. If you really want to reset the synchronization, you can just remove your Cozy folder.",
   "SyncDirEmpty Message": "Look like you Cozy folder got emptied. May be it is on a hard-drive which is not plugged at the moment?",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -133,6 +133,8 @@
   "Settings Settings": "Préférences",
   "Settings Start Cozy Drive on system startup": "Lancement au démarrage",
   "Settings Startup": "Votre Cozy sera synchronisé avec votre ordinateur automatiquement",
+  "Settings Sync": "Synchroniser",
+  "Settings Synchronize manually": "Synchroniser manuellement",
   "Settings Version": "Version",
   "SyncDirEmpty Detail": "Afin d'éviter toute perte de données, ces changements ne seront pas synchronisés. Si vous souhaitez vraiment réinitialiser la synchronisation, vous pouvez simplement supprimer votre dossier Cozy.",
   "SyncDirEmpty Message": "Il semblerait que votre dossier Cozy ait été vidé. Peut-être se trouve-t-il sur un disque externe qui n'est pas connecté actuellement ?",

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -80,6 +80,10 @@ elmectron.ports.startSync.subscribe((folder) => {
   ipcRenderer.send('start-sync', folder)
 })
 
+elmectron.ports.manualStartSync.subscribe(() => {
+  ipcRenderer.send('manual-start-sync')
+})
+
 ipcRenderer.on('new-release-available', (event, notes, name) => {
   console.log('new-release-available', notes, name)
   elmectron.ports.newRelease.send([notes, name])


### PR DESCRIPTION
By adding a button in Settings, an end-user is able
to start a sync manually.

In the code, it is called `start-manual-sync` because
so many things are called `sync` with among others: 
updating the status of the synchronization, 
starting the synchronization of a file, 
the handler of the button that starts the synchronization of a file, etc.