### PR TITLE
test: Extract MetadataBuilders#whateverChange() from constructor

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -35,7 +35,6 @@ module.exports = class BaseMetadataBuilder {
     if (old) {
       this.old = old
       this.doc = _.cloneDeep(old)
-      this.doc.tags.push('changed-tag')
     } else {
       this.doc = {
         _id: id('foo'),
@@ -50,6 +49,13 @@ module.exports = class BaseMetadataBuilder {
         updated_at: timestamp.stringify(timestamp.current())
       }
     }
+  }
+
+  /** Make sure the doc is not the same as before. */
+  whateverChange () /*: this */ {
+    this.doc.tags = this.doc.tags || []
+    this.doc.tags.push('changed-tag')
+    return this
   }
 
   unmerged (sideName /*: SideName */) /*: this */ {

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -247,7 +247,7 @@ describe('Merge', function () {
 
     it('saves a new version of an existing folder', async function () {
       const old = await builders.dir().path('existing-folder').create()
-      const doc = builders.dir(old).changedSide(this.side).build()
+      const doc = builders.dir(old).whateverChange().changedSide(this.side).build()
 
       await this.merge.putFolderAsync(this.side, doc)
 


### PR DESCRIPTION
So builders don't force changed tags on docs built from existing ones.
Will make future Merge tests easier.
