### PR TITLE
dev/docker: Update cozy-app-dev to 2018M4S3

### DIFF
--- a/dev/cozy-stack/Dockerfile
+++ b/dev/cozy-stack/Dockerfile
@@ -1,6 +1,6 @@
 # Use explicit tag (not latest which doesn't necessarily mean the last stable
 # version of the image)
-FROM cozy/cozy-app-dev:2018M3S6
+FROM cozy/cozy-app-dev:2018M4S3
 
 # Bring back git so we can install Cozy apps later
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
So corrupt file reupload tests work with docker-compose.