### PR TITLE
core: Rename Side#assignNewRev() to #readUpdatedRev()

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -305,8 +305,8 @@ module.exports = class Local /*:: implements Side */ {
     await this.addFolderAsync(doc)
   }
 
-  async assignNewRev (doc /*: Metadata */) /*: Promise<void> */ {
-    log.info({path: doc.path}, 'Local assignNewRev = noop')
+  async readUpdatedRev (doc /*: Metadata */) /*: Promise<void> */ {
+    // noop
   }
 
   /** Move a file, eventually updating its content */

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -296,8 +296,8 @@ class Remote /*:: implements Side */ {
     }
   }
 
-  async assignNewRev (doc /*: Metadata */) /*: Promise<void> */ {
-    log.info({path: doc.path}, 'Assigning new rev...')
+  async readUpdatedRev (doc /*: Metadata */) /*: Promise<void> */ {
+    log.info({path: doc.path}, 'Reading updated rev...')
     const {_rev} = await this.remoteCozy.client.files.statById(doc.remote._id)
     doc.remote._rev = _rev
   }

--- a/core/side.js
+++ b/core/side.js
@@ -11,7 +11,7 @@ export interface Side {
   updateFolderAsync (doc: Metadata, old: Metadata): Promise<void>;
   moveFileAsync (doc: Metadata, from: Metadata): Promise<void>;
   moveFolderAsync (doc: Metadata, from: Metadata): Promise<void>;
-  assignNewRev (doc: Metadata): Promise<void>;
+  readUpdatedRev (doc: Metadata): Promise<void>;
   trashAsync (doc: Metadata): Promise<void>;
   deleteFolderAsync (doc: Metadata): Promise<void>;
   renameConflictingDocAsync (doc: Metadata, newPath: string): Promise<void>;

--- a/core/sync.js
+++ b/core/sync.js
@@ -292,7 +292,7 @@ class Sync {
       if (from.incompatibilities) {
         await this.doAdd(side, doc)
       } else if (from.childMove) {
-        await side.assignNewRev(doc)
+        await side.readUpdatedRev(doc)
         this.events.emit('transfer-move', _.clone(doc), _.clone(from))
       } else {
         await this.doMove(side, doc, from)

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -14,7 +14,7 @@ const METHODS = [
   'updateFolderAsync',
   'moveFileAsync',
   'moveFolderAsync',
-  'assignNewRev',
+  'readUpdatedRev',
   'trashAsync',
   'deleteFolderAsync',
   'renameConflictingDocAsync'

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -724,8 +724,8 @@ describe('remote.Remote', function () {
     })
   })
 
-  describe('assignNewRev', () => {
-    it('updates the rev of a moved file', async function () {
+  describe('readUpdatedRev', () => {
+    it('reads the rev of a moved child and assigns it to its doc', async function () {
       const remote = {src: {}, dst: {}}
 
       remote.src.dir = await builders.remote.dir().name('src-dir').inRootDir().create()
@@ -735,7 +735,7 @@ describe('remote.Remote', function () {
 
       const doc /*: Metadata */ = metadata.fromRemoteDoc(remote.src.foo)
       doc.path = 'dst-dir/foo' // File metadata was updated as part of the move
-      await this.remote.assignNewRev(doc)
+      await this.remote.readUpdatedRev(doc)
       should(doc).deepEqual(metadata.fromRemoteDoc(remote.dst.foo))
     })
   })


### PR DESCRIPTION
Makes it clear we're not writing something in the Cozy.
Also stop logging method call on Local (useless since noop).
Courtesy of @taratatach :)