### PR TITLE
jq: Rename conflicts filter to conflict & keep props [ci skip]

### DIFF
--- a/.jq
+++ b/.jq
@@ -71,10 +71,10 @@ def noproxy: select(.component | test("GUI:proxy") | not);
 
 # Find conflicts:
 #
-#     yarn jq -c conflicts path/to/logs*
+#     yarn jq -c conflict path/to/logs*
 #
 def is_conflict: .msg == "resolveConflictAsync";
-def conflicts: clean | select(is_conflict) | {time,path};
+def conflict: clean | select(is_conflict);
 
 # Non-issue filters (so we can ignore them when looking for real issues):
 def is_net_error: .msg | test("net::");


### PR DESCRIPTION
- Singular, same as most of our filters
- Keeping only path/time is easy to do by hand
- Doing it by default sometimes makes the filter useless
