### PR TITLE
test: Fix Metadata size in all scenarios

### DIFF
--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -162,7 +162,7 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
         mime: 'text/plain',
         path: localPath,
         ino,
-        size: 0,
+        size: content.length,
         tags: [],
         sides: {local: 1, remote: 1}
       }


### PR DESCRIPTION
Hardcoding 0 was plain broken, triggering swallowed corrupt file errors.
The issue possibly didn't happen when file content was explicitely defined.

Also errors should definitely be explicit, but this will require more work
and should be fixed later in a separate commit.