### PR TITLE
Update revisions of renamed subdir of renamed dir

### DIFF
--- a/core/local/change.js
+++ b/core/local/change.js
@@ -301,7 +301,11 @@ function dirMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalD
   const unlinkChange /*: ?LocalDirDeletion */ = maybeDeleteFolder(sameInodeChange)
   if (!unlinkChange) return
   if (_.get(unlinkChange, 'old.path') === e.path) return dirAddition(e)
-  log.debug({oldpath: unlinkChange.path, path: e.path}, 'unlinkDir + addDir = DirMove')
+  if (!e.wip) {
+    log.debug({oldpath: unlinkChange.path, path: e.path}, 'unlinkDir + addDir = DirMove')
+  } else {
+    log.debug({oldpath: unlinkChange.path, path: e.path}, 'unlinkDir + addDir wip = DirMove wip')
+  }
   return build('DirMove', e.path, {
     stats: e.stats,
     old: unlinkChange.old,

--- a/core/local/chokidar_watcher.js
+++ b/core/local/chokidar_watcher.js
@@ -307,7 +307,6 @@ module.exports = class LocalWatcher {
         if (c.needRefetch) {
           // $FlowFixMe
           c.old = await this.pouch.db.get(metadata.id(c.old.path))
-          c.old.childMove = false
         }
         switch (c.type) {
           // TODO: Inline old LocalWatcher methods

--- a/core/merge.js
+++ b/core/merge.js
@@ -339,6 +339,7 @@ class Merge {
   async moveFolderRecursivelyAsync (side /*: SideName */, folder /*: Metadata */, was /*: Metadata */, newRemoteRevs /*: ?RemoteRevisionsByID */) {
     log.debug({path: folder.path, oldpath: was.path}, 'moveFolderRecursivelyAsync')
     const docs = await this.pouch.byRecursivePathAsync(was._id)
+
     move(was, folder)
     let bulk = [was, folder]
 

--- a/core/merge.js
+++ b/core/merge.js
@@ -337,6 +337,7 @@ class Merge {
 
   // Move a folder and all the things inside it
   async moveFolderRecursivelyAsync (side /*: SideName */, folder /*: Metadata */, was /*: Metadata */, newRemoteRevs /*: ?RemoteRevisionsByID */) {
+    log.debug({path: folder.path, oldpath: was.path}, 'moveFolderRecursivelyAsync')
     const docs = await this.pouch.byRecursivePathAsync(was._id)
     move(was, folder)
     let bulk = [was, folder]

--- a/core/move.js
+++ b/core/move.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-const _ = require('lodash')
-
 /*::
 import type { Metadata } from './metadata'
 */
@@ -32,7 +30,7 @@ function move (src /*: Metadata */, dst /*: Metadata */) {
   // trashed property on the source, or explain why it doesn't.
   delete dst.trashed
 
-  dst.moveFrom = _.omit(src, 'moveFrom')
+  dst.moveFrom = src
 }
 
 // Same as move() but mark the source as a child move so it will be moved with

--- a/core/sync.js
+++ b/core/sync.js
@@ -290,6 +290,9 @@ class Sync {
         await side.assignNewRev(doc)
         this.events.emit('transfer-move', _.clone(doc), _.clone(from))
       } else {
+        if (from.moveFrom && from.moveFrom.childMove) {
+          await side.assignNewRev(from)
+        }
         await this.doMove(side, doc, from)
       }
       delete doc.moveFrom // the move succeeded, delete moveFrom before attempting overwrite

--- a/core/sync.js
+++ b/core/sync.js
@@ -282,6 +282,8 @@ class Sync {
       log.debug({path: doc.path}, `Ignoring deleted ${doc.docType} metadata as move source`)
     } else if (doc.moveFrom != null) {
       const from = (doc.moveFrom /*: Metadata */)
+      log.debug({path: doc.path}, `Applying ${doc.docType} change with moveFrom`)
+
       if (from.incompatibilities) {
         await this.doAdd(side, doc)
       } else if (from.childMove) {
@@ -295,11 +297,14 @@ class Sync {
         await side.overwriteFileAsync(doc, doc) // move & update
       }
     } else if (doc._deleted) {
+      log.debug({path: doc.path}, `Applying ${doc.docType} deletion`)
       if (doc.docType === 'file') await side.trashAsync(doc)
       else await side.deleteFolderAsync(doc)
     } else if (rev === 0) {
+      log.debug({path: doc.path}, `Applying ${doc.docType} addition`)
       await this.doAdd(side, doc)
     } else {
+      log.debug({path: doc.path}, `Applying else for ${doc.docType} change`)
       let old
       try {
         old = await this.pouch.getPreviousRevAsync(doc._id, rev)

--- a/test/scenarios/rename_subdir_after_parent/local/linux.json
+++ b/test/scenarios/rename_subdir_after_parent/local/linux.json
@@ -1,0 +1,89 @@
+[
+  {
+    "breakpoints": [0]
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent/subdir/subsubdir"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent/subdir"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent"
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2",
+    "stats": {
+      "ino": 1,
+      "size": 96,
+      "mtime": "2019-01-29T14:58:06.415Z",
+      "ctime": "2019-01-29T14:58:08.503Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2/subdir",
+    "stats": {
+      "ino": 2,
+      "size": 96,
+      "mtime": "2019-01-29T14:58:06.416Z",
+      "ctime": "2019-01-29T14:58:06.416Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2/subdir/subsubdir",
+    "stats": {
+      "ino": 3,
+      "size": 64,
+      "mtime": "2019-01-29T14:58:06.416Z",
+      "ctime": "2019-01-29T14:58:06.416Z"
+    }
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent-2/subdir/subsubdir"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent-2/subdir"
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2/subdir-2",
+    "stats": {
+      "ino": 2,
+      "size": 96,
+      "mtime": "2019-01-29T14:58:06.416Z",
+      "ctime": "2019-01-29T14:58:10.006Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2/subdir-2/subsubdir",
+    "stats": {
+      "ino": 3,
+      "size": 64,
+      "mtime": "2019-01-29T14:58:06.416Z",
+      "ctime": "2019-01-29T14:58:06.416Z"
+    }
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent-2/subdir-2/subsubdir"
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2/subdir-2/subsubdir-2",
+    "stats": {
+      "ino": 3,
+      "size": 64,
+      "mtime": "2019-01-29T14:58:06.416Z",
+      "ctime": "2019-01-29T14:58:11.511Z"
+    }
+  }
+]

--- a/test/scenarios/rename_subdir_after_parent/local/win32.json
+++ b/test/scenarios/rename_subdir_after_parent/local/win32.json
@@ -1,0 +1,89 @@
+[
+  {
+    "breakpoints": [0]
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent\\subdir\\subsubdir"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent\\subdir"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent"
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2",
+    "stats": {
+      "ino": 1,
+      "size": 0,
+      "mtime": "2019-01-29T16:14:00.036Z",
+      "ctime": "2019-01-29T16:14:02.836Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2\\subdir",
+    "stats": {
+      "ino": 2,
+      "size": 0,
+      "mtime": "2019-01-29T16:14:00.037Z",
+      "ctime": "2019-01-29T16:14:00.037Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2\\subdir\\subsubdir",
+    "stats": {
+      "ino": 3,
+      "size": 0,
+      "mtime": "2019-01-29T16:14:00.037Z",
+      "ctime": "2019-01-29T16:14:00.037Z"
+    }
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent-2\\subdir\\subsubdir"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent-2\\subdir"
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2\\subdir-2",
+    "stats": {
+      "ino": 2,
+      "size": 0,
+      "mtime": "2019-01-29T16:14:00.037Z",
+      "ctime": "2019-01-29T16:14:04.341Z"
+    }
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2\\subdir-2\\subsubdir",
+    "stats": {
+      "ino": 3,
+      "size": 0,
+      "mtime": "2019-01-29T16:14:00.037Z",
+      "ctime": "2019-01-29T16:14:00.037Z"
+    }
+  },
+  {
+    "type": "unlinkDir",
+    "path": "parent-2\\subdir-2\\subsubdir"
+  },
+  {
+    "type": "addDir",
+    "path": "parent-2\\subdir-2\\subsubdir-2",
+    "stats": {
+      "ino": 3,
+      "size": 0,
+      "mtime": "2019-01-29T16:14:00.037Z",
+      "ctime": "2019-01-29T16:14:05.844Z"
+    }
+  }
+]

--- a/test/scenarios/rename_subdir_after_parent/scenario.js
+++ b/test/scenarios/rename_subdir_after_parent/scenario.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  side: 'local',
+  init: [
+    {ino: 1, path: 'parent/'},
+    {ino: 2, path: 'parent/subdir/'},
+    {ino: 3, path: 'parent/subdir/subsubdir/'}
+  ],
+  actions: [
+    {type: 'mv', src: 'parent', dst: 'parent-2'},
+    {type: 'wait', ms: 1500},
+    {type: 'mv', src: 'parent-2/subdir', dst: 'parent-2/subdir-2'},
+    {type: 'wait', ms: 1500},
+    {type: 'mv', src: 'parent-2/subdir-2/subsubdir', dst: 'parent-2/subdir-2/subsubdir-2'}
+  ],
+  expected: {
+    tree: [
+      'parent-2/',
+      'parent-2/subdir-2/',
+      'parent-2/subdir-2/subsubdir-2/'
+    ],
+    remoteTrash: []
+  }
+} /*: Scenario */)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -771,7 +771,7 @@ describe('Merge', function () {
         md5sum: doc.md5sum,
         moveFrom: _.defaults({
           _rev: was._rev,
-          moveTo: doc._id, // FIXME: Should be doc._id?
+          moveTo: dstId,
           updated_at: was.updated_at // FIXME: Stop mixing dates & strings
         }, src),
         path: dstPath,


### PR DESCRIPTION
When renaming a sub-directory of a directory renamed in the same
  synchronisation loop, we missed two updates to the source directory:
  - one local update when we merge the renaming of the parent directory
  which triggers changes on its children (i.e. the local side and
  revision were updated and merging the sub-directory change would
  trigger a Pouch conflict)
  - one remote update when we synchronise the renaming of the parent
  directory with the remote Cozy and it does the thing that we do with
  the local Pouch document (we could then not update the remote
  sub-directory as its revision had changed)

  To avoid those issues, we refetch the local document right before
  merging the sub-directory renaming and the remote revision right
  before synchronising it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
