### PR TITLE
fix: Use a RegExp to rename conflicting files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": false,
+  "mocha.files.glob": "test/unit/**/metadata.js"
+}

--- a/core/merge.js
+++ b/core/merge.js
@@ -3,24 +3,11 @@
 const autoBind = require('auto-bind')
 const _ = require('lodash')
 const { clone } = _
-const { dirname } = require('path')
+const path = require('path')
 
 const IdConflict = require('./IdConflict')
 const logger = require('./logger')
-const {
-  assignMaxDate,
-  detectPlatformIncompatibilities,
-  isAtLeastUpToDate,
-  isUpToDate,
-  markAsNeverSynced,
-  markAsNew,
-  markSide,
-  sameBinary,
-  sameFile,
-  sameFolder,
-  upToDate,
-  createConflictingDoc
-} = require('./metadata')
+const metadata = require('./metadata')
 const move = require('./move')
 const { otherSide } = require('./side')
 
@@ -71,11 +58,11 @@ class Merge {
   // Be sure that the tree structure for the given path exists
   async ensureParentExistAsync (side /*: SideName */, doc /*: * */) {
     log.trace({path: doc.path}, 'ensureParentExistAsync')
-    let parentId = dirname(doc._id)
+    let parentId = path.dirname(doc._id)
     if (parentId === '.') { return }
 
     // BUG on windows with incompatible names like "D:IR"
-    if (dirname(parentId) === parentId) { return }
+    if (path.dirname(parentId) === parentId) { return }
 
     try {
       let folder = await this.pouch.db.get(parentId)
@@ -86,7 +73,7 @@ class Merge {
 
     let parentDoc = {
       _id: parentId,
-      path: dirname(doc.path),
+      path: path.dirname(doc.path),
       docType: 'folder',
       updated_at: new Date()
     }
@@ -104,7 +91,7 @@ class Merge {
   // A suffix composed of -conflict- and the date is added to the path.
   async resolveConflictAsync (side /*: SideName */, doc /*: Metadata */, was /*: ?Metadata */) {
     log.warn({path: doc.path, oldpath: was && was.path, doc, was}, 'resolveConflictAsync')
-    let dst = createConflictingDoc(doc)
+    const dst = metadata.createConflictingDoc(doc)
     try {
       // $FlowFixMe
       await this[side].renameConflictingDocAsync(doc, dst.path)
@@ -122,7 +109,7 @@ class Merge {
     log.debug({path: doc.path}, 'addFileAsync')
     const {path} = doc
     const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
-    markSide(side, doc, file)
+    metadata.markSide(side, doc, file)
     const idConflict /*: ?IdConflictInfo */ = IdConflict.detect(side, doc, file)
     if (idConflict) {
       log.warn({idConflict}, IdConflict.description(idConflict))
@@ -131,8 +118,8 @@ class Merge {
     } else if (file && file.docType === 'folder') {
       return this.resolveConflictAsync(side, doc, file)
     }
-    assignMaxDate(doc, file)
-    if (file && sameBinary(file, doc)) {
+    metadata.assignMaxDate(doc, file)
+    if (file && metadata.sameBinary(file, doc)) {
       doc._rev = file._rev
       if (doc.size == null) { doc.size = file.size }
       if (doc.class == null) { doc.class = file.class }
@@ -140,7 +127,7 @@ class Merge {
       if (doc.tags == null) { doc.tags = file.tags || [] }
       if (doc.remote == null) { doc.remote = file.remote }
       if (doc.ino == null) { doc.ino = file.ino }
-      if (sameFile(file, doc)) {
+      if (metadata.sameFile(file, doc)) {
         log.info({path}, 'up to date')
         return null
       } else {
@@ -189,22 +176,22 @@ class Merge {
     log.debug({path: doc.path}, 'updateFileAsync')
     const {path} = doc
     const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
-    markSide(side, doc, file)
+    metadata.markSide(side, doc, file)
     if (file && file.docType === 'folder') {
       throw new Error("Can't resolve this conflict!")
     }
-    assignMaxDate(doc, file)
+    metadata.assignMaxDate(doc, file)
     if (file) {
       doc._rev = file._rev
       doc.moveFrom = file.moveFrom
       if (doc.tags == null) { doc.tags = file.tags || [] }
       if (doc.remote == null) { doc.remote = file.remote }
       if (doc.ino == null) { doc.ino = file.ino }
-      if (sameBinary(file, doc)) {
+      if (metadata.sameBinary(file, doc)) {
         if (doc.size == null) { doc.size = file.size }
         if (doc.class == null) { doc.class = file.class }
         if (doc.mime == null) { doc.mime = file.mime }
-      } else if (!isAtLeastUpToDate(side, file)) {
+      } else if (!metadata.isAtLeastUpToDate(side, file)) {
         await this.resolveConflictAsync(side, doc, file)
         if (side === 'remote') {
           // we just renamed the remote file as a conflict
@@ -215,7 +202,7 @@ class Merge {
         }
         return
       }
-      if (sameFile(file, doc)) {
+      if (metadata.sameFile(file, doc)) {
         log.info({path}, 'up to date')
         return null
       } else {
@@ -232,11 +219,11 @@ class Merge {
     log.debug({path: doc.path}, 'putFolderAsync')
     const {path} = doc
     const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
-    markSide(side, doc, folder)
+    metadata.markSide(side, doc, folder)
     if (folder && folder.docType === 'file') {
       return this.resolveConflictAsync(side, doc, folder)
     }
-    assignMaxDate(doc, folder)
+    metadata.assignMaxDate(doc, folder)
     const idConflict /*: ?IdConflictInfo */ = IdConflict.detect(side, doc, folder)
     if (idConflict) {
       log.warn({idConflict}, IdConflict.description(idConflict))
@@ -247,7 +234,7 @@ class Merge {
       if (doc.tags == null) { doc.tags = folder.tags || [] }
       if (doc.remote == null) { doc.remote = folder.remote }
       if (doc.ino == null && folder.ino) { doc.ino = folder.ino }
-      if (sameFolder(folder, doc)) {
+      if (metadata.sameFolder(folder, doc)) {
         log.info({path}, 'up to date')
         return null
       } else {
@@ -264,7 +251,7 @@ class Merge {
     log.debug({path: doc.path, oldpath: was.path}, 'moveFileAsync')
     const {path} = doc
     if (was.sides && !was.sides[otherSide(side)]) {
-      await this.pouch.remove(upToDate(was))
+      await this.pouch.remove(metadata.upToDate(was))
       return this.addFileAsync(side, doc)
     } else if (was.sides && was.sides[side]) {
       const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
@@ -274,16 +261,16 @@ class Merge {
         await this.resolveConflictAsync(side, doc, file)
         return
       }
-      markSide(side, doc, file)
-      markSide(side, was, was)
-      assignMaxDate(doc, was)
+      metadata.markSide(side, doc, file)
+      metadata.markSide(side, was, was)
+      metadata.assignMaxDate(doc, was)
       if (doc.size == null) { doc.size = was.size }
       if (doc.class == null) { doc.class = was.class }
       if (doc.mime == null) { doc.mime = was.mime }
       if (doc.tags == null) { doc.tags = was.tags || [] }
       if (doc.ino == null) { doc.ino = was.ino }
       move(was, doc)
-      if (file && sameFile(file, doc)) {
+      if (file && metadata.sameFile(file, doc)) {
         log.info({path}, 'up to date (move)')
         return null
       } else if (file && !doc.overwrite && doc.path === file.path) {
@@ -310,9 +297,9 @@ class Merge {
     }
 
     const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
-    markSide(side, doc, folder)
-    markSide(side, was, was)
-    assignMaxDate(doc, was)
+    metadata.markSide(side, doc, folder)
+    metadata.markSide(side, was, was)
+    metadata.assignMaxDate(doc, was)
     if (doc.tags == null) { doc.tags = was.tags || [] }
     if (doc.ino == null) { doc.ino = was.ino }
 
@@ -356,12 +343,12 @@ class Merge {
       dst._id = makeDestinationID(doc)
       dst.path = doc.path.replace(was.path, folder.path)
       if (src.sides && src.sides[side] && !src.sides[otherSide(side)]) {
-        markAsNeverSynced(src)
-        markAsNew(dst)
-        markSide(side, dst)
+        metadata.markAsNeverSynced(src)
+        metadata.markAsNew(dst)
+        metadata.markSide(side, dst)
       } else {
         move.child(src, dst)
-        markSide(side, dst, src)
+        metadata.markSide(side, dst, src)
       }
 
       let existingDstRev = existingDstRevs[dst._id]
@@ -371,7 +358,7 @@ class Merge {
 
       bulk.push(src)
       // FIXME: Find a cleaner way to pass the syncPath to the Merge
-      const incompatibilities = detectPlatformIncompatibilities(dst, this.pouch.config.syncPath)
+      const incompatibilities = metadata.detectPlatformIncompatibilities(dst, this.pouch.config.syncPath)
       if (incompatibilities.length > 0) dst.incompatibilities = incompatibilities
       else delete dst.incompatibilities
       bulk.push(dst)
@@ -415,7 +402,7 @@ class Merge {
       log.error({doc, oldMetadata, sentry: true}, 'Mismatch on doctype for doTrash')
       return
     }
-    if (side === 'remote' && !sameBinary(oldMetadata, doc)) {
+    if (side === 'remote' && !metadata.sameBinary(oldMetadata, doc)) {
       // We have a conflict: the file was updated in local and trash on the remote.
       // We dissociate the file on the remote to be able to apply the local change.
       delete oldMetadata.remote
@@ -424,12 +411,12 @@ class Merge {
     }
     delete oldMetadata.errors
     const newMetadata = clone(oldMetadata)
-    markSide(side, newMetadata, oldMetadata)
+    metadata.markSide(side, newMetadata, oldMetadata)
     newMetadata._id = doc._id
     newMetadata._rev = doc._rev
     newMetadata.trashed = true
     if (oldMetadata.sides && oldMetadata.sides[side]) {
-      markSide(side, oldMetadata, oldMetadata)
+      metadata.markSide(side, oldMetadata, oldMetadata)
       oldMetadata._deleted = true
       try {
         await this.pouch.put(oldMetadata)
@@ -453,7 +440,7 @@ class Merge {
     let children = await this.pouch.byRecursivePathAsync(was._id)
     children = children.reverse()
     for (let child of Array.from(children)) {
-      if (child.docType === 'file' && !isUpToDate(side, child)) {
+      if (child.docType === 'file' && !metadata.isUpToDate(side, child)) {
         delete was.trashed
         delete was.errors
         if (was.sides) {
@@ -491,7 +478,7 @@ class Merge {
     const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
     if (!file) return null
     if (file.sides && file.sides[side]) {
-      markSide(side, file, file)
+      metadata.markSide(side, file, file)
       file._deleted = true
       delete file.errors
       return this.pouch.put(file)
@@ -527,16 +514,16 @@ class Merge {
     docs.push(folder)
     const toPreserve = new Set()
     for (let doc of Array.from(docs)) {
-      if (toPreserve.has(doc.path) || (doc.sides && !isUpToDate(side, doc))) {
+      if (toPreserve.has(doc.path) || (doc.sides && !metadata.isUpToDate(side, doc))) {
         log.warn({path: folder.path},
           `${doc.path}: cannot be deleted with ${folder.path}: ` +
           `${doc.docType} was modified on the ${otherSide(side)} side`)
         log.info({path: doc.path}, 'Dissociating from remote...')
         delete doc.remote
         if (doc.sides) delete doc.sides.remote
-        toPreserve.add(dirname(doc.path))
+        toPreserve.add(path.dirname(doc.path))
       } else {
-        markSide(side, doc, doc)
+        metadata.markSide(side, doc, doc)
         doc._deleted = true
         delete doc.errors
       }

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -774,7 +774,7 @@ describe('metadata', function () {
     })
   })
 
-  describe('generated a doc with conflict', () => {
+  describe('createConflictingDoc', () => {
     it('should get the correct path', () => {
       const doc = {
         path: 'docname'
@@ -798,6 +798,15 @@ describe('metadata', function () {
       }
       const newDoc = createConflictingDoc(doc)
       should(path.extname(newDoc.path)).equal(ext)
+    })
+    it('should but does not handle complex extension `.tar.gz`', () => {
+      // FIXME: must be docname-conflict-:ISODATE:.tar.gz instead of docname.tar-conflict-:ISODATE:.gz
+      const ext = '.tar.gz'
+      const doc = {
+        path: `docname${ext}`
+      }
+      const newDoc = createConflictingDoc(doc)
+      should(path.extname(newDoc.path)).equal('.gz')
     })
     it('should not have more than 180 characters', () => {
       const doc = {

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -23,7 +23,8 @@ const {
   buildDir,
   buildFile,
   invariants,
-  upToDate
+  upToDate,
+  createConflictingDoc
 } = metadata
 const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const timestamp = require('../../core/timestamp')
@@ -770,6 +771,48 @@ describe('metadata', function () {
       doc.errors = 1
 
       should(upToDate(doc).errors).be.undefined()
+    })
+  })
+
+  describe('generated a doc with conflict', () => {
+    it('should get the correct path', () => {
+      const doc = {
+        path: 'docname'
+      }
+      const newDoc = createConflictingDoc(doc)
+      const pathRegExp = RegExp(`(${doc.path})-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z`)
+      should(newDoc.path).match(pathRegExp)
+    })
+    it('should get the correct _id', () => {
+      const doc = {
+        path: 'docname'
+      }
+      const newDoc = createConflictingDoc(doc)
+      const pathRegExp = RegExp(`(${doc.path})-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z`)
+      should(newDoc._id).match(pathRegExp)
+    })
+    it('should keep the correct extension', () => {
+      const ext = '.pdf'
+      const doc = {
+        path: `docname${ext}`
+      }
+      const newDoc = createConflictingDoc(doc)
+      should(path.extname(newDoc.path)).equal(ext)
+    })
+    it('should not have more than 180 characters', () => {
+      const doc = {
+        path: 'Lorem ipsum dolor sit amet consectetur adipiscing elit Nam a velit at dolor euismod tincidunt sit amet id ante Cras vehicula lectus purus In lobortis risus lectus vitae rhoncus quam porta nullam'
+      }
+      const newDoc = createConflictingDoc(doc)
+      const newDocBasename = RegExp('(.*)-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z').exec(path.basename(newDoc.path))[1]
+      should(newDocBasename.length).equal(180)
+    })
+    it('should have an id', () => {
+      const doc = {
+        path: 'docname'
+      }
+      const newDoc = createConflictingDoc(doc)
+      should(newDoc).have.property('_id').not.null()
     })
   })
 })

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -24,7 +24,8 @@ const {
   buildFile,
   invariants,
   upToDate,
-  createConflictingDoc
+  createConflictingDoc,
+  conflictRegExp
 } = metadata
 const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const timestamp = require('../../core/timestamp')
@@ -780,16 +781,16 @@ describe('metadata', function () {
         path: 'docname'
       }
       const newDoc = createConflictingDoc(doc)
-      const pathRegExp = RegExp(`(${doc.path})-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z`)
-      should(newDoc.path).match(pathRegExp)
+      const pathRegExp = conflictRegExp(doc.path)
+      should(newDoc.path).be.a.String().and.match(pathRegExp)
     })
     it('should get the correct _id', () => {
       const doc = {
         path: 'docname'
       }
       const newDoc = createConflictingDoc(doc)
-      const pathRegExp = RegExp(`(${doc.path})-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z`)
-      should(newDoc._id).match(pathRegExp)
+      const pathRegExp = new RegExp(conflictRegExp(doc.path).source, 'i')
+      should(newDoc._id).be.a.String().and.match(pathRegExp)
     })
     it('should keep the correct extension', () => {
       const ext = '.pdf'
@@ -813,15 +814,20 @@ describe('metadata', function () {
         path: 'Lorem ipsum dolor sit amet consectetur adipiscing elit Nam a velit at dolor euismod tincidunt sit amet id ante Cras vehicula lectus purus In lobortis risus lectus vitae rhoncus quam porta nullam'
       }
       const newDoc = createConflictingDoc(doc)
-      const newDocBasename = RegExp('(.*)-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z').exec(path.basename(newDoc.path))[1]
+      const newDocBasename = conflictRegExp('(.*)').exec(path.basename(newDoc.path))[1]
       should(newDocBasename.length).equal(180)
     })
-    it('should have an id', () => {
+    it('should handle the renaming of a conflict', () => {
+      const ext = `.pdf`
+      const base = `docname`
       const doc = {
-        path: 'docname'
+        path: `${base}-conflict-1970-01-01T13_37_00.666Z${ext}`
       }
-      const newDoc = createConflictingDoc(doc)
-      should(newDoc).have.property('_id').not.null()
+      const secondConflict = createConflictingDoc(doc)
+      const pathRegExp = conflictRegExp(base)
+      should(doc.path).not.equal(secondConflict.path)
+      should(secondConflict.path).be.a.String().and.match(pathRegExp)
+      should(path.extname(secondConflict.path)).equal(ext)
     })
   })
 })


### PR DESCRIPTION
The function were extracted to metadata.js,
then covered by tests.


Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation