### PR TITLE
core/remote/watcher: Remote overwriting dir moves

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -273,9 +273,10 @@ function squashMoves (changes /*: LocalChange[] */) {
         log.debug({oldpath: b.old.path, path: b.path}, 'descendant move')
         a.wip = a.wip || b.wip
         if (b.path.substr(a.path.length) === b.old.path.substr(a.old.path.length)) {
+          log.debug({oldpath: b.old.path, path: b.path}, 'ignoring explicit child move')
           changes.splice(j--, 1)
         } else {
-          // move inside move
+          log.debug({oldpath: b.old.path, path: b.path}, 'move inside move')
           b.old.path = b.old.path.replace(a.old.path, a.path)
           b.needRefetch = true
         }

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -7,7 +7,7 @@ import type { Metadata } from '../metadata'
 
 const path = require('path')
 
-const { isFile } = require('../metadata')
+const metadata = require('../metadata')
 
 /*::
 export type RemoteFileAddition = {sideName: 'remote', type: 'FileAddition', doc: Metadata}
@@ -62,19 +62,19 @@ const sideName = 'remote'
 
 // FIXME: return types
 function added (doc /*: Metadata */) /*: * */ {
-  return {sideName, type: (isFile(doc) ? 'FileAddition' : 'DirAddition'), doc}
+  return {sideName, type: (metadata.isFile(doc) ? 'FileAddition' : 'DirAddition'), doc}
 }
 
 function trashed (doc /*: Metadata */, was /*: Metadata */) /*: * */ {
-  return {sideName, type: (isFile(doc) ? 'FileTrashing' : 'DirTrashing'), doc, was}
+  return {sideName, type: (metadata.isFile(doc) ? 'FileTrashing' : 'DirTrashing'), doc, was}
 }
 
 function deleted (doc /*: Metadata */) /*: * */ {
-  return {sideName, type: (isFile(doc) ? 'FileDeletion' : 'DirDeletion'), doc}
+  return {sideName, type: (metadata.isFile(doc) ? 'FileDeletion' : 'DirDeletion'), doc}
 }
 
 function restored (doc /*: Metadata */, was /*: Metadata */) /*: * */ {
-  return {sideName, type: (isFile(doc) ? 'FileRestoration' : 'DirRestoration'), doc, was}
+  return {sideName, type: (metadata.isFile(doc) ? 'FileRestoration' : 'DirRestoration'), doc, was}
 }
 
 function upToDate (doc /*: Metadata */, was /*: Metadata */) /*: * */ {
@@ -82,7 +82,7 @@ function upToDate (doc /*: Metadata */, was /*: Metadata */) /*: * */ {
 }
 
 function updated (doc /*: Metadata */) /*: * */ {
-  return {sideName, type: (isFile(doc) ? 'FileUpdate' : 'DirAddition'), doc}
+  return {sideName, type: (metadata.isFile(doc) ? 'FileUpdate' : 'DirAddition'), doc}
 }
 
 // TODO: Rename args
@@ -120,8 +120,8 @@ function includeDescendant (parent /*: RemoteDirMove */, e /*: RemoteDescendantC
   delete e.descendantMoves
 }
 
-const addPath = (a /*: RemoteChange */) /*: ?string */ => isAdd(a) || isMove(a) || isRestore(a) ? a.doc.path : null
-const delPath = (a /*: RemoteChange */) /*: ?string */ => isDelete(a) ? a.doc.path : isMove(a) || isTrash(a) ? a.was.path : null
+const addPath = (a /*: RemoteChange */) /*: ?string */ => isAdd(a) || isMove(a) || isRestore(a) ? metadata.id(a.doc.path) : null
+const delPath = (a /*: RemoteChange */) /*: ?string */ => isDelete(a) ? metadata.id(a.doc.path) : isMove(a) || isTrash(a) ? metadata.id(a.was.path) : null
 const childOf = (p1 /*: ?string */, p2 /*: ?string */)/*: boolean */ => p1 != null && p2 != null && p2 !== p1 && p2.startsWith(p1 + path.sep)
 const lower = (p1 /*: ?string */, p2 /*: ?string */)/*: boolean */ => p1 != null && p2 != null && p2 !== p1 && p1 < p2
 

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -240,7 +240,7 @@ class RemoteWatcher {
       }
       const previousMoveToSamePath = _.find(previousChanges, change =>
         // $FlowFixMe
-        (change.type === 'DescendantChange' || change.type === 'FileMove') && change.doc.path === was.path)
+        (change.type === 'DescendantChange' || change.type === 'FileMove' || change.type === 'DirMove') && change.doc.path === was.path)
 
       if (previousMoveToSamePath) {
         previousMoveToSamePath.doc.overwrite = was
@@ -249,7 +249,7 @@ class RemoteWatcher {
           type: 'IgnoredChange',
           doc,
           was,
-          detail: `File ${was.path} overwritten by ${previousMoveToSamePath.was.path}`
+          detail: `${was.docType} ${was.path} overwritten by ${previousMoveToSamePath.was.path}`
         }
       }
       return remoteChange.trashed(doc, was)
@@ -304,7 +304,7 @@ class RemoteWatcher {
             if (previousChange.type === 'DirMove') remoteChange.includeDescendant(previousChange, descendantChange)
             return descendantChange
           }
-        } else if (previousChange.type === 'FileTrashing' && previousChange.was._id === change.doc._id) {
+        } else if (previousChange.type === 'FileTrashing' && previousChange.was.path === change.doc.path) {
           _.assign(previousChange, {
             type: 'IgnoredChange',
             detail: `File ${previousChange.was.path} overwritten by ${change.was.path}`
@@ -334,6 +334,13 @@ class RemoteWatcher {
             remoteChange.includeDescendant(change, previousChange)
             continue
           }
+        } else if (previousChange.type === 'DirTrashing' && previousChange.was.path === change.doc.path) {
+          _.assign(previousChange, {
+            type: 'IgnoredChange',
+            detail: `Folder ${previousChange.was.path} overwritten by ${change.was.path}`
+          })
+          change.doc.overwrite = previousChange.was
+          return change
         } else if (remoteChange.isChildMove(previousChange, change)) {
           const descendantChange = {
             sideName,

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/win_mac/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/win_mac/scenario.js
@@ -15,16 +15,14 @@ module.exports = ({
   ],
   expected: {
     localTree: [
-      'FOO/',
-      'FOO/subdir/',
-      'FOO/subdir/file'
-      // foo-conflict-... will be synced on next polling
+      'foo'
+      // FOO-conflict-.../ will be synced on next polling
     ],
     remoteTree: [
-      'FOO/',
-      'FOO/subdir/',
-      'FOO/subdir/file',
-      'foo-conflict-...'
+      'FOO-conflict-.../',
+      'FOO-conflict-.../subdir/',
+      'FOO-conflict-.../subdir/file',
+      'foo'
     ],
     remoteTrash: []
   }

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -2,18 +2,11 @@
 
 const crypto = require('crypto')
 
-const metadata = require('../../../../core/metadata')
-const {
-  assignId,
-  ensureValidPath
-} = metadata
-
 const BaseMetadataBuilder = require('./base')
 
 /*::
 import type Pouch from '../../../../core/pouch'
 import type { Metadata } from '../../../../core/metadata'
-import type { RemoteDoc } from '../../../../core/remote/document'
 */
 
 module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
@@ -21,13 +14,6 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
     super(pouch, old)
     this.doc.docType = 'file'
     this.data('')
-  }
-
-  fromRemote (remoteDoc /*: RemoteDoc */) /*: this */ {
-    this.doc = metadata.fromRemoteDoc(remoteDoc)
-    ensureValidPath(this.doc)
-    assignId(this.doc)
-    return this
   }
 
   data (data /*: string */) /*: this */ {

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash')
 const { posix } = require('path')
+const uuid = require('uuid/v4')
 
 const {
   FILES_DOCTYPE,
@@ -26,20 +27,24 @@ module.exports = class RemoteBaseBuilder {
   remoteDoc: RemoteDoc
   */
 
-  constructor (cozy /*: ?Cozy */) {
+  constructor (cozy /*: ?Cozy */, old /*: ?RemoteDoc */) {
     this.cozy = cozy
-    const name = 'whatever'
-    this.remoteDoc = {
-      _id: dbBuilders.id(),
-      _rev: dbBuilders.rev(1),
-      _type: FILES_DOCTYPE,
-      type: 'directory',
-      created_at: defaultTimestamp,
-      dir_id: ROOT_DIR_ID,
-      name,
-      path: posix.join(posix.sep, name),
-      tags: [],
-      updated_at: defaultTimestamp
+    if (old) {
+      this.remoteDoc = _.cloneDeep(old)
+    } else {
+      const name = 'whatever'
+      this.remoteDoc = {
+        _id: dbBuilders.id(),
+        _rev: dbBuilders.rev(1),
+        _type: FILES_DOCTYPE,
+        type: 'directory',
+        created_at: defaultTimestamp,
+        dir_id: ROOT_DIR_ID,
+        name,
+        path: posix.join(posix.sep, name),
+        tags: [],
+        updated_at: defaultTimestamp
+      }
     }
   }
 
@@ -61,6 +66,15 @@ module.exports = class RemoteBaseBuilder {
       _id: TRASH_DIR_ID,
       path: `/${TRASH_DIR_NAME}`
     })
+  }
+
+  restored () /*: this */ {
+    return this.inRootDir()
+  }
+
+  shortRev (revNumber /*: number */) /*: this */ {
+    this.remoteDoc._rev = revNumber.toString() + '-' + uuid().replace(/-/g, '')
+    return this
   }
 
   timestamp (...args /*: number[] */) /*: this */ {

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -21,10 +21,13 @@ var dirNumber = 1
 //     const dir: RemoteDoc = await builders.remoteDir().inDir(...).create()
 //
 module.exports = class RemoteDirBuilder extends RemoteBaseBuilder {
-  constructor (cozy /*: Cozy */) {
-    super(cozy)
+  constructor (cozy /*: Cozy */, old /*: ?RemoteDoc */) {
+    super(cozy, old)
+
+    if (!old) {
+      this.name(`directory-${dirNumber++}`)
+    }
     this.remoteDoc.type = 'directory'
-    this.name(`directory-${dirNumber++}`)
   }
 
   async create () /*: Promise<RemoteDoc> */ {

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -31,15 +31,17 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder {
   _data: string | stream.Readable | Buffer
   */
 
-  constructor (cozy /*: Cozy */) {
-    super(cozy)
+  constructor (cozy /*: Cozy */, old /*: ?RemoteDoc */) {
+    super(cozy, old)
 
+    if (!old) {
+      this.name(`remote-file-${fileNumber}`)
+      this.data(`Content of remote file ${fileNumber}`)
+      this.remoteDoc.class = 'application'
+      this.remoteDoc.mime = 'application/octet-stream'
+      this.remoteDoc.executable = true
+    }
     this.remoteDoc.type = 'file'
-    this.name(`remote-file-${fileNumber}`)
-    this.data(`Content of remote file ${fileNumber}`)
-    this.remoteDoc.class = 'application'
-    this.remoteDoc.mime = 'application/octet-stream'
-    this.remoteDoc.executable = true
 
     fileNumber++
   }


### PR DESCRIPTION
  If a directory was moved remotely and overwrites an existing dir,
  we would try to trash the destination and then make the move without
  trying to overwrite any existing document at this path.

  We're now ignoring the trash part since we'll overwrite the
  destination and the move overwrites any existing document at the
  destination path.

  To test this with a real case scenario, comment out the `side` line of
  the `test/scenarios/move_overwriting_dir/scenario.js` file and run
  this test.
  It might not pass right away as remote scenario tests are a bit
  unpredictable but should pass eventually.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
