### PR TITLE
appveyor: Split build steps between 2 workers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,9 @@ clone_depth: 10
 environment:
   MOCHA_TIMEOUT: "60000"
   NO_BREAKPOINTS: "1"
+  matrix:
+      - BUILD_JOB: "short_tests"
+      - BUILD_JOB: "scenarios_build"
 
 install:
   - cmd: appveyor-retry yarn install:all
@@ -13,13 +16,13 @@ install:
 build: off
 
 test_script:
-  - yarn build
-  - cmd: yarn test:elm
-  - cmd: yarn test:world --timeout $env:MOCHA_TIMEOUT
-  - cmd: yarn test:unit --timeout $env:MOCHA_TIMEOUT
-  - cmd: yarn test:integration --timeout $env:MOCHA_TIMEOUT
-  - cmd: yarn test:scenarios --timeout $env:MOCHA_TIMEOUT
-  - yarn dist:all
+  - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn build:css; yarn build:elm }
+  - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:elm }
+  - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:world --timeout $env:MOCHA_TIMEOUT }
+  - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:unit --timeout $env:MOCHA_TIMEOUT }
+  - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:integration --timeout $env:MOCHA_TIMEOUT }
+  - ps: if ($env:BUILD_JOB -eq "scenarios_build") { yarn test:scenarios --timeout $env:MOCHA_TIMEOUT }
+  - ps: if ($env:BUILD_JOB -eq "scenarios_build") { yarn dist:all }
 
 on_failure:
   - node --version

--- a/dev/remote/generate-test-env.js
+++ b/dev/remote/generate-test-env.js
@@ -5,16 +5,14 @@ const fse = require('fs-extra')
 const pkg = require('../../package.json')
 const automatedRegistration = require('./automated_registration')
 
-const cozyUrl = chooseCozyUrl(process.env.APPVEYOR_BUILD_NUMBER)
+const cozyUrl = chooseCozyUrl(process.env.BUILD_JOB)
 const passphrase = process.env.COZY_PASSPHRASE
 const storage = new cozy.MemoryStorage()
 
-function chooseCozyUrl (buildNumber) {
-  if (!!buildNumber && buildNumber % 2 === 1) {
-    return process.env.COZY_URL_2
-  }
-
-  return process.env.COZY_URL_1
+function chooseCozyUrl (buildJob) {
+  return buildJob === 'scenarios_build'
+    ? process.env.COZY_URL_2
+    : process.env.COZY_URL_1
 }
 
 function readAccessToken () {


### PR DESCRIPTION
  Our builds take more time with each test we add (especially
  scenarios).
  Besides, AppVeyor has a hard limit of 60 minutes per build that we've
  finally reached.

  Split our builds in two will give us some time to figure out how to
  have shorter builds.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
