### PR TITLE
test/unit/remote/offline: Increase test timeout

### DIFF
--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -43,6 +43,6 @@ describe('Remote', function () {
       await this.remote.watcher.watch()
       eventsSpy.should.have.been.calledWith('online')
       eventsSpy.restore()
-    })
+    }).timeout(120000)
   })
 })


### PR DESCRIPTION
This test can take more than 20 seconds which is the default timeout
  for asynchonous mocha tests and leads to erratic behavior on our CI.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
