### PR TITLE
core: Alias fs-extra as fse everywhere & stop promisifying it

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 const autoBind = require('auto-bind')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const os = require('os')
 const path = require('path')
@@ -122,7 +122,7 @@ class App {
 
   // Save the config with all the informations for synchonization
   saveConfig (cozyUrl /*: string */, syncPath /*: string */) {
-    fs.ensureDirSync(syncPath)
+    fse.ensureDirSync(syncPath)
     this.config.cozyUrl = cozyUrl
     this.config.syncPath = syncPath
     this.config.persist()
@@ -175,9 +175,9 @@ class App {
 
   async removeConfig () {
     await this.pouch.db.destroy()
-    for (const name of await fs.readdir(this.basePath)) {
+    for (const name of await fse.readdir(this.basePath)) {
       if (name.startsWith(LOG_FILENAME)) continue
-      await fs.remove(path.join(this.basePath, name))
+      await fse.remove(path.join(this.basePath, name))
     }
   }
 
@@ -217,7 +217,7 @@ class App {
       memLevel: 7,
       level: 3
     })
-    const logs = fs.createReadStream(LOG_FILE)
+    const logs = fse.createReadStream(LOG_FILE)
     const pouchdbTree = await this.pouch.treeAsync()
 
     const logsSent = Promise.all([

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -18,8 +18,6 @@ const measureTime = require('../perftools')
 const { withContentLength } = require('../file_stream_provider')
 const syncDir = require('./sync_dir')
 
-bluebird.promisifyAll(fse)
-
 /*::
 import type EventEmitter from 'events'
 import type Config from '../config'
@@ -92,7 +90,7 @@ module.exports = class Local /*:: implements Side */ {
   async createReadStreamAsync (doc /*: Metadata */) /*: Promise<ReadableWithContentLength> */ {
     try {
       let filePath = path.resolve(this.syncPath, doc.path)
-      let pStats = fse.statAsync(filePath)
+      let pStats = fse.stat(filePath)
       let pStream = new Promise((resolve, reject) => {
         let stream = fse.createReadStream(filePath)
         stream.on('open', () => resolve(stream))
@@ -374,7 +372,7 @@ module.exports = class Local /*:: implements Side */ {
 
     try {
       log.info({path: doc.path}, 'Deleting empty folder...')
-      await fse.rmdirAsync(fullpath)
+      await fse.rmdir(fullpath)
       this.events.emit('delete-file', doc)
       return
     } catch (err) {

--- a/core/logger.js
+++ b/core/logger.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 
 const bunyan = require('bunyan')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const os = require('os')
 const path = require('path')
 const _ = require('lodash')
@@ -10,7 +10,7 @@ const LOG_DIR = path.join(process.env.COZY_DESKTOP_DIR || os.homedir(), '.cozy-d
 const LOG_FILENAME = 'logs.txt'
 const LOG_FILE = path.join(LOG_DIR, LOG_FILENAME)
 
-fs.ensureDirSync(LOG_DIR)
+fse.ensureDirSync(LOG_DIR)
 
 const defaultLogger = bunyan.createLogger({
   name: 'Cozy Desktop',
@@ -30,7 +30,7 @@ const defaultLogger = bunyan.createLogger({
 
 if (process.env.DEBUG) {
   const logPath = 'debug.log'
-  if (fs.existsSync(logPath)) fs.unlinkSync(logPath)
+  if (fse.existsSync(logPath)) fse.unlinkSync(logPath)
   defaultLogger.addStream({type: 'file', path: logPath, level: 'trace'})
 }
 if (process.env.TESTDEBUG) {

--- a/core/pouch.js
+++ b/core/pouch.js
@@ -4,7 +4,7 @@ const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const PouchDB = require('pouchdb')
 const async = require('async')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const { isEqual } = _
 const path = require('path')
@@ -82,7 +82,7 @@ class Pouch {
   // Create database and recreate all filters
   resetDatabase (callback) {
     this.db.destroy(() => {
-      fs.ensureDirSync(this.config.dbPath)
+      fse.ensureDirSync(this.config.dbPath)
       this.db = new PouchDB(this.config.dbPath)
       this.db.setMaxListeners(100)
       this.db.on('error', err => log.warn(err))

--- a/dev/capture/local.js
+++ b/dev/capture/local.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird')
 const chokidar = require('chokidar')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const path = require('path')
 const fixturesHelpers = require('../../test/support/helpers/scenarios')
@@ -46,13 +46,13 @@ const setupInitialState = (scenario) => {
     let {ino, path: relpath} = opts
     if (relpath.endsWith('/')) {
       debug('- mkdir', relpath)
-      return fs.ensureDir(abspath(relpath))
-             .then(() => fs.stat(abspath(relpath)))
+      return fse.ensureDir(abspath(relpath))
+             .then(() => fse.stat(abspath(relpath)))
              .then(stats => { mapInode[stats.ino] = ino })
     } else {
       debug('- >', relpath)
-      return fs.outputFile(abspath(relpath), 'whatever')
-             .then(() => fs.stat(abspath(relpath)))
+      return fse.outputFile(abspath(relpath), 'whatever')
+             .then(() => fse.stat(abspath(relpath)))
              .then(stats => { mapInode[stats.ino] = ino })
     }
   })
@@ -68,7 +68,7 @@ const buildFSEvent = (type, relpath, stats) => {
 }
 
 const triggerDone = () => {
-  return fs.outputFile(path.join(syncPath, DONE_FILE), '')
+  return fse.outputFile(path.join(syncPath, DONE_FILE), '')
 }
 
 const isDone = (relpath) => {
@@ -80,7 +80,7 @@ const saveFSEventsToFile = (scenario, events) => {
   const eventsFile = scenario.path
     .replace(/scenario\.js/, path.join('local', `${process.platform}.json`))
 
-  return fs.outputFile(eventsFile, json)
+  return fse.outputFile(eventsFile, json)
     .then(() => path.basename(eventsFile))
 }
 
@@ -135,8 +135,8 @@ const runAndRecordFSEvents = (scenario) => {
 }
 
 const captureScenario = (scenario) => {
-  return fs.emptyDir(syncPath)
-    .then(() => fs.emptyDir(outsidePath))
+  return fse.emptyDir(syncPath)
+    .then(() => fse.emptyDir(outsidePath))
     .then(() => setupInitialState(scenario))
     .then(() => runAndRecordFSEvents(scenario))
 }

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 const Promise = require('bluebird')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const path = require('path')
 
@@ -177,7 +177,7 @@ const captureScenario = async (scenario /*: * */) => {
   const json = JSON.stringify(docs, null, 2)
   const changesFile = scenario.path
     .replace(/scenario\.js/, path.join('remote', 'changes.json'))
-  await fs.outputFile(changesFile, json)
+  await fse.outputFile(changesFile, json)
 
   return path.basename(changesFile)
 }

--- a/dev/chokidar.js
+++ b/dev/chokidar.js
@@ -2,7 +2,7 @@
 const chokidar = require('chokidar')
 const program = require('commander')
 const local = require('./capture/local')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const opn = require('opn')
 const scenarioHelpers = require('../test/support/helpers/scenarios')
@@ -33,7 +33,7 @@ function startChokidar () {
   const syncPath = local.syncPath
   opn(syncPath)
 
-  fs.ensureDirSync(syncPath)
+  fse.ensureDirSync(syncPath)
 
   const watcher = chokidar.watch('.', {
     cwd: syncPath,

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -4,7 +4,7 @@
 const should = require('should')
 const sinon = require('sinon')
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
@@ -105,7 +105,7 @@ describe('Conflict resolution', () => {
       await helpers.local.scan()
       await helpers.syncAll()
 
-      const conflictedPath = (await fs.readdir(helpers.local.syncPath))
+      const conflictedPath = (await fse.readdir(helpers.local.syncPath))
         .filter(x => x.indexOf('-conflict-') !== -1)[0]
 
       await helpers.local.syncDir.remove(conflictedPath)
@@ -124,7 +124,7 @@ describe('Conflict resolution', () => {
       await helpers.local.scan()
       await helpers.syncAll()
 
-      const conflictedPath = (await fs.readdir(helpers.local.syncPath))
+      const conflictedPath = (await fse.readdir(helpers.local.syncPath))
         .filter(x => x.indexOf('-conflict-') !== -1)[0]
 
       const remoteBadFile = await cozy.files.statByPath('/' + conflictedPath)

--- a/test/integration/mtime-update.js
+++ b/test/integration/mtime-update.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 
 const should = require('should')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const _ = require('lodash')
 
@@ -42,17 +42,17 @@ describe('Update only a file mtime', () => {
     await cozy.files.updateById(file._id, 'changedcontent', {contentType: 'text/plain'})
     await cozy.files.updateById(file._id, 'basecontent', {contentType: 'text/plain'})
 
-    const statBefore = await fs.stat(localPath)
+    const statBefore = await fse.stat(localPath)
     helpers.spyPouch()
     await helpers.remote.pullChanges()
     await helpers.syncAll()
 
-    const statAfter = await fs.stat(localPath)
+    const statAfter = await fse.stat(localPath)
     statBefore.mtime.toISOString().should.equal(statAfter.mtime.toISOString())
 
     // actually change the file
-    await fs.appendFile(localPath, ' appended')
-    const stats = await fs.stat(localPath)
+    await fse.appendFile(localPath, ' appended')
+    const stats = await fse.stat(localPath)
 
     await helpers.local.simulateEvents([{
       type: 'change',
@@ -62,8 +62,8 @@ describe('Update only a file mtime', () => {
 
     await helpers.syncAll()
 
-    should(await fs.readFile(localPath, 'utf8')).equal('basecontent appended')
-    should((await fs.stat(localPath)).mtime).not.equal(statAfter.mtime)
+    should(await fse.readFile(localPath, 'utf8')).equal('basecontent appended')
+    should((await fse.stat(localPath)).mtime).not.equal(statAfter.mtime)
   })
 
   it('local', async () => {

--- a/test/performance/local/watcher.js
+++ b/test/performance/local/watcher.js
@@ -2,7 +2,7 @@
 /* @flow */
 
 const Promise = require('bluebird')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 
 const Watcher = require('../../../core/local/chokidar_watcher')
@@ -83,7 +83,7 @@ describe('LocalWatcher charge', () => {
   before('instanciate config', configHelpers.createConfig)
   before('instanciate pouch', pouchHelpers.createDatabase)
   before('create outside dir', async function () {
-    await fs.emptyDir(path.resolve(path.join(this.syncPath, '..', 'outside')))
+    await fse.emptyDir(path.resolve(path.join(this.syncPath, '..', 'outside')))
   })
   before('instanciate local watcher', async function () {
     prep = new SpyPrep()
@@ -93,7 +93,7 @@ describe('LocalWatcher charge', () => {
   })
 
   before('cleanup test directory', async function () {
-    await fs.emptyDir(this.syncPath)
+    await fse.emptyDir(this.syncPath)
   })
 
   before(function () {
@@ -111,10 +111,10 @@ describe('LocalWatcher charge', () => {
       const stats = {ino: i, mtime: now, ctime: now}
       if (i % 2) { // type.startsWith('add')
         if (i % 3) {
-          await fs.ensureDir(abspath(p))
+          await fse.ensureDir(abspath(p))
         } else {
-          await fs.ensureDir(path.dirname(abspath(p)))
-          await fs.writeFileSync(abspath(p))
+          await fse.ensureDir(path.dirname(abspath(p)))
+          await fse.writeFileSync(abspath(p))
         }
       } else {
         await createDoc(this.pouch, i % 3, p, i)

--- a/test/regression/TRELLO_484_local_sort_before_squash.js
+++ b/test/regression/TRELLO_484_local_sort_before_squash.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* @flow */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const should = require('should')
 const sinon = require('sinon')
@@ -23,7 +23,7 @@ describe('TRELLO #484: Local sort before squash (https://trello.com/c/RcRmqymw)'
   beforeEach(pouchHelpers.createDatabase)
   beforeEach(cozyHelpers.deleteAll)
   beforeEach('set up synced dir', async function () {
-    await fs.emptyDir(this.syncPath)
+    await fse.emptyDir(this.syncPath)
   })
 
   afterEach(pouchHelpers.cleanDatabase)

--- a/test/regression/TRELLO_646_move_overridden_before_sync.js
+++ b/test/regression/TRELLO_646_move_overridden_before_sync.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* @flow */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const should = require('should')
 
@@ -21,7 +21,7 @@ describe('TRELLO #646: Déplacement écrasé avant synchro (malgré la synchro p
   beforeEach(pouchHelpers.createDatabase)
   beforeEach(cozyHelpers.deleteAll)
   beforeEach('set up synced dir', async function () {
-    await fs.emptyDir(this.syncPath)
+    await fse.emptyDir(this.syncPath)
   })
 
   afterEach(pouchHelpers.cleanDatabase)

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -2,7 +2,7 @@
 /* @flow */
 
 const Promise = require('bluebird')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const path = require('path')
 const should = require('should')
@@ -24,10 +24,10 @@ describe('Test scenarios', function () {
   beforeEach(pouchHelpers.createDatabase)
   beforeEach(cozyHelpers.deleteAll)
   beforeEach('set up synced dir', async function () {
-    await fs.emptyDir(this.syncPath)
+    await fse.emptyDir(this.syncPath)
   })
   beforeEach('set up outside dir', async function () {
-    await fs.emptyDir(path.resolve(path.join(this.syncPath, '..', 'outside')))
+    await fse.emptyDir(path.resolve(path.join(this.syncPath, '..', 'outside')))
   })
 
   afterEach(pouchHelpers.cleanDatabase)

--- a/test/support/coverage.js
+++ b/test/support/coverage.js
@@ -10,7 +10,7 @@
 
 const glob = require('glob')
 const path = require('path')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const { hookRequire } = require('istanbul-lib-hook')
 const { createInstrumenter } = require('istanbul-lib-instrument') // eslint-disable-line node/no-extraneous-require
 
@@ -26,17 +26,17 @@ const instrumenter = createInstrumenter()
 const shouldInstrument = fileset.has.bind(fileset)
 const instrumentSync = instrumenter.instrumentSync.bind(instrumenter)
 
-fs.ensureDirSync(tmpd)
+fse.ensureDirSync(tmpd)
 hookRequire(shouldInstrument, instrumentSync, {})
 process.on('exit', () => {
   for (let file of fileset) {
     if (!cov[file]) {
       // Files that are not touched by code ran by the test runner are
       // manually instrumented, to illustrate the missing coverage.
-      instrumentSync(fs.readFileSync(file, 'utf-8'), file)
+      instrumentSync(fse.readFileSync(file, 'utf-8'), file)
       cov[file] = instrumenter.lastFileCoverage()
     }
   }
 
-  fs.writeFileSync(path.join(tmpd, `${process.type}.json`), JSON.stringify(cov), 'utf-8')
+  fse.writeFileSync(path.join(tmpd, `${process.type}.json`), JSON.stringify(cov), 'utf-8')
 })

--- a/test/support/helpers/TmpDir.js
+++ b/test/support/helpers/TmpDir.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 
 const rootDir = path.resolve(__dirname, '../..')
@@ -22,7 +22,7 @@ module.exports = {
 //     await TmpDir.ensureEmpty(__filename)
 async function emptyForTestFile (filename /*: string */) /*: Promise<string> */ {
   const fpath = pathForTestFile(filename)
-  await fs.emptyDir(fpath)
+  await fse.emptyDir(fpath)
   return fpath
 }
 

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const del = require('del')
 const path = require('path')
 
@@ -11,7 +11,7 @@ module.exports = {
     let parent = process.env.COZY_DESKTOP_DIR || 'tmp'
     this.basePath = path.resolve(`${parent}/test/${+new Date()}`)
     this.syncPath = path.join(this.basePath, 'Cozy Drive')
-    fs.ensureDirSync(this.syncPath)
+    fse.ensureDirSync(this.syncPath)
     this.config = new Config(path.join(this.basePath, '.cozy-desktop'))
     this.config.syncPath = this.syncPath
     this.config.cozyUrl = COZY_URL

--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -2,14 +2,14 @@
 
 const autoBind = require('auto-bind')
 const Promise = require('bluebird')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const path = require('path')
 
 const checksumer = require('../../../core/local/checksumer')
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 
-Promise.promisifyAll(fs) // FIXME: Isn't fs-extra already promisified?
+Promise.promisifyAll(fse) // FIXME: Isn't fs-extra already promisified?
 Promise.promisifyAll(checksumer)
 
 function getPath (target /*: string | {path: string} */) /*: string */ {
@@ -47,9 +47,9 @@ class ContextDir {
       const dir = dirsToRead.shift()
       if (dir == null) break
 
-      for (const name of await fs.readdirAsync(dir)) {
+      for (const name of await fse.readdirAsync(dir)) {
         const absPath = path.join(dir, name)
-        const stat = await fs.statAsync(absPath)
+        const stat = await fse.statAsync(absPath)
         let relPath = this.relpath(absPath)
 
         if (stat.isDirectory()) {
@@ -67,19 +67,19 @@ class ContextDir {
   }
 
   existsSync (target /*: string | {path: string} */) /*: bool */ {
-    return fs.existsSync(this.abspath(target))
+    return fse.existsSync(this.abspath(target))
   }
 
   exists (target /*: string | {path: string} */) /*: Promise<bool> */ {
-    return fs.exists(this.abspath(target))
+    return fse.exists(this.abspath(target))
   }
 
   emptyDir (target /*: string | {path: string} */) /*: Promise<void> */ {
-    return fs.emptyDir(this.abspath(target))
+    return fse.emptyDir(this.abspath(target))
   }
 
   async ensureDir (target /*: string | {path: string} */) {
-    await fs.ensureDir(this.abspath(target))
+    await fse.ensureDir(this.abspath(target))
   }
 
   async ensureParentDir (target /*: string | {path: string} */) {
@@ -98,48 +98,48 @@ class ContextDir {
   }
 
   async unlink (target /*: string | {path: string} */) {
-    await fs.unlinkAsync(this.abspath(target))
+    await fse.unlinkAsync(this.abspath(target))
   }
 
   async rmdir (target /*: string | {path: string} */) {
-    await fs.rmdirSync(this.abspath(target))
+    await fse.rmdirSync(this.abspath(target))
   }
 
   async readFile (target /*: string | {path: string} */, opts /*: * */ = 'utf8') /*: Promise<string> */ {
-    return fs.readFile(this.abspath(target), opts)
+    return fse.readFile(this.abspath(target), opts)
   }
 
   async chmod (target /*: string | {path: string} */, mode /*: number */) {
-    await fs.chmod(this.abspath(target), mode)
+    await fse.chmod(this.abspath(target), mode)
   }
 
   async ensureFileMode (target /*: string | {path: string} */, mode /*: number */) {
-    await fs.ensureFile(this.abspath(target))
+    await fse.ensureFile(this.abspath(target))
     await this.chmod(target, mode) // Post-creation so it ignores umask
   }
 
   async outputFile (target /*: string | {path: string} */, data /*: string|Buffer */) {
-    return fs.outputFile(this.abspath(target), data)
+    return fse.outputFile(this.abspath(target), data)
   }
 
   async move (src /*: string */, dst /*: string */) {
-    return fs.move(this.abspath(src), this.abspath(dst))
+    return fse.move(this.abspath(src), this.abspath(dst))
   }
 
   async checksum (target /*: string | {path: string} */) /*: Promise<string> */ {
     return checksumer.computeChecksumAsync(this.abspath(target))
   }
 
-  stat (target /*: string | {path: string} */) /*: Promise<fs.Stat> */ {
-    return fs.stat(this.abspath(target))
+  stat (target /*: string | {path: string} */) /*: Promise<fse.Stat> */ {
+    return fse.stat(this.abspath(target))
   }
 
   remove (target /*: string | {path: string} */) /*: Promise<void> */ {
-    return fs.remove(this.abspath(target))
+    return fse.remove(this.abspath(target))
   }
 
   async removeParentDir (target /*: string | {path: string} */) /*: Promise<void> */ {
-    await fs.remove(this.abspath(path.dirname(getPath(target))))
+    await fse.remove(this.abspath(path.dirname(getPath(target))))
   }
 
   async rename (target /*: string | {path: string} */, newName /*: string */) {
@@ -147,7 +147,7 @@ class ContextDir {
     const oldName = path.basename(oldPath)
     const newPath = oldPath.replace(oldName, newName)
 
-    await fs.rename(oldPath, newPath)
+    await fse.rename(oldPath, newPath)
   }
 }
 

--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -9,7 +9,6 @@ const path = require('path')
 const checksumer = require('../../../core/local/checksumer')
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 
-Promise.promisifyAll(fse) // FIXME: Isn't fs-extra already promisified?
 Promise.promisifyAll(checksumer)
 
 function getPath (target /*: string | {path: string} */) /*: string */ {
@@ -47,9 +46,9 @@ class ContextDir {
       const dir = dirsToRead.shift()
       if (dir == null) break
 
-      for (const name of await fse.readdirAsync(dir)) {
+      for (const name of await fse.readdir(dir)) {
         const absPath = path.join(dir, name)
-        const stat = await fse.statAsync(absPath)
+        const stat = await fse.stat(absPath)
         let relPath = this.relpath(absPath)
 
         if (stat.isDirectory()) {
@@ -98,7 +97,7 @@ class ContextDir {
   }
 
   async unlink (target /*: string | {path: string} */) {
-    await fse.unlinkAsync(this.abspath(target))
+    await fse.unlink(this.abspath(target))
   }
 
   async rmdir (target /*: string | {path: string} */) {

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -2,7 +2,7 @@
 
 const autoBind = require('auto-bind')
 const Promise = require('bluebird')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const path = require('path')
 const rimraf = require('rimraf')
@@ -12,7 +12,7 @@ const { ContextDir } = require('./context_dir')
 
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 
-Promise.promisifyAll(fs)
+Promise.promisifyAll(fse)
 const rimrafAsync = Promise.promisify(rimraf)
 
 /*::
@@ -51,7 +51,7 @@ class LocalTestHelpers {
     for (const src of paths) {
       const dst = path.join(this.trashPath, path.basename(src))
       try {
-        await fs.renameAsync(src, dst)
+        await fse.renameAsync(src, dst)
       } catch (err) {
         throw err
       }
@@ -59,7 +59,7 @@ class LocalTestHelpers {
   }
 
   async setupTrash () {
-    await fs.emptyDir(this.trashPath)
+    await fse.emptyDir(this.trashPath)
     this.trashDir = new ContextDir(this.trashPath)
     this.local._trash = this.trashFunc
   }

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -12,7 +12,6 @@ const { ContextDir } = require('./context_dir')
 
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 
-Promise.promisifyAll(fse)
 const rimrafAsync = Promise.promisify(rimraf)
 
 /*::
@@ -51,7 +50,7 @@ class LocalTestHelpers {
     for (const src of paths) {
       const dst = path.join(this.trashPath, path.basename(src))
       try {
-        await fse.renameAsync(src, dst)
+        await fse.rename(src, dst)
       } catch (err) {
         throw err
       }

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const glob = require('glob')
 const _ = require('lodash')
 const path = require('path')
@@ -61,7 +61,7 @@ module.exports.loadFSEventFiles = (scenario) => {
     .map(f => {
       const name = path.basename(f)
       const disabled = scenario.disabled || disabledEventsFile(name)
-      const events = fs.readJsonSync(f).map(e => {
+      const events = fse.readJsonSync(f).map(e => {
         if (e.stats) {
           e.stats.mtime = new Date(e.stats.mtime)
           e.stats.ctime = new Date(e.stats.ctime)
@@ -85,7 +85,7 @@ module.exports.loadRemoteChangesFiles = (scenario) => {
   return glob.sync(pattern).map(f => {
     const name = path.basename(f)
     const disabled = scenario.disabled || f.endsWith(disabledExtension)
-    const changes = fs.readJsonSync(f)
+    const changes = fse.readJsonSync(f)
     return {name, disabled, changes}
   })
 }
@@ -109,8 +109,8 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
     if (relpath.endsWith('/')) {
       if (!trashed) {
         debug(`- create local dir: ${localPath}`)
-        await fs.ensureDir(abspath(localPath))
-        if (trueino) ino = (await fs.stat(abspath(localPath))).ino
+        await fse.ensureDir(abspath(localPath))
+        if (trueino) ino = (await fse.stat(abspath(localPath))).ino
       }
 
       const doc = {
@@ -148,8 +148,8 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
 
       if (!trashed) {
         debug(`- create local file: ${localPath}`)
-        await fs.outputFile(abspath(localPath), content)
-        if (trueino) ino = (await fs.stat(abspath(localPath))).ino
+        await fse.outputFile(abspath(localPath), content)
+        if (trueino) ino = (await fse.stat(abspath(localPath))).ino
       }
 
       const doc = {
@@ -195,34 +195,34 @@ module.exports.runActions = (scenario, abspath) => {
     switch (action.type) {
       case 'mkdir':
         debug('- mkdir', action.path)
-        return fs.ensureDir(abspath(action.path))
+        return fse.ensureDir(abspath(action.path))
 
       case '>':
         debug('- >', action.path)
-        return fs.outputFile(abspath(action.path), 'whatever')
+        return fse.outputFile(abspath(action.path), 'whatever')
 
       case '>>':
         debug('- >>', action.path)
-        return fs.appendFile(abspath(action.path), ' blah')
+        return fse.appendFile(abspath(action.path), ' blah')
 
       case 'trash':
         debug('- trash', action.path)
-        return fs.remove(abspath(action.path))
+        return fse.remove(abspath(action.path))
 
       case 'delete':
         debug('- delete', action.path)
-        return fs.remove(abspath(action.path))
+        return fse.remove(abspath(action.path))
 
       case 'mv':
         debug('- mv', action.force ? 'force' : '', action.src, action.dst)
         if (action.merge) {
           // FIXME: Does this preserve inode ?
           mergedirs(abspath(action.src), abspath(action.dst), 'overwrite')
-          return fs.remove(abspath(action.src))
+          return fse.remove(abspath(action.src))
         } else if (action.force) {
-          return fs.move(abspath(action.src), abspath(action.dst), {overwrite: true})
+          return fse.move(abspath(action.src), abspath(action.dst), {overwrite: true})
         } else {
-          return fs.rename(abspath(action.src), abspath(action.dst))
+          return fse.rename(abspath(action.src), abspath(action.dst))
         }
 
       case 'wait':

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const os = require('os')
 const path = require('path')
 const should = require('should')
@@ -89,11 +89,11 @@ describe('App', function () {
       // Make sure current & rotated logs exist
       const logFilenames = [LOG_FILENAME, LOG_FILENAME + '.1']
       for (const filename of logFilenames) {
-        await fs.ensureFile(path.join(configDir, filename))
+        await fse.ensureFile(path.join(configDir, filename))
       }
 
       await app.removeConfig()
-      should(await fs.readdir(configDir)).deepEqual(logFilenames)
+      should(await fse.readdir(configDir)).deepEqual(logFilenames)
     })
   })
 
@@ -120,14 +120,14 @@ describe('App', function () {
     })
 
     it('can be an existing non-empty dir', () => {
-      const syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'existing-non-empty-dir'))
+      const syncPath = fse.mkdtempSync(path.join(os.tmpdir(), 'existing-non-empty-dir'))
       try {
-        fs.writeFileSync(path.join(syncPath, 'some-file'), 'some-content')
+        fse.writeFileSync(path.join(syncPath, 'some-file'), 'some-content')
         const result = App.prototype.checkSyncPath(syncPath)
         should(result).have.properties({syncPath})
         should(result).not.have.property('error')
       } finally {
-        fs.removeSync(syncPath)
+        fse.removeSync(syncPath)
       }
     })
 
@@ -160,7 +160,7 @@ describe('App', function () {
 
   describe('clientInfo', () => {
     it('works when app is not configured', () => {
-      const basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'base-dir-'))
+      const basePath = fse.mkdtempSync(path.join(os.tmpdir(), 'base-dir-'))
       const app = new App(basePath)
 
       const info = app.clientInfo()

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const should = require('should')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const configHelpers = require('../support/helpers/config')
 const { COZY_URL } = require('../support/helpers/cozy')
 
@@ -15,11 +15,11 @@ describe('Config', function () {
   describe('read', function () {
     context('when a tmp config file exists', function () {
       beforeEach('create tmp config file', function () {
-        fs.ensureFileSync(this.config.tmpConfigPath)
+        fse.ensureFileSync(this.config.tmpConfigPath)
       })
       afterEach('remove tmp config file', function () {
-        if (fs.existsSync(this.config.tmpConfigPath)) {
-          fs.unlinkSync(this.config.tmpConfigPath)
+        if (fse.existsSync(this.config.tmpConfigPath)) {
+          fse.unlinkSync(this.config.tmpConfigPath)
         }
       })
 
@@ -27,7 +27,7 @@ describe('Config', function () {
         const config = { 'url': 'https://cozy.test/' }
 
         beforeEach('write valid content', function () {
-          fs.writeFileSync(this.config.tmpConfigPath, JSON.stringify(config, null, 2))
+          fse.writeFileSync(this.config.tmpConfigPath, JSON.stringify(config, null, 2))
         })
 
         it('reads the tmp config', function () {
@@ -37,14 +37,14 @@ describe('Config', function () {
         it('persists the tmp config file as the new config file', function () {
           this.config.read()
 
-          const persistedConfig = fs.readJSONSync(this.config.configPath)
+          const persistedConfig = fse.readJSONSync(this.config.configPath)
           should(persistedConfig).match(config)
         })
       })
 
       context('and it does not have a valid JSON content', function () {
         beforeEach('write invalid content', function () {
-          fs.writeFileSync(this.config.tmpConfigPath, '\0')
+          fse.writeFileSync(this.config.tmpConfigPath, '\0')
           this.config.persist()
         })
 
@@ -58,8 +58,8 @@ describe('Config', function () {
 
     context('when no tmp config files exist', function () {
       beforeEach('remove any tmp config file', function () {
-        if (fs.existsSync(this.config.tmpConfigPath)) {
-          fs.unlinkSync(this.config.tmpConfigPath)
+        if (fse.existsSync(this.config.tmpConfigPath)) {
+          fse.unlinkSync(this.config.tmpConfigPath)
         }
         this.config.persist()
       })
@@ -73,8 +73,8 @@ describe('Config', function () {
 
     context('when the read config is empty', function () {
       beforeEach('empty local config', function () {
-        fs.ensureFileSync(this.config.configPath)
-        fs.writeFileSync(this.config.configPath, '')
+        fse.ensureFileSync(this.config.configPath)
+        fse.writeFileSync(this.config.configPath, '')
       })
 
       it('creates a new empty one', function () {
@@ -90,7 +90,7 @@ describe('Config', function () {
       const conf = { 'url': 'https://cozy.test/' }
 
       beforeEach('write valid content', function () {
-        fs.writeFileSync(this.config.configPath, JSON.stringify(conf, null, 2))
+        fse.writeFileSync(this.config.configPath, JSON.stringify(conf, null, 2))
       })
 
       it('returns an object matching the file content', function () {
@@ -102,8 +102,8 @@ describe('Config', function () {
 
     context('when the file does not exist', function () {
       beforeEach('remove config file', function () {
-        if (fs.existsSync(this.config.configPath)) {
-          fs.unlinkSync(this.config.configPath)
+        if (fse.existsSync(this.config.configPath)) {
+          fse.unlinkSync(this.config.configPath)
         }
       })
 
@@ -116,7 +116,7 @@ describe('Config', function () {
 
     context('when the file content is not valid JSON', function () {
       beforeEach('write invalid content', function () {
-        fs.writeFileSync(this.config.configPath, '\0')
+        fse.writeFileSync(this.config.configPath, '\0')
       })
 
       it('does not throw any errors', function () {
@@ -132,9 +132,9 @@ describe('Config', function () {
       })
 
       it('deletes the file', function () {
-        fs.existsSync(this.config.configPath).should.be.true()
+        fse.existsSync(this.config.configPath).should.be.true()
         Config.safeLoad(this.config.configPath)
-        fs.existsSync(this.config.configPath).should.be.false()
+        fse.existsSync(this.config.configPath).should.be.false()
       })
     })
   })

--- a/test/unit/local/chokidar_watcher.js
+++ b/test/unit/local/chokidar_watcher.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const sinon = require('sinon')
 const should = require('should')
@@ -32,7 +32,7 @@ describe('LocalWatcher Tests', function () {
   afterEach('stop watcher and clean path', function (done) {
     this.watcher.stop(true)
     this.watcher.checksumer.kill()
-    fs.emptyDir(this.syncPath, done)
+    fse.emptyDir(this.syncPath, done)
   })
   after('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
@@ -43,8 +43,8 @@ describe('LocalWatcher Tests', function () {
     })
 
     it('calls addFile/putFolder for files that are aleady here', async function () {
-      fs.ensureDirSync(path.join(this.syncPath, 'aa'))
-      fs.ensureFileSync(path.join(this.syncPath, 'aa/ab'))
+      fse.ensureDirSync(path.join(this.syncPath, 'aa'))
+      fse.ensureFileSync(path.join(this.syncPath, 'aa/ab'))
       this.prep.putFolderAsync = sinon.stub().resolves()
       this.prep.addFileAsync = sinon.stub().resolves()
       await this.watcher.start()
@@ -63,10 +63,10 @@ describe('LocalWatcher Tests', function () {
       const changedPath = path.join(this.syncPath, changedFilename)
       const unchangedData = 'Unchanged file content'
       const changedData = 'Changed file initial content'
-      await fs.outputFile(unchangedPath, unchangedData)
-      await fs.outputFile(changedPath, changedData)
-      const unchangedStats = await fs.stat(unchangedPath)
-      const {ino: changedIno} = await fs.stat(changedPath)
+      await fse.outputFile(unchangedPath, unchangedData)
+      await fse.outputFile(changedPath, changedData)
+      const unchangedStats = await fse.stat(unchangedPath)
+      const {ino: changedIno} = await fse.stat(changedPath)
       const unchangedDoc = await builders.metafile()
         .upToDate()
         .path(unchangedFilename)
@@ -81,7 +81,7 @@ describe('LocalWatcher Tests', function () {
         .updatedAt(new Date('2017-03-19T16:44:39.102Z'))
         .create()
 
-      await fs.outputFile(changedPath, 'Changed file NEW content')
+      await fse.outputFile(changedPath, 'Changed file NEW content')
       this.prep.addFileAsync = sinon.stub().resolves()
       sinon.spy(this.watcher, 'checksum')
 
@@ -98,8 +98,8 @@ describe('LocalWatcher Tests', function () {
     })
 
     it('ignores the temporary directory', async function () {
-      fs.ensureDirSync(path.join(this.syncPath, TMP_DIR_NAME))
-      fs.ensureFileSync(path.join(this.syncPath, TMP_DIR_NAME, 'ac'))
+      fse.ensureDirSync(path.join(this.syncPath, TMP_DIR_NAME))
+      fse.ensureFileSync(path.join(this.syncPath, TMP_DIR_NAME, 'ac'))
       this.prep.putFolder = sinon.spy()
       this.prep.addFile = sinon.spy()
       this.prep.updateFile = sinon.spy()
@@ -119,7 +119,7 @@ describe('LocalWatcher Tests', function () {
     })
 
     it('resolves with the md5sum for the given relative path', async function () {
-      await fs.outputFile(abspath, 'foo')
+      await fse.outputFile(abspath, 'foo')
       await should(this.watcher.checksum(relpath))
         .be.fulfilledWith('rL0Y20zC+Fzt72VPzMSk2A==') // foo
     })
@@ -168,7 +168,7 @@ describe('LocalWatcher Tests', function () {
         }
         let src = path.join(__dirname, '../../fixtures/chat-mignon.jpg')
         let dst = path.join(this.syncPath, 'aaa.jpg')
-        fs.copySync(src, dst)
+        fse.copySync(src, dst)
       })
     })
 
@@ -210,7 +210,7 @@ describe('LocalWatcher Tests', function () {
           done()
           return Promise.resolve()
         }
-        fs.mkdirSync(path.join(this.syncPath, 'aba'))
+        fse.mkdirSync(path.join(this.syncPath, 'aba'))
         return Promise.resolve()
       })
     })
@@ -230,10 +230,10 @@ describe('LocalWatcher Tests', function () {
             done()
             return Promise.resolve()
           }
-          fs.mkdirSync(path.join(this.syncPath, 'abb/abc'))
+          fse.mkdirSync(path.join(this.syncPath, 'abb/abc'))
           return Promise.resolve()
         }
-        fs.mkdirSync(path.join(this.syncPath, 'abb'))
+        fse.mkdirSync(path.join(this.syncPath, 'abb'))
       })
     })
   })
@@ -248,7 +248,7 @@ describe('LocalWatcher Tests', function () {
       // This test does not create the file in pouchdb.
       // the watcher will not find a inode number for the unlink
       // and therefore discard it.
-      fs.ensureFileSync(path.join(this.syncPath, 'aca'))
+      fse.ensureFileSync(path.join(this.syncPath, 'aca'))
       this.prep.addFileAsync = () => {  // For aca file
         this.prep.trashFileAsync = function (side, doc) {
           side.should.equal('local')
@@ -257,7 +257,7 @@ describe('LocalWatcher Tests', function () {
           done()
           return Promise.resolve()
         }
-        fs.unlinkSync(path.join(this.syncPath, 'aca'))
+        fse.unlinkSync(path.join(this.syncPath, 'aca'))
         return Promise.resolve()
       }
       this.watcher.start()
@@ -274,7 +274,7 @@ describe('LocalWatcher Tests', function () {
       // This test does not create the file in pouchdb.
       // the watcher will not find a inode number for the unlink
       // and therefore discard it.
-      fs.mkdirSync(path.join(this.syncPath, 'ada'))
+      fse.mkdirSync(path.join(this.syncPath, 'ada'))
       this.prep.putFolderAsync = () => {  // For ada folder
         this.prep.trashFolderAsync = function (side, doc) {
           side.should.equal('local')
@@ -283,7 +283,7 @@ describe('LocalWatcher Tests', function () {
           done()
           return Promise.resolve()
         }
-        fs.rmdirSync(path.join(this.syncPath, 'ada'))
+        fse.rmdirSync(path.join(this.syncPath, 'ada'))
         return Promise.resolve()
       }
       this.watcher.start()
@@ -294,7 +294,7 @@ describe('LocalWatcher Tests', function () {
     it('detects when a file is changed', function (done) {
       let src = path.join(__dirname, '../../fixtures/chat-mignon.jpg')
       let dst = path.join(this.syncPath, 'aea.jpg')
-      fs.copySync(src, dst)
+      fse.copySync(src, dst)
       this.prep.addFileAsync = () => {
         this.prep.updateFileAsync = function (side, doc) {
           side.should.equal('local')
@@ -309,7 +309,7 @@ describe('LocalWatcher Tests', function () {
         }
         src = src.replace(/\.jpg$/, '-mod.jpg')
         dst = path.join(this.syncPath, 'aea.jpg')
-        fs.copySync(src, dst)
+        fse.copySync(src, dst)
         return Promise.resolve()
       }
       this.watcher.start()
@@ -335,7 +335,7 @@ describe('LocalWatcher Tests', function () {
       // and therefore discard it.
       let src = path.join(__dirname, '../../fixtures/chat-mignon.jpg')
       let dst = path.join(this.syncPath, 'afa.jpg')
-      fs.copySync(src, dst)
+      fse.copySync(src, dst)
       this.prep.addFileAsync = (side, doc) => {
         doc._id = doc.path
         return this.pouch.db.put(doc)
@@ -364,7 +364,7 @@ describe('LocalWatcher Tests', function () {
             done()
             return Promise.resolve()
           }
-          fs.renameSync(dst, path.join(this.syncPath, 'afb.jpg'))
+          fse.renameSync(dst, path.join(this.syncPath, 'afb.jpg'))
         }, 2000)
       })
     })
@@ -389,8 +389,8 @@ describe('LocalWatcher Tests', function () {
       // and therefore discard it.
       let src = path.join(this.syncPath, 'aga')
       let dst = path.join(this.syncPath, 'agb')
-      fs.ensureDirSync(src)
-      fs.writeFileSync(`${src}/agc`, 'agc')
+      fse.ensureDirSync(src)
+      fse.writeFileSync(`${src}/agc`, 'agc')
       this.prep.addFileAsync = this.prep.putFolderAsync = (side, doc) => {
         doc._id = doc.path
         return this.pouch.db.put(doc)
@@ -426,7 +426,7 @@ describe('LocalWatcher Tests', function () {
             }, 5000)
             return Promise.resolve()
           }
-          fs.renameSync(src, dst)
+          fse.renameSync(src, dst)
         }, 1800)
       })
     })

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -17,8 +17,6 @@ const { ContextDir } = require('../../support/helpers/context_dir')
 const { WINDOWS_DEFAULT_MODE } = require('../../support/helpers/platform')
 const pouchHelpers = require('../../support/helpers/pouch')
 
-Promise.promisifyAll(fse)
-
 describe('Local', function () {
   let builders, syncDir
 
@@ -635,11 +633,11 @@ describe('Local', function () {
 
     it('deletes an empty folder', async function () {
       const doc = builders.metadir().build()
-      await fse.emptyDirAsync(fullPath(doc))
+      await fse.emptyDir(fullPath(doc))
 
       await this.local.deleteFolderAsync(doc)
 
-      should(await fse.pathExistsAsync(fullPath(doc))).be.false()
+      should(await fse.pathExists(fullPath(doc))).be.false()
       should(this.events.emit.args).deepEqual([
         ['delete-file', doc]
       ])
@@ -647,11 +645,11 @@ describe('Local', function () {
 
     it('trashes a non-empty folder (ENOTEMPTY)', async function () {
       const doc = builders.metadir().build()
-      await fse.ensureDirAsync(path.join(fullPath(doc), 'something-inside'))
+      await fse.ensureDir(path.join(fullPath(doc), 'something-inside'))
 
       await this.local.deleteFolderAsync(doc)
 
-      should(await fse.pathExistsAsync(fullPath(doc))).be.false()
+      should(await fse.pathExists(fullPath(doc))).be.false()
       should(this.local.trashAsync.args).deepEqual([
         [doc]
       ])
@@ -667,7 +665,7 @@ describe('Local', function () {
     it('throws when given non-folder metadata', async function () {
       // TODO: FileMetadataBuilder
       const doc = {path: 'FILE-TO-DELETE', docType: 'file'}
-      await fse.ensureFileAsync(fullPath(doc))
+      await fse.ensureFile(fullPath(doc))
 
       await should(this.local.deleteFolderAsync(doc))
         .be.rejectedWith(/metadata/)

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -2,7 +2,7 @@
 
 const Promise = require('bluebird')
 const crypto = require('crypto')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const sinon = require('sinon')
 const should = require('should')
@@ -17,7 +17,7 @@ const { ContextDir } = require('../../support/helpers/context_dir')
 const { WINDOWS_DEFAULT_MODE } = require('../../support/helpers/platform')
 const pouchHelpers = require('../../support/helpers/pouch')
 
-Promise.promisifyAll(fs)
+Promise.promisifyAll(fse)
 
 describe('Local', function () {
   let builders, syncDir
@@ -55,7 +55,7 @@ describe('Local', function () {
     it('creates a readable stream for the document', function (done) {
       let src = path.join(__dirname, '../../fixtures/chat-mignon.jpg')
       let dst = syncDir.abspath('read-stream.jpg')
-      fs.copySync(src, dst)
+      fse.copySync(src, dst)
       let doc = {
         path: 'read-stream.jpg',
         md5sum: 'bf268fcb32d2fd7243780ad27af8ae242a6f0d30'
@@ -97,7 +97,7 @@ describe('Local', function () {
     it('chmod +x for an executable file', function (done) {
       let date = new Date('2015-11-09T05:06:07Z')
       let filePath = syncDir.abspath('exec-file')
-      fs.ensureFileSync(filePath)
+      fse.ensureFileSync(filePath)
       let updater = this.local.metadataUpdater({
         docType: 'file',
         path: 'exec-file',
@@ -106,7 +106,7 @@ describe('Local', function () {
       })
       updater(function (err) {
         should.not.exist(err)
-        let mode = +fs.statSync(filePath).mode
+        let mode = +fse.statSync(filePath).mode
         if (process.platform === 'win32') {
           (mode & 0o100).should.equal(0)
         } else {
@@ -119,14 +119,14 @@ describe('Local', function () {
     it('updates mtime for a file', function (done) {
       let date = new Date('2015-10-09T05:06:07Z')
       let filePath = syncDir.abspath('utimes-file')
-      fs.ensureFileSync(filePath)
+      fse.ensureFileSync(filePath)
       let updater = this.local.metadataUpdater({
         path: 'utimes-file',
         updated_at: date
       })
       updater(function (err) {
         should.not.exist(err)
-        let mtime = +fs.statSync(filePath).mtime
+        let mtime = +fse.statSync(filePath).mtime
         mtime.should.equal(+date)
         done()
       })
@@ -135,14 +135,14 @@ describe('Local', function () {
     it('updates mtime for a directory', function (done) {
       let date = new Date('2015-10-09T05:06:07Z')
       let folderPath = syncDir.abspath('utimes-folder')
-      fs.ensureDirSync(folderPath)
+      fse.ensureDirSync(folderPath)
       let updater = this.local.metadataUpdater({
         path: 'utimes-folder',
         updated_at: date
       })
       updater(function (err) {
         should.not.exist(err)
-        let mtime = +fs.statSync(folderPath).mtime
+        let mtime = +fse.statSync(folderPath).mtime
         mtime.should.equal(+date)
         done()
       })
@@ -158,7 +158,7 @@ describe('Local', function () {
 
     it('sets ino for a file', function (done) {
       const doc = {path: 'file-needs-ino'}
-      fs.ensureFileSync(fullPath(doc))
+      fse.ensureFileSync(fullPath(doc))
       const inodeSetter = this.local.inodeSetter(doc)
       inodeSetter(err => {
         should.not.exist(err)
@@ -169,7 +169,7 @@ describe('Local', function () {
 
     it('sets ino for a directory', function (done) {
       const doc = {path: 'dir-needs-ino'}
-      fs.ensureDirSync(fullPath(doc))
+      fse.ensureDirSync(fullPath(doc))
       const inodeSetter = this.local.inodeSetter(doc)
       inodeSetter(err => {
         should.not.exist(err)
@@ -206,7 +206,7 @@ describe('Local', function () {
       let filePath = path.resolve(this.syncPath, 'folder', 'testfile')
       let exist = await this.local.fileExistsLocallyAsync('deadcafe')
       exist.should.not.be.ok()
-      fs.ensureFileSync(filePath)
+      fse.ensureFileSync(filePath)
       let doc = {
         _id: 'folder/testfile',
         path: 'folder/testfile',
@@ -245,10 +245,10 @@ describe('Local', function () {
       let filePath = syncDir.abspath(doc.path)
       await this.local.addFileAsync(doc)
       this.local.other = null
-      fs.statSync(filePath).isFile().should.be.true()
-      let content = fs.readFileSync(filePath, {encoding: 'utf-8'})
+      fse.statSync(filePath).isFile().should.be.true()
+      let content = fse.readFileSync(filePath, {encoding: 'utf-8'})
       content.should.equal('foobar')
-      let mtime = +fs.statSync(filePath).mtime
+      let mtime = +fse.statSync(filePath).mtime
       mtime.should.equal(+doc.updated_at)
       should(doc.ino).be.a.Number()
     })
@@ -260,16 +260,16 @@ describe('Local', function () {
         md5sum: 'qwesux5JaAGTet+nckJL9w=='
       }
       let alt = syncDir.abspath('files/my-checkum-is-456')
-      fs.writeFileSync(alt, 'foo bar baz')
+      fse.writeFileSync(alt, 'foo bar baz')
       let stub = sinon.stub(this.local, 'fileExistsLocally').yields(null, alt)
       let filePath = syncDir.abspath(doc.path)
       await this.local.addFileAsync(doc)
       stub.restore()
       stub.calledWith(doc.md5sum).should.be.true()
-      fs.statSync(filePath).isFile().should.be.true()
-      let content = fs.readFileSync(filePath, {encoding: 'utf-8'})
+      fse.statSync(filePath).isFile().should.be.true()
+      let content = fse.readFileSync(filePath, {encoding: 'utf-8'})
       content.should.equal('foo bar baz')
-      let mtime = +fs.statSync(filePath).mtime
+      let mtime = +fse.statSync(filePath).mtime
       mtime.should.equal(+doc.updated_at)
     })
 
@@ -294,10 +294,10 @@ describe('Local', function () {
       let filePath = syncDir.abspath(doc.path)
       await this.local.addFileAsync(doc)
       this.local.other = null
-      fs.statSync(filePath).isFile().should.be.true()
-      let content = fs.readFileSync(filePath, {encoding: 'utf-8'})
+      fse.statSync(filePath).isFile().should.be.true()
+      let content = fse.readFileSync(filePath, {encoding: 'utf-8'})
       content.should.equal('foobaz')
-      let mtime = +fs.statSync(filePath).mtime
+      let mtime = +fse.statSync(filePath).mtime
       mtime.should.equal(+doc.updated_at)
     })
 
@@ -324,7 +324,7 @@ describe('Local', function () {
       await should(this.local.addFileAsync(doc))
         .be.rejectedWith('Invalid checksum')
       this.local.other = null
-      fs.existsSync(filePath).should.be.false()
+      fse.existsSync(filePath).should.be.false()
     })
   })
 
@@ -336,8 +336,8 @@ describe('Local', function () {
       }
       let folderPath = syncDir.abspath(doc.path)
       await this.local.addFolderAsync(doc)
-      fs.statSync(folderPath).isDirectory().should.be.true()
-      let mtime = +fs.statSync(folderPath).mtime
+      fse.statSync(folderPath).isDirectory().should.be.true()
+      let mtime = +fse.statSync(folderPath).mtime
       mtime.should.equal(+doc.updated_at)
       should(doc.ino).be.a.Number()
     })
@@ -348,10 +348,10 @@ describe('Local', function () {
         updated_at: new Date('2015-10-09T05:06:08Z')
       }
       let folderPath = syncDir.abspath(doc.path)
-      fs.ensureDirSync(folderPath)
+      fse.ensureDirSync(folderPath)
       await this.local.addFolderAsync(doc)
-      fs.statSync(folderPath).isDirectory().should.be.true()
-      let mtime = +fs.statSync(folderPath).mtime
+      fse.statSync(folderPath).isDirectory().should.be.true()
+      let mtime = +fse.statSync(folderPath).mtime
       mtime.should.equal(+doc.updated_at)
     })
   })
@@ -378,13 +378,13 @@ describe('Local', function () {
         }
       }
       let filePath = syncDir.abspath(doc.path)
-      fs.writeFileSync(filePath, 'old content')
+      fse.writeFileSync(filePath, 'old content')
       await this.local.overwriteFileAsync(doc, {})
       this.local.other = null
-      fs.statSync(filePath).isFile().should.be.true()
-      let content = fs.readFileSync(filePath, {encoding: 'utf-8'})
+      fse.statSync(filePath).isFile().should.be.true()
+      let content = fse.readFileSync(filePath, {encoding: 'utf-8'})
       content.should.equal('Hello world')
-      let mtime = +fs.statSync(filePath).mtime
+      let mtime = +fse.statSync(filePath).mtime
       mtime.should.equal(+doc.updated_at)
     })
   })
@@ -397,10 +397,10 @@ describe('Local', function () {
         updated_at: new Date('2015-11-10T05:06:07Z')
       }
       let filePath = syncDir.abspath(doc.path)
-      fs.ensureFileSync(filePath)
+      fse.ensureFileSync(filePath)
       await this.local.updateFileMetadataAsync(doc, {})
-      fs.existsSync(filePath).should.be.true()
-      let mtime = +fs.statSync(filePath).mtime
+      fse.existsSync(filePath).should.be.true()
+      let mtime = +fse.statSync(filePath).mtime
       mtime.should.equal(+doc.updated_at)
     })
   })
@@ -426,7 +426,7 @@ describe('Local', function () {
       srcFile = builders.metafile().path('src/file').build()
       dstFile = builders.metafile().path('dst/file').olderThan(srcFile).build()
 
-      await fs.emptyDir(syncDir.root)
+      await fse.emptyDir(syncDir.root)
     })
 
     it('moves the file and updates its mtime', async function () {
@@ -511,7 +511,7 @@ describe('Local', function () {
       srcDir = builders.metadir().path('src/dir').build()
       dstDir = builders.metadir().path('dst/dir').olderThan(srcDir).build()
 
-      await fs.emptyDir(syncDir.root)
+      await fse.emptyDir(syncDir.root)
     })
 
     it('moves the folder and updates its mtime', async function () {
@@ -595,12 +595,12 @@ describe('Local', function () {
         docType: 'file'
       }
       let filePath = syncDir.abspath(doc.path)
-      fs.ensureFileSync(filePath)
+      fse.ensureFileSync(filePath)
       const inserted = await this.pouch.db.put(doc)
       doc._rev = inserted.rev
       await this.pouch.db.remove(doc)
       await this.local.trashAsync(doc)
-      fs.existsSync(filePath).should.be.false()
+      fse.existsSync(filePath).should.be.false()
     })
 
     it('deletes a folder from the local filesystem', async function () {
@@ -610,12 +610,12 @@ describe('Local', function () {
         docType: 'folder'
       }
       let folderPath = syncDir.abspath(doc.path)
-      fs.ensureDirSync(folderPath)
+      fse.ensureDirSync(folderPath)
       const inserted = await this.pouch.db.put(doc)
       doc._rev = inserted.rev
       await this.pouch.db.remove(doc)
       await this.local.trashAsync(doc)
-      fs.existsSync(folderPath).should.be.false()
+      fse.existsSync(folderPath).should.be.false()
     })
   })
 
@@ -635,11 +635,11 @@ describe('Local', function () {
 
     it('deletes an empty folder', async function () {
       const doc = builders.metadir().build()
-      await fs.emptyDirAsync(fullPath(doc))
+      await fse.emptyDirAsync(fullPath(doc))
 
       await this.local.deleteFolderAsync(doc)
 
-      should(await fs.pathExistsAsync(fullPath(doc))).be.false()
+      should(await fse.pathExistsAsync(fullPath(doc))).be.false()
       should(this.events.emit.args).deepEqual([
         ['delete-file', doc]
       ])
@@ -647,11 +647,11 @@ describe('Local', function () {
 
     it('trashes a non-empty folder (ENOTEMPTY)', async function () {
       const doc = builders.metadir().build()
-      await fs.ensureDirAsync(path.join(fullPath(doc), 'something-inside'))
+      await fse.ensureDirAsync(path.join(fullPath(doc), 'something-inside'))
 
       await this.local.deleteFolderAsync(doc)
 
-      should(await fs.pathExistsAsync(fullPath(doc))).be.false()
+      should(await fse.pathExistsAsync(fullPath(doc))).be.false()
       should(this.local.trashAsync.args).deepEqual([
         [doc]
       ])
@@ -667,7 +667,7 @@ describe('Local', function () {
     it('throws when given non-folder metadata', async function () {
       // TODO: FileMetadataBuilder
       const doc = {path: 'FILE-TO-DELETE', docType: 'file'}
-      await fs.ensureFileAsync(fullPath(doc))
+      await fse.ensureFileAsync(fullPath(doc))
 
       await should(this.local.deleteFolderAsync(doc))
         .be.rejectedWith(/metadata/)
@@ -683,13 +683,13 @@ describe('Local', function () {
       let newPath = 'conflict/file-conflict-2015-10-09T05_05_10Z'
       let srcPath = syncDir.abspath(doc.path)
       let dstPath = syncDir.abspath(newPath)
-      fs.ensureDirSync(path.dirname(srcPath))
-      fs.writeFileSync(srcPath, 'foobar')
+      fse.ensureDirSync(path.dirname(srcPath))
+      fse.writeFileSync(srcPath, 'foobar')
       await this.local.renameConflictingDocAsync(doc, newPath)
-      fs.existsSync(srcPath).should.be.false()
-      fs.statSync(dstPath).isFile().should.be.true()
+      fse.existsSync(srcPath).should.be.false()
+      fse.statSync(dstPath).isFile().should.be.true()
       let enc = {encoding: 'utf-8'}
-      fs.readFileSync(dstPath, enc).should.equal('foobar')
+      fse.readFileSync(dstPath, enc).should.equal('foobar')
     })
   )
 })

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 const _ = require('lodash')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const should = require('should')
 const path = require('path')
 
@@ -665,7 +665,7 @@ describe('metadata', function () {
 
   describe('buildFile', function () {
     it('creates a document for an existing file', async function () {
-      const stats = await fs.stat(path.join(__dirname, '../fixtures/chat-mignon.jpg'))
+      const stats = await fse.stat(path.join(__dirname, '../fixtures/chat-mignon.jpg'))
       const md5sum = '+HBGS7uN4XdB0blqLv5tFQ=='
       const doc = buildFile('chat-mignon.jpg', stats, md5sum)
       doc.should.have.properties({
@@ -686,9 +686,9 @@ describe('metadata', function () {
       it('sets the executable bit', async function () {
         const filePath = path.join(__dirname, '../../tmp/test/executable')
         const whateverChecksum = '1B2M2Y8AsgTpgAmY7PhCfg=='
-        await fs.ensureFile(filePath)
-        await fs.chmod(filePath, '755')
-        const stats = await fs.stat(filePath)
+        await fse.ensureFile(filePath)
+        await fse.chmod(filePath, '755')
+        const stats = await fse.stat(filePath)
         const doc = buildFile('executable', stats, whateverChecksum)
         should(doc.executable).be.true()
       })

--- a/test/unit/regressions/850.js
+++ b/test/unit/regressions/850.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const sinon = require('sinon')
 // import should from 'should'
@@ -45,15 +45,15 @@ describe('issue 850', function () {
   after('stop watcher and clean path', async function () {
     this.watcher.stop(true)
     this.watcher.checksumer.kill()
-    await fs.emptyDir(this.syncPath)
+    await fse.emptyDir(this.syncPath)
   })
   after('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
 
   before('create dst dir', async function () {
     let dirPath = path.join(this.syncPath, 'dst')
-    await fs.mkdirp(dirPath)
-    let stat = await fs.stat(dirPath)
+    await fse.mkdirp(dirPath)
+    let stat = await fse.stat(dirPath)
     await this.pouch.put({
       _id: metadata.id('dst'),
       docType: 'folder',
@@ -70,11 +70,11 @@ describe('issue 850', function () {
   it('is fixed', async function () {
     let filePath = path.join(this.syncPath, 'file')
     let dstPath = path.join(this.syncPath, 'dst', 'file')
-    await fs.outputFile(filePath, 'whatever')
+    await fse.outputFile(filePath, 'whatever')
     await this.watcher.onFlush([
-      ChokidarEvent.build('add', 'file', await fs.stat(filePath))
+      ChokidarEvent.build('add', 'file', await fse.stat(filePath))
     ])
-    await fs.move(filePath, dstPath)
+    await fse.move(filePath, dstPath)
 
     const doMove = async () => {
       // let _resolve
@@ -86,7 +86,7 @@ describe('issue 850', function () {
       //   return that.pouch.lock()
       // }
       this.watcher.onFlush([
-        ChokidarEvent.build('add', 'dst/file', await fs.stat(dstPath)),
+        ChokidarEvent.build('add', 'dst/file', await fse.stat(dstPath)),
         ChokidarEvent.build('unlink', 'file')
       ])
 

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -4,7 +4,7 @@
 const Promise = require('bluebird')
 const crypto = require('crypto')
 const EventEmitter = require('events')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const _ = require('lodash')
 const { pick } = _
 const path = require('path')
@@ -100,7 +100,7 @@ describe('remote.Remote', function () {
 
       this.remote.other = {
         createReadStreamAsync (localDoc) {
-          const stream = fs.createReadStream(CHAT_MIGNON_MOD_PATH)
+          const stream = fse.createReadStream(CHAT_MIGNON_MOD_PATH)
           return Promise.resolve(stream)
         }
       }
@@ -188,7 +188,7 @@ describe('remote.Remote', function () {
 
       this.remote.other = {
         createReadStreamAsync (localDoc) {
-          const stream = fs.createReadStream(CHAT_MIGNON_MOD_PATH)
+          const stream = fse.createReadStream(CHAT_MIGNON_MOD_PATH)
           return Promise.resolve(stream)
         }
       }
@@ -213,7 +213,7 @@ describe('remote.Remote', function () {
       const doc /*: Metadata */ = builders.metafile().path('foo').build()
       this.remote.other = {
         createReadStreamAsync (localDoc) {
-          return fs.readFile('/path/do/not/exists')
+          return fse.readFile('/path/do/not/exists')
         }
       }
       await this.remote.addFileAsync(doc)
@@ -328,7 +328,7 @@ describe('remote.Remote', function () {
         const doc /*: Metadata */ = builders.metafile().path('foo').build()
         this.remote.other = {
           createReadStreamAsync (localDoc) {
-            return fs.readFile('/path/do/not/exists')
+            return fse.readFile('/path/do/not/exists')
           }
         }
         await this.remote.overwriteFileAsync(doc)

--- a/test/unit/utils/fs.js
+++ b/test/unit/utils/fs.js
@@ -12,7 +12,6 @@ const { hideOnWindows } = require('../../../core/utils/fs')
 const configHelpers = require('../../support/helpers/config')
 
 Promise.promisifyAll(childProcess)
-Promise.promisifyAll(fse)
 
 describe('utils/fs', () => {
   before('instanciate config', configHelpers.createConfig)
@@ -28,7 +27,7 @@ describe('utils/fs', () => {
       dirPath = path.join(parentPath, dirName)
       missingPath = path.join(parentPath, 'missing')
 
-      await fse.ensureDirAsync(dirPath)
+      await fse.ensureDir(dirPath)
     })
 
     if (platform === 'win32') {

--- a/test/unit/utils/fs.js
+++ b/test/unit/utils/fs.js
@@ -3,7 +3,7 @@
 
 const Promise = require('bluebird')
 const childProcess = require('child_process')
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const should = require('should')
 
@@ -12,7 +12,7 @@ const { hideOnWindows } = require('../../../core/utils/fs')
 const configHelpers = require('../../support/helpers/config')
 
 Promise.promisifyAll(childProcess)
-Promise.promisifyAll(fs)
+Promise.promisifyAll(fse)
 
 describe('utils/fs', () => {
   before('instanciate config', configHelpers.createConfig)
@@ -28,7 +28,7 @@ describe('utils/fs', () => {
       dirPath = path.join(parentPath, dirName)
       missingPath = path.join(parentPath, 'missing')
 
-      await fs.ensureDirAsync(dirPath)
+      await fse.ensureDirAsync(dirPath)
     })
 
     if (platform === 'win32') {

--- a/test/world/case_and_encoding.js
+++ b/test/world/case_and_encoding.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint-env mocha */
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 const should = require('should')
 
@@ -20,11 +20,11 @@ describe('Case and encoding basics', () => {
   // Test helpers
   const tmpdir = path.resolve(`tmp/test/unit/case_and_encoding`)
   const abspath = (relpath) => path.join(tmpdir, relpath)
-  const createFile = (filename) => fs.ensureFile(abspath(filename))
-  const rename = (src, dst) => fs.rename(abspath(src), abspath(dst))
-  const listFiles = () => fs.readdir(tmpdir)
+  const createFile = (filename) => fse.ensureFile(abspath(filename))
+  const rename = (src, dst) => fse.rename(abspath(src), abspath(dst))
+  const listFiles = () => fse.readdir(tmpdir)
 
-  beforeEach(() => fs.emptyDir(tmpdir))
+  beforeEach(() => fse.emptyDir(tmpdir))
 
   it('Node.js strings', () => {
     should('e').have.hex('            65       ')


### PR DESCRIPTION
So one can easily know whether she's using the standard Node.js `fs` module or `fs-extra` just by looking at the function prefix, e.g. `fs.rename(...)` vs `fse.rename(...)`.

Also we were uselessly using Bluebird to promisify `fs-extra` in a few places although it's already promisified by itself.