### PR TITLE
core: Setup a dev env for Elm windows

### DIFF
--- a/dev/elm.html
+++ b/dev/elm.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Main</title>
+        <link rel="stylesheet" href="../gui/app.css" />
+        <script src="../gui/elm.js"></script>
+    </head>
+    <body>
+        <div id="container" role="application"></div>
+        <script>
+            const node = document.getElementById("container");
+            const flags = {
+                hash: window.location.hash,
+                version: "debug",
+                platform: "linux",
+                locale: "en",
+                locales: {
+                    // FIXME: load locales in elm dev mode
+                    en: {}
+                },
+                folder: "/"
+            };
+            var app = Elm.Main.init({
+                node,
+                flags
+            });
+        </script>
+    </body>
+</html>

--- a/doc/developer/setup.md
+++ b/doc/developer/setup.md
@@ -61,3 +61,9 @@ N.B.: the address of the development cozy-stack is http://cozy.tools:8080. Don't
 ## Run tests
 
 See [./test.md]().
+
+## Develop Elm
+
+The script `yarn dev:elm` let you develop elm in standalone.
+
+Open the browser at [http://localhost:8000/dev/elm.html#updater](). See [`Window.elm@fromHash`](../../gui/elm/Data/Window.elm) for different windows (updater, tray, help, …).

--- a/gui/main.js
+++ b/gui/main.js
@@ -369,13 +369,13 @@ ipcMain.on('userActionInProgress', () => {
 })
 
 // On watch mode, automatically reload the window when sources are updated
-// FIXME: Why does it reload in a new popover with onboarding inside?
 if (process.env.WATCH === 'true') {
   const chokidar = require('chokidar')
-  chokidar.watch(['*.{html,js,css}'], { cwd: __dirname })
-    .on('change', () => {
-      if (trayWindow) {
-        trayWindow.reload()
-      }
-    })
+  chokidar.watch(['*.{html,js,css}'], { cwd: __dirname }).on('change', () => {
+    if (updaterWindow) {
+      updaterWindow.reload()
+    } else if (trayWindow) {
+      trayWindow.reload()
+    }
+  })
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "clean": "rimraf core/lib/ core/tmp/ gui/elm.js gui/app.css* gui/dist/",
     "cozy-stack": "yarn docker:exec cozy-stack",
     "dev:setup": "bash ./dev/setup.sh",
+    "dev:elm": "yarn watch:css & yarn watch:elm & python2 -m SimpleHTTPServer 8000",
     "dist": "electron-builder build",
     "dist:all": "yarn dist --x64 --ia32",
     "docker:exec": "docker exec -it cozy-desktop-stack",


### PR DESCRIPTION
Elm windows do not need the whole app to start when they need works.
Here a fake HTML file is used to load elm windows and css and
it is served by a simple http server, so developers can see
their changes in milliseconds.

Here I added
- one HTML file for dev purpose
- an update in chokidar watch eventlistener
- a npm/yarn script to start the whole thing
- some documentation to explain what to do

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [x] it includes relevant documentation