### PR TITLE
test/unit/local/analysis: Group tests by outputs & inputs

### DIFF
--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -17,552 +17,614 @@ describe('core/local/analysis', function () {
   const sideName = 'local'
   const builders = new Builders()
 
-  describe('file changes', () => {
-    it('do not break on empty array', () => {
-      const events /*: LocalEvent[] */ = []
-      const pendingChanges /*: LocalChange[] */ = []
-      const result /*: LocalChange[] */ = analysis(events, pendingChanges)
-      should(result).have.length(0)
-    })
-
-    it('handles partial successive moves (add+unlink+add, then unlink later)', () => {
-      const old /*: Metadata */ = builders.metafile().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'add', path: 'dst1', stats, wip: true},
-        {type: 'unlink', path: 'src', old},
-        {type: 'add', path: 'dst2', stats, md5sum: 'yolo'}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'dst2',
-        ino: 1,
-        md5sum: 'yolo',
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-
-      const nextEvents /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'dst1'}
-      ]
-      should(analysis(nextEvents, pendingChanges)).deepEqual([])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('handles unlink+add', () => {
-      const old /*: Metadata */ = builders.metafile().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'src', old},
-        {type: 'add', path: 'dst', stats, md5sum: 'yolo'}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'dst',
-        md5sum: 'yolo',
-        ino: 1,
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('identifies a FileMove + an incomplete FileMove as an incomplete FileMove', () => {
-      const old /*: Metadata */ = builders.metafile().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'src', old},
-        {type: 'add', path: 'dst1', stats, md5sum: 'yolo'},
-        // dropped: {type: 'unlink', path: 'dst1', old},
-        {type: 'add', path: 'dst2', stats, wip: true}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([])
-      should(pendingChanges).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'dst2',
-        md5sum: undefined,
-        ino: 1,
-        wip: true,
-        stats,
-        old
-      }])
-    })
-
-    it('identifies an incomplete FileMove + a complete FileMove as a complete FileMove', () => {
-      const old /*: Metadata */ = builders.metafile().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'src', old},
-        {type: 'add', path: 'dst1', stats, wip: true},
-        // dropped: {type: 'unlink', path: 'dst1', old},
-        {type: 'add', path: 'dst2', stats, md5sum: 'yolo'}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'dst2',
-        ino: 1,
-        md5sum: 'yolo',
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('handles unlink(x,old=X)+add(X,old=X) (identical renaming loopback) as FileAddition(X) because we lack an x doc to build FileMove(x → X)', () => {
-      const ino = 1
-      const oldPath = 'x'
-      const newPath = 'X'
-      const old /*: Metadata */ = builders.metafile().path(newPath).ino(ino).build()
-      const { md5sum } = old
-      const stats = {ino}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlink', path: oldPath, old},
-        {type: 'add', path: newPath, stats, md5sum, old}
-      ]
-      const pendingChanges = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileAddition',
-        path: newPath,
-        ino,
-        md5sum,
-        stats,
-        old
-      }])
-    })
-
-    it('handles unlink+add+change', () => {
-      const old /*: Metadata */ = builders.metafile().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'src', old},
-        {type: 'add', path: 'dst', stats, md5sum: old.md5sum},
-        {type: 'change', path: 'dst', stats, md5sum: 'yata'}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'dst',
-        md5sum: old.md5sum,
-        ino: 1,
-        stats,
-        old,
-        update: {
-          type: 'change',
-          path: 'dst',
-          stats,
-          md5sum: 'yata'
-        }
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('does not mistakenly identifies a partial file addition + a file change on same inode as an identical renaming', () => {
-      const partiallyAddedPath = 'partially-added-file'
-      const changedPath = 'changed-file'
-      const old = builders.metafile().path(changedPath).ino(111).build()
-      const ino = 222
-      const md5sum = 'changedSum'
-      const events /*: LocalEvent[] */ = [
-        {type: 'add', path: partiallyAddedPath, stats: {ino}, old: null, wip: true},
-        // In real life, the partially-added-file would be unlinked here.
-        // But this would defeat the purpose of reproducing this issue.
-        // So let's assume it was not.
-        {type: 'change', path: changedPath, stats: {ino}, md5sum, old}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      const changes = analysis(events, pendingChanges)
-
-      should({changes, pendingChanges}).deepEqual({
-        changes: [
-          {
-            sideName,
-            type: 'FileUpdate',
-            path: changedPath,
-            stats: {ino},
-            ino,
-            md5sum,
-            old
-          }
-        ],
-        pendingChanges: [
-          // In real life, the temporary file should have been ignored.
-          // Here, since it has the same inode as the change event, is is overridden.
-          // So no pending change in the end.
-        ]
+  describe('No change', () => {
+    describe('empty event list', () => {
+      it('may happen when all events were dropped', () => {
+        const events /*: LocalEvent[] */ = []
+        const pendingChanges /*: LocalChange[] */ = []
+        const result /*: LocalChange[] */ = analysis(events, pendingChanges)
+        should(result).have.length(0)
       })
     })
 
-    it('identifies add({path: FOO, ino: 1}) + change({path: foo, ino: 1}) as FileMove(foo, FOO)', () => {
-      const old /*: Metadata */ = builders.metafile().path('foo').ino(1).build()
-      const stats = {ino: 1}
-      const { md5sum } = old
-      const events /*: LocalEvent[] */ = [
-        {type: 'add', path: 'FOO', stats, old, md5sum},
-        {type: 'change', path: 'foo', stats, old, md5sum}
-      ]
-      const pendingChanges = []
+    describe('add(x) + unlink(x)', () => {
+      it('is ignored as a temporarily added then deleted file', () => {
+        const path = 'whatever'
+        const ino = 532806
+        const stats = {ino}
+        const events /*: LocalEvent[] */ = [
+          {type: 'add', path, stats, old: null, wip: true},
+          {type: 'unlink', path, old: null}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
 
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        update: {
-          md5sum,
-          old,
-          path: 'FOO',
-          stats,
-          type: 'change'
-        },
-        type: 'FileMove',
-        path: 'FOO',
-        ino: 1,
-        stats,
-        old,
-        md5sum
-      }])
-    })
-
-    it('identifies unlink+add then unlink (incomplete move then deletion) as FileDeletion', () => {
-      const old /*: Metadata */ = builders.metafile().path('src').ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'src', old},
-        {type: 'add', path: 'dst1', stats, wip: true}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([])
-      should(pendingChanges).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'dst1',
-        ino: 1,
-        stats,
-        old,
-        wip: true
-      }])
-
-      const nextEvents /*: LocalEvent[] */ = [
-        {type: 'unlink', path: 'dst1'}
-      ]
-      should(analysis(nextEvents, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileDeletion',
-        ino: 1,
-        path: 'src',
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('identifies add({path: FOO, stats: {ino}, old: {path: foo, ino}}) as offline FileMove(foo, FOO)', () => {
-      const ino = 123
-      const stats = {ino}
-      const md5sum = 'badbeef'
-      const old = {path: 'foo', ino}
-      const events /*: LocalEvent[] */ = [
-        {type: 'add', path: 'FOO', md5sum, stats, old}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'FileMove',
-        path: 'FOO',
-        md5sum,
-        ino,
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('ignores a file added+deleted (e.g. temporary file)', () => {
-      const path = 'whatever'
-      const ino = 532806
-      const stats = {ino}
-      const events /*: LocalEvent[] */ = [
-        {type: 'add', path, stats, old: null, wip: true},
-        {type: 'unlink', path, old: null}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      const changes = analysis(events, pendingChanges)
-      should({changes, pendingChanges}).deepEqual({
-        changes: [
-          {
-            sideName,
-            type: 'Ignored',
-            path,
-            ino,
-            stats
-          }
-        ],
-        pendingChanges: []
+        const changes = analysis(events, pendingChanges)
+        should({changes, pendingChanges}).deepEqual({
+          changes: [
+            {
+              sideName,
+              type: 'Ignored',
+              path,
+              ino,
+              stats
+            }
+          ],
+          pendingChanges: []
+        })
       })
     })
   })
 
-  describe('directory changes', () => {
-    it('does not mistakenly identifies a partial dir addition + another on same inode as identical renaming', () => {
-      const partiallyAddedPath = 'partially-added-dir'
-      const newAddedPath = 'new-added-dir'
-      const ino = 123
-      const events /*: LocalEvent[] */ = [
-        {type: 'addDir', path: partiallyAddedPath, stats: {ino}, old: null, wip: true},
-        // In real life, it should not happen so often that two addDir events
-        // follow without an intermediate unlinkDir one.
-        // But lets assume it happens in order to reproduce this issue.
-        {type: 'addDir', path: newAddedPath, stats: {ino}, old: null} // not wip because dir still exists
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      const changes = analysis(events, pendingChanges)
-
-      should({changes, pendingChanges}).deepEqual({
-        changes: [
-          {
-            sideName,
-            type: 'DirAddition',
-            path: newAddedPath,
-            stats: {ino},
-            ino
-          }
-        ],
-        pendingChanges: [
-          // In real life, a dir addition+move analysis would identify only the
-          // addition of the destination.
-          // Here, since both addDir events have the same inode, first one is overridden.
-          // So no pending change in the end.
+  describe('DirAddition(x)', () => {
+    describe('addDir(x)', () => {
+      it('is the most common case', () => {
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'addDir', path: 'foo', stats}
         ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirAddition',
+          path: 'foo',
+          ino: 1,
+          stats
+        }])
+        should(pendingChanges).deepEqual([])
       })
     })
 
-    it('handles unlinkDir+addDir', () => {
-      const old /*: Metadata */ = builders.metadir().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlinkDir', path: 'src', old},
-        {type: 'addDir', path: 'dst', stats}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
+    describe('addDir(x) + addDir(x)', () => {
+      it('is has the last stats', () => {
+        const path = 'foo'
+        const ino = 1
+        const old /*: Metadata */ = builders.metadir().path(path).ino(ino).build()
+        const stats1 = {ino, size: 64}
+        const stats2 = {ino, size: 1312}
+        const events /*: LocalEvent[] */ = [
+          {type: 'addDir', path, stats: stats1, old},
+          {type: 'addDir', path, stats: stats2, old}
+        ]
+        const pendingChanges = []
 
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirMove',
-        path: 'dst',
-        ino: 1,
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirAddition',
+          path,
+          ino,
+          stats: stats2,
+          old
+        }])
+      })
     })
 
-    it('identifies a DirMove + an incomplete DirMove as an incomplete DirMove', () => {
-      const old /*: Metadata */ = builders.metadir().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlinkDir', path: 'src', old},
-        {type: 'addDir', path: 'dst1', stats},
-        // dropped: {type: 'unlinkDir', path: 'dst1', old},
-        {type: 'addDir', path: 'dst2', stats, wip: true}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
+    describe('addDir(y, ino, wip) + addDir(x, ino)', () => {
+      it('is is not confused with an identical renaming', () => {
+        const partiallyAddedPath = 'partially-added-dir'
+        const newAddedPath = 'new-added-dir'
+        const ino = 123
+        const events /*: LocalEvent[] */ = [
+          {type: 'addDir', path: partiallyAddedPath, stats: {ino}, old: null, wip: true},
+          // In real life, it should not happen so often that two addDir events
+          // follow without an intermediate unlinkDir one.
+          // But lets assume it happens in order to reproduce this issue.
+          {type: 'addDir', path: newAddedPath, stats: {ino}, old: null} // not wip because dir still exists
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
 
-      should(analysis(events, pendingChanges)).deepEqual([])
-      should(pendingChanges).deepEqual([{
-        sideName,
-        type: 'DirMove',
-        path: 'dst2',
-        wip: true,
-        ino: 1,
-        stats,
-        old
-      }])
-    })
+        const changes = analysis(events, pendingChanges)
 
-    it('identifies an incomplete DirMove + a complete DirMove as a complete DirMove', () => {
-      const old /*: Metadata */ = builders.metadir().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlinkDir', path: 'src', old},
-        {type: 'addDir', path: 'dst1', stats, wip: true},
-        // dropped: {type: 'unlinkDir', path: 'dst1', old},
-        {type: 'addDir', path: 'dst2', stats}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirMove',
-        path: 'dst2',
-        ino: 1,
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('handles unlinkDir(x,old=X)+addDir(X,old=X) (identical renaming loopback) as DirAddition(X) because we lack an x doc to build DirMove(x → X)', () => {
-      const ino = 1
-      const oldPath = 'x'
-      const newPath = 'X'
-      const old /*: Metadata */ = builders.metadir().path(newPath).ino(ino).build()
-      const stats = {ino}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlinkDir', path: oldPath, old},
-        {type: 'addDir', path: newPath, stats, old}
-      ]
-      const pendingChanges = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirAddition',
-        path: newPath,
-        ino,
-        stats,
-        old
-      }])
-    })
-
-    it('handles addDir', () => {
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'addDir', path: 'foo', stats}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirAddition',
-        path: 'foo',
-        ino: 1,
-        stats
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('handles addDir+unlinkDir', () => {
-      const old /*: Metadata */ = builders.metadir().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'addDir', path: 'dst', stats},
-        {type: 'unlinkDir', path: 'src', old}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirMove',
-        path: 'dst',
-        ino: 1,
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
-    })
-
-    it('identifies 2 successive addDir on same path/ino but different stats as DirAddition(foo/) with the last stats', () => {
-      const path = 'foo'
-      const ino = 1
-      const old /*: Metadata */ = builders.metadir().path(path).ino(ino).build()
-      const stats1 = {ino, size: 64}
-      const stats2 = {ino, size: 1312}
-      const events /*: LocalEvent[] */ = [
-        {type: 'addDir', path, stats: stats1, old},
-        {type: 'addDir', path, stats: stats2, old}
-      ]
-      const pendingChanges = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirAddition',
-        path,
-        ino,
-        stats: stats2,
-        old
-      }])
-    })
-
-    it('identifies addDir({path: foo, ino: 1}) + addDir({path: FOO, ino: 1}) as DirMove(foo, FOO)', () => {
-      const old /*: Metadata */ = builders.metadir().path('foo').ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'addDir', path: 'foo', stats, old},
-        {type: 'addDir', path: 'FOO', stats, old}
-      ]
-      const pendingChanges = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirMove',
-        path: 'FOO',
-        ino: 1,
-        stats,
-        old
-      }])
-    })
-
-    it('identifies addDir({path: FOO, stats: {ino}, old: {path: foo, ino}}) as offline DirMove(foo, FOO)', () => {
-      const ino = 456
-      const stats = {ino}
-      const old = {path: 'foo', ino}
-      const events /*: LocalEvent[] */ = [
-        {type: 'addDir', path: 'FOO', stats, old}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-
-      should(analysis(events, pendingChanges)).deepEqual([{
-        sideName,
-        type: 'DirMove',
-        path: 'FOO',
-        ino,
-        stats,
-        old
-      }])
-      should(pendingChanges).deepEqual([])
+        should({changes, pendingChanges}).deepEqual({
+          changes: [
+            {
+              sideName,
+              type: 'DirAddition',
+              path: newAddedPath,
+              stats: {ino},
+              ino
+            }
+          ],
+          pendingChanges: [
+            // In real life, a dir addition+move analysis would identify only the
+            // addition of the destination.
+            // Here, since both addDir events have the same inode, first one is overridden.
+            // So no pending change in the end.
+          ]
+        })
+      })
     })
   })
 
-  describe('miscellaneous changes', () => {
-    it('handles chokidar mistakes', () => {
-      const old /*: Metadata */ = builders.metafile().ino(1).build()
-      const stats = {ino: 1}
-      const events /*: LocalEvent[] */ = [
-        {type: 'unlinkDir', path: 'src', old},
-        {type: 'add', path: 'dst', stats, md5sum: 'yolo'}
-      ]
-      const pendingChanges /*: LocalChange[] */ = []
-      should(analysis(events, pendingChanges)).deepEqual([
-        {
+  describe('FileDeletion(x)', () => {
+    describe('unlink(x) + wip add(y) + flush + unlink(y)', () => {
+      it('is a pending move finally resolved to the deletion of the source', () => {
+        const old /*: Metadata */ = builders.metafile().path('src').ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'src', old},
+          {type: 'add', path: 'dst1', stats, wip: true}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([])
+        should(pendingChanges).deepEqual([{
           sideName,
           type: 'FileMove',
+          path: 'dst1',
+          ino: 1,
+          stats,
+          old,
+          wip: true
+        }])
+
+        const nextEvents /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'dst1'}
+        ]
+        should(analysis(nextEvents, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileDeletion',
+          ino: 1,
+          path: 'src',
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+  })
+
+  describe('FileMove(src => dst)', () => {
+    describe('unlink(src) + add(dst)', () => {
+      it('is the most common case', () => {
+        const old /*: Metadata */ = builders.metafile().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'src', old},
+          {type: 'add', path: 'dst', stats, md5sum: 'yolo'}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileMove',
+          path: 'dst',
           md5sum: 'yolo',
+          ino: 1,
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+
+    describe('unlinkDir(src) + add(dst)', () => {
+      it('is a chokidar bug', () => {
+        const old /*: Metadata */ = builders.metafile().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlinkDir', path: 'src', old},
+          {type: 'add', path: 'dst', stats, md5sum: 'yolo'}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+        should(analysis(events, pendingChanges)).deepEqual([
+          {
+            sideName,
+            type: 'FileMove',
+            md5sum: 'yolo',
+            path: 'dst',
+            ino: 1,
+            stats,
+            old
+          }
+        ])
+      })
+    })
+
+    describe('add(tmp) + unlink(src) + add(dst) + flush + unlink(tmp)', () => {
+      it('is already complete on first flush', () => {
+        const old /*: Metadata */ = builders.metafile().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'add', path: 'dst1', stats, wip: true},
+          {type: 'unlink', path: 'src', old},
+          {type: 'add', path: 'dst2', stats, md5sum: 'yolo'}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileMove',
+          path: 'dst2',
+          ino: 1,
+          md5sum: 'yolo',
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+
+        const nextEvents /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'dst1'}
+        ]
+        should(analysis(nextEvents, pendingChanges)).deepEqual([])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+
+    describe('unlink(src) + add(tmp) + dropped unlink(tmp) + wip add(dst)', () => {
+      it('is incomplete', () => {
+        const old /*: Metadata */ = builders.metafile().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'src', old},
+          {type: 'add', path: 'dst1', stats, md5sum: 'yolo'},
+          // dropped: {type: 'unlink', path: 'dst1', old},
+          {type: 'add', path: 'dst2', stats, wip: true}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([])
+        should(pendingChanges).deepEqual([{
+          sideName,
+          type: 'FileMove',
+          path: 'dst2',
+          md5sum: undefined,
+          ino: 1,
+          wip: true,
+          stats,
+          old
+        }])
+      })
+    })
+
+    describe('unlink(src) + wip add(tmp) + add(dst)', () => {
+      it('is complete', () => {
+        const old /*: Metadata */ = builders.metafile().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'src', old},
+          {type: 'add', path: 'dst1', stats, wip: true},
+          // dropped: {type: 'unlink', path: 'dst1', old},
+          {type: 'add', path: 'dst2', stats, md5sum: 'yolo'}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileMove',
+          path: 'dst2',
+          ino: 1,
+          md5sum: 'yolo',
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+  })
+
+  describe('FileMove.update(src => dst)', () => {
+    describe('unlink(src) + add(dst) + change(dst)', () => {
+      it('happens when there is sufficient delay betwen move & change', () => {
+        const old /*: Metadata */ = builders.metafile().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlink', path: 'src', old},
+          {type: 'add', path: 'dst', stats, md5sum: old.md5sum},
+          {type: 'change', path: 'dst', stats, md5sum: 'yata'}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileMove',
+          path: 'dst',
+          md5sum: old.md5sum,
+          ino: 1,
+          stats,
+          old,
+          update: {
+            type: 'change',
+            path: 'dst',
+            stats,
+            md5sum: 'yata'
+          }
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+  })
+
+  describe('FileMove(a => A)', () => {
+    describe('add(A) + change(a) on same inode', () => {
+      it('is a chokidar bug with weird reversed events on macOS', () => {
+        const old /*: Metadata */ = builders.metafile().path('foo').ino(1).build()
+        const stats = {ino: 1}
+        const { md5sum } = old
+        const events /*: LocalEvent[] */ = [
+          {type: 'add', path: 'FOO', stats, old, md5sum},
+          {type: 'change', path: 'foo', stats, old, md5sum}
+        ]
+        const pendingChanges = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          update: {
+            md5sum,
+            old,
+            path: 'FOO',
+            stats,
+            type: 'change'
+          },
+          type: 'FileMove',
+          path: 'FOO',
+          ino: 1,
+          stats,
+          old,
+          md5sum
+        }])
+      })
+    })
+
+    describe('wip add(b) + change(a)', () => {
+      it('is a FileUpdate(a) not to be confused with', () => {
+        const partiallyAddedPath = 'partially-added-file'
+        const changedPath = 'changed-file'
+        const old = builders.metafile().path(changedPath).ino(111).build()
+        const ino = 222
+        const md5sum = 'changedSum'
+        const events /*: LocalEvent[] */ = [
+          {type: 'add', path: partiallyAddedPath, stats: {ino}, old: null, wip: true},
+          // In real life, the partially-added-file would be unlinked here.
+          // But this would defeat the purpose of reproducing this issue.
+          // So let's assume it was not.
+          {type: 'change', path: changedPath, stats: {ino}, md5sum, old}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        const changes = analysis(events, pendingChanges)
+
+        should({changes, pendingChanges}).deepEqual({
+          changes: [
+            {
+              sideName,
+              type: 'FileUpdate',
+              path: changedPath,
+              stats: {ino},
+              ino,
+              md5sum,
+              old
+            }
+          ],
+          pendingChanges: [
+            // In real life, the temporary file should have been ignored.
+            // Here, since it has the same inode as the change event, is is overridden.
+            // So no pending change in the end.
+          ]
+        })
+      })
+    })
+
+    describe('unwatched add(A, ino, old={a, ino})', () => {
+      it('is a case/normalization only change', () => {
+        const ino = 123
+        const stats = {ino}
+        const md5sum = 'badbeef'
+        const old = {path: 'foo', ino}
+        const events /*: LocalEvent[] */ = [
+          {type: 'add', path: 'FOO', md5sum, stats, old}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileMove',
+          path: 'FOO',
+          md5sum,
+          ino,
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+  })
+
+  describe('FileAddition(A) instead of FileMove(a => A)', () => {
+    describe('unlink(x, old=X) + add(X,old=X)', () => {
+      it('is an identical renaming loopback except we lack doc a to build the FileMove from', () => {
+        const ino = 1
+        const oldPath = 'x'
+        const newPath = 'X'
+        const old /*: Metadata */ = builders.metafile().path(newPath).ino(ino).build()
+        const { md5sum } = old
+        const stats = {ino}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlink', path: oldPath, old},
+          {type: 'add', path: newPath, stats, md5sum, old}
+        ]
+        const pendingChanges = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'FileAddition',
+          path: newPath,
+          ino,
+          md5sum,
+          stats,
+          old
+        }])
+      })
+    })
+  })
+
+  describe('DirMove(src => dst)', () => {
+    describe('unlinkDir(src) + addDir(dst)', () => {
+      it('is the most common case', () => {
+        const old /*: Metadata */ = builders.metadir().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlinkDir', path: 'src', old},
+          {type: 'addDir', path: 'dst', stats}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirMove',
           path: 'dst',
           ino: 1,
           stats,
           old
-        }
-      ])
+        }])
+        should(pendingChanges).deepEqual([])
+      })
     })
 
-    it('sort correctly unlink + add + move dir', () => {
+    describe('addDir(dst) + unlinkDir(src)', () => {
+      it('may happen with this reversed order on some platforms', () => {
+        const old /*: Metadata */ = builders.metadir().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'addDir', path: 'dst', stats},
+          {type: 'unlinkDir', path: 'src', old}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirMove',
+          path: 'dst',
+          ino: 1,
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+
+    describe('unlinkDir(src) + wip addDir(tmp) + addDir(dst)', () => {
+      it('ignores the intermediate move', () => {
+        const old /*: Metadata */ = builders.metadir().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlinkDir', path: 'src', old},
+          {type: 'addDir', path: 'dst1', stats, wip: true},
+          // dropped: {type: 'unlinkDir', path: 'dst1', old},
+          {type: 'addDir', path: 'dst2', stats}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirMove',
+          path: 'dst2',
+          ino: 1,
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+
+    describe('unlinkDir(src) + addDir(tmp) + wip addDir(dst)', () => {
+      it('is incomplete, waiting for an upcoming unlinkDir(tmp)', () => {
+        const old /*: Metadata */ = builders.metadir().ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlinkDir', path: 'src', old},
+          {type: 'addDir', path: 'dst1', stats},
+          // dropped: {type: 'unlinkDir', path: 'dst1', old},
+          {type: 'addDir', path: 'dst2', stats, wip: true}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([])
+        should(pendingChanges).deepEqual([{
+          sideName,
+          type: 'DirMove',
+          path: 'dst2',
+          wip: true,
+          ino: 1,
+          stats,
+          old
+        }])
+      })
+    })
+  })
+
+  describe('DirMove(a => A)', () => {
+    describe('addDir(a, ino) + addDir(A, ino)', () => {
+      it('is a case/normalization only change', () => {
+        const old /*: Metadata */ = builders.metadir().path('foo').ino(1).build()
+        const stats = {ino: 1}
+        const events /*: LocalEvent[] */ = [
+          {type: 'addDir', path: 'foo', stats, old},
+          {type: 'addDir', path: 'FOO', stats, old}
+        ]
+        const pendingChanges = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirMove',
+          path: 'FOO',
+          ino: 1,
+          stats,
+          old
+        }])
+      })
+    })
+
+    describe('addDir(A, ino, old={a, ino})', () => {
+      it('is an unwatched case/normalization only change', () => {
+        const ino = 456
+        const stats = {ino}
+        const old = {path: 'foo', ino}
+        const events /*: LocalEvent[] */ = [
+          {type: 'addDir', path: 'FOO', stats, old}
+        ]
+        const pendingChanges /*: LocalChange[] */ = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirMove',
+          path: 'FOO',
+          ino,
+          stats,
+          old
+        }])
+        should(pendingChanges).deepEqual([])
+      })
+    })
+  })
+
+  describe('DirAddition(A) instead of DirMove(a => A)', () => {
+    describe('unlinkDir(a,old) + addDir(A, old)', () => {
+      it('is an identical renaming loopback except we lack doc a to build DirMove(a → A)', () => {
+        const ino = 1
+        const oldPath = 'x'
+        const newPath = 'X'
+        const old /*: Metadata */ = builders.metadir().path(newPath).ino(ino).build()
+        const stats = {ino}
+        const events /*: LocalEvent[] */ = [
+          {type: 'unlinkDir', path: oldPath, old},
+          {type: 'addDir', path: newPath, stats, old}
+        ]
+        const pendingChanges = []
+
+        should(analysis(events, pendingChanges)).deepEqual([{
+          sideName,
+          type: 'DirAddition',
+          path: newPath,
+          ino,
+          stats,
+          old
+        }])
+      })
+    })
+  })
+
+  describe('Sorting', () => {
+    it('sorts correctly unlink + add + move dir', () => {
       const dirStats = {ino: 1}
       const fileStats = {ino: 2}
       const newFileStats = {ino: 3}


### PR DESCRIPTION
To make it easier to see (e.g. using editor folding):

- which output cases are not covered yet
- for the same output, which input cases are not covered yet

Tests with more than 1 change as the output can still end up in their own group.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
