### PR TITLE
test/unit/local/analysis: Fix md5sum in a few tests

### DIFF
--- a/test/unit/local/analysis.js
+++ b/test/unit/local/analysis.js
@@ -178,9 +178,10 @@ describe('core/local/analysis', function () {
       it('is the most common case', () => {
         const old /*: Metadata */ = builders.metafile().ino(1).build()
         const stats = {ino: 1}
+        const { md5sum } = old
         const events /*: LocalEvent[] */ = [
           {type: 'unlink', path: 'src', old},
-          {type: 'add', path: 'dst', stats, md5sum: 'yolo'}
+          {type: 'add', path: 'dst', stats, md5sum}
         ]
         const pendingChanges /*: LocalChange[] */ = []
 
@@ -188,7 +189,7 @@ describe('core/local/analysis', function () {
           sideName,
           type: 'FileMove',
           path: 'dst',
-          md5sum: 'yolo',
+          md5sum,
           ino: 1,
           stats,
           old
@@ -201,16 +202,17 @@ describe('core/local/analysis', function () {
       it('is a chokidar bug', () => {
         const old /*: Metadata */ = builders.metafile().ino(1).build()
         const stats = {ino: 1}
+        const { md5sum } = old
         const events /*: LocalEvent[] */ = [
           {type: 'unlinkDir', path: 'src', old},
-          {type: 'add', path: 'dst', stats, md5sum: 'yolo'}
+          {type: 'add', path: 'dst', stats, md5sum}
         ]
         const pendingChanges /*: LocalChange[] */ = []
         should(analysis(events, pendingChanges)).deepEqual([
           {
             sideName,
             type: 'FileMove',
-            md5sum: 'yolo',
+            md5sum,
             path: 'dst',
             ino: 1,
             stats,
@@ -224,10 +226,11 @@ describe('core/local/analysis', function () {
       it('is already complete on first flush', () => {
         const old /*: Metadata */ = builders.metafile().ino(1).build()
         const stats = {ino: 1}
+        const { md5sum } = old
         const events /*: LocalEvent[] */ = [
           {type: 'add', path: 'dst1', stats, wip: true},
           {type: 'unlink', path: 'src', old},
-          {type: 'add', path: 'dst2', stats, md5sum: 'yolo'}
+          {type: 'add', path: 'dst2', stats, md5sum}
         ]
         const pendingChanges /*: LocalChange[] */ = []
 
@@ -236,7 +239,7 @@ describe('core/local/analysis', function () {
           type: 'FileMove',
           path: 'dst2',
           ino: 1,
-          md5sum: 'yolo',
+          md5sum,
           stats,
           old
         }])
@@ -256,7 +259,7 @@ describe('core/local/analysis', function () {
         const stats = {ino: 1}
         const events /*: LocalEvent[] */ = [
           {type: 'unlink', path: 'src', old},
-          {type: 'add', path: 'dst1', stats, md5sum: 'yolo'},
+          {type: 'add', path: 'dst1', stats, md5sum: old.md5sum},
           // dropped: {type: 'unlink', path: 'dst1', old},
           {type: 'add', path: 'dst2', stats, wip: true}
         ]
@@ -280,11 +283,12 @@ describe('core/local/analysis', function () {
       it('is complete', () => {
         const old /*: Metadata */ = builders.metafile().ino(1).build()
         const stats = {ino: 1}
+        const { md5sum } = old
         const events /*: LocalEvent[] */ = [
           {type: 'unlink', path: 'src', old},
           {type: 'add', path: 'dst1', stats, wip: true},
           // dropped: {type: 'unlink', path: 'dst1', old},
-          {type: 'add', path: 'dst2', stats, md5sum: 'yolo'}
+          {type: 'add', path: 'dst2', stats, md5sum}
         ]
         const pendingChanges /*: LocalChange[] */ = []
 
@@ -293,7 +297,7 @@ describe('core/local/analysis', function () {
           type: 'FileMove',
           path: 'dst2',
           ino: 1,
-          md5sum: 'yolo',
+          md5sum,
           stats,
           old
         }])


### PR DESCRIPTION
So they match the values in real life.
So we can fix unwatched dir move + subfile update without breaking them.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
