### PR TITLE
Detect moves from outside the sync dir

### DIFF
--- a/core/local/atom_watcher.js
+++ b/core/local/atom_watcher.js
@@ -9,6 +9,7 @@ const LinuxProducer = require('./steps/linux_producer')
 const WinProducer = require('./steps/win_producer')
 const addInfos = require('./steps/add_infos')
 const filterIgnored = require('./steps/filter_ignored')
+const scanFolder = require('./steps/scan_folder')
 const awaitWriteFinish = require('./steps/await_write_finish')
 const initialDiff = require('./steps/initial_diff')
 const addChecksum = require('./steps/add_checksum')
@@ -56,11 +57,11 @@ module.exports = class AtomWatcher {
     let steps
     if (process.platform === 'linux') {
       this.producer = new LinuxProducer(this)
-      steps = [addInfos, filterIgnored, awaitWriteFinish, initialDiff, addChecksum]
+      steps = [addInfos, filterIgnored, scanFolder, awaitWriteFinish, initialDiff, addChecksum]
     } else if (process.platform === 'win32') {
       this.producer = new WinProducer(this)
       // TODO add a layer to detect moves
-      steps = [addInfos, filterIgnored, awaitWriteFinish, initialDiff, addChecksum]
+      steps = [addInfos, filterIgnored, scanFolder, awaitWriteFinish, initialDiff, addChecksum]
     } else {
       throw new Error('The experimental watcher is not available on this platform')
     }

--- a/core/local/steps/add_checksum.js
+++ b/core/local/steps/add_checksum.js
@@ -18,7 +18,7 @@ module.exports = function (buffer /*: Buffer */, opts /*: { syncPath: string , c
     const batch = []
     for (const event of events) {
       try {
-        if (['created', 'modified', 'scan', 'renamed'].includes(event.action) && event.docType === 'file') {
+        if (['created', 'modified', 'scan', 'renamed'].includes(event.action) && event.kind === 'file') {
           log.debug({path: event.path, action: event.action}, 'checksum')
           const absPath = path.join(opts.syncPath, event.path)
           event.md5sum = await opts.checksumer.push(absPath)

--- a/core/local/steps/add_infos.js
+++ b/core/local/steps/add_infos.js
@@ -28,10 +28,10 @@ module.exports = function (buffer /*: Buffer */, opts /*: { syncPath: string } *
             event.stats = await stater.stat(path.join(opts.syncPath, event.path))
           }
           if (event.stats) { // created, modified, renamed, scan
-            event.docType = stater.kind(event.stats)
+            event.kind = stater.kind(event.stats)
           } else { // deleted
             // If kind is unknown, we say it's a file arbitrary
-            event.docType = event.kind === 'directory' ? 'directory' : 'file'
+            event.kind = event.kind === 'directory' ? 'directory' : 'file'
           }
         }
         batch.push(event)

--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -31,10 +31,10 @@ module.exports = function (buffer /*: Buffer */, opts /*: { events: EventEmitter
           actions.initialScanDone()
         } else {
           // $FlowFixMe
-          await actions[event.action + event.docType](event)
+          await actions[event.action + event.kind](event)
         }
       } catch (err) {
-        console.log('Dispatch error:', err) // TODO
+        console.log('Dispatch error:', err, event) // TODO
       }
     }
   })

--- a/core/local/steps/event.js
+++ b/core/local/steps/event.js
@@ -9,7 +9,6 @@ export type AtomWatcherEvent = {
   path: string,
   oldPath?: string,
   _id?: string,
-  docType?: "file" | "directory",
   stats?: Stats,
   md5sum?: string,
 }

--- a/core/local/steps/linux_producer.js
+++ b/core/local/steps/linux_producer.js
@@ -13,7 +13,7 @@ const log = logger({
 })
 
 /*::
-import type { Runner } from './runner'
+import type { Producer } from './producer'
 */
 
 // This class is a producer: it watches the filesystem and the events are
@@ -26,7 +26,7 @@ import type { Runner } from './runner'
 // Even if inotify has a IN_ISDIR hint, atom/watcher does not report it. So, we
 // have to call stat on the path to know if it's a file or a directory for add
 // and update events.
-module.exports = class LinuxProducer /*:: implements Runner */ {
+module.exports = class LinuxProducer /*:: implements Producer */ {
   /*::
   buffer: Buffer
   syncPath: string

--- a/core/local/steps/producer.js
+++ b/core/local/steps/producer.js
@@ -4,5 +4,6 @@
 export interface Producer {
   start(): Promise<*>,
   stop(): *,
+  scan(string): Promise<*>,
 }
 */

--- a/core/local/steps/producer.js
+++ b/core/local/steps/producer.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 /*::
-export interface Runner {
+export interface Producer {
   start(): Promise<*>,
   stop(): *,
 }

--- a/core/local/steps/scan_folder.js
+++ b/core/local/steps/scan_folder.js
@@ -14,7 +14,7 @@ import type { Producer } from './producer'
 module.exports = function (buffer /*: Buffer */, opts /*: { producer: Producer } */) /*: Buffer */ {
   return buffer.asyncMap(async (batch) => {
     for (const event of batch) {
-      if (event.action === 'created' && event.docType === 'directory') {
+      if (event.action === 'created' && event.kind === 'directory') {
         opts.producer.scan(event.path)
           .catch((err) => log.info({err, event}, 'Error on scan'))
       }

--- a/core/local/steps/scan_folder.js
+++ b/core/local/steps/scan_folder.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+const logger = require('../../logger')
+const log = logger({
+  component: 'scanFolder'
+})
+
+/*::
+import type Buffer from './buffer'
+import type { Producer } from './producer'
+*/
+
+// This step
+module.exports = function (buffer /*: Buffer */, opts /*: { producer: Producer } */) /*: Buffer */ {
+  return buffer.asyncMap(async (batch) => {
+    for (const event of batch) {
+      if (event.action === 'created' && event.docType === 'directory') {
+        opts.producer.scan(event.path)
+          .catch((err) => log.info({err, event}, 'Error on scan'))
+      }
+    }
+    return batch
+  })
+}

--- a/core/local/steps/scan_folder.js
+++ b/core/local/steps/scan_folder.js
@@ -10,7 +10,10 @@ import type Buffer from './buffer'
 import type { Producer } from './producer'
 */
 
-// This step
+// When a directory that was not in the synchronized dir is moved to it,
+// atom/Watcher emits a single event for the added directory. In this step,
+// when this happens, we scan the directory to see if it contains files and
+// sub-directories.
 module.exports = function (buffer /*: Buffer */, opts /*: { producer: Producer } */) /*: Buffer */ {
   return buffer.asyncMap(async (batch) => {
     for (const event of batch) {

--- a/core/local/steps/win_producer.js
+++ b/core/local/steps/win_producer.js
@@ -14,7 +14,7 @@ const log = logger({
 })
 
 /*::
-import type { Runner } from './runner'
+import type { Producer } from './producer'
 */
 
 // This class is a producer: it watches the filesystem and the events are
@@ -29,7 +29,7 @@ import type { Runner } from './runner'
 // the directory was restored from the trash or moved from outside the watched
 // directory, ReadDirectoryChangesW won't send us events for the files and
 // sub-directories.
-module.exports = class WinProducer /*:: implements Runner */ {
+module.exports = class WinProducer /*:: implements Producer */ {
   /*::
   buffer: Buffer
   syncPath: string

--- a/test/property/local_watcher/index.js
+++ b/test/property/local_watcher/index.js
@@ -52,6 +52,7 @@ async function step (state, op) {
       state.watcher.start()
       break
     case 'stop':
+      await Promise.delay(1000)
       await state.watcher.stop()
       state.watcher = null
       break

--- a/test/property/local_watcher/keyboard_rubber.json
+++ b/test/property/local_watcher/keyboard_rubber.json
@@ -1,0 +1,176 @@
+[
+  { "op": "mkdir", "path": "keyboard.shtml" },
+  { "op": "create_file", "path": "keyboard.shtml/@rubber.mseed", "size": 145 },
+  { "op": "create_file", "path": "online.scm", "size": 33 },
+  { "op": "mkdir", "path": "keyboard.shtml/Égeneric_granite_fish.mseq" },
+  { "op": "mkdir", "path": "analyzing_hacking_belize.pls" },
+  {
+    "op": "create_file",
+    "path": "buckinghamshire_terrace_music.aiff",
+    "size": 70
+  },
+  {
+    "op": "create_file",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/%users.mb",
+    "size": 65547
+  },
+  { "op": "mkdir", "path": "KEYBOARD.SHTML" },
+  {
+    "op": "mkdir",
+    "path": "buckinghamshire_terrace_music.aiff/granite_calculate_usability.pic"
+  },
+  {
+    "op": "create_file",
+    "path": "synchronised_cambridgeshire_cohesive.src",
+    "size": 282
+  },
+  { "op": "mkdir", "path": "buckinghamshire_terrace_music.aiff/green.md" },
+  {
+    "op": "mkdir",
+    "path": "keyboard.shtml/@rubber.mseed/:steel_radial_synthesizing.msty"
+  },
+  {
+    "op": "mkdir",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/music_usability_computers.sm"
+  },
+  { "op": "mkdir", "path": "keyboard.shtml/5th_generation_wooden.dvb" },
+  { "op": "create_file", "path": "bi_directional_copying.kpt", "size": 22 },
+  { "op": "mkdir", "path": "KEYBOARD.SHTML/@RUBBER.MSEED" },
+  {
+    "op": "mkdir",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/mint_green_tasty_plastic_bike.spq"
+  },
+  { "op": "mkdir", "path": " rustic_forint.bed" },
+  {
+    "op": "create_file",
+    "path": "keyboard.shtml/user_centric_burgs_open_source.h261",
+    "size": 40
+  },
+  { "op": "mkdir", "path": "../outside" },
+  { "op": "start" },
+  { "op": "create_file", "path": " RUSTIC_FORINT.BED", "size": 16408 },
+  { "op": "create_file", "path": "refined_architect_cyan.wqd" },
+  { "op": "mv", "from": " rustic_forint.bed", "to": "ONLINE.SCM" },
+  {
+    "op": "mkdir",
+    "path": " rustic_forint.bed/credit_card_account_gb_specialist.def"
+  },
+  {
+    "op": "mkdir",
+    "path": "keyboard.shtml/5th_generation_wooden.dvb/%borders_technologies.cab"
+  },
+  {
+    "op": "rm",
+    "path": "keyboard.shtml/5th_generation_wooden.dvb/%borders_technologies.cab"
+  },
+  {
+    "op": "rm",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/music_usability_computers.sm"
+  },
+  {
+    "op": "mv",
+    "from": "refined_architect_cyan.wqd",
+    "to": "keyboard.shtml/Égeneric_granite_fish.mseq/music_usability_computers.sm"
+  },
+  {
+    "op": "mkdir",
+    "path": "keyboard.shtml/@rubber.mseed/ extend_tennessee.gex"
+  },
+  { "op": "rm", "path": "keyboard.shtml/Égeneric_granite_fish.mseq" },
+  { "op": "mkdir", "path": "operations_markets.icc" },
+  {
+    "op": "create_file",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/%users.mb/shoes.ufd",
+    "size": 40
+  },
+  {
+    "op": "rm",
+    "path": "keyboard.shtml/@rubber.mseed/:steel_radial_synthesizing.msty"
+  },
+  {
+    "op": "mv",
+    "from": "synchronised_cambridgeshire_cohesive.src",
+    "to": "keyboard.shtml/Égeneric_granite_fish.mseq"
+  },
+  { "op": "mkdir", "path": " rustic_forint.bed" },
+  {
+    "op": "mv",
+    "from": "keyboard.shtml/Égeneric_granite_fish.mseq/%users.mb",
+    "to": "../outside/checking_account_rubber.wmx"
+  },
+  { "op": "mkdir", "path": "sports.umj" },
+  {
+    "op": "mv",
+    "from": "keyboard.shtml/Égeneric_granite_fish.mseq/%users.mb",
+    "to": "keyboard.shtml/5th_generation_wooden.dvb/payment_connect_grey.hqx"
+  },
+  {
+    "op": "mkdir",
+    "path": "buckinghamshire_terrace_music.aiff/deposit_buckinghamshire.gca"
+  },
+  {
+    "op": "mkdir",
+    "path": "keyboard.shtml/5th_generation_wooden.dvb/%borders_technologies.cab"
+  },
+  { "op": "stop" },
+  { "op": "mkdir", "path": "colombian_peso_unidad_de_valor_real.ez3" },
+  { "op": "mkdir", "path": "sports.umj/metal_bedfordshire_incentivize.h264" },
+  {
+    "op": "create_file",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/music_usability_computers.sm"
+  },
+  { "op": "rm", "path": " rustic_forint.bed" },
+  { "op": "rm", "path": "keyboard.shtml/5th_generation_wooden.dvb" },
+  { "op": "rm", "path": "keyboard.shtml/user_centric_burgs_open_source.h261" },
+  {
+    "op": "mkdir",
+    "path": "buckinghamshire_terrace_music.aiff/green.md/fresh_aggregate_sensor.dra"
+  },
+  {
+    "op": "rm",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/music_usability_computers.sm"
+  },
+  {
+    "op": "rm",
+    "path": "keyboard.shtml/@rubber.mseed/:steel_radial_synthesizing.msty"
+  },
+  { "op": "mkdir", "path": "refined_architect_cyan.wqd" },
+  { "op": "mkdir", "path": "BUCKINGHAMSHIRE_TERRACE_MUSIC.AIFF" },
+  { "op": "rm", "path": "keyboard.shtml/5th_generation_wooden.dvb" },
+  { "op": "update_file", "path": "operations_markets.icc", "size": 2097152 },
+  { "op": "mkdir", "path": "repurpose.qps" },
+  {
+    "op": "create_file",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/mint_green_tasty_plastic_bike.spq/practical_generic_steel_table_junction.ra",
+    "size": 131096
+  },
+  { "op": "restart" },
+  { "op": "rm", "path": "online.scm" },
+  { "op": "mkdir", "path": " rustic_forint.bed/blue_sql.sema" },
+  {
+    "op": "mv",
+    "from": "keyboard.shtml/@rubber.mseed/ extend_tennessee.gex",
+    "to": "keyboard.shtml/5th_generation_wooden.dvb"
+  },
+  { "op": "rm", "path": "online.scm" },
+  {
+    "op": "mv",
+    "from": "../outside/checking_account_rubber.wmx",
+    "to": "keyboard.shtml/@rubber.mseed/ united_kingdom.gca"
+  },
+  {
+    "op": "mv",
+    "from": "keyboard.shtml/5th_generation_wooden.dvb/payment_connect_grey.hqx",
+    "to": "../outside/fresh.bpk"
+  },
+  {
+    "op": "update_file",
+    "path": "synchronised_cambridgeshire_cohesive.src",
+    "size": 4107
+  },
+  { "op": "rm", "path": " rustic_forint.bed" },
+  {
+    "op": "rm",
+    "path": "keyboard.shtml/Égeneric_granite_fish.mseq/%users.mb/shoes.ufd"
+  }
+]


### PR DESCRIPTION
When a directory is moved from outside the synchronized directory to it, atom/watcher gives us only one event (the directory was added), and it's our job to scan it to add the files and sub-directories inside it.