### PR TITLE
[WIP] Fix an invariant

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -310,7 +310,7 @@ function isAtLeastUpToDate (side /*: SideName */, doc /*: Metadata */) {
 
 function markAsNeverSynced (doc /*: Metadata */) {
   doc._deleted = true
-  doc.sides = { local: 1, remote: 1 }
+  doc.sides = { local: 0, remote: 0 }
 }
 
 function markAsNew (doc /*: Metadata */) {


### PR DESCRIPTION
When a file is added on local, and its parent is moved just after, the file has only the local side and no remote. The document for this file is given to markAsNeverSynced, and then it fails on an invariant with the message: doc has 'sides.remote' but not remote. This commit fix it.