### PR TITLE
Release v3.11.2-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.11.2-beta.1 - 2018-12-21
+
+Improvements for all users:
+
+- We've improved the wording of the updater window so it says it's downloading
+  the new version and displays the Cozy Cloud logo so you know what's being
+  updated at first glance.
+- If a directory is overwritten by a move on your Cozy, we would move it to the
+  trash and, in some situations, after synchronising your local client, the
+  directory would not be overwritten on your computer. We're now skipping the
+  move to the trash and overwriting the directory.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.11.1 - 2018-12-17
 
 See [3.11.1-beta.1](https://github.com/cozy-labs/cozy-desktop/releases/tag/v3.11.1-beta.1)

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -169,7 +169,7 @@
   "Unlinked Your device is no longer registered on your Cozy.": "Su periférico ya no está registrado en su Cozy.",
   "Update": "Actualizar",
   "Updater Checking for Update": "Verificando las actualizaciones...",
-  "Updater Downloading": "Una actualización está disponible",
+  "Updater Downloading": "Actualizando Cozy Drive",
   "Updater Error ENOSPC": "Su disco está lleno, la actualización no puede cargardse.",
   "Updater Error EPERM": "Al actualizar se produjo un error de permisos",
   "Updater Error Other": "Un error no especificado ha impedido su actualización. Por favor contacte su servicio técnico.",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.11.1",
+  "version": "3.11.2-beta.1",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- We've improved the wording of the updater window so it says it's downloading
  the new version and displays the Cozy Cloud logo so you know what's being
  updated at first glance.
- If a directory is overwritten by a move on your Cozy, we would move it to the
  trash and, in some situations, after synchronising your local client, the
  directory would not be overwritten on your computer. We're now skipping the
  move to the trash and overwriting the directory.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
