### PR TITLE
core/metadata: Don't add side when not syncing doc

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -254,7 +254,8 @@ class Merge {
     log.debug({path: doc.path, oldpath: was.path}, 'moveFileAsync')
     const {path} = doc
     if (was.sides && !was.sides[otherSide(side)]) {
-      await this.pouch.remove(metadata.upToDate(was))
+      metadata.markAsUnsyncable(side, was)
+      await this.pouch.put(was)
       return this.addFileAsync(side, doc)
     } else if (was.sides && was.sides[side]) {
       const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
@@ -348,7 +349,7 @@ class Merge {
       dst._id = makeDestinationID(doc)
       dst.path = doc.path.replace(was.path, folder.path)
       if (src.sides && src.sides[side] && !src.sides[otherSide(side)]) {
-        metadata.markAsNeverSynced(src)
+        metadata.markAsUnsyncable(side, src)
         metadata.markAsNew(dst)
         metadata.markSide(side, dst)
       } else {

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -106,8 +106,8 @@ module.exports = {
   extractRevNumber,
   isUpToDate,
   isAtLeastUpToDate,
-  markAsNeverSynced,
   markAsNew,
+  markAsUnsyncable,
   markAsUpToDate,
   sameFolder,
   sameFile,
@@ -227,8 +227,6 @@ function invariants (doc /*: Metadata */) {
   let err
   if (!doc.sides) {
     err = new Error(`${doc._id} has no sides`)
-  } else if (doc._deleted && isUpToDate('local', doc) && isUpToDate('remote', doc)) {
-    err = null
   } else if (doc.sides.remote && !doc.remote) {
     err = new Error(`${doc._id} has 'sides.remote' but no remote`)
   } else if (doc.docType === 'file' && doc.md5sum == null) {
@@ -308,9 +306,9 @@ function isAtLeastUpToDate (side /*: SideName */, doc /*: Metadata */) {
   return currentRev >= lastRev
 }
 
-function markAsNeverSynced (doc /*: Metadata */) {
+function markAsUnsyncable (side /*: SideName */, doc /*: Metadata */) {
   doc._deleted = true
-  doc.sides = { local: 1, remote: 1 }
+  markSide(side, doc, doc)
 }
 
 function markAsNew (doc /*: Metadata */) {

--- a/core/sync.js
+++ b/core/sync.js
@@ -364,7 +364,9 @@ class Sync {
   selectSide (doc /*: Metadata */) {
     let localRev = doc.sides.local || 0
     let remoteRev = doc.sides.remote || 0
-    if (localRev > remoteRev) {
+    if ((localRev === 0 || remoteRev === 0) && doc._deleted) {
+      return []
+    } else if (localRev > remoteRev) {
       return [this.remote, 'remote', remoteRev]
     } else if (remoteRev > localRev) {
       return [this.local, 'local', localRev]

--- a/test/unit/pouch.js
+++ b/test/unit/pouch.js
@@ -93,20 +93,6 @@ describe('Pouch', function () {
           should((await this.pouch.db.get(doc._id))._rev).equal(old._rev)
         })
       })
-
-      context('when doc is deleted and up to date', () => {
-        beforeEach(function () {
-          _.assign(doc, { _deleted: true, sides: { local: 1, remote: 1 } })
-        })
-
-        it('updates doc without remote', async function () {
-          _.assign(doc, { remote: undefined })
-
-          await (() => { this.pouch.put(doc) }).should.not.throw()
-          await should(this.pouch.db.get(doc._id)).be.rejectedWith({status: 404})
-          await should(this.pouch.db.get(old._id)).be.rejectedWith({status: 404})
-        })
-      })
     })
 
     describe('remove', () => {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -603,5 +603,37 @@ describe('Sync', function () {
       should.not.exist(name)
       should.not.exist(rev)
     })
+
+    it('returns an empty array if a local only doc is deleted', function () {
+      let doc = {
+        _id: 'selectSide/5',
+        _rev: '5-0123456789',
+        _deleted: true,
+        docType: 'file',
+        sides: {
+          local: 5
+        }
+      }
+      let [side, name, rev] = this.sync.selectSide(doc)
+      should.not.exist(side)
+      should.not.exist(name)
+      should.not.exist(rev)
+    })
+
+    it('returns an empty array if a remote only doc is deleted', function () {
+      let doc = {
+        _id: 'selectSide/5',
+        _rev: '5-0123456789',
+        _deleted: true,
+        docType: 'file',
+        sides: {
+          remote: 5
+        }
+      }
+      let [side, name, rev] = this.sync.selectSide(doc)
+      should.not.exist(side)
+      should.not.exist(name)
+      should.not.exist(rev)
+    })
   })
 })


### PR DESCRIPTION
  Marking a file or directory as unsyncable (previously "never synced")
  should not add a new side to the metadata, especially when not syncing
  a local document as this can lead to errors with documents not having
  a remote object but a remote side.

  We now simply mark the document for deletion, increase its existing
  side and save it to the Pouch.
  The Sync component is now responsible for not synchronising deleted
  documents with only one side.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
