### PR TITLE
core/merge: Local change & unapplied remote change

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -156,6 +156,11 @@ class Merge {
     } else if (file.sides.local && file.sides.local >= file.sides.remote) {
       // The file was updated on local after being synched to remote
       return this.updateFileAsync(side, doc)
+    } else if (file.sides.local && file.sides.local < file.sides.remote) {
+      delete doc.remote
+      delete doc.sides
+      metadata.markSide('local', doc)
+      return this.resolveConflictAsync('local', doc, doc)
     } else {
       // The file was updated on remote and maybe in local too
       let shortRev = file.sides.local

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -281,7 +281,7 @@ describe('Merge', function () {
       it('resolves a conflict between an unchanged file & an unsynced remote update', async function () {
         const initial = await builders.metafile().sides({local: 1}).data('previous content').create()
         const synced = await builders.metafile(initial).sides({local: 2, remote: 2}).create()
-        await builders.metafile(synced).sides({local: 2, remote: 3}).data('remote update').create()
+        const remoteUpdate = await builders.metafile(synced).sides({local: 2, remote: 3}).data('remote update').create()
         const sameAsSynced = builders.metafile(synced).unmerged('local').build()
 
         const sideEffects = await mergeSideEffects(this, () =>
@@ -291,7 +291,7 @@ describe('Merge', function () {
         should(sideEffects).deepEqual({
           savedDocs: [],
           resolvedConflicts: [
-            ['local', _.pick(sameAsSynced, ['path'])]
+            ['local', _.pick(remoteUpdate, ['path', 'remote'])]
           ]
         })
       })
@@ -300,17 +300,17 @@ describe('Merge', function () {
         const initial = await builders.metafile().sides({local: 1}).data('initial content').create()
         const synced = await builders.metafile(initial).sides({local: 2, remote: 2}).create()
 
-        await builders.metafile(synced).sides({local: 2, remote: 3}).data('remote update').create()
+        const remoteUpdate = await builders.metafile(synced).sides({local: 2, remote: 3}).data('remote update').create()
         const localUpdate = builders.metafile(synced).unmerged('local').data('local update').build()
 
         const sideEffects = await mergeSideEffects(this, () =>
-          this.merge.addFileAsync('local', localUpdate)
+          this.merge.addFileAsync('local', _.cloneDeep(localUpdate))
         )
 
         should(sideEffects).deepEqual({
           savedDocs: [],
           resolvedConflicts: [
-            ['local', _.pick(localUpdate, ['path'])]
+            ['local', _.pick(remoteUpdate, ['path', 'remote'])]
           ]
         })
       })


### PR DESCRIPTION
  When we have fetched a remote change and failed to apply it, we end up
  with a remote side superior to our local side.
  If in this situation we try to merge a local change, we'll try to
  resolve the conflict remotely and end up renaming the existing file
  with the conflict suffix and potentially lose the local data after
  successfully applying the remote changes.

  We can avoid this situation by doing a local conflict resolution,
  ensuring we have both the existing file and its conflicting copy.
  This has the additionnal advantage of keeping potential sharings of the
  remote file clean.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
