### PR TITLE
core/merge: Separate files with different inodes

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -158,6 +158,14 @@ class Merge {
     }
     metadata.assignMaxDate(doc, file)
     if (file) {
+      let inConflict = doc.ino && doc.ino !== file.ino
+      if (file.fileid && doc.fileid) {
+        inConflict = file.fileid !== doc.fileid
+      }
+      if (inConflict) {
+        return this.resolveConflictAsync(side, doc, file)
+      }
+
       doc._rev = file._rev
       doc.moveFrom = file.moveFrom
       if (doc.tags == null) { doc.tags = file.tags || [] }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -99,6 +99,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  fileid (fileid /*: string */) /*: this */ {
+    this.doc.fileid = fileid
+    return this
+  }
+
   stats ({ino, mtime, ctime} /*: fs.Stats */) /*: this */ {
     return this.ino(ino).updatedAt(timestamp.maxDate(mtime, ctime))
   }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -278,6 +278,44 @@ describe('Merge', function () {
         })
       })
 
+      onPlatform('win32', () => {
+        it('resolves a conflict after an offline replacement', async function () {
+          const initial = await builders.metafile().path('yafile').sides({local: 1}).fileid('37').data('initial content').create()
+          const synced = await builders.metafile(initial).sides({local: 2, remote: 2}).create()
+          const replacement = builders.metafile(synced).unmerged('local').fileid('38').data('replaced content').newerThan(synced).build()
+
+          const sideEffects = await mergeSideEffects(this, () =>
+            this.merge.addFileAsync('local', _.cloneDeep(replacement))
+          )
+
+          should(sideEffects).deepEqual({
+            savedDocs: [],
+            resolvedConflicts: [
+              ['local', _.pick(replacement, ['path'])]
+            ]
+          })
+        })
+      })
+
+      onPlatforms(['linux', 'darwin'], () => {
+        it('resolves a conflict after an offline replacement', async function () {
+          const initial = await builders.metafile().path('yafile').sides({local: 1}).ino(37).data('initial content').create()
+          const synced = await builders.metafile(initial).sides({local: 2, remote: 2}).create()
+          const replacement = builders.metafile(synced).unmerged('local').ino(38).data('replaced content').newerThan(synced).build()
+
+          const sideEffects = await mergeSideEffects(this, () =>
+            this.merge.addFileAsync('local', _.cloneDeep(replacement))
+          )
+
+          should(sideEffects).deepEqual({
+            savedDocs: [],
+            resolvedConflicts: [
+              ['local', _.pick(replacement, ['path'])]
+            ]
+          })
+        })
+      })
+
       it('resolves a conflict between an unchanged file & an unsynced remote update', async function () {
         const initial = await builders.metafile().sides({local: 1}).data('previous content').create()
         const synced = await builders.metafile(initial).sides({local: 2, remote: 2}).create()


### PR DESCRIPTION
When we try to apply locally an update to a file at a path already
  known in the Pouch DB (i.e. during an initial scan), we override the
  existing document and remote copy if we can (i.e. no changes were
  fetched from the Cozy).

  However, if the previous and the new files have different inodes, it
  means the first one was deleted and then a new file was created at
  the same path. It doesn't mean those files are the same or different
  versions of the same file. We should not override the previous copy in
  this situation and do a conflict resolution instead.

Based on #1366, it should be merged after.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
