### PR TITLE
test/scenarios: create_file & update_file actions

### DIFF
--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -83,9 +83,7 @@ const runActions = (scenario /*: * */, cozy /*: * */) => {
         debug('- update_file', action.path)
         {
           const remoteFile = await cozy.files.statByPath(`/${action.path}`)
-          const resp = await cozy.files.downloadByPath(`/${action.path}`)
-          const contents = await resp.text()
-          return cozy.files.updateById(remoteFile._id, `${contents} blah`, {
+          return cozy.files.updateById(remoteFile._id, action.content, {
             contentType: 'text/plain'
           })
         }

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -79,8 +79,8 @@ const runActions = (scenario /*: * */, cozy /*: * */) => {
           })
         }
 
-      case '>>':
-        debug('- >>', action.path)
+      case 'update_file':
+        debug('- update_file', action.path)
         {
           const remoteFile = await cozy.files.statByPath(`/${action.path}`)
           const resp = await cozy.files.downloadByPath(`/${action.path}`)

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -34,7 +34,7 @@ const createInitialTree = async function (scenario /*: * */, cozy /*: * */, pouc
         remote: {_id: remoteDir._id, _rev: remoteDir._rev}
       })
     } else {
-      debug('- >', relpath)
+      debug('- create_file', relpath)
       const parent = await cozy.files.statByPath(path.posix.dirname(relpath))
       let remoteFile = await cozy.files.create(Buffer.from(''), {
         dirID: parent._id,
@@ -67,8 +67,8 @@ const runActions = (scenario /*: * */, cozy /*: * */) => {
         debug('- mkdir', action.path)
         return cozy.files.createDirectoryByPath(`/${action.path}`)
 
-      case '>':
-        debug('- >', action.path)
+      case 'create_file':
+        debug('- create_file', action.path)
         {
           const parentDir = await cozy.files.statByPath(
             `/${path.posix.dirname(action.path)}`)

--- a/test/scenarios/add_delete_dir_and_file/scenario.js
+++ b/test/scenarios/add_delete_dir_and_file/scenario.js
@@ -5,7 +5,7 @@
 module.exports = ({
   actions: [
     {type: 'mkdir', path: 'dir'},
-    {type: '>', path: 'file'},
+    {type: 'create_file', path: 'file'},
     {type: 'wait', ms: 1500},
     {type: 'delete', path: 'dir'},
     {type: 'delete', path: 'file'}

--- a/test/scenarios/add_file/scenario.js
+++ b/test/scenarios/add_file/scenario.js
@@ -4,7 +4,7 @@
 
 module.exports = ({
   actions: [
-    {type: '>', path: 'file'}
+    {type: 'create_file', path: 'file'}
   ],
   expected: {
     tree: [

--- a/test/scenarios/add_trash_file/scenario.js
+++ b/test/scenarios/add_trash_file/scenario.js
@@ -4,7 +4,7 @@
 
 module.exports = ({
   actions: [
-    {type: '>', path: 'file'},
+    {type: 'create_file', path: 'file'},
     {type: 'wait', ms: 1500},
     {type: 'trash', path: 'file'}
   ],

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/actions.js
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/actions.js
@@ -4,13 +4,13 @@
 module.exports = [
   {type: 'mkdir', path: 'JOHN'},
   {type: 'mkdir', path: 'JOHN/exact-same-subdir'},
-  {type: '>',     path: 'JOHN/exact-same-subdir/a.txt'},
-  {type: '>',     path: 'JOHN/exact-same-subdir/b.txt'},
+  {type: 'create_file', path: 'JOHN/exact-same-subdir/a.txt'},
+  {type: 'create_file', path: 'JOHN/exact-same-subdir/b.txt'},
   {type: 'mkdir', path: 'JOHN/other-subdir-JOHN-1'},
   {type: 'mkdir', path: 'john'},
   {type: 'mkdir', path: 'john/exact-same-subdir'},
-  {type: '>',     path: 'john/exact-same-subdir/a.txt'},
-  {type: '>',     path: 'john/exact-same-subdir/b.txt'},
+  {type: 'create_file', path: 'john/exact-same-subdir/a.txt'},
+  {type: 'create_file', path: 'john/exact-same-subdir/b.txt'},
   {type: 'mkdir', path: 'john/other-subdir-john-2'}
   // TODO:
   // {type: 'mkdir', path: 'JOHN/IDENTICAL-SUBDIR'},

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/scenario.js
@@ -8,8 +8,8 @@ module.exports = ({
   actions: [
     {type: 'mkdir', path: 'FOO'},
     {type: 'mkdir', path: 'FOO/subdir'},
-    {type: '>',     path: 'FOO/subdir/file'},
-    {type: '>',     path: 'foo'}
+    {type: 'create_file', path: 'FOO/subdir/file'},
+    {type: 'create_file', path: 'foo'}
   ],
   expected: {
     tree: [

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/win_mac/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/win_mac/scenario.js
@@ -10,8 +10,8 @@ module.exports = ({
   actions: [
     {type: 'mkdir', path: 'FOO'},
     {type: 'mkdir', path: 'FOO/subdir'},
-    {type: '>',     path: 'FOO/subdir/file'},
-    {type: '>',     path: 'foo'}
+    {type: 'create_file', path: 'FOO/subdir/file'},
+    {type: 'create_file', path: 'foo'}
   ],
   expected: {
     localTree: [

--- a/test/scenarios/change_file/scenario.js
+++ b/test/scenarios/change_file/scenario.js
@@ -7,7 +7,7 @@ module.exports = ({
     { ino: 1, path: 'file' }
   ],
   actions: [
-    {type: '>>', path: 'file'}
+    {type: 'update_file', path: 'file'}
   ],
   expected: {
     tree: [

--- a/test/scenarios/change_file/scenario.js
+++ b/test/scenarios/change_file/scenario.js
@@ -4,10 +4,10 @@
 
 module.exports = ({
   init: [
-    { ino: 1, path: 'file' }
+    {ino: 1, path: 'file', content: 'initial content'}
   ],
   actions: [
-    {type: 'update_file', path: 'file'}
+    {type: 'update_file', path: 'file', content: 'updated content'}
   ],
   expected: {
     tree: [
@@ -15,7 +15,7 @@ module.exports = ({
     ],
     remoteTrash: [],
     contents: {
-      'file': 'foo blah'
+      'file': 'updated content'
     }
   }
 } /*: Scenario */)

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -38,7 +38,8 @@ type FSTrashAction = {|
 
 type FSUpdateFileAction = {|
   type: 'update_file',
-  path: string
+  path: string,
+  content: string
 |}
 
 type FSWaitAction = {|

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -37,7 +37,7 @@ type FSTrashAction = {|
 |}
 
 type FSUpdateFileAction = {|
-  type: '>>',
+  type: 'update_file',
   path: string
 |}
 

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -8,8 +8,8 @@ type FSAddDirAction = {|
   path: string
 |}
 
-type FSAddFileAction = {|
-  type: '>',
+type FSCreateFileAction = {|
+  type: 'create_file',
   path: string
 |}
 
@@ -48,7 +48,7 @@ type FSWaitAction = {|
 
 type FSAction
   = FSAddDirAction
-  | FSAddFileAction
+  | FSCreateFileAction
   | FSDeleteAction
   | FSMoveAction
   | FSRestoreAction

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -3,14 +3,48 @@
 /*::
 import type { SideName } from '../../core/metadata'
 
-type FSAddDirAction = {|type: 'mkdir', path: string|}
-type FSAddFileAction = {|type: '>', path: string|}
-type FSDeleteAction = {|type: 'delete', path: string|}
-type FSMoveAction = {|type: 'mv', force?: true, merge?: true, src: string, dst: string|}
-type FSRestoreAction = {|type: 'restore', pathInTrash: string|}
-type FSTrashAction = {|type: 'trash', path: string|}
-type FSUpdateFileAction = {|type: '>>', path: string|}
-type FSWaitAction = {|type: 'wait', ms: number|}
+type FSAddDirAction = {|
+  type: 'mkdir',
+  path: string
+|}
+
+type FSAddFileAction = {|
+  type: '>',
+  path: string
+|}
+
+type FSDeleteAction = {|
+  type: 'delete',
+  path: string
+|}
+
+type FSMoveAction = {|
+  type: 'mv',
+  force?: true,
+  merge?: true,
+  src: string,
+  dst: string
+|}
+
+type FSRestoreAction = {|
+  type: 'restore',
+  pathInTrash: string
+|}
+
+type FSTrashAction = {|
+  type: 'trash',
+  path: string
+|}
+
+type FSUpdateFileAction = {|
+  type: '>>',
+  path: string
+|}
+
+type FSWaitAction = {|
+  type: 'wait',
+  ms: number
+|}
 
 type FSAction
   = FSAddDirAction

--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -11,7 +11,7 @@ module.exports = ({
   actions: [
     {type: 'mv', src: 'src/file', dst: 'dst/file'},
     {type: 'wait', ms: 1500},
-    {type: '>>', path: 'dst/file'}
+    {type: 'update_file', path: 'dst/file'}
   ],
   expected: {
     tree: [

--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -6,12 +6,12 @@ module.exports = ({
   init: [
     {ino: 1, path: 'dst/'},
     {ino: 2, path: 'src/'},
-    {ino: 3, path: 'src/file'}
+    {ino: 3, path: 'src/file', content: 'initial content'}
   ],
   actions: [
     {type: 'mv', src: 'src/file', dst: 'dst/file'},
     {type: 'wait', ms: 1500},
-    {type: 'update_file', path: 'dst/file'}
+    {type: 'update_file', path: 'dst/file', content: 'updated content'}
   ],
   expected: {
     tree: [
@@ -20,7 +20,7 @@ module.exports = ({
       'src/'
     ],
     contents: {
-      'dst/file': 'foo blah'
+      'dst/file': 'updated content'
     }
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_and_update_subfile_remotely/scenario.js
+++ b/test/scenarios/move_dir_and_update_subfile_remotely/scenario.js
@@ -7,11 +7,11 @@ module.exports = ({
   side: 'remote',
   init: [
     {ino: 1, path: 'src/'},
-    {ino: 2, path: 'src/file'}
+    {ino: 2, path: 'src/file', content: 'initial content'}
   ],
   actions: [
     {type: 'mv', src: 'src', dst: 'dst'},
-    {type: 'update_file', path: 'dst/file'}
+    {type: 'update_file', path: 'dst/file', content: 'updated content'}
   ],
   expected: {
     tree: [
@@ -20,7 +20,7 @@ module.exports = ({
     ],
     remoteTrash: [],
     contents: {
-      'dst/file': 'foo blah'
+      'dst/file': 'updated content'
     }
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_and_update_subfile_remotely/scenario.js
+++ b/test/scenarios/move_dir_and_update_subfile_remotely/scenario.js
@@ -11,7 +11,7 @@ module.exports = ({
   ],
   actions: [
     {type: 'mv', src: 'src', dst: 'dst'},
-    {type: '>>', path: 'dst/file'}
+    {type: 'update_file', path: 'dst/file'}
   ],
   expected: {
     tree: [

--- a/test/scenarios/replace_dir_with_file/scenario.js.DISABLED
+++ b/test/scenarios/replace_dir_with_file/scenario.js.DISABLED
@@ -8,7 +8,7 @@ module.exports = ({
   ],
   actions: [
     {type: 'delete', path: 'foo'},
-    {type: '>', path: 'foo'}
+    {type: 'create_file', path: 'foo'}
   ],
   expected: {
     tree: [

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -203,7 +203,7 @@ module.exports.runActions = (scenario, abspath, opts /*: {skipWait?: true} */ = 
 
       case 'update_file':
         debug('- update_file', action.path)
-        return fse.appendFile(abspath(action.path), ' blah')
+        return fse.writeFile(abspath(action.path), action.content)
 
       case 'trash':
         debug('- trash', action.path)

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -197,8 +197,8 @@ module.exports.runActions = (scenario, abspath, opts /*: {skipWait?: true} */ = 
         debug('- mkdir', action.path)
         return fse.ensureDir(abspath(action.path))
 
-      case '>':
-        debug('- >', action.path)
+      case 'create_file':
+        debug('- create_file', action.path)
         return fse.outputFile(abspath(action.path), 'whatever')
 
       case '>>':

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -201,8 +201,8 @@ module.exports.runActions = (scenario, abspath, opts /*: {skipWait?: true} */ = 
         debug('- create_file', action.path)
         return fse.outputFile(abspath(action.path), 'whatever')
 
-      case '>>':
-        debug('- >>', action.path)
+      case 'update_file':
+        debug('- update_file', action.path)
         return fse.appendFile(abspath(action.path), ' blah')
 
       case 'trash':


### PR DESCRIPTION
- `>` becomes `create_file` (same a property-based tests)
- `>>` becomes `update_file` (same a property-based tests)
- `update_file` explicit `content` is now mandatory (makes scenarios easier to understand and remote instrumentation doesn't need to download previous content anymore)

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
