### PR TITLE
test/support: Add AtomWatcherEvent builder

### DIFF
--- a/core/local/steps/event.js
+++ b/core/local/steps/event.js
@@ -3,9 +3,22 @@
 /*::
 import type { Stats } from 'fs'
 
+export type EventAction =
+  | 'created'
+  | 'modified'
+  | 'deleted'
+  | 'renamed'
+  | 'scan'
+  | 'initial-scan-done'
+export type EventKind =
+  | 'file'
+  | 'directory'
+  | 'symlink'
+  | 'unknown'
+
 export type AtomWatcherEvent = {
-  action: "created" | "modified" | "deleted" | "renamed" | "scan" | "initial-scan-done",
-  kind: "file" | "directory" | "symlink" | "unknown",
+  action: EventAction,
+  kind: EventKind,
   path: string,
   oldPath?: string,
   _id?: string,
@@ -15,3 +28,15 @@ export type AtomWatcherEvent = {
 
 export type Batch = AtomWatcherEvent[]
 */
+
+const ACTIONS /*: EventAction[] */ = [
+  'created', 'modified', 'deleted', 'renamed', 'scan', 'initial-scan-done'
+]
+const KINDS /*: EventKind[] */ = [
+  'file', 'directory', 'symlink', 'unknown'
+]
+
+module.exports = {
+  ACTIONS,
+  KINDS
+}

--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -1,0 +1,70 @@
+/* @flow */
+
+const metadata = require('../../../core/metadata')
+const events = require('../../../core/local/steps/event')
+
+/*::
+import type { Stats } from 'fs'
+import type { AtomWatcherEvent, EventAction, EventKind, Batch } from '../../../core/local/steps/event'
+*/
+
+function randomPick /*:: <T> */ (elements /*: Array<T> */) /*: T */{
+  const l = elements.length
+  const i = Math.floor(Math.random() * l)
+  return elements[i]
+}
+
+module.exports = class AtomWatcherEventBuilder {
+  /*::
+  _event: AtomWatcherEvent
+  */
+
+  constructor () {
+    this._event = {
+      action: randomPick(events.ACTIONS),
+      kind: randomPick(events.KINDS),
+      path: '/',
+      _id: '/'
+    }
+  }
+
+  build () /*: AtomWatcherEvent */ {
+    return this._event
+  }
+
+  action (newAction /*: EventAction */) /*: this */ {
+    this._event.action = newAction
+    return this
+  }
+
+  kind (newKind /*: EventKind */) /*: this */ {
+    this._event.kind = newKind
+    return this
+  }
+
+  path (newPath /*: string */) /*: this */ {
+    this._event.path = newPath
+    this._event._id = metadata.id(newPath)
+    return this
+  }
+
+  oldPath (newPath /*: string */) /*: this */{
+    this._event.oldPath = newPath
+    return this
+  }
+
+  id (newId /*: string */) /*: this */ {
+    this._event._id = newId
+    return this
+  }
+
+  stats (newStats /*: Stats */) /*: this */ {
+    this._event.stats = newStats
+    return this
+  }
+
+  md5sum (newMd5sum /*: string */) /*: this */ {
+    this._event.md5sum = newMd5sum
+    return this
+  }
+}

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -8,6 +8,7 @@ const FileMetadataBuilder = require('./metadata/file')
 const RemoteDirBuilder = require('./remote/dir')
 const RemoteFileBuilder = require('./remote/file')
 const StreamBuilder = require('./stream')
+const AtomWatcherEventBuilder = require('./atom_watcher_event')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
@@ -86,5 +87,9 @@ module.exports = class Builders {
 
   stream () /*: StreamBuilder */ {
     return new StreamBuilder()
+  }
+
+  event () /*: AtomWatcherEventBuilder */ {
+    return new AtomWatcherEventBuilder()
   }
 }


### PR DESCRIPTION
  This builder follows the same principles as the metadata and remote
  builders to create AtomWatcherEvent objects.

  Some types and constants used in AtomWatcherEvent were exported for
  consistency.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
