### PR TITLE
core/ignore: Change isIgnored signature

### DIFF
--- a/core/ignore.js
+++ b/core/ignore.js
@@ -19,10 +19,6 @@ export type IgnorePattern = {
 }
 */
 
-/* ::
-import type {Metadata} from './metadata.js'
-*/
-
 /** Load both given file rules & default ones */
 function loadSync (rulesFilePath /*: string */) /*: Ignore */ {
   let ignored
@@ -46,7 +42,7 @@ function readLinesSync (filePath /*: string */) /*: string[] */ {
 }
 
 // Parse a line and build the corresponding pattern
-function buildPattern (line) {
+function buildPattern (line /*: string */) /*: IgnorePattern */ {
   let folder = false
   let negate = false
   let noslash = line.indexOf('/') === -1
@@ -94,7 +90,7 @@ function isNotBlankOrComment (line /*: string */) /*: boolean */ {
   return line !== '' && line[0] !== '#'
 }
 
-function match (path, isFolder, pattern /*: IgnorePattern */) {
+function match (path /*: string */, isFolder /*: boolean */, pattern /*: IgnorePattern */) /*: boolean */ {
   if (pattern.basename) {
     if (pattern.match(basename(path))) {
       return true
@@ -132,23 +128,23 @@ class Ignore {
 
   // Add some rules for things that should be always ignored (temporary
   // files, thumbnails db, trash, etc.)
-  addDefaultRules () {
+  addDefaultRules () /*: this */ {
     const defaultPatterns = buildPatternArray(readLinesSync(defaultRulesPath))
     this.patterns = defaultPatterns.concat(this.patterns)
     return this
   }
 
   // Return true if the given file/folder path should be ignored
-  isIgnored (doc /*: Metadata */) {
+  isIgnored ({ relativePath, isFolder } /*: {relativePath: string, isFolder: boolean} */) /*: boolean */ {
     let result = false
     for (let pattern of Array.from(this.patterns)) {
       if (pattern.negate) {
         if (result) {
-          result = !match(doc._id, doc.docType === 'folder', pattern)
+          result = !match(relativePath, isFolder, pattern)
         }
       } else {
         if (!result) {
-          result = match(doc._id, doc.docType === 'folder', pattern)
+          result = match(relativePath, isFolder, pattern)
         }
       }
     }

--- a/core/local/steps/filter_ignored.js
+++ b/core/local/steps/filter_ignored.js
@@ -2,6 +2,7 @@
 
 /*::
 import type Buffer from './buffer'
+import type { AtomWatcherEvent } from './event'
 import type { Ignore } from '../../ignore'
 */
 
@@ -11,8 +12,18 @@ import type { Ignore } from '../../ignore'
 // watchers), but it needs to be put after the AddInfos step as the docType is
 // required to know if the event can be ignored.
 module.exports = function (buffer /*: Buffer */, opts /*: { ignore: Ignore } */) /*: Buffer */ {
+  const notIgnored = buildNotIgnored(opts.ignore)
+
   return buffer.map((batch) => {
-    // $FlowFixMe
-    return batch.filter(event => !opts.ignore.isIgnored(event))
+    return batch.filter(notIgnored)
   })
+}
+
+function buildNotIgnored (ignoreRules /*: Ignore */) /*: ((AtomWatcherEvent) => boolean) */ {
+  return (event /*: AtomWatcherEvent */) /*: boolean */ => {
+    return !ignoreRules.isIgnored({
+      relativePath: event.path,
+      isFolder: event.kind === 'directory'
+    })
+  }
 }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -17,6 +17,7 @@ import type fs from 'fs'
 import type { PathIssue } from './path_restrictions'
 import type { RemoteDoc } from './remote/document'
 import type { Stats } from './local/stater'
+import type { Ignore } from './ignore'
 */
 
 const log = logger({
@@ -121,7 +122,8 @@ module.exports = {
   buildFile,
   upToDate,
   createConflictingDoc,
-  conflictRegExp
+  conflictRegExp,
+  shouldIgnore
 }
 
 function localDocType (remoteDocType /*: string */) /*: string */ {
@@ -492,4 +494,8 @@ function createConflictingDoc (doc /*: Metadata */) /*: Metadata */ {
   dst.path = `${path.join(dir, notToLongFilename)}-conflict-${date}${ext}`
   assignId(dst)
   return dst
+}
+
+function shouldIgnore (doc /*: Metadata */, ignoreRules /*: Ignore */) /*: boolean */ {
+  return ignoreRules.isIgnored({ relativePath: doc._id, isFolder: doc.docType === 'folder' })
 }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -29,6 +29,9 @@ const { platform } = process
 export type SideName =
   | "local"
   | "remote";
+export type DocType =
+  | "file"
+  | "folder";
 
 export type MetadataRemoteInfo = {
   _id: string,
@@ -51,7 +54,7 @@ export type Metadata = {
   _rev?: string,
   md5sum?: string,
   class?: string,
-  docType: string,
+  docType: DocType,
   errors?: number,
   executable?: true,
   updated_at: string|Date,

--- a/core/prep.js
+++ b/core/prep.js
@@ -53,7 +53,7 @@ class Prep {
 
     doc.docType = 'file'
     metadata.assignId(doc)
-    if ((side === 'local') && this.ignore.isIgnored(doc)) { return }
+    if ((side === 'local') && metadata.shouldIgnore(doc, this.ignore)) { return }
     return this.merge.addFileAsync(side, doc)
   }
 
@@ -67,7 +67,7 @@ class Prep {
 
     doc.docType = 'file'
     metadata.assignId(doc)
-    if ((side === 'local') && this.ignore.isIgnored(doc)) { return }
+    if ((side === 'local') && metadata.shouldIgnore(doc, this.ignore)) { return }
     return this.merge.updateFileAsync(side, doc)
   }
 
@@ -79,7 +79,7 @@ class Prep {
 
     doc.docType = 'folder'
     metadata.assignId(doc)
-    if ((side === 'local') && this.ignore.isIgnored(doc)) { return }
+    if ((side === 'local') && metadata.shouldIgnore(doc, this.ignore)) { return }
     return this.merge.putFolderAsync(side, doc)
   }
 
@@ -109,8 +109,8 @@ class Prep {
     doc.docType = 'file'
     metadata.assignId(doc)
     metadata.assignId(was)
-    let docIgnored = this.ignore.isIgnored(doc)
-    let wasIgnored = this.ignore.isIgnored(was)
+    let docIgnored = metadata.shouldIgnore(doc, this.ignore)
+    let wasIgnored = metadata.shouldIgnore(was, this.ignore)
     if ((side === 'local') && docIgnored && wasIgnored) { return }
     if ((side === 'local') && docIgnored) {
       return this.merge.deleteFileAsync(side, was)
@@ -146,8 +146,8 @@ class Prep {
     doc.docType = 'folder'
     metadata.assignId(doc)
     metadata.assignId(was)
-    let docIgnored = this.ignore.isIgnored(doc)
-    let wasIgnored = this.ignore.isIgnored(was)
+    let docIgnored = metadata.shouldIgnore(doc, this.ignore)
+    let wasIgnored = metadata.shouldIgnore(was, this.ignore)
     if ((side === 'local') && docIgnored && wasIgnored) { return }
     if ((side === 'local') && docIgnored) {
       return this.merge.deleteFolderAsync(side, was)
@@ -169,7 +169,7 @@ class Prep {
     doc.docType = 'file'
     metadata.assignId(doc)
     metadata.assignId(was)
-    // TODO ignore.isIgnored
+    // TODO metadata.shouldIgnore
     return this.merge.restoreFileAsync(side, was, doc)
   }
 
@@ -183,7 +183,7 @@ class Prep {
     doc.docType = 'folder'
     metadata.assignId(doc)
     metadata.assignId(was)
-    // TODO ignore.isIgnored
+    // TODO metadata.shouldIgnore
     return this.merge.restoreFolderAsync(side, was, doc)
   }
 
@@ -203,7 +203,7 @@ class Prep {
     doc.docType = 'file'
     metadata.assignId(doc)
     metadata.assignId(was)
-    // TODO ignore.isIgnored
+    // TODO metadata.shouldIgnore
     return this.merge.trashFileAsync(side, was, doc)
   }
 
@@ -223,7 +223,7 @@ class Prep {
     doc.docType = 'folder'
     metadata.assignId(doc)
     metadata.assignId(was)
-    // TODO ignore.isIgnored
+    // TODO metadata.shouldIgnore
     return this.merge.trashFolderAsync(side, was, doc)
   }
 
@@ -235,7 +235,7 @@ class Prep {
 
     doc.docType = 'file'
     metadata.assignId(doc)
-    if ((side === 'local') && this.ignore.isIgnored(doc)) { return }
+    if ((side === 'local') && metadata.shouldIgnore(doc, this.ignore)) { return }
     return this.merge.deleteFileAsync(side, doc)
   }
 
@@ -247,7 +247,7 @@ class Prep {
 
     doc.docType = 'folder'
     metadata.assignId(doc)
-    if ((side === 'local') && this.ignore.isIgnored(doc)) { return }
+    if ((side === 'local') && metadata.shouldIgnore(doc, this.ignore)) { return }
     return this.merge.deleteFolderAsync(side, doc)
   }
 }

--- a/core/sync.js
+++ b/core/sync.js
@@ -222,7 +222,7 @@ class Sync {
     const { path } = doc
     log.debug({path, seq, doc}, 'Applying change...')
 
-    if (this.ignore.isIgnored(doc)) {
+    if (metadata.shouldIgnore(doc, this.ignore)) {
       return this.pouch.setLocalSeqAsync(change.seq)
     }
 

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -23,8 +23,8 @@ describe('Ignore', function () {
     it('loads user-defined ignore rules', () => {
       fs.writeFileSync(userIgnoreRules(), 'foo\r\nbar\r\n\r\n')
       const ignore = loadSync(userIgnoreRules())
-      should(ignore.isIgnored({_id: 'foo'})).be.true()
-      should(ignore.isIgnored({_id: 'bar'})).be.true()
+      should(ignore.isIgnored({ relativePath: 'foo', isFolder: false })).be.true()
+      should(ignore.isIgnored({ relativePath: 'bar', isFolder: false })).be.true()
     })
   })
 
@@ -44,269 +44,129 @@ describe('Ignore', function () {
   describe('Ignored patterns', () => {
     it("don't ignore file name not matching to the pattern", function () {
       const ignore = new Ignore(['foo'])
-      const doc = {
-        _id: 'bar',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.false()
+      ignore.isIgnored({ relativePath: 'bar', isFolder: false }).should.be.false()
     })
 
     it('ignore file name matching to the pattern', function () {
       const ignore = new Ignore(['foo'])
-      const doc = {
-        _id: 'foo',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.true()
     })
 
     it('ignore folder name matching to the pattern', function () {
       const ignore = new Ignore(['foo'])
-      const doc = {
-        _id: 'foo',
-        docType: 'folder'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: true }).should.be.true()
     })
 
     it("don't ignore file name when the pattern match folders", function () {
       const ignore = new Ignore(['foo/'])
-      const file = {
-        _id: 'foo',
-        docType: 'file'
-      }
-      const folder = {
-        _id: 'foo',
-        docType: 'folder'
-      }
-      ignore.isIgnored(file).should.be.false()
-      ignore.isIgnored(folder).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.false()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: true }).should.be.true()
     })
   })
 
   describe('Patterns operators', () => {
     it('match to the glob with *', function () {
       const ignore = new Ignore(['*.txt'])
-      const doc = {
-        _id: 'foo.txt',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo.txt', isFolder: false }).should.be.true()
     })
 
     it('match to the glob with ?', function () {
       const ignore = new Ignore(['ba?'])
-      const bar = {
-        _id: 'bar',
-        docType: 'file'
-      }
-      const baz = {
-        _id: 'baz',
-        docType: 'file'
-      }
-      const foo = {
-        _id: 'foo',
-        docType: 'file'
-      }
-      const barbaz = {
-        _id: 'barbaz',
-        docType: 'file'
-      }
-      ignore.isIgnored(bar).should.be.true()
-      ignore.isIgnored(baz).should.be.true()
-      ignore.isIgnored(foo).should.be.false()
-      ignore.isIgnored(barbaz).should.be.false()
+      ignore.isIgnored({ relativePath: 'bar', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'baz', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.false()
+      ignore.isIgnored({ relativePath: 'barbaz', isFolder: false }).should.be.false()
     })
 
     it('match braces {p1,p2}', function () {
       const ignore = new Ignore(['{bar,baz}.txt'])
-      const foo = {
-        _id: 'foo.txt',
-        docType: 'file'
-      }
-      const bar = {
-        _id: 'bar.txt',
-        docType: 'file'
-      }
-      const baz = {
-        _id: 'baz.txt',
-        docType: 'file'
-      }
-      ignore.isIgnored(bar).should.be.true()
-      ignore.isIgnored(baz).should.be.true()
-      ignore.isIgnored(foo).should.be.false()
+      ignore.isIgnored({ relativePath: 'bar.txt', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'baz.txt', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo.txt', isFolder: false }).should.be.false()
     })
 
     it('match to the glob with range [a-c]', function () {
       const ignore = new Ignore(['foo[a-c]'])
-      const fooa = {
-        _id: 'fooa',
-        docType: 'file'
-      }
-      const foob = {
-        _id: 'foob',
-        docType: 'file'
-      }
-      const fooc = {
-        _id: 'fooc',
-        docType: 'file'
-      }
-      const food = {
-        _id: 'food',
-        docType: 'file'
-      }
-      ignore.isIgnored(fooa).should.be.true()
-      ignore.isIgnored(foob).should.be.true()
-      ignore.isIgnored(fooc).should.be.true()
-      ignore.isIgnored(food).should.be.false()
+      ignore.isIgnored({ relativePath: 'fooa', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'foob', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'fooc', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'food', isFolder: false }).should.be.false()
     })
   })
 
   describe('Path patterns', () => {
     it('ignore files in subdirectory', function () {
-      const doc = {
-        _id: 'bar/foo',
-        docType: 'file'
-      }
-      new Ignore(['foo']).isIgnored(doc).should.be.true()
-      new Ignore(['/foo']).isIgnored(doc).should.be.false()
+      new Ignore(['foo']).isIgnored({ relativePath: 'bar/foo', isFolder: false }).should.be.true()
+      new Ignore(['/foo']).isIgnored({ relativePath: 'bar/foo', isFolder: false }).should.be.false()
     })
 
     it('ignore files in a ignored directory', function () {
-      const doc = {
-        _id: 'foo/bar',
-        docType: 'file'
-      }
-      new Ignore(['foo']).isIgnored(doc).should.be.true()
-      new Ignore(['foo/']).isIgnored(doc).should.be.true()
+      new Ignore(['foo']).isIgnored({ relativePath: 'foo/bar', isFolder: false }).should.be.true()
+      new Ignore(['foo/']).isIgnored({ relativePath: 'foo/bar', isFolder: false }).should.be.true()
     })
 
     it('ignore folders in a ignored directory', function () {
       const ignore = new Ignore(['foo'])
-      const doc = {
-        _id: 'foo/bar',
-        docType: 'folder'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo/bar', isFolder: true }).should.be.true()
     })
 
     it('match leading slash pattern', function () {
       const ignore = new Ignore(['/foo'])
-      const file = {
-        _id: 'foo',
-        docType: 'folder'
-      }
-      const subfile = {
-        _id: 'bar/foo',
-        docType: 'file'
-      }
-      ignore.isIgnored(file).should.be.true()
-      ignore.isIgnored(subfile).should.be.false()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: true }).should.be.true()
+      ignore.isIgnored({ relativePath: 'bar/foo', isFolder: false }).should.be.false()
     })
 
     it('match nested file with leading **', function () {
       const ignore = new Ignore(['**/baz'])
-      const doc = {
-        _id: 'foo/bar/baz',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo/bar/baz', isFolder: false }).should.be.true()
     })
 
     it('match nested files with trailing **', function () {
       const ignore = new Ignore(['foo/**'])
-      const doc = {
-        _id: 'foo/bar/baz',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo/bar/baz', isFolder: false }).should.be.true()
     })
 
     it('match nested files with middle **', function () {
       const ignore = new Ignore(['a/**/b'])
-      const nestedFile = {
-        _id: 'a/foo/bar/b',
-        docType: 'file'
-      }
-      const unnestedFile = {
-        _id: 'a/b',
-        docType: 'file'
-      }
-      ignore.isIgnored(nestedFile).should.be.true()
-      ignore.isIgnored(unnestedFile).should.be.true()
+      ignore.isIgnored({ relativePath: 'a/foo/bar/b', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'a/b', isFolder: false }).should.be.true()
     })
 
     it("doen't match misnested file with middle **", function () {
       const ignore = new Ignore(['a/**/b'])
-      const doc = {
-        _id: 'foo/a/b',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.false()
+      ignore.isIgnored({ relativePath: 'foo/a/b', isFolder: false }).should.be.false()
     })
   })
 
   describe('Escaping', () => {
     it('escapes the comment character', function () {
       const ignore = new Ignore(['\\#foo'])
-      const doc = {
-        _id: '#foo',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: '#foo', isFolder: false }).should.be.true()
     })
 
     it('escapes the negation character', function () {
       const ignore = new Ignore(['\\!foo'])
-      const doc = {
-        _id: '!foo',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: '!foo', isFolder: false }).should.be.true()
     })
   })
 
   describe('Negate rules', () => {
     it('can negate a rule', () => {
       const ignore = new Ignore(['!foo'])
-      const foo = {
-        _id: 'foo',
-        docType: 'file'
-      }
-      ignore.isIgnored(foo).should.be.false()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.false()
     })
 
     it('can negate a previous rule', function () {
       const ignore = new Ignore(['*.foo', '!bar.foo'])
-      const bar = {
-        _id: 'bar.foo',
-        docType: 'file'
-      }
-      const baz = {
-        _id: 'baz.foo',
-        docType: 'file'
-      }
-      ignore.isIgnored(bar).should.be.false()
-      ignore.isIgnored(baz).should.be.true()
+      ignore.isIgnored({ relativePath: 'bar.foo', isFolder: false }).should.be.false()
+      ignore.isIgnored({ relativePath: 'baz.foo', isFolder: false }).should.be.true()
     })
 
     it('can negate a more complex previous rules organization', function () {
       const ignore = new Ignore(['/*', '!/foo', '/foo/*', '!/foo/bar'])
-      const foobar = {
-        _id: 'foo/bar',
-        docType: 'file'
-      }
-      const foobaz = {
-        _id: 'foo/baz',
-        docType: 'file'
-      }
-      const bazbar = {
-        _id: 'baz/bar',
-        docType: 'file'
-      }
-      ignore.isIgnored(foobar).should.be.false()
-      ignore.isIgnored(foobaz).should.be.true()
-      ignore.isIgnored(bazbar).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo/bar', isFolder: false }).should.be.false()
+      ignore.isIgnored({ relativePath: 'foo/baz', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: 'baz/bar', isFolder: false }).should.be.true()
     })
   })
 
@@ -314,82 +174,46 @@ describe('Ignore', function () {
     it('has some defaults rules for dropbox', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      const doc = {
-        _id: '.dropbox',
-        docType: 'folder'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: '.dropbox', isFolder: true }).should.be.true()
     })
 
     it('has some defaults rules for editors', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      const doc = {
-        _id: 'foo.c.swp~',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'foo.c.swp~', isFolder: false }).should.be.true()
     })
 
     it('has some defaults rules for OSes', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      const doc = {
-        _id: 'Thumbs.db',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'Thumbs.db', isFolder: false }).should.be.true()
     })
 
     it('does ignore Icon', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      const doc = {
-        _id: 'path/to/Icon',
-        docType: 'file'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: 'path/to/Icon', isFolder: false }).should.be.true()
     })
 
     it('does ignore any hidden file or directory', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      const doc = {
-        _id: '.eclipse',
-        docType: 'folder'
-      }
-      ignore.isIgnored(doc).should.be.true()
+      ignore.isIgnored({ relativePath: '.eclipse', isFolder: true }).should.be.true()
     })
 
     it('ignores Microsoft Office temporary files', function () {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      ignore
-        .isIgnored({ _id: metadata.id('~$whatever.docx'), docType: 'file' })
-        .should.be.true()
-      ignore
-        .isIgnored({ _id: metadata.id('~$whatever.xlsx'), docType: 'file' })
-        .should.be.true()
-      ignore
-        .isIgnored({ _id: metadata.id('~$whatever.pptx'), docType: 'file' })
-        .should.be.true()
+      ignore.isIgnored({ relativePath: metadata.id('~$whatever.docx'), isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: metadata.id('~$whatever.xlsx'), isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: metadata.id('~$whatever.pptx'), isFolder: false }).should.be.true()
     })
 
     it('ignores hidden folder $Recycle.bin', () => {
       const ignore = new Ignore([])
       ignore.addDefaultRules()
-      ignore
-        .isIgnored({
-          _id: '$Recycle.bin/foo',
-          type: 'file'
-        })
-        .should.be.true()
-      ignore
-        .isIgnored({
-          _id: '$Recycle.bin',
-          type: 'folder'
-        })
-        .should.be.true()
+      ignore.isIgnored({ relativePath: '$Recycle.bin/foo', isFolder: false }).should.be.true()
+      ignore.isIgnored({ relativePath: '$Recycle.bin', isFolder: true }).should.be.true()
     })
 
     it('can be loaded from file with CRLF', () => {
@@ -398,8 +222,8 @@ describe('Ignore', function () {
       try {
         readFileSync.returns('foo\r\nbar\r\n\r\n')
         should(() => ignore.addDefaultRules()).not.throwError()
-        should(ignore.isIgnored({_id: 'foo'})).be.true()
-        should(ignore.isIgnored({_id: 'bar'})).be.true()
+        should(ignore.isIgnored({ relativePath: 'foo', isFolder: false })).be.true()
+        should(ignore.isIgnored({ relativePath: 'bar', isFolder: false })).be.true()
       } finally {
         readFileSync.restore()
       }
@@ -422,12 +246,7 @@ describe('Ignore', function () {
         value: 'linux'
       })
       const ignore = new Ignore(['Foo'])
-      ignore
-        .isIgnored({
-          _id: 'foo',
-          type: 'file'
-        })
-        .should.be.false()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.false()
     })
 
     it('match files even if case does not match on darwin', () => {
@@ -435,12 +254,7 @@ describe('Ignore', function () {
         value: 'darwin'
       })
       const ignore = new Ignore(['Foo'])
-      ignore
-        .isIgnored({
-          _id: 'foo',
-          type: 'file'
-        })
-        .should.be.true()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.true()
     })
 
     it('match files even if case does not match on darwin', () => {
@@ -448,12 +262,7 @@ describe('Ignore', function () {
         value: 'win32'
       })
       const ignore = new Ignore(['Foo'])
-      ignore
-        .isIgnored({
-          _id: 'foo',
-          type: 'file'
-        })
-        .should.be.true()
+      ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.true()
     })
   })
 })


### PR DESCRIPTION
We're starting to use Ignore#isIgnored with different types of
  "documents" (i.e. Metadata and AtomWatcherEvent) while they don't all
  have the expected `_id` and `docType` properties.

  Since those 2 properties are the only information we need to decide
  whether a "document" should be ignored or not, we can request them as
  parameters so their values can be computed correctly by the caller
  depending on the type of "document" it's dealing with.
  Also, since we'll move to the new Atom Watcher, we'll use its
  EventKind type instead of the current DocType type to determine
  whether the given "document" is a directory or not.

To help transition to the new format, we replace all calls to
  isIgnored for Metadata objects with calls to a new method
  isIgnoredDoc which uses isIgnored internally and maps the document's
  docType to an EventKind.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
