### PR TITLE
core/local: Replace change.fromEvent() with dedicated builders

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -100,7 +100,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
 
             changeFound(
               localChange.fileMoveIdenticalOffline(e) ||
-              localChange.fromEvent(e)
+              localChange.fileAddition(e)
             )
           }
           break
@@ -123,7 +123,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             }
             changeFound(
               localChange.dirMoveIdenticalOffline(e) ||
-              localChange.fromEvent(e)
+              localChange.dirAddition(e)
             )
           }
           break
@@ -148,7 +148,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             break
           }
 
-          changeFound(localChange.fromEvent(e))
+          changeFound(localChange.fileUpdate(e))
           break
         case 'unlink':
           {
@@ -167,7 +167,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               changeFound(localChange.fileMoveFromAddUnlink(addChange, e))
               break
             } else if (getInode(e)) {
-              changeFound(localChange.fromEvent(e))
+              changeFound(localChange.fileDeletion(e))
               break
             }
             const moveChangeSamePath /*: ?LocalFileMove */ = localChange.maybeMoveFile(getChangeByPath(e))
@@ -179,6 +179,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               // $FlowFixMe
               addChangeSamePath.type = 'Ignored'
               delete addChangeSamePath.wip
+              delete addChangeSamePath.md5sum
               break
             }
             // Otherwise, skip unlink event by multiple moves
@@ -199,7 +200,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             if (addChange) {
               changeFound(localChange.dirMoveFromAddUnlink(addChange, e))
             } else if (getInode(e)) {
-              changeFound(localChange.fromEvent(e))
+              changeFound(localChange.dirDeletion(e))
             } else {
               const addChangeSamePath /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByPath(e))
               if (addChangeSamePath && addChangeSamePath.wip) {


### PR DESCRIPTION
Flow typechecking is terribly inaccurate in `local/analysis` & `local/change`.
The `change.fromEvent()` function in particular is messing up flow in unexpected ways.
For example, it prevents using the `?: ...` syntax (vs `: ?...`) in a few type definitions.

Replacing it with dedicated builders is a first necessary step to regain sanity.

The builders currently include some duplication.
But this should be easy to DRY later, once the code is more reliable.

Also the `LocalFileAddition` type is currently lying: `md5sum` is missing when `wip` is `true`.
Fixing it will require quite more work, hence the temporary `delete md5sum` hack when a file
is added then unlinked.