### PR TITLE
test: Cover linux_producer with tests

### DIFF
--- a/test/unit/local/steps/linux_producer.js
+++ b/test/unit/local/steps/linux_producer.js
@@ -4,6 +4,7 @@
 const should = require('should')
 const os = require('os')
 const fs = require('fs')
+const fse = require('fs-extra')
 const path = require('path')
 const { onPlatform } = require('../../../support/helpers/platform')
 const LinuxProducer = require('../../../../core/local/steps/linux_producer')
@@ -169,13 +170,4 @@ onPlatform('linux', () => {
   })
 })
 
-function mkdirsSync (mypath = '/') {
-  mypath.split('/').reduce((acc, folder) => {
-    try {
-      fs.mkdirSync(path.join(acc, folder))
-    } catch (ex) {
-      // `EEXIST ${path.join(acc, folder)}`
-    }
-    return `${acc}/${folder}`
-  }, '/')
-}
+const mkdirsSync = fse.mkdirsSync

--- a/test/unit/local/steps/linux_producer.js
+++ b/test/unit/local/steps/linux_producer.js
@@ -5,9 +5,10 @@ const should = require('should')
 const os = require('os')
 const fs = require('fs')
 const path = require('path')
+const { onPlatform } = require('../../../support/helpers/platform')
 const LinuxProducer = require('../../../../core/local/steps/linux_producer')
 
-if (os.platform() === 'linux') {
+onPlatform('linux', () => {
   describe('core/local/steps/linux_producer', () => {
     describe('API of the producer', () => {
       let syncPath
@@ -174,7 +175,7 @@ if (os.platform() === 'linux') {
       })
     })
   })
-}
+})
 
 function mkdirSyncRecursive (syncPath = '/', mypath = '/') {
   mypath.split('/').reduce((acc, folder) => {

--- a/test/unit/local/steps/linux_producer.js
+++ b/test/unit/local/steps/linux_producer.js
@@ -7,166 +7,174 @@ const fs = require('fs')
 const path = require('path')
 const LinuxProducer = require('../../../../core/local/steps/linux_producer')
 
-describe.only('core/local/steps/linux_producer', () => {
-  describe('API of the producer', () => {
-    let syncPath
-    let producer
+if (os.platform() === 'linux') {
+  describe('core/local/steps/linux_producer', () => {
+    describe('API of the producer', () => {
+      let syncPath
+      let producer
 
-    beforeEach(() => {
-      syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'))
-      producer = new LinuxProducer({
-        syncPath
+      beforeEach(() => {
+        syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'))
+        producer = new LinuxProducer({
+          syncPath
+        })
+      })
+
+      it('should register on start and dispose on stop the watcher', async () => {
+        await producer.start()
+        should(producer.watcher).be.not.null()
+        await producer.stop()
+        should(producer.watcher).be.null()
+      })
+
+      it('should change absolute path to relative with process', async () => {
+        const dirname = 'foobar'
+        const batch = [
+          {
+            action: 'created',
+            kind: 'directory',
+            path: path.join(syncPath, dirname)
+          }
+        ]
+        producer.process(batch.map(evt => Object.assign({}, evt)))
+        should(await producer.buffer.pop()).eql(
+          batch.map(evt => Object.assign({}, evt, { path: dirname }))
+        )
+      })
+
+      it('should scan a subfolder tree', async () => {
+        const mypath = ['foo', 'bar', 'baz']
+        mkdirSyncRecursive(syncPath, mypath.join('/'))
+        await producer.start()
+        should(
+          (await producer.buffer.pop()).map(({ action, kind, path }) => ({
+            action,
+            kind,
+            path
+          }))
+        ).eql([
+          {
+            action: 'scan',
+            kind: 'unknown',
+            path: mypath[0]
+          }
+        ])
+        should(
+          (await producer.buffer.pop()).map(({ action, kind, path }) => ({
+            action,
+            kind,
+            path
+          }))
+        ).eql([
+          {
+            action: 'scan',
+            kind: 'unknown',
+            path: `${mypath[0]}/${mypath[1]}`
+          }
+        ])
+        should(
+          (await producer.buffer.pop()).map(({ action, kind, path }) => ({
+            action,
+            kind,
+            path
+          }))
+        ).eql([
+          {
+            action: 'scan',
+            kind: 'unknown',
+            path: mypath.join('/')
+          }
+        ])
       })
     })
 
-    it('should register on start and dispose on stop the watcher', async () => {
-      await producer.start()
-      should(producer.watcher).be.not.null()
-      await producer.stop()
-      should(producer.watcher).be.null()
-    })
+    describe('register an event on FS events', () => {
+      let syncPath
+      let producer
 
-    it('should change absolute path to relative with process', async () => {
-      const dirname = 'foobar'
-      const batch = [
-        {
-          action: 'created',
-          kind: 'directory',
-          path: path.join(syncPath, dirname)
-        }
-      ]
-      producer.process(batch.map(evt => Object.assign({}, evt)))
-      should(await producer.buffer.pop()).eql(
-        batch.map(evt => Object.assign({}, evt, { path: dirname }))
-      )
-    })
-
-    it('should scan a subfolder tree', async () => {
-      const mypath = ['foo', 'bar', 'baz']
-      mkdirSyncRecursive(syncPath, mypath.join('/'))
-      await producer.start()
-      should(
-        (await producer.buffer.pop()).map(({ action, kind, path }) => ({
-          action,
-          kind,
-          path
-        }))
-      ).eql([
-        {
-          action: 'scan',
-          kind: 'unknown',
-          path: mypath[0]
-        }
-      ])
-      should(
-        (await producer.buffer.pop()).map(({ action, kind, path }) => ({
-          action,
-          kind,
-          path
-        }))
-      ).eql([
-        {
-          action: 'scan',
-          kind: 'unknown',
-          path: `${mypath[0]}/${mypath[1]}`
-        }
-      ])
-      should(
-        (await producer.buffer.pop()).map(({ action, kind, path }) => ({
-          action,
-          kind,
-          path
-        }))
-      ).eql([
-        {
-          action: 'scan',
-          kind: 'unknown',
-          path: mypath.join('/')
-        }
-      ])
-    })
-  })
-
-  describe('register an event on FS events', () => {
-    let syncPath
-    let producer
-
-    before(async () => {
-      syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'))
-      producer = new LinuxProducer({
-        syncPath
+      before(async () => {
+        syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'))
+        producer = new LinuxProducer({
+          syncPath
+        })
+        await producer.start()
+        await producer.buffer.pop()
       })
-      await producer.start()
-      await producer.buffer.pop()
-    })
 
-    it('detect events on folder in temp dir', async () => {
-      const dirname = 'foobaz'
-      const newname = 'foobarbaz'
-      fs.mkdirSync(path.join(syncPath, dirname))
-      should(await producer.buffer.pop()).eql([
-        {
-          action: 'created',
-          kind: 'directory',
-          path: dirname
-        }
-      ])
-      fs.renameSync(path.join(syncPath, dirname), path.join(syncPath, newname))
-      should(await producer.buffer.pop()).eql([
-        {
-          action: 'renamed',
-          kind: 'directory',
-          oldPath: dirname,
-          path: newname
-        }
-      ])
-      fs.rmdirSync(path.join(syncPath, newname))
-      should(await producer.buffer.pop()).eql([
-        {
-          action: 'deleted',
-          kind: 'directory',
-          path: newname
-        }
-      ])
-    })
+      it('detect events on folder in temp dir', async () => {
+        const dirname = 'foobaz'
+        const newname = 'foobarbaz'
+        fs.mkdirSync(path.join(syncPath, dirname))
+        should(await producer.buffer.pop()).eql([
+          {
+            action: 'created',
+            kind: 'directory',
+            path: dirname
+          }
+        ])
+        fs.renameSync(
+          path.join(syncPath, dirname),
+          path.join(syncPath, newname)
+        )
+        should(await producer.buffer.pop()).eql([
+          {
+            action: 'renamed',
+            kind: 'directory',
+            oldPath: dirname,
+            path: newname
+          }
+        ])
+        fs.rmdirSync(path.join(syncPath, newname))
+        should(await producer.buffer.pop()).eql([
+          {
+            action: 'deleted',
+            kind: 'directory',
+            path: newname
+          }
+        ])
+      })
 
-    it('detect events on file in temp dir', async () => {
-      const filename = 'barbaz'
-      const newname = 'barfoobaz'
-      const content = 'Hello, Cozy Drive for Desktop'
-      fs.writeFileSync(path.join(syncPath, filename), content)
-      should(await producer.buffer.pop()).eql([
-        {
-          action: 'created',
-          kind: 'file',
-          path: filename
-        },
-        {
-          action: 'modified',
-          kind: 'file',
-          path: filename
-        }
-      ])
-      fs.renameSync(path.join(syncPath, filename), path.join(syncPath, newname))
-      should(await producer.buffer.pop()).eql([
-        {
-          action: 'renamed',
-          kind: 'file',
-          oldPath: 'barbaz',
-          path: 'barfoobaz'
-        }
-      ])
-      fs.unlinkSync(path.join(syncPath, newname))
-      should(await producer.buffer.pop()).eql([
-        {
-          action: 'deleted',
-          kind: 'file',
-          path: newname
-        }
-      ])
+      it('detect events on file in temp dir', async () => {
+        const filename = 'barbaz'
+        const newname = 'barfoobaz'
+        const content = 'Hello, Cozy Drive for Desktop'
+        fs.writeFileSync(path.join(syncPath, filename), content)
+        should(await producer.buffer.pop()).eql([
+          {
+            action: 'created',
+            kind: 'file',
+            path: filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: filename
+          }
+        ])
+        fs.renameSync(
+          path.join(syncPath, filename),
+          path.join(syncPath, newname)
+        )
+        should(await producer.buffer.pop()).eql([
+          {
+            action: 'renamed',
+            kind: 'file',
+            oldPath: 'barbaz',
+            path: 'barfoobaz'
+          }
+        ])
+        fs.unlinkSync(path.join(syncPath, newname))
+        should(await producer.buffer.pop()).eql([
+          {
+            action: 'deleted',
+            kind: 'file',
+            path: newname
+          }
+        ])
+      })
     })
   })
-})
+}
 
 function mkdirSyncRecursive (syncPath = '/', mypath = '/') {
   mypath.split('/').reduce((acc, folder) => {

--- a/test/unit/local/steps/linux_producer.js
+++ b/test/unit/local/steps/linux_producer.js
@@ -47,45 +47,37 @@ onPlatform('linux', () => {
         const mypath = ['foo', 'bar', 'baz']
         mkdirSyncRecursive(syncPath, mypath.join('/'))
         await producer.start()
-        should(
-          (await producer.buffer.pop()).map(({ action, kind, path }) => ({
-            action,
-            kind,
-            path
-          }))
-        ).eql([
+
+        const batches = [
           {
-            action: 'scan',
-            kind: 'unknown',
-            path: mypath[0]
-          }
-        ])
-        should(
-          (await producer.buffer.pop()).map(({ action, kind, path }) => ({
-            action,
-            kind,
-            path
-          }))
-        ).eql([
+            batch: await producer.buffer.pop(),
+            path: path.join(mypath[0])
+          },
           {
-            action: 'scan',
-            kind: 'unknown',
-            path: `${mypath[0]}/${mypath[1]}`
-          }
-        ])
-        should(
-          (await producer.buffer.pop()).map(({ action, kind, path }) => ({
-            action,
-            kind,
-            path
-          }))
-        ).eql([
+            batch: await producer.buffer.pop(),
+            path: path.join(mypath[0], mypath[1])
+          },
           {
-            action: 'scan',
-            kind: 'unknown',
-            path: mypath.join('/')
+            batch: await producer.buffer.pop(),
+            path: path.join(mypath[0], mypath[1], mypath[2])
           }
-        ])
+        ]
+
+        batches.forEach(({ batch, path: originalPath }) => {
+          should(
+            batch.map(({ action, kind, path }) => ({
+              action,
+              kind,
+              path
+            }))
+          ).eql([
+            {
+              action: 'scan',
+              kind: 'unknown',
+              path: originalPath
+            }
+          ])
+        })
       })
     })
 

--- a/test/unit/local/steps/linux_producer.js
+++ b/test/unit/local/steps/linux_producer.js
@@ -1,0 +1,176 @@
+/* eslint-env mocha */
+/* @flow */
+
+const should = require('should')
+const os = require('os')
+const fs = require('fs')
+const path = require('path')
+const LinuxProducer = require('../../../../core/local/steps/linux_producer')
+
+describe.only('core/local/steps/linux_producer', () => {
+  describe('API of the producer', () => {
+    let syncPath
+    let producer
+
+    beforeEach(() => {
+      syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'))
+      producer = new LinuxProducer({
+        syncPath
+      })
+    })
+
+    it('should register on start and dispose on stop the watcher', async () => {
+      await producer.start()
+      should(producer.watcher).be.not.null()
+      await producer.stop()
+      should(producer.watcher).be.null()
+    })
+
+    it('should change absolute path to relative with process', async () => {
+      const dirname = 'foobar'
+      const batch = [
+        {
+          action: 'created',
+          kind: 'directory',
+          path: path.join(syncPath, dirname)
+        }
+      ]
+      producer.process(batch.map(evt => Object.assign({}, evt)))
+      should(await producer.buffer.pop()).eql(
+        batch.map(evt => Object.assign({}, evt, { path: dirname }))
+      )
+    })
+
+    it('should scan a subfolder tree', async () => {
+      const mypath = ['foo', 'bar', 'baz']
+      mkdirSyncRecursive(syncPath, mypath.join('/'))
+      await producer.start()
+      should(
+        (await producer.buffer.pop()).map(({ action, kind, path }) => ({
+          action,
+          kind,
+          path
+        }))
+      ).eql([
+        {
+          action: 'scan',
+          kind: 'unknown',
+          path: mypath[0]
+        }
+      ])
+      should(
+        (await producer.buffer.pop()).map(({ action, kind, path }) => ({
+          action,
+          kind,
+          path
+        }))
+      ).eql([
+        {
+          action: 'scan',
+          kind: 'unknown',
+          path: `${mypath[0]}/${mypath[1]}`
+        }
+      ])
+      should(
+        (await producer.buffer.pop()).map(({ action, kind, path }) => ({
+          action,
+          kind,
+          path
+        }))
+      ).eql([
+        {
+          action: 'scan',
+          kind: 'unknown',
+          path: mypath.join('/')
+        }
+      ])
+    })
+  })
+
+  describe('register an event on FS events', () => {
+    let syncPath
+    let producer
+
+    before(async () => {
+      syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'))
+      producer = new LinuxProducer({
+        syncPath
+      })
+      await producer.start()
+      await producer.buffer.pop()
+    })
+
+    it('detect events on folder in temp dir', async () => {
+      const dirname = 'foobaz'
+      const newname = 'foobarbaz'
+      fs.mkdirSync(path.join(syncPath, dirname))
+      should(await producer.buffer.pop()).eql([
+        {
+          action: 'created',
+          kind: 'directory',
+          path: dirname
+        }
+      ])
+      fs.renameSync(path.join(syncPath, dirname), path.join(syncPath, newname))
+      should(await producer.buffer.pop()).eql([
+        {
+          action: 'renamed',
+          kind: 'directory',
+          oldPath: dirname,
+          path: newname
+        }
+      ])
+      fs.rmdirSync(path.join(syncPath, newname))
+      should(await producer.buffer.pop()).eql([
+        {
+          action: 'deleted',
+          kind: 'directory',
+          path: newname
+        }
+      ])
+    })
+
+    it('detect events on file in temp dir', async () => {
+      const filename = 'barbaz'
+      const newname = 'barfoobaz'
+      const content = 'Hello, Cozy Drive for Desktop'
+      fs.writeFileSync(path.join(syncPath, filename), content)
+      should(await producer.buffer.pop()).eql([
+        {
+          action: 'created',
+          kind: 'file',
+          path: filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: filename
+        }
+      ])
+      fs.renameSync(path.join(syncPath, filename), path.join(syncPath, newname))
+      should(await producer.buffer.pop()).eql([
+        {
+          action: 'renamed',
+          kind: 'file',
+          oldPath: 'barbaz',
+          path: 'barfoobaz'
+        }
+      ])
+      fs.unlinkSync(path.join(syncPath, newname))
+      should(await producer.buffer.pop()).eql([
+        {
+          action: 'deleted',
+          kind: 'file',
+          path: newname
+        }
+      ])
+    })
+  })
+})
+
+function mkdirSyncRecursive (syncPath = '/', mypath = '/') {
+  mypath.split('/').reduce((acc, folder) => {
+    fs.mkdirSync(path.join(acc, folder))
+    return `${acc}/${folder}`
+  }, syncPath)
+}

--- a/test/unit/local/steps/linux_producer.js
+++ b/test/unit/local/steps/linux_producer.js
@@ -45,7 +45,7 @@ onPlatform('linux', () => {
 
       it('should scan a subfolder tree', async () => {
         const mypath = ['foo', 'bar', 'baz']
-        mkdirSyncRecursive(syncPath, mypath.join('/'))
+        mkdirsSync(path.join(syncPath, ...mypath))
         await producer.start()
 
         const batches = [
@@ -169,9 +169,13 @@ onPlatform('linux', () => {
   })
 })
 
-function mkdirSyncRecursive (syncPath = '/', mypath = '/') {
+function mkdirsSync (mypath = '/') {
   mypath.split('/').reduce((acc, folder) => {
-    fs.mkdirSync(path.join(acc, folder))
+    try {
+      fs.mkdirSync(path.join(acc, folder))
+    } catch (ex) {
+      // `EEXIST ${path.join(acc, folder)}`
+    }
     return `${acc}/${folder}`
-  }, syncPath)
+  }, '/')
 }


### PR DESCRIPTION
This PR aims to cover `core/local/steps/linux_producer.js`.
It uses temporary folder to create folders and files in an asynchronous mode.
I tried to stay clear by reducing variable declaration, but let me know if reviewers think it will be clearer to name variable.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [ ] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation