### PR TITLE
Revert "Enable atom/watcher by default for Windows and Linux"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,6 @@ clone_depth: 10
 environment:
   MOCHA_TIMEOUT: "60000"
   NO_BREAKPOINTS: "1"
-  COZY_FS_WATCHER: "chokidar"
   matrix:
       - BUILD_JOB: "short_tests"
       - BUILD_JOB: "scenarios_build"

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -2,6 +2,7 @@
 
 const AtomWatcher = require('./atom_watcher')
 const ChokidarWatcher = require('./chokidar_watcher')
+const logger = require('../logger')
 
 /*::
 import type Pouch from '../pouch'
@@ -11,8 +12,6 @@ import type { Ignore } from '../ignore'
 import type { ChokidarEvent } from './chokidar_event'
 import type { Checksumer } from './checksumer'
 
-type WatcherType = 'atom' | 'chokidar'
-
 export interface Watcher {
   checksumer: Checksumer,
   running: Promise<*>,
@@ -21,33 +20,20 @@ export interface Watcher {
 }
 */
 
-function userDefinedWatcherType (env) /*: WatcherType | null */ {
-  const { COZY_FS_WATCHER } = env
-  if (COZY_FS_WATCHER === 'atom') {
-    return 'atom'
-  } else if (COZY_FS_WATCHER === 'chokidar') {
-    return 'chokidar'
-  }
-  return null
-}
-
-function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ {
-  if (platform === 'darwin') {
-    return 'chokidar'
-  }
-  return 'atom'
-}
+const log = logger({
+  component: 'LocalWatcher'
+})
 
 function build (syncPath /*: string */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
-  const watcherType = (
-    userDefinedWatcherType(process.env) ||
-    platformDefaultWatcherType(process.platform)
-  )
-  if (watcherType === 'atom') {
-    return new AtomWatcher(syncPath, prep, pouch, events, ignore)
-  } else {
-    return new ChokidarWatcher(syncPath, prep, pouch, events)
+  const env = process.env.COZY_FS_WATCHER
+  if (['experimental', 'atom'].includes(env)) {
+    try {
+      return new AtomWatcher(syncPath, prep, pouch, events, ignore)
+    } catch (err) {
+      log.error({err}, 'Cannot use AtomWatcher')
+    }
   }
+  return new ChokidarWatcher(syncPath, prep, pouch, events)
 }
 
 module.exports = { build }

--- a/dev/ci/scenarios.sh
+++ b/dev/ci/scenarios.sh
@@ -4,9 +4,5 @@ set -ex
 
 . "./dev/ci/start_xvfb.sh"
 
-# FIXME Scenario tests use ChokidarEvents and onFlush
-# So, they are not yet compatible with atom/watcher
-export COZY_FS_WATCHER=chokidar
-
 yarn install:electron
 yarn test:scenarios --timeout $MOCHA_TIMEOUT --forbid-only

--- a/dev/ci/tests.sh
+++ b/dev/ci/tests.sh
@@ -4,10 +4,6 @@ set -ex
 
 . "./dev/ci/start_xvfb.sh"
 
-# FIXME Integration tests use ChokidarEvents and onFlush
-# So, they are not yet compatible with atom/watcher
-export COZY_FS_WATCHER=chokidar
-
 yarn install:all
 yarn build:elm
 yarn lint


### PR DESCRIPTION
Reverts cozy-labs/cozy-desktop#1381.

We're not ready for a public release of the new watcher so we'll revert its activation prior to the next public release.