### PR TITLE
core/config: Fix harmless error on load

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -27,7 +27,9 @@ module.exports = class Config {
   // Load a config JSON file or return an empty object
   static safeLoad (configPath) {
     try {
-      return fse.readJSONSync(configPath)
+      const content = fs.readFileSync(configPath, 'utf8')
+      if (content === '') return {}
+      return JSON.parse(content)
     } catch (e) {
       if (e instanceof SyntaxError) {
         log.error(`Could not read config file at ${configPath}:`, e)

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -114,6 +114,22 @@ describe('Config', function () {
       })
     })
 
+    context('when the file is empty', function () {
+      beforeEach('create empty file', function () {
+        fse.writeFileSync(this.config.configPath, '')
+      })
+
+      it('returns an empty object', function () {
+        const config = Config.safeLoad(this.config.configPath)
+        should(config).deepEqual({})
+      })
+
+      it('does not delete it', function () {
+        Config.safeLoad(this.config.configPath)
+        should(fse.existsSync(this.config.configPath)).be.true()
+      })
+    })
+
     context('when the file content is not valid JSON', function () {
       beforeEach('write invalid content', function () {
         fse.writeFileSync(this.config.configPath, '\0')


### PR DESCRIPTION
The constructor ensures the config file exists, even if empty.
So ending up with a JSON.parse error because it is, then deleting it
doesn't really make sense...

Also logging a harmless error didn't help debugging.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
