### PR TITLE
core/local/analysis: Intermediate refactoring

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -181,21 +181,23 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               break
             }
           }
-          withChangeByPath(e, samePathChange => {
-            const moveChangeSamePath /*: ?LocalFileMove */ = localChange.maybeMoveFile(samePathChange)
-            if (moveChangeSamePath && moveChangeSamePath.md5sum == null) { // FIXME: if change && change.wip?
-              localChange.convertFileMoveToDeletion(moveChangeSamePath)
-              return
-            }
-            const addChangeSamePath /*: ?LocalFileAddition */ = localChange.maybeAddFile(samePathChange)
-            if (addChangeSamePath && addChangeSamePath.wip) {
-              // $FlowFixMe
-              addChangeSamePath.type = 'Ignored'
-              delete addChangeSamePath.wip
-              delete addChangeSamePath.md5sum
-            }
-            // Otherwise, skip unlink event by multiple moves
-          })
+          changeFound(
+            withChangeByPath(e, samePathChange => {
+              const moveChangeSamePath /*: ?LocalFileMove */ = localChange.maybeMoveFile(samePathChange)
+              if (moveChangeSamePath && moveChangeSamePath.md5sum == null) { // FIXME: if change && change.wip?
+                localChange.convertFileMoveToDeletion(moveChangeSamePath)
+                return
+              }
+              const addChangeSamePath /*: ?LocalFileAddition */ = localChange.maybeAddFile(samePathChange)
+              if (addChangeSamePath && addChangeSamePath.wip) {
+                // $FlowFixMe
+                addChangeSamePath.type = 'Ignored'
+                delete addChangeSamePath.wip
+                delete addChangeSamePath.md5sum
+              }
+              // Otherwise, skip unlink event by multiple moves
+            })
+          )
           break
         case 'unlinkDir':
           {
@@ -218,21 +220,23 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               break
             }
           }
-          withChangeByPath(e, samePathChange => {
-            const addChangeSamePath /*: ?LocalDirAddition */ = localChange.maybePutFolder(samePathChange)
-            if (addChangeSamePath && addChangeSamePath.wip) {
-              log.debug({path: addChangeSamePath.path, ino: addChangeSamePath.ino},
-                'Folder was added then deleted. Ignoring add.')
-              // $FlowFixMe
-              addChangeSamePath.type = 'Ignored'
-              return
-            }
+          changeFound(
+            withChangeByPath(e, samePathChange => {
+              const addChangeSamePath /*: ?LocalDirAddition */ = localChange.maybePutFolder(samePathChange)
+              if (addChangeSamePath && addChangeSamePath.wip) {
+                log.debug({path: addChangeSamePath.path, ino: addChangeSamePath.ino},
+                  'Folder was added then deleted. Ignoring add.')
+                // $FlowFixMe
+                addChangeSamePath.type = 'Ignored'
+                return
+              }
 
-            const moveChangeSamePath /*: ?LocalDirMove */ = localChange.maybeMoveFolder(samePathChange)
-            if (moveChangeSamePath && moveChangeSamePath.wip) {
-              localChange.convertDirMoveToDeletion(moveChangeSamePath)
-            }
-          })
+              const moveChangeSamePath /*: ?LocalDirMove */ = localChange.maybeMoveFolder(samePathChange)
+              if (moveChangeSamePath && moveChangeSamePath.wip) {
+                localChange.convertDirMoveToDeletion(moveChangeSamePath)
+              }
+            })
+          )
           break
         default:
           throw new TypeError(`Unknown event type: ${e.type}`)

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -53,7 +53,11 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
   const getChangeByPath = (e) => {
     return changesByPath.get(e.path)
   }
-  const changeFound = (c /*: LocalChange | true */) => {
+  const changeFound = (c /*: ?LocalChange | true */) => {
+    if (c == null) {
+      // No change was found. Nothing to do.
+      return
+    }
     if (c === true) {
       // A previous change was transformed. Nothing more to index.
       return

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -173,6 +173,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             const moveChangeSamePath /*: ?LocalFileMove */ = localChange.maybeMoveFile(getChangeByPath(e))
             if (moveChangeSamePath && moveChangeSamePath.md5sum == null) { // FIXME: if change && change.wip?
               localChange.convertFileMoveToDeletion(moveChangeSamePath)
+              break
             }
             const addChangeSamePath /*: ?LocalFileAddition */ = localChange.maybeAddFile(getChangeByPath(e))
             if (addChangeSamePath && addChangeSamePath.wip) {
@@ -180,7 +181,6 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               addChangeSamePath.type = 'Ignored'
               delete addChangeSamePath.wip
               delete addChangeSamePath.md5sum
-              break
             }
             // Otherwise, skip unlink event by multiple moves
           }
@@ -211,6 +211,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 'Folder was added then deleted. Ignoring add.')
               // $FlowFixMe
               addChangeSamePath.type = 'Ignored'
+              break
             }
 
             const moveChangeSamePath /*: ?LocalDirMove */ = localChange.maybeMoveFolder(getChangeByPath(e))

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -53,7 +53,11 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
   const getChangeByPath = (e) => {
     return changesByPath.get(e.path)
   }
-  const changeFound = (c /*: LocalChange */) => {
+  const changeFound = (c /*: LocalChange | true */) => {
+    if (c === true) {
+      // A previous change was transformed. Nothing more to index.
+      return
+    }
     changesByPath.set(c.path, c)
     if (typeof c.ino === 'number') changesByInode.set(c.ino, c)
     else changes.push(c)

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -199,21 +199,23 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByInode(e))
             if (addChange) {
               changeFound(localChange.dirMoveFromAddUnlink(addChange, e))
-            } else if (getInode(e)) {
+              break
+            }
+            if (getInode(e)) {
               changeFound(localChange.dirDeletion(e))
-            } else {
-              const addChangeSamePath /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByPath(e))
-              if (addChangeSamePath && addChangeSamePath.wip) {
-                log.debug({path: addChangeSamePath.path, ino: addChangeSamePath.ino},
-                  'Folder was added then deleted. Ignoring add.')
-                // $FlowFixMe
-                addChangeSamePath.type = 'Ignored'
-              }
+              break
+            }
+            const addChangeSamePath /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByPath(e))
+            if (addChangeSamePath && addChangeSamePath.wip) {
+              log.debug({path: addChangeSamePath.path, ino: addChangeSamePath.ino},
+                'Folder was added then deleted. Ignoring add.')
+              // $FlowFixMe
+              addChangeSamePath.type = 'Ignored'
+            }
 
-              const moveChangeSamePath /*: ?LocalDirMove */ = localChange.maybeMoveFolder(getChangeByPath(e))
-              if (moveChangeSamePath && moveChangeSamePath.wip) {
-                localChange.convertDirMoveToDeletion(moveChangeSamePath)
-              }
+            const moveChangeSamePath /*: ?LocalDirMove */ = localChange.maybeMoveFolder(getChangeByPath(e))
+            if (moveChangeSamePath && moveChangeSamePath.wip) {
+              localChange.convertDirMoveToDeletion(moveChangeSamePath)
             }
           }
           break

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -91,16 +91,18 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
         e.type = 'unlinkDir'
       }
 
+      const sameInodeChange = getChangeByInode(e)
+
       switch (e.type) {
         case 'add':
           {
-            const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(getChangeByInode(e))
+            const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(sameInodeChange)
             if (moveChange) {
               localChange.includeAddEventInFileMove(moveChange, e)
               break
             }
 
-            const unlinkChange /*: ?LocalFileDeletion */ = localChange.maybeDeleteFile(getChangeByInode(e))
+            const unlinkChange /*: ?LocalFileDeletion */ = localChange.maybeDeleteFile(sameInodeChange)
             if (unlinkChange) {
               changeFound(localChange.fileMoveFromUnlinkAdd(unlinkChange, e))
               break
@@ -114,17 +116,17 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           break
         case 'addDir':
           {
-            const moveChange /*: ?LocalDirMove */ = localChange.maybeMoveFolder(getChangeByInode(e))
+            const moveChange /*: ?LocalDirMove */ = localChange.maybeMoveFolder(sameInodeChange)
             if (moveChange) {
               localChange.includeAddDirEventInDirMove(moveChange, e)
               break
             }
-            const unlinkChange /*: ?LocalDirDeletion */ = localChange.maybeDeleteFolder(getChangeByInode(e))
+            const unlinkChange /*: ?LocalDirDeletion */ = localChange.maybeDeleteFolder(sameInodeChange)
             if (unlinkChange) {
               changeFound(localChange.dirMoveFromUnlinkAdd(unlinkChange, e))
               break
             }
-            const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByInode(e))
+            const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(sameInodeChange)
             if (addChange && metadata.id(addChange.path) === metadata.id(e.path) && addChange.path !== e.path) {
               changeFound(localChange.dirRenamingCaseOnlyFromAddAdd(addChange, e))
               break
@@ -136,21 +138,21 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           }
           break
         case 'change':
-          const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(getChangeByInode(e))
+          const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(sameInodeChange)
           if (moveChange) {
             localChange.includeChangeEventIntoFileMove(moveChange, e)
             break
           }
 
           // There was an unlink on the same file, this is most probably a move and replace
-          const unlinkChange /*: ?LocalFileDeletion */ = localChange.maybeDeleteFile(getChangeByInode(e))
+          const unlinkChange /*: ?LocalFileDeletion */ = localChange.maybeDeleteFile(sameInodeChange)
           if (unlinkChange) {
             const moveChange = localChange.fileMoveFromFileDeletionChange(unlinkChange, e)
             changeFound(moveChange)
             break
           }
 
-          const addChange /*: ?LocalFileAddition */ = localChange.maybeAddFile(getChangeByInode(e))
+          const addChange /*: ?LocalFileAddition */ = localChange.maybeAddFile(sameInodeChange)
           if (addChange && metadata.id(addChange.path) === metadata.id(e.path) && addChange.path !== e.path) {
             changeFound(localChange.fileMoveIdentical(addChange, e))
             break
@@ -160,7 +162,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           break
         case 'unlink':
           {
-            const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(getChangeByInode(e))
+            const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(sameInodeChange)
             /* istanbul ignore next */
             if (moveChange) {
               // TODO: Pending move
@@ -169,7 +171,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 'checksumless adds and inode-less unlink events are dropped')
             }
 
-            const addChange /*: ?LocalFileAddition */ = localChange.maybeAddFile(getChangeByInode(e))
+            const addChange /*: ?LocalFileAddition */ = localChange.maybeAddFile(sameInodeChange)
             if (addChange) {
               // TODO: pending move
               changeFound(localChange.fileMoveFromAddUnlink(addChange, e))
@@ -195,7 +197,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           break
         case 'unlinkDir':
           {
-            const moveChange /*: ?LocalDirMove */ = localChange.maybeMoveFolder(getChangeByInode(e))
+            const moveChange /*: ?LocalDirMove */ = localChange.maybeMoveFolder(sameInodeChange)
             /* istanbul ignore next */
             if (moveChange) {
               // TODO: pending move
@@ -204,7 +206,7 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 'non-existing addDir and inode-less unlinkDir events are dropped')
             }
 
-            const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(getChangeByInode(e))
+            const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(sameInodeChange)
             if (addChange) {
               changeFound(localChange.dirMoveFromAddUnlink(addChange, e))
               break


### PR DESCRIPTION
This refactoring is a first necessary step to simplify the deeply nested conditionals in analysis (in upcoming #1396). The values newly accepted by `changeFound()` feel a bit weird, but this will be improved in a subsequent PR (they will either be replaced by something more meaningful, or dropped because not necessary anymore).

Please see commit messages for the motivation behind each change.