### PR TITLE
core/local/analysis: Conditionals refactoring

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -102,13 +102,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               break
             }
 
-            const unlinkChange /*: ?LocalFileDeletion */ = localChange.maybeDeleteFile(sameInodeChange)
-            if (unlinkChange) {
-              changeFound(localChange.fileMoveFromUnlinkAdd(unlinkChange, e))
-              break
-            }
-
             changeFound(
+              localChange.fileMoveFromUnlinkAdd(sameInodeChange, e) ||
               localChange.fileMoveIdenticalOffline(e) ||
               localChange.fileAddition(e)
             )

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -122,15 +122,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             break
           }
 
-          // There was an unlink on the same file, this is most probably a move and replace
-          const unlinkChange /*: ?LocalFileDeletion */ = localChange.maybeDeleteFile(sameInodeChange)
-          if (unlinkChange) {
-            const moveChange = localChange.fileMoveFromFileDeletionChange(unlinkChange, e)
-            changeFound(moveChange)
-            break
-          }
-
           changeFound(
+            localChange.fileMoveFromFileDeletionChange(sameInodeChange, e) ||
             localChange.fileMoveIdentical(sameInodeChange, e) ||
             localChange.fileUpdate(e)
           )

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -139,12 +139,10 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               // TODO: pending move
               changeFound(localChange.fileMoveFromAddUnlink(addChange, e))
               break
-            } else if (getInode(e)) {
-              changeFound(localChange.fileDeletion(e))
-              break
             }
           }
           changeFound(
+            localChange.fileDeletion(e) ||
             withChangeByPath(e, samePathChange => {
               return (
                 localChange.convertFileMoveToDeletion(samePathChange) ||

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -116,12 +116,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               changeFound(localChange.dirMoveFromUnlinkAdd(unlinkChange, e))
               break
             }
-            const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(sameInodeChange)
-            if (addChange && metadata.id(addChange.path) === metadata.id(e.path) && addChange.path !== e.path) {
-              changeFound(localChange.dirRenamingCaseOnlyFromAddAdd(addChange, e))
-              break
-            }
             changeFound(
+              localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||
               localChange.dirMoveIdenticalOffline(e) ||
               localChange.dirAddition(e)
             )

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -6,7 +6,6 @@ const _ = require('lodash')
 const { getInode } = require('./event')
 const localChange = require('./change')
 const logger = require('../logger')
-const metadata = require('../metadata')
 const measureTime = require('../perftools')
 
 /*::
@@ -95,25 +94,21 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
 
       switch (e.type) {
         case 'add':
-          {
-            changeFound(
-              localChange.includeAddEventInFileMove(sameInodeChange, e) ||
-              localChange.fileMoveFromUnlinkAdd(sameInodeChange, e) ||
-              localChange.fileMoveIdenticalOffline(e) ||
-              localChange.fileAddition(e)
-            )
-          }
+          changeFound(
+            localChange.includeAddEventInFileMove(sameInodeChange, e) ||
+            localChange.fileMoveFromUnlinkAdd(sameInodeChange, e) ||
+            localChange.fileMoveIdenticalOffline(e) ||
+            localChange.fileAddition(e)
+          )
           break
         case 'addDir':
-          {
-            changeFound(
-              localChange.includeAddDirEventInDirMove(sameInodeChange, e) ||
-              localChange.dirMoveFromUnlinkAdd(sameInodeChange, e) ||
-              localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||
-              localChange.dirMoveIdenticalOffline(e) ||
-              localChange.dirAddition(e)
-            )
-          }
+          changeFound(
+            localChange.includeAddDirEventInDirMove(sameInodeChange, e) ||
+            localChange.dirMoveFromUnlinkAdd(sameInodeChange, e) ||
+            localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||
+            localChange.dirMoveIdenticalOffline(e) ||
+            localChange.dirAddition(e)
+          )
           break
         case 'change':
           changeFound(

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -151,13 +151,9 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 localChange.convertFileMoveToDeletion(moveChangeSamePath)
                 return
               }
-              const addChangeSamePath /*: ?LocalFileAddition */ = localChange.maybeAddFile(samePathChange)
-              if (addChangeSamePath && addChangeSamePath.wip) {
-                // $FlowFixMe
-                addChangeSamePath.type = 'Ignored'
-                delete addChangeSamePath.wip
-                delete addChangeSamePath.md5sum
-              }
+              return (
+                localChange.ignoreFileAdditionThenDeletion(samePathChange)
+              )
               // Otherwise, skip unlink event by multiple moves
             })
           )

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -96,13 +96,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
       switch (e.type) {
         case 'add':
           {
-            const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(sameInodeChange)
-            if (moveChange) {
-              localChange.includeAddEventInFileMove(moveChange, e)
-              break
-            }
-
             changeFound(
+              localChange.includeAddEventInFileMove(sameInodeChange, e) ||
               localChange.fileMoveFromUnlinkAdd(sameInodeChange, e) ||
               localChange.fileMoveIdenticalOffline(e) ||
               localChange.fileAddition(e)

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -137,13 +137,11 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           changeFound(
             localChange.fileMoveFromAddUnlink(sameInodeChange, e) ||
             localChange.fileDeletion(e) ||
-            withChangeByPath(e, samePathChange => {
-              return (
-                localChange.convertFileMoveToDeletion(samePathChange) ||
-                localChange.ignoreFileAdditionThenDeletion(samePathChange)
-              )
+            withChangeByPath(e, samePathChange => (
+              localChange.convertFileMoveToDeletion(samePathChange) ||
+              localChange.ignoreFileAdditionThenDeletion(samePathChange)
               // Otherwise, skip unlink event by multiple moves
-            })
+            ))
           )
           break
         case 'unlinkDir':
@@ -160,12 +158,10 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           changeFound(
             localChange.dirMoveFromAddUnlink(sameInodeChange, e) ||
             localChange.dirDeletion(e) ||
-            withChangeByPath(e, samePathChange => {
-              return (
-                localChange.ignoreDirAdditionThenDeletion(samePathChange) ||
-                localChange.convertDirMoveToDeletion(samePathChange)
-              )
-            })
+            withChangeByPath(e, samePathChange => (
+              localChange.ignoreDirAdditionThenDeletion(samePathChange) ||
+              localChange.convertDirMoveToDeletion(samePathChange)
+            ))
           )
           break
         default:

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -185,16 +185,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           }
           changeFound(
             withChangeByPath(e, samePathChange => {
-              const addChangeSamePath /*: ?LocalDirAddition */ = localChange.maybePutFolder(samePathChange)
-              if (addChangeSamePath && addChangeSamePath.wip) {
-                log.debug({path: addChangeSamePath.path, ino: addChangeSamePath.ino},
-                  'Folder was added then deleted. Ignoring add.')
-                // $FlowFixMe
-                addChangeSamePath.type = 'Ignored'
-                return
-              }
-
               return (
+                localChange.ignoreDirAdditionThenDeletion(samePathChange) ||
                 localChange.convertDirMoveToDeletion(samePathChange)
               )
             })

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -146,12 +146,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           }
           changeFound(
             withChangeByPath(e, samePathChange => {
-              const moveChangeSamePath /*: ?LocalFileMove */ = localChange.maybeMoveFile(samePathChange)
-              if (moveChangeSamePath && moveChangeSamePath.md5sum == null) { // FIXME: if change && change.wip?
-                localChange.convertFileMoveToDeletion(moveChangeSamePath)
-                return
-              }
               return (
+                localChange.convertFileMoveToDeletion(samePathChange) ||
                 localChange.ignoreFileAdditionThenDeletion(samePathChange)
               )
               // Otherwise, skip unlink event by multiple moves

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -116,13 +116,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           }
           break
         case 'change':
-          const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(sameInodeChange)
-          if (moveChange) {
-            localChange.includeChangeEventIntoFileMove(moveChange, e)
-            break
-          }
-
           changeFound(
+            localChange.includeChangeEventIntoFileMove(sameInodeChange, e) ||
             localChange.fileMoveFromFileDeletionChange(sameInodeChange, e) ||
             localChange.fileMoveIdentical(sameInodeChange, e) ||
             localChange.fileUpdate(e)

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -130,13 +130,10 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
             break
           }
 
-          const addChange /*: ?LocalFileAddition */ = localChange.maybeAddFile(sameInodeChange)
-          if (addChange && metadata.id(addChange.path) === metadata.id(e.path) && addChange.path !== e.path) {
-            changeFound(localChange.fileMoveIdentical(addChange, e))
-            break
-          }
-
-          changeFound(localChange.fileUpdate(e))
+          changeFound(
+            localChange.fileMoveIdentical(sameInodeChange, e) ||
+            localChange.fileUpdate(e)
+          )
           break
         case 'unlink':
           {

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -170,12 +170,9 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               changeFound(localChange.dirMoveFromAddUnlink(addChange, e))
               break
             }
-            if (getInode(e)) {
-              changeFound(localChange.dirDeletion(e))
-              break
-            }
           }
           changeFound(
+            localChange.dirDeletion(e) ||
             withChangeByPath(e, samePathChange => {
               return (
                 localChange.ignoreDirAdditionThenDeletion(samePathChange) ||

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -111,12 +111,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
               localChange.includeAddDirEventInDirMove(moveChange, e)
               break
             }
-            const unlinkChange /*: ?LocalDirDeletion */ = localChange.maybeDeleteFolder(sameInodeChange)
-            if (unlinkChange) {
-              changeFound(localChange.dirMoveFromUnlinkAdd(unlinkChange, e))
-              break
-            }
             changeFound(
+              localChange.dirMoveFromUnlinkAdd(sameInodeChange, e) ||
               localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||
               localChange.dirMoveIdenticalOffline(e) ||
               localChange.dirAddition(e)

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -164,14 +164,9 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 'We should not have both move and unlinkDir changes since ' +
                 'non-existing addDir and inode-less unlinkDir events are dropped')
             }
-
-            const addChange /*: ?LocalDirAddition */ = localChange.maybePutFolder(sameInodeChange)
-            if (addChange) {
-              changeFound(localChange.dirMoveFromAddUnlink(addChange, e))
-              break
-            }
           }
           changeFound(
+            localChange.dirMoveFromAddUnlink(sameInodeChange, e) ||
             localChange.dirDeletion(e) ||
             withChangeByPath(e, samePathChange => {
               return (

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -194,10 +194,9 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 return
               }
 
-              const moveChangeSamePath /*: ?LocalDirMove */ = localChange.maybeMoveFolder(samePathChange)
-              if (moveChangeSamePath && moveChangeSamePath.wip) {
-                localChange.convertDirMoveToDeletion(moveChangeSamePath)
-              }
+              return (
+                localChange.convertDirMoveToDeletion(samePathChange)
+              )
             })
           )
           break

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -106,12 +106,8 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
           break
         case 'addDir':
           {
-            const moveChange /*: ?LocalDirMove */ = localChange.maybeMoveFolder(sameInodeChange)
-            if (moveChange) {
-              localChange.includeAddDirEventInDirMove(moveChange, e)
-              break
-            }
             changeFound(
+              localChange.includeAddDirEventInDirMove(sameInodeChange, e) ||
               localChange.dirMoveFromUnlinkAdd(sameInodeChange, e) ||
               localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||
               localChange.dirMoveIdenticalOffline(e) ||

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -133,15 +133,9 @@ function analyseEvents (events /*: LocalEvent[] */, pendingChanges /*: LocalChan
                 'We should not have both move and unlink changes since ' +
                 'checksumless adds and inode-less unlink events are dropped')
             }
-
-            const addChange /*: ?LocalFileAddition */ = localChange.maybeAddFile(sameInodeChange)
-            if (addChange) {
-              // TODO: pending move
-              changeFound(localChange.fileMoveFromAddUnlink(addChange, e))
-              break
-            }
           }
           changeFound(
+            localChange.fileMoveFromAddUnlink(sameInodeChange, e) ||
             localChange.fileDeletion(e) ||
             withChangeByPath(e, samePathChange => {
               return (

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -463,7 +463,9 @@ function includeAddDirEventInDirMove (sameInodeChange /*: ?LocalChange */, e /*:
   return true
 }
 
-function includeChangeEventIntoFileMove (moveChange /*: LocalFileMove */, e /*: LocalFileUpdated */) {
+function includeChangeEventIntoFileMove (sameInodeChange /*: ?LocalChange */, e /*: LocalFileUpdated */) {
+  const moveChange /*: ?LocalFileMove */ = maybeMoveFile(sameInodeChange)
+  if (!moveChange) return
   log.debug({path: e.path}, 'FileMove + change')
   moveChange.md5sum = moveChange.old.md5sum || moveChange.md5sum
   moveChange.update = _.defaults({
@@ -475,6 +477,7 @@ function includeChangeEventIntoFileMove (moveChange /*: LocalFileMove */, e /*: 
     // should already be the same as moveChange.path
     path: moveChange.path
   }, e)
+  return true
 }
 
 function convertFileMoveToDeletion (change /*: LocalFileMove */) {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -244,7 +244,8 @@ function fileAddition (e /*: LocalFileAdded */) /*: LocalFileAddition */ {
   return change
 }
 
-function fileDeletion (e /*: LocalFileUnlinked */) /*: LocalFileDeletion */ {
+function fileDeletion (e /*: LocalFileUnlinked */) /*: ?LocalFileDeletion */ {
+  if (!getInode(e)) return
   log.debug({path: e.path}, 'unlink = FileDeletion')
   const change /*: LocalFileDeletion */ = {
     sideName,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -490,7 +490,9 @@ function convertFileMoveToDeletion (change /*: LocalFileMove */) {
   delete change.wip
 }
 
-function convertDirMoveToDeletion (change /*: LocalDirMove */) {
+function convertDirMoveToDeletion (samePathChange /*: ?LocalChange */) {
+  const change /*: ?LocalDirMove */ = maybeMoveFolder(samePathChange)
+  if (!change || !change.wip) return
   log.debug({path: change.old.path, ino: change.ino},
     'DirMove + unlinkDir = DirDeletion')
   // $FlowFixMe
@@ -498,4 +500,5 @@ function convertDirMoveToDeletion (change /*: LocalDirMove */) {
   change.path = change.old.path
   delete change.stats
   delete change.wip
+  return true
 }

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -334,7 +334,9 @@ function dirMoveFromAddUnlink (addChange /*: LocalDirAddition */, e /*: LocalDir
   })
 }
 
-function fileMoveIdentical (addChange /*: LocalFileAddition */, e /*: LocalFileUpdated */) /*: * */ {
+function fileMoveIdentical (sameInodeChange /*: ?LocalChange */, e /*: LocalFileUpdated */) /*: * */ {
+  const addChange /*: ?LocalFileAddition */ = maybeAddFile(sameInodeChange)
+  if (!addChange || metadata.id(addChange.path) !== metadata.id(e.path) || addChange.path === e.path) return
   log.debug({oldpath: e.path, path: addChange.path}, 'add + change = FileMove (same id)')
   return build('FileMove', addChange.path, {
     stats: e.stats,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -385,7 +385,9 @@ export type LocalMove = LocalFileMove|LocalDirMove
 export type LocalMoveEvent = LocalFileAdded|LocalDirAdded
 */
 
-function includeAddEventInFileMove (moveChange /*: LocalFileMove */, e /*: LocalFileAdded */) {
+function includeAddEventInFileMove (sameInodeChange /*: ?LocalChange */, e /*: LocalFileAdded */) {
+  const moveChange /*: ?LocalFileMove */ = maybeMoveFile(sameInodeChange)
+  if (!moveChange) return
   if (!moveChange.wip &&
        moveChange.path === e.path &&
        moveChange.stats.ino === e.stats.ino &&
@@ -405,6 +407,7 @@ function includeAddEventInFileMove (moveChange /*: LocalFileMove */, e /*: Local
       {path: e.path, oldpath: moveChange.old.path, ino: moveChange.stats.ino},
       'FileMove + add without checksum = FileMove wip')
   }
+  return true
 }
 
 function includeAddDirEventInDirMove (moveChange /*: LocalDirMove */, e /*: LocalDirAdded */) {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 const path = require('path')
 
 const metadata = require('../metadata')
+const { getInode } = require('./event')
 
 /*::
 import type fs from 'fs'
@@ -215,7 +216,8 @@ function dirAddition (e /*: LocalDirAdded */) /*: LocalDirAddition */ {
   return change
 }
 
-function dirDeletion (e /*: LocalDirUnlinked */) /*: LocalDirDeletion */ {
+function dirDeletion (e /*: LocalDirUnlinked */) /*: ?LocalDirDeletion */ {
+  if (!getInode(e)) return
   log.debug({path: e.path}, 'unlinkDir = DirDeletion')
   const change /*: LocalDirDeletion */ = {
     sideName,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -418,7 +418,9 @@ function includeAddEventInFileMove (sameInodeChange /*: ?LocalChange */, e /*: L
   return true
 }
 
-function includeAddDirEventInDirMove (moveChange /*: LocalDirMove */, e /*: LocalDirAdded */) {
+function includeAddDirEventInDirMove (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) {
+  const moveChange /*: ?LocalDirMove */ = maybeMoveFolder(sameInodeChange)
+  if (!moveChange) return
   if (!moveChange.wip &&
        moveChange.path === e.path &&
        moveChange.stats.ino === e.stats.ino
@@ -430,7 +432,7 @@ function includeAddDirEventInDirMove (moveChange /*: LocalDirMove */, e /*: Loca
       {path: e.path, oldpath: moveChange.old.path, ino: moveChange.stats.ino},
       'DirMove(a, b) + addDir(b) = DirMove.overwrite(a, b) [chokidar bug]')
     moveChange.overwrite = true
-    return
+    return true
   }
   if (moveChange.old.path === e.path) {
     log.debug(
@@ -438,7 +440,7 @@ function includeAddDirEventInDirMove (moveChange /*: LocalDirMove */, e /*: Loca
       `DirMove(a, b) + addDir(a) = Ignored(b, a) (identical renaming loopback)`)
     // $FlowFixMe
     moveChange.type = 'Ignored'
-    return
+    return true
   }
   moveChange.path = e.path
   moveChange.stats = e.stats
@@ -453,6 +455,7 @@ function includeAddDirEventInDirMove (moveChange /*: LocalDirMove */, e /*: Loca
       {path: e.path, oldpath: moveChange.old.path, ino: moveChange.stats.ino},
       'DirMove + addDir wip = DirMove wip')
   }
+  return true
 }
 
 function includeChangeEventIntoFileMove (moveChange /*: LocalFileMove */, e /*: LocalFileUpdated */) {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -265,7 +265,9 @@ function fileUpdate (e /*: LocalFileUpdated */) /*: LocalFileUpdate */ {
   return change
 }
 
-function fileMoveFromUnlinkAdd (unlinkChange /*: LocalFileDeletion */, e /*: LocalFileAdded */) /*: * */ {
+function fileMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalFileAdded */) /*: * */ {
+  const unlinkChange /*: ?LocalFileDeletion */ = maybeDeleteFile(sameInodeChange)
+  if (!unlinkChange) return
   if (_.get(unlinkChange, 'old.path') === e.path) return fileAddition(e)
   log.debug({oldpath: unlinkChange.path, path: e.path, ino: unlinkChange.ino}, 'unlink + add = FileMove')
   return build('FileMove', e.path, {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -305,7 +305,10 @@ function fileMoveFromAddUnlink (addChange /*: LocalFileAddition */, e /*: LocalF
   })
 }
 
-function fileMoveFromFileDeletionChange (fileDeletion /* :LocalFileDeletion */, e /* : LocalFileUpdated */) {
+function fileMoveFromFileDeletionChange (sameInodeChange /*: ?LocalChange */, e /*: LocalFileUpdated */) {
+  const fileDeletion /*: ?LocalFileDeletion */ = maybeDeleteFile(sameInodeChange)
+  if (!fileDeletion) return
+  // There was an unlink on the same file, this is most probably a move and replace
   const src = fileDeletion.old
   const dst = e.old
   const newDst = e

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -281,7 +281,9 @@ function fileMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: Local
   })
 }
 
-function dirMoveFromUnlinkAdd (unlinkChange /*: LocalDirDeletion */, e /*: LocalDirAdded */) /*: * */ {
+function dirMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) /*: * */ {
+  const unlinkChange /*: ?LocalDirDeletion */ = maybeDeleteFolder(sameInodeChange)
+  if (!unlinkChange) return
   if (_.get(unlinkChange, 'old.path') === e.path) return dirAddition(e)
   log.debug({oldpath: unlinkChange.path, path: e.path}, 'unlinkDir + addDir = DirMove')
   return build('DirMove', e.path, {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -299,7 +299,9 @@ function dirMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalD
   })
 }
 
-function fileMoveFromAddUnlink (addChange /*: LocalFileAddition */, e /*: LocalFileUnlinked */) /*: * */ {
+function fileMoveFromAddUnlink (sameInodeChange /*: ?LocalChange */, e /*: LocalFileUnlinked */) /*: * */ {
+  const addChange /*: ?LocalFileAddition */ = maybeAddFile(sameInodeChange)
+  if (!addChange) return
   log.debug({oldpath: e.path, path: addChange.path, ino: addChange.ino}, 'add + unlink = FileMove')
   return build('FileMove', addChange.path, {
     stats: addChange.stats,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -51,6 +51,7 @@ module.exports = {
   dirMoveFromAddUnlink,
   dirRenamingCaseOnlyFromAddAdd,
   dirMoveIdenticalOffline,
+  ignoreDirAdditionThenDeletion,
   includeAddEventInFileMove,
   includeAddDirEventInDirMove,
   includeChangeEventIntoFileMove,
@@ -501,4 +502,15 @@ function convertDirMoveToDeletion (samePathChange /*: ?LocalChange */) {
   delete change.stats
   delete change.wip
   return true
+}
+
+function ignoreDirAdditionThenDeletion (samePathChange /*: ?LocalChange */) {
+  const addChangeSamePath /*: ?LocalDirAddition */ = maybePutFolder(samePathChange)
+  if (addChangeSamePath && addChangeSamePath.wip) {
+    log.debug({path: addChangeSamePath.path, ino: addChangeSamePath.ino},
+      'Folder was added then deleted. Ignoring add.')
+    // $FlowFixMe
+    addChangeSamePath.type = 'Ignored'
+    return true
+  }
 }

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -331,7 +331,9 @@ function fileMoveFromFileDeletionChange (sameInodeChange /*: ?LocalChange */, e 
   return fileMove
 }
 
-function dirMoveFromAddUnlink (addChange /*: LocalDirAddition */, e /*: LocalDirUnlinked */) /*: * */ {
+function dirMoveFromAddUnlink (sameInodeChange /*: ?LocalChange */, e /*: LocalDirUnlinked */) /*: * */ {
+  const addChange /*: ?LocalDirAddition */ = maybePutFolder(sameInodeChange)
+  if (!addChange) return
   log.debug({oldpath: e.path, path: addChange.path}, 'addDir + unlinkDir = DirMove')
   return build('DirMove', addChange.path, {
     stats: addChange.stats,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -3,6 +3,8 @@
 const _ = require('lodash')
 const path = require('path')
 
+const metadata = require('../metadata')
+
 /*::
 import type fs from 'fs'
 import type { Metadata } from '../metadata'
@@ -356,7 +358,11 @@ function fileMoveIdenticalOffline (dstEvent /*: LocalFileAdded */) /*: ?LocalFil
   } /*: LocalFileMove */)
 }
 
-function dirRenamingCaseOnlyFromAddAdd (addChange /*: LocalDirAddition */, e /*: LocalDirAdded */) /*: * */ {
+function dirRenamingCaseOnlyFromAddAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) /*: * */ {
+  const addChange /*: ?LocalDirAddition */ = maybePutFolder(sameInodeChange)
+  if (!addChange || metadata.id(addChange.path) !== metadata.id(e.path) || addChange.path === e.path) {
+    return
+  }
   log.debug({oldpath: addChange.path, path: e.path}, 'addDir + addDir = DirMove (same id)')
   return build('DirMove', e.path, {
     stats: addChange.stats,

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -482,7 +482,9 @@ function includeChangeEventIntoFileMove (sameInodeChange /*: ?LocalChange */, e 
   return true
 }
 
-function convertFileMoveToDeletion (change /*: LocalFileMove */) {
+function convertFileMoveToDeletion (samePathChange /*: ?LocalChange */) {
+  const change /*: ?LocalFileMove */ = maybeMoveFile(samePathChange)
+  if (!change || change.md5sum) return
   log.debug({path: change.old.path, ino: change.ino},
     'FileMove + unlink = FileDeletion')
   // $FlowFixMe
@@ -490,6 +492,7 @@ function convertFileMoveToDeletion (change /*: LocalFileMove */) {
   change.path = change.old.path
   delete change.stats
   delete change.wip
+  return true
 }
 
 function convertDirMoveToDeletion (samePathChange /*: ?LocalChange */) {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -52,6 +52,7 @@ module.exports = {
   dirRenamingCaseOnlyFromAddAdd,
   dirMoveIdenticalOffline,
   ignoreDirAdditionThenDeletion,
+  ignoreFileAdditionThenDeletion,
   includeAddEventInFileMove,
   includeAddDirEventInDirMove,
   includeChangeEventIntoFileMove,
@@ -511,6 +512,17 @@ function ignoreDirAdditionThenDeletion (samePathChange /*: ?LocalChange */) {
       'Folder was added then deleted. Ignoring add.')
     // $FlowFixMe
     addChangeSamePath.type = 'Ignored'
+    return true
+  }
+}
+
+function ignoreFileAdditionThenDeletion (samePathChange /*: ?LocalChange */) {
+  const addChangeSamePath /*: ?LocalFileAddition */ = maybeAddFile(samePathChange)
+  if (addChangeSamePath && addChangeSamePath.wip) {
+    // $FlowFixMe
+    addChangeSamePath.type = 'Ignored'
+    delete addChangeSamePath.wip
+    delete addChangeSamePath.md5sum
     return true
   }
 }


### PR DESCRIPTION
The local changes analysis includes a succession of detection steps for each event type.
This was previously implemented as if/else statements nested into a switch/case one + block statements.
The goal here is to turn this into plain function chaining using `or` (`||`) expressions.

Requires #1395.

More improvements can be done later but are **out of the scope** of this already big PR:

- Extracting the remaing *panic* blocks as `ensure*()` function calls.
- Extracting the `switch/case` block into a separate function returning the detection result instead of calling `changeFound()` directly
- Extracting some kind of `ChangeMap` class
- Improve naming
- Introduce chokidar watcher steps, same as in the atom watcher
