### PR TITLE
core/local/steps/initial_diff: Cover basic cases

### DIFF
--- a/core/local/steps/initial_diff.js
+++ b/core/local/steps/initial_diff.js
@@ -3,27 +3,42 @@
 const { id } = require('../../metadata')
 const Buffer = require('./buffer')
 
-const logger = require('../../logger')
-const log = logger({
-  component: 'initialDiff'
-})
-
 /*::
 import type Pouch from '../../pouch'
-import type { Batch, EventKind } from './event'
+import type { AtomWatcherEvent, Batch, EventKind } from './event'
 import type { Metadata } from '../../metadata'
 
 type WatchedPath = {
   path: string,
   kind: EventKind,
 }
+
+type WaitingItem = {
+  batch: AtomWatcherEvent[],
+  nbCandidates: number,
+  timeout: TimeoutID
+}
 */
+
+// Wait this delay (in milliseconds) after the last event for a given file
+// before pushing this event to the next steps.
+// TODO tweak the value (the initial value was chosen because it looks like a
+//      good value, it is not something that was computed)
+const DELAY = 200
 
 // Some files and directories can have been deleted while cozy-desktop was
 // stopped. So, at the end of the initial scan, we have to do a diff between
 // what was in pouchdb and the events from the local watcher to find what was
 // deleted.
+module.exports = function (buffer /*: Buffer */, opts /*: { pouch: Pouch } */) /*: Buffer */ {
+  const out = new Buffer()
+  initialDiff(buffer, out, opts.pouch)
+  return out
+}
+
 async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: Pouch */) /*: Promise<void> */ {
+  const waiting /*: WaitingItem[] */ = []
+
   // XXX we wait to receive the first batch of events before initializing this
   // component, as pouchdb may not be initialized when initialDiff is created
   // (its views are added later, but before the local watcher is started, thus
@@ -42,13 +57,11 @@ async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: P
       byInode.set(doc.fileid || doc.ino, { path: doc.path, kind: kind })
     }
   }
-  let done = false
 
   while (true) {
-    if (done) {
-      out.push(events)
-      continue
-    }
+    let nbCandidates = 0
+
+    debounce(waiting, events)
 
     const batch /*: Batch */ = []
     for (const event of events) {
@@ -71,6 +84,7 @@ async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: P
             // TODO for a directory, maybe we should check the children
             event.action = 'renamed'
             event.oldPath = was.path
+            nbCandidates++
           } else {
             // On linux, the inodes can have been reused: a file was deleted
             // and a directory created just after while the client was stopped
@@ -101,19 +115,57 @@ async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: P
           })
         }
         byInode.clear()
-        done = true
       }
       batch.push(event)
     }
 
-    out.push(batch)
+    // Push the new batch of events in the queue
+    const timeout = setTimeout(() => {
+      out.push(waiting.shift().batch)
+      sendReadyBatches(waiting, out)
+    }, DELAY)
+    waiting.push({ batch, nbCandidates, timeout })
+
+    // Look if some batches can be sent without waiting
+    sendReadyBatches(waiting, out)
+
     events = await buffer.pop()
   }
 }
 
-module.exports = function (buffer /*: Buffer */, opts /*: { pouch: Pouch } */) /*: Buffer */ {
-  const out = new Buffer()
-  initialDiff(buffer, out, opts.pouch)
-    .catch(err => log.error({err}))
-  return out
+function sendReadyBatches (waiting /*: WaitingItem[] */, out /*: Buffer */) {
+  while (waiting.length > 0) {
+    if (waiting[0].nbCandidates !== 0) {
+      break
+    }
+    const item = waiting.shift()
+    clearTimeout(item.timeout)
+    if (item.batch.length > 0) {
+      out.push(item.batch)
+    }
+  }
+}
+
+// Look if we can debounce some waiting events with the current events
+function debounce (waiting /*: WaitingItem[] */, events /*: AtomWatcherEvent[] */) {
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i]
+    if (event.incomplete) {
+      continue
+    }
+    if (event.action === 'scan') {
+      for (let j = 0; j < waiting.length; j++) {
+        const w = waiting[j]
+        if (w.nbCandidates === 0) { continue }
+        for (let k = 0; k < w.batch.length; k++) {
+          const e = w.batch[k]
+          if (e.action === 'renamed' && e.path === event.path) {
+            events.splice(i, 1)
+            w.nbCandidates--
+            break
+          }
+        }
+      }
+    }
+  }
 }

--- a/core/local/steps/initial_diff.js
+++ b/core/local/steps/initial_diff.js
@@ -10,15 +10,20 @@ const log = logger({
 
 /*::
 import type Pouch from '../../pouch'
+import type { Batch, EventKind } from './event'
+import type { Metadata } from '../../metadata'
+
+type WatchedPath = {
+  path: string,
+  kind: EventKind,
+}
 */
 
-// TODO add unit tests
-
 // Some files and directories can have been deleted while cozy-desktop was
-// stopped. So, at the end of the initial scan, we have to to a diff between
+// stopped. So, at the end of the initial scan, we have to do a diff between
 // what was in pouchdb and the events from the local watcher to find what was
 // deleted.
-async function initialDiff (buffer, out, pouch) {
+async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: Pouch */) /*: Promise<void> */ {
   // XXX we wait to receive the first batch of events before initializing this
   // component, as pouchdb may not be initialized when initialDiff is created
   // (its views are added later, but before the local watcher is started, thus
@@ -28,15 +33,14 @@ async function initialDiff (buffer, out, pouch) {
   // Using inode/fileId is more robust that using path or id for detecting
   // which files/folders have been deleted, as it is stable even if the
   // file/folder has been moved or renamed
-  const byInode = new Map()
-  const docs = await pouch.byRecursivePathAsync('')
+  const byInode /*: Map<number|string, WatchedPath> */ = new Map()
+  const docs /*: Metadata[] */ = await pouch.byRecursivePathAsync('')
   for (const doc of docs) {
-    if (!doc.ino) {
-      // Ignore files/dirs created on the remote and never synchronized
-      continue
+    if (doc.ino != null) {
+      // Process only files/dirs that were created locally or synchronized
+      const kind = doc.docType === 'file' ? 'file' : 'directory'
+      byInode.set(doc.fileid || doc.ino, { path: doc.path, kind: kind })
     }
-    const kind = doc.docType === 'file' ? 'file' : 'directory'
-    byInode.set(doc.fileid || doc.ino, { path: doc.path, kind: kind })
   }
   let done = false
 
@@ -46,7 +50,7 @@ async function initialDiff (buffer, out, pouch) {
       continue
     }
 
-    const batch = []
+    const batch /*: Batch */ = []
     for (const event of events) {
       if (event.incomplete) {
         batch.push(event)
@@ -55,7 +59,7 @@ async function initialDiff (buffer, out, pouch) {
 
       // Detect if the file was moved while the client was stopped
       if (['created', 'scan'].includes(event.action)) {
-        let was
+        let was /*: ?WatchedPath */
         if (event.stats.fileid) {
           was = byInode.get(event.stats.fileid)
         }

--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 const fs = require('fs')
+const _ = require('lodash')
 
 const metadata = require('../../../core/metadata')
 const events = require('../../../core/local/steps/event')
@@ -21,12 +22,16 @@ module.exports = class AtomWatcherEventBuilder {
   _event: AtomWatcherEvent
   */
 
-  constructor () {
-    this._event = {
-      action: randomPick(events.ACTIONS),
-      kind: randomPick(events.KINDS),
-      path: '/',
-      _id: '/'
+  constructor (old /*: ?AtomWatcherEvent */) {
+    if (old) {
+      this._event = _.cloneDeep(old)
+    } else {
+      this._event = {
+        action: randomPick(events.ACTIONS),
+        kind: randomPick(events.KINDS),
+        path: '/',
+        _id: '/'
+      }
     }
   }
 

--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const fs = require('fs')
+
 const metadata = require('../../../core/metadata')
 const events = require('../../../core/local/steps/event')
 
@@ -58,8 +60,11 @@ module.exports = class AtomWatcherEventBuilder {
     return this
   }
 
-  stats (newStats /*: Stats */) /*: this */ {
-    this._event.stats = newStats
+  stats (newStats /*: { ino?: number } */) /*: this */ {
+    const stats /*: Stats */ = fs.statSync(__filename)
+    Object.assign(stats, newStats)
+
+    this._event.stats = stats
     return this
   }
 

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -16,6 +16,7 @@ import type { Metadata } from '../../../core/metadata'
 import type Pouch from '../../../core/pouch'
 import type { Warning } from '../../../core/remote/warning'
 import type { RemoteDoc } from '../../../core/remote/document'
+import type { AtomWatcherEvent } from '../../../core/local/steps/event'
 */
 
 // Test data builders facade.
@@ -89,7 +90,7 @@ module.exports = class Builders {
     return new StreamBuilder()
   }
 
-  event () /*: AtomWatcherEventBuilder */ {
-    return new AtomWatcherEventBuilder()
+  event (old /*: ?AtomWatcherEvent */) /*: AtomWatcherEventBuilder */ {
+    return new AtomWatcherEventBuilder(old)
   }
 }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -99,6 +99,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  fileid (fileid /*: string */) /*: this */ {
+    this.doc.fileid = fileid
+    return this
+  }
+
   stats ({ino, mtime, ctime} /*: fs.Stats */) /*: this */ {
     return this.ino(ino).updatedAt(timestamp.maxDate(mtime, ctime))
   }

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -1,0 +1,100 @@
+/* eslint-env mocha */
+/* @flow */
+
+const should = require('should')
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
+const Buffer = require('../../../../core/local/steps/buffer')
+const initialDiff = require('../../../../core/local/steps/initial_diff')
+
+describe('local/steps/initialDiff', () => {
+  let builders
+  let buffer
+
+  before('instanciate config', configHelpers.createConfig)
+  beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+  beforeEach('populate pouch with documents', function () {
+    builders = new Builders({pouch: this.pouch})
+    buffer = new Buffer()
+  })
+  afterEach('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  it('detects documents moved while client was stopped', async function () {
+    await builders.metadir().path('foo').ino(1).create()
+    await builders.metafile().path('fizz').ino(2).create()
+
+    const bar = builders.event().action('scan').kind('directory').path('bar').stats({ ino: 1 }).build()
+    const buzz = builders.event().action('scan').kind('file').path('buzz').stats({ ino: 2 }).build()
+    buffer.push([bar, buzz])
+    buffer = initialDiff(buffer, { pouch: this.pouch })
+
+    const events = await buffer.pop()
+    should(events).deepEqual([
+      builders.event(bar).action('renamed').oldPath('foo').build(),
+      builders.event(buzz).action('renamed').oldPath('fizz').build()
+    ])
+  })
+
+  it('detects documents moved while client is doing initial scan', async function () {
+    await builders.metadir().path('foo').ino(1).create()
+    await builders.metafile().path('foo/baz').ino(2).create()
+    await builders.metadir().path('bar').ino(3).create()
+
+    const foo = builders.event().action('scan').kind('directory').path('foo').stats({ ino: 1 }).build()
+    const barbaz = builders.event().action('created').kind('file').path('bar/baz').stats({ ino: 2 }).build()
+    buffer.push([foo, barbaz])
+    const bar = builders.event().action('scan').kind('directory').path('bar').stats({ ino: 3 }).build()
+    buffer.push([
+      bar,
+      builders.event().action('scan').kind('file').path('bar/baz').stats({ ino: 2 }).build()
+    ])
+    buffer = initialDiff(buffer, { pouch: this.pouch })
+
+    const events = [].concat(
+      await buffer.pop(),
+      await buffer.pop()
+    )
+    should(events).deepEqual([
+      foo,
+      builders.event(barbaz).action('renamed').oldPath('foo/baz').build(),
+      bar
+    ])
+  })
+
+  it('detects documents replaced by another one of a different kind while client was stopped', async function () {
+    await builders.metadir().path('foo').ino(1).create()
+    await builders.metafile().path('bar').ino(2).create()
+    await builders.metadir().path('fizz').ino(3).create()
+    await builders.metafile().path('buzz').ino(4).create()
+
+    const foo = builders.event().action('scan').kind('file').path('foo').stats({ ino: 2 }).build()
+    const buzz = builders.event().action('scan').kind('directory').path('buzz').stats({ ino: 3 }).build()
+    buffer.push([foo, buzz])
+    buffer = initialDiff(buffer, { pouch: this.pouch })
+
+    const events = await buffer.pop()
+    should(events).deepEqual([
+      builders.event(foo).action('renamed').oldPath('bar').build(),
+      builders.event(buzz).action('renamed').oldPath('fizz').build()
+    ])
+  })
+
+  it('detects documents removed while client was stopped', async function () {
+    await builders.metadir().path('foo').ino(1).create()
+    await builders.metafile().path('bar').ino(2).create()
+
+    const initial = builders.event().action('initial-scan-done').build()
+    buffer.push([initial])
+    buffer = initialDiff(buffer, { pouch: this.pouch })
+
+    const events = await buffer.pop()
+    should(events).deepEqual([
+      builders.event().action('deleted').kind('file').path('bar').build(),
+      builders.event().action('deleted').kind('directory').path('foo').build(),
+      initial
+    ])
+  })
+})


### PR DESCRIPTION
 To avoid processing a `scan` event following the transformation of a
  `created` event into `renamed` event, we wait before passing it along
  to the next step and remove any `scan` event for the same path.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
