### PR TITLE
core/local: Single type change builders

### DIFF
--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -139,6 +139,7 @@ function analyseEvent (e /*: LocalEvent */, previousChanges /*: LocalChangeMap *
       )
     case 'addDir':
       return (
+        localChange.dirMoveOverwriteOnMacAPFS(sameInodeChange, e) ||
         localChange.includeAddDirEventInDirMove(sameInodeChange, e) ||
         localChange.dirMoveFromUnlinkAdd(sameInodeChange, e) ||
         localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||

--- a/core/local/analysis.js
+++ b/core/local/analysis.js
@@ -140,6 +140,7 @@ function analyseEvent (e /*: LocalEvent */, previousChanges /*: LocalChangeMap *
     case 'addDir':
       return (
         localChange.dirMoveOverwriteOnMacAPFS(sameInodeChange, e) ||
+        localChange.dirRenamingIdenticalLoopback(sameInodeChange, e) ||
         localChange.includeAddDirEventInDirMove(sameInodeChange, e) ||
         localChange.dirMoveFromUnlinkAdd(sameInodeChange, e) ||
         localChange.dirRenamingCaseOnlyFromAddAdd(sameInodeChange, e) ||

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -279,7 +279,7 @@ function fileUpdate (e /*: LocalFileUpdated */) /*: LocalFileUpdate */ {
 function fileMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalFileAdded */) /*: * */ {
   const unlinkChange /*: ?LocalFileDeletion */ = maybeDeleteFile(sameInodeChange)
   if (!unlinkChange) return
-  if (_.get(unlinkChange, 'old.path') === e.path) return fileAddition(e)
+  if (_.get(unlinkChange, 'old.path') === e.path) return
   const fileMove /*: Object */ = build('FileMove', e.path, {
     stats: e.stats,
     md5sum: e.md5sum,
@@ -300,7 +300,7 @@ function fileMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: Local
 function dirMoveFromUnlinkAdd (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) /*: * */ {
   const unlinkChange /*: ?LocalDirDeletion */ = maybeDeleteFolder(sameInodeChange)
   if (!unlinkChange) return
-  if (_.get(unlinkChange, 'old.path') === e.path) return dirAddition(e)
+  if (_.get(unlinkChange, 'old.path') === e.path) return
   if (!e.wip) {
     log.debug({oldpath: unlinkChange.path, path: e.path}, 'unlinkDir + addDir = DirMove')
   } else {

--- a/core/local/change.js
+++ b/core/local/change.js
@@ -53,6 +53,7 @@ module.exports = {
   dirMoveFromAddUnlink,
   dirMoveOverwriteOnMacAPFS,
   dirRenamingCaseOnlyFromAddAdd,
+  dirRenamingIdenticalLoopback,
   dirMoveIdenticalOffline,
   ignoreDirAdditionThenDeletion,
   ignoreFileAdditionThenDeletion,
@@ -465,7 +466,7 @@ function dirMoveOverwriteOnMacAPFS (sameInodeChange /*: ?LocalChange */, e /*: L
   }
 }
 
-function includeAddDirEventInDirMove (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) {
+function dirRenamingIdenticalLoopback (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) {
   const moveChange /*: ?LocalDirMove */ = maybeMoveFolder(sameInodeChange)
   if (!moveChange) return
   if (moveChange.old.path === e.path) {
@@ -476,6 +477,11 @@ function includeAddDirEventInDirMove (sameInodeChange /*: ?LocalChange */, e /*:
     moveChange.type = 'Ignored'
     return true
   }
+}
+
+function includeAddDirEventInDirMove (sameInodeChange /*: ?LocalChange */, e /*: LocalDirAdded */) {
+  const moveChange /*: ?LocalDirMove */ = maybeMoveFolder(sameInodeChange)
+  if (!moveChange) return
   moveChange.path = e.path
   moveChange.stats = e.stats
   if (!e.wip) {


### PR DESCRIPTION
Some functions that build `LocalChange`s may handle many edge cases and return different change types. This makes it harder to understand them & to add type annotations (flow errors end up being quite hard to understand/debug).

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes (I'm confident there is at least 1 test that exercise each of those cases)
- [ ] it includes relevant documentation
