### PR TITLE
yarn: Ensure test:scenarios run with chokidar, not atom

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test:integration": "yarn mocha test/integration",
     "test:performance": "yarn mocha test/performance",
     "test:property": "env NO_ELECTRON=true BLUEBIRD_WARNINGS=0 mocha --exit test/property",
-    "test:scenarios": "yarn mocha test/scenarios/run.js",
+    "test:scenarios": "cross-env COZY_FS_WATCHER=chokidar yarn mocha test/scenarios/run.js",
     "test:setup": "yarn docker:exec /cozy-desktop/test/setup.sh",
     "test:unit": "yarn mocha test/unit/",
     "test:unit:coverage": "yarn mocha:coverage test/unit/",


### PR DESCRIPTION
Since atom is not supported yet.
So `yarn test:scenarios` doesn't fail locally on GNU/Linux & Windows.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
