### PR TITLE
test/support/helpers/context_dir: Use fse.rename()

### DIFF
--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -122,7 +122,7 @@ class ContextDir {
   }
 
   async move (src /*: string */, dst /*: string */) {
-    return fse.move(this.abspath(src), this.abspath(dst))
+    return fse.rename(this.abspath(src), this.abspath(dst))
   }
 
   async checksum (target /*: string | {path: string} */) /*: Promise<string> */ {


### PR DESCRIPTION
Which is a promisified version of the standard fs.rename().
While fs-extra's move() is definitely not the same:

- It is doing some magic to allow moving accross separate volumes.
- It may change the inode unnecessarily
- We use fse.rename() in Local writer, so better match our own actions

Extracted from https://github.com/cozy-labs/cozy-desktop/pull/1334.
Courtesy of @aenario.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes (all tests are using it)
- [x] it includes relevant documentation (see commit message)
