### PR TITLE
core/merge: Reset child move destination sides

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -252,7 +252,7 @@ class Merge {
   async moveFileAsync (side /*: SideName */, doc /*: Metadata */, was /*: Metadata */) /*: Promise<*> */ {
     log.debug({path: doc.path, oldpath: was.path}, 'moveFileAsync')
     const {path} = doc
-    if (was.sides && !was.sides[otherSide(side)]) {
+    if (!metadata.wasSynced(was)) {
       metadata.markAsUnsyncable(side, was)
       await this.pouch.put(was)
       return this.addFileAsync(side, doc)
@@ -351,12 +351,11 @@ class Merge {
       dst.path = doc.path.replace(was.path, folder.path)
       if (src.sides && src.sides[side] && !src.sides[otherSide(side)]) {
         metadata.markAsUnsyncable(side, src)
-        metadata.markAsNew(dst)
-        metadata.markSide(side, dst)
       } else {
         move.child(src, dst)
-        metadata.markSide(side, dst, src)
       }
+      metadata.markAsNew(dst)
+      metadata.markSide(side, dst)
 
       let existingDstRev = existingDstRevs[dst._id]
       if (existingDstRev && folder.overwrite) dst._rev = existingDstRev

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -118,6 +118,7 @@ module.exports = {
   sameFileIgnoreRev,
   sameBinary,
   markSide,
+  wasSynced,
   buildDir,
   buildFile,
   upToDate,
@@ -435,6 +436,13 @@ function markSide (side /*: string */, doc /*: Metadata */, prev /*: ?Metadata *
   }
   doc.sides[side] = ++rev
   return doc
+}
+
+function wasSynced (doc /*: Metadata */) /*: boolean */ {
+  const hasBothSides /*: boolean */ = doc.sides && (doc.sides.local != null) && (doc.sides.remote != null)
+  const comesFromSyncedDoc /*: boolean */ = doc.moveFrom != null
+
+  return hasBothSides || comesFromSyncedDoc
 }
 
 function buildDir (fpath /*: string */, stats /*: Stats */, remote /*: ?MetadataRemoteInfo */) /*: Metadata */ {

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -51,7 +51,13 @@ module.exports = class BaseMetadataBuilder {
   fromRemote (remoteDoc /*: RemoteDoc */) /*: this */ {
     this.doc = metadata.fromRemoteDoc(remoteDoc)
     metadata.ensureValidPath(this.doc)
-    metadata.assignId(this.doc)
+    this._assignId()
+    return this
+  }
+
+  moveFrom (was /*: Metadata */) /*: this */ {
+    this.doc.moveFrom = _.defaultsDeep({ moveTo: this.doc._id }, was)
+    this.noRev()
     return this
   }
 
@@ -111,7 +117,8 @@ module.exports = class BaseMetadataBuilder {
 
   path (newPath /*: string */) /*: this */ {
     this.doc.path = path.normalize(newPath)
-    metadata.assignId(this.doc)
+    metadata.ensureValidPath(this.doc)
+    this._assignId()
     return this
   }
 
@@ -184,5 +191,13 @@ module.exports = class BaseMetadataBuilder {
     const { rev } = await this.pouch.put(doc)
     doc._rev = rev
     return doc
+  }
+
+  _assignId () /* void */ {
+    metadata.assignId(this.doc)
+
+    if (this.doc.moveFrom) {
+      this.doc.moveFrom.moveTo = this.doc._id
+    }
   }
 }


### PR DESCRIPTION
  When moving a document as part of a parent move, we create a new
  document in Pouch and have therefore a new `_rev` starting with 1.
  Thus, we should have clean sides with only one side set to 1.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
