### PR TITLE
test/support: Normalise paths in builders

### DIFF
--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const _ = require('lodash')
+const path = require('path')
 
 const metadata = require('../../../core/metadata')
 const events = require('../../../core/local/steps/event')
@@ -50,13 +51,13 @@ module.exports = class AtomWatcherEventBuilder {
   }
 
   path (newPath /*: string */) /*: this */ {
-    this._event.path = newPath
+    this._event.path = path.normalize(newPath)
     this._event._id = metadata.id(newPath)
     return this
   }
 
   oldPath (newPath /*: string */) /*: this */{
-    this._event.oldPath = newPath
+    this._event.oldPath = path.normalize(newPath)
     return this
   }
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 const _ = require('lodash')
+const path = require('path')
 
 const metadata = require('../../../../core/metadata')
 const timestamp = require('../../../../core/timestamp')
@@ -108,8 +109,8 @@ module.exports = class BaseMetadataBuilder {
     return this.ino(ino).updatedAt(timestamp.maxDate(mtime, ctime))
   }
 
-  path (path /*: string */) /*: this */ {
-    this.doc.path = path
+  path (newPath /*: string */) /*: this */ {
+    this.doc.path = path.normalize(newPath)
     metadata.assignId(this.doc)
     return this
   }


### PR DESCRIPTION
  Instead of normalising the paths in every test using a builder we can
  do it in the builder itself.
  This is necessary for some tests to pass on all platforms.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
