### PR TITLE
test/support/builders/metadata: _rev matches sides

### DIFF
--- a/core/pouch.js
+++ b/core/pouch.js
@@ -109,11 +109,11 @@ class Pouch {
 
   /* Mini ODM */
 
-  put (doc /*: Metadata */, callback /*: ?Callback */) {
+  put (doc /*: Metadata */) /*: Promise<void> */ {
     metadata.invariants(doc)
     const {local, remote} = doc.sides
     log.debug({path: doc.path, local, remote, _deleted: doc._deleted, doc}, 'Saving metadata...')
-    return this.db.put(doc).asCallback(callback)
+    return this.db.put(doc)
   }
 
   remove (doc /*: Metadata */) /*: Promise<*> */ {

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -760,7 +760,7 @@ describe('Merge', function () {
         moveTo: dstId,
         path: was.path,
         remote: was.remote,
-        sides: {local: 2, remote: 2},
+        sides: {local: 3, remote: 2},
         size: was.size,
         tags: was.tags,
         updated_at: new Date(was.updated_at) // FIXME: Stop mixing dates & strings
@@ -935,7 +935,7 @@ describe('Merge', function () {
     })
   })
 
-  describe('moveFolder', function () {
+  describe('moveFolderAsync', function () {
     // @TODO fixme intermittent failure
     // `Error in .on("change", function): {
     // AssertionError: expected 'FOOBAR/OLD' to be 'FOOBAR/OLD-HINT'`
@@ -1034,7 +1034,7 @@ describe('Merge', function () {
         moveTo: dstId,
         path: was.path,
         remote: was.remote,
-        sides: {local: 2, remote: 2},
+        sides: {local: 3, remote: 2},
         tags: was.tags,
         updated_at: new Date(was.updated_at) // FIXME: Stop mixing dates & strings
       }


### PR DESCRIPTION
Based on #1423 

When we were building documents using the metadata builders and
  setting their sides, we would not necessarily have a coherent
  revision (i.e. as high as the highest side).
  We now save the document until the revision is at least as high as the
  highest side we're setting.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
