### PR TITLE
core/merge: Fix sides after pouch rev reuse

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -526,6 +526,7 @@ class Merge {
   }
 
   async bulkFixSideInPouch ({ side, results, docs } /*: { side: SideName, results: { id: string, rev: string }[], docs: Metadata[] } */) /*: Promise<any> */ {
+    log.debug({ side, results, docs }, 'bulkFixSideInPouch')
     const fixedDocs = []
     const reusingRevs = results.filter(this.isReusingRev)
     for (const { id, rev } of reusingRevs) {
@@ -539,6 +540,7 @@ class Merge {
   }
 
   async fixSideInPouch ({ side, result, doc } /*: { side: SideName, result: { rev: string }, doc: Metadata } */) /*: Promise<any> */ {
+    log.debug({ side, result, doc }, 'fixSideInPouch')
     const { rev } = result
 
     if (!doc._rev && this.isReusingRev(result)) {

--- a/core/merge.js
+++ b/core/merge.js
@@ -528,10 +528,15 @@ class Merge {
   async bulkFixSideInPouch ({ side, results, docs } /*: { side: SideName, results: { id: string, rev: string }[], docs: Metadata[] } */) /*: Promise<any> */ {
     log.debug({ side, results, docs }, 'bulkFixSideInPouch')
     const fixedDocs = []
-    const reusingRevs = results.filter(this.isReusingRev)
+    const uniqResultsById = _.chain(results)
+      .sortBy('rev')
+      .reverse()
+      .uniqBy('id')
+      .value()
+    const reusingRevs = uniqResultsById.filter(this.isReusingRev)
     for (const { id, rev } of reusingRevs) {
-      const doc = _.find(docs, { _id: id })
-      if (doc && !doc._rev) {
+      const doc = _.find(docs, doc => !doc._rev && doc._id === id)
+      if (doc) {
         fixedDocs.push(this.fixSide({ side, rev, doc }))
       }
     }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -828,25 +828,6 @@ describe('Merge', function () {
       })
     })
 
-    it('does not identify an identical renaming as a conflict', async function () {
-      const banana = await builders.metafile().path('banana').upToDate().create()
-      const BANANA = builders.metafile(banana).path('BANANA').noRev().build()
-
-      sinon.spy(this.merge, 'resolveConflictAsync')
-      await this.merge.moveFileAsync(this.side, BANANA, banana)
-
-      should(this.merge.resolveConflictAsync.args).not.have.been.called()
-      should(await this.pouch.db.get(BANANA._id)).have.properties(
-        _.omit(
-          BANANA,
-          ['class', 'mime', 'ino', 'fileid']
-        )
-      )
-      if (banana._id !== BANANA._id) {
-        await should(this.pouch.db.get(banana._id)).be.rejectedWith({status: 404})
-      }
-    })
-
     it('identifies a local move without existing remote side as an addition', async function () {
       let doc = {
         _id: 'FOO/NEW',
@@ -908,6 +889,26 @@ describe('Merge', function () {
     })
 
     onPlatforms(['win32', 'darwin'], () => {
+      it('does not identify an identical renaming as a conflict', async function () {
+        const expectedReNumber = 5 // up to date + delete + create + update side
+
+        const banana = await builders.metafile().path('banana').upToDate().create()
+        const BANANA = builders.metafile(banana).path('BANANA').noRev().build()
+
+        await this.merge.moveFileAsync(this.side, BANANA, banana)
+
+        should(this.merge.resolveConflictAsync).not.have.been.called()
+        should(await this.pouch.db.get(BANANA._id)).have.properties(
+          _.chain({ sides: { [this.side]: expectedReNumber } })
+            .defaultsDeep(BANANA)
+            .omit(['class', 'mime', 'ino', 'fileid'])
+            .value()
+        )
+        if (banana._id !== BANANA._id) {
+          await should(this.pouch.db.get(banana._id)).be.rejectedWith({status: 404})
+        }
+      })
+
       it('resolves an identity conflict with an existing file', async function () {
         const identical = await builders.metafile().path('QUX').create()
         const was = builders.metafile().path('baz').upToDate().build()
@@ -927,6 +928,26 @@ describe('Merge', function () {
     })
 
     onPlatform('linux', () => {
+      it('does not identify an identical renaming as a conflict', async function () {
+        const expectedReNumber = 1 // new unsynced document
+
+        const banana = await builders.metafile().path('banana').upToDate().create()
+        const BANANA = builders.metafile(banana).path('BANANA').noRev().build()
+
+        await this.merge.moveFileAsync(this.side, BANANA, banana)
+
+        should(this.merge.resolveConflictAsync).not.have.been.called()
+        should(await this.pouch.db.get(BANANA._id)).have.properties(
+          _.chain({ sides: { [this.side]: expectedReNumber } })
+            .defaultsDeep(BANANA)
+            .omit(['class', 'mime', 'ino', 'fileid'])
+            .value()
+        )
+        if (banana._id !== BANANA._id) {
+          await should(this.pouch.db.get(banana._id)).be.rejectedWith({status: 404})
+        }
+      })
+
       it('does not have identity conflicts', async function () {
         await builders.metafile().path('QUX').create()
         const baz = builders.metafile().path('baz').upToDate().build()
@@ -1137,29 +1158,27 @@ describe('Merge', function () {
       newMetadata.remote.should.have.property('_id', was.remote._id)
     })
 
-    it('does not identify an identical renaming as a conflict', async function () {
-      const apple = await builders.metadir().path('apple').upToDate().create()
-      const APPLE = _({_id: metadata.id('APPLE'), path: 'APPLE'})
-        .defaults(apple)
-        .omit(['_rev'])
-        .value()
-
-      sinon.spy(this.merge, 'resolveConflictAsync')
-      await this.merge.moveFolderAsync(this.side, APPLE, apple)
-
-      should(this.merge.resolveConflictAsync.args).not.have.been.called()
-      should(await this.pouch.db.get(APPLE._id)).have.properties(
-        _.omit(
-          APPLE,
-          ['ino', 'fileid']
-        )
-      )
-      if (apple._id !== APPLE._id) {
-        await should(this.pouch.db.get(apple._id)).be.rejectedWith({status: 404})
-      }
-    })
-
     onPlatforms(['win32', 'darwin'], () => {
+      it('does not identify an identical renaming as a conflict', async function () {
+        const expectedReNumber = 5 // up to date + delete + create + update side
+
+        const apple = await builders.metadir().path('apple').upToDate().create()
+        const APPLE = builders.metadir(apple).path('APPLE').noRev().build()
+
+        await this.merge.moveFolderAsync(this.side, APPLE, apple)
+
+        should(this.merge.resolveConflictAsync).not.have.been.called()
+        should(await this.pouch.db.get(APPLE._id)).have.properties(
+          _.chain({ sides: { [this.side]: expectedReNumber } })
+            .defaultsDeep(APPLE)
+            .omit(['ino', 'fileid'])
+            .value()
+        )
+        if (apple._id !== APPLE._id) {
+          await should(this.pouch.db.get(apple._id)).be.rejectedWith({status: 404})
+        }
+      })
+
       it('resolves an identity conflict with an existing file', async function () {
         const LINUX = await builders.metadir().path('LINUX').create()
         const torvalds = builders.metadir().path('torvalds').upToDate().build()
@@ -1179,6 +1198,26 @@ describe('Merge', function () {
     })
 
     onPlatform('linux', () => {
+      it('does not identify an identical renaming as a conflict', async function () {
+        const expectedReNumber = 1 // new unsynced document
+
+        const apple = await builders.metadir().path('apple').upToDate().create()
+        const APPLE = builders.metadir(apple).path('APPLE').noRev().build()
+
+        await this.merge.moveFolderAsync(this.side, APPLE, apple)
+
+        should(this.merge.resolveConflictAsync).not.have.been.called()
+        should(await this.pouch.db.get(APPLE._id)).have.properties(
+          _.chain({ sides: { [this.side]: expectedReNumber } })
+            .defaultsDeep(APPLE)
+            .omit(['ino', 'fileid'])
+            .value()
+        )
+        if (apple._id !== APPLE._id) {
+          await should(this.pouch.db.get(apple._id)).be.rejectedWith({status: 404})
+        }
+      })
+
       it('does not have identity conflicts', async function () {
         await builders.metadir().path('NUKEM').create()
         const duke = builders.metadir().path('duke').upToDate().build()


### PR DESCRIPTION
When creating a document with an id that has already been used and
  deleted, PouchDB will reuse its rev. This means our new documents
  won't have the expected short rev number of 1 and their sides won't
  match it.

  Whenever we create new documents in Merge, we make sure their sides
  are updated to match the actual revision if it has been reused.

  Since we might call the fix on the source of movements or an existing
  directory document, we only fix documents which didn't have a rev when
  calling the Pouch method (i.e. we are creating them).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
