### PR TITLE
core/metadata: Use ISO string dates in builders

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -9,6 +9,7 @@ const IdConflict = require('./IdConflict')
 const logger = require('./logger')
 const metadata = require('./metadata')
 const move = require('./move')
+const timestamp = require('./timestamp')
 const { otherSide } = require('./side')
 
 /*::
@@ -75,7 +76,7 @@ class Merge {
       _id: parentId,
       path: path.dirname(doc.path),
       docType: 'folder',
-      updated_at: new Date()
+      updated_at: timestamp.fromDate(new Date()).toISOString()
     }
 
     try {

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -9,7 +9,7 @@ const path = require('path')
 const logger = require('./logger')
 const { detectPathIssues, detectPathLengthIssue } = require('./path_restrictions')
 const { DIR_TYPE, FILE_TYPE } = require('./remote/constants')
-const { maxDate } = require('./timestamp')
+const timestamp = require('./timestamp')
 
 const fsutils = require('./utils/fs')
 /*::
@@ -58,7 +58,7 @@ export type Metadata = {
   docType: DocType,
   errors?: number,
   executable?: true,
-  updated_at: string|Date,
+  updated_at: string,
   mime?: string,
   moveTo?: string, // Destination id
   overwrite?: Metadata,
@@ -450,7 +450,7 @@ function buildDir (fpath /*: string */, stats /*: Stats */, remote /*: ?Metadata
     _id: id(fpath),
     path: fpath,
     docType: 'folder',
-    updated_at: maxDate(stats.mtime, stats.ctime),
+    updated_at: timestamp.fromDate(timestamp.maxDate(stats.mtime, stats.ctime)).toISOString(),
     ino: stats.ino,
     sides: {},
     remote
@@ -470,7 +470,7 @@ function buildFile (filePath /*: string */, stats /*: Stats */, md5sum /*: strin
     docType: 'file',
     md5sum,
     ino: stats.ino,
-    updated_at: maxDate(mtime, ctime),
+    updated_at: timestamp.fromDate(timestamp.maxDate(mtime, ctime)).toISOString(),
     mime: mimeType,
     class: mimeType.split('/')[0],
     size: stats.size,

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -43,7 +43,7 @@ module.exports = class BaseMetadataBuilder {
         },
         tags: [],
         sides: {},
-        updated_at: timestamp.stringify(timestamp.current())
+        updated_at: timestamp.current().toISOString()
       }
     }
   }
@@ -138,12 +138,12 @@ module.exports = class BaseMetadataBuilder {
   }
 
   newerThan (doc /*: Metadata */) /*: this */ {
-    this.doc.updated_at = new Date(timestamp.fromDate(doc.updated_at).getTime() + 2000)
+    this.doc.updated_at = timestamp.fromDate(new Date(timestamp.fromDate(doc.updated_at).getTime() + 2000)).toISOString()
     return this
   }
 
   olderThan (doc /*: Metadata */) /*: this */ {
-    this.doc.updated_at = new Date(timestamp.fromDate(doc.updated_at).getTime() - 2000)
+    this.doc.updated_at = timestamp.fromDate(new Date(timestamp.fromDate(doc.updated_at).getTime() - 2000)).toISOString()
     return this
   }
 

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -416,7 +416,7 @@ describe('Local', function () {
         'dst/file',
         'src/'
       ])
-      should(+(await syncDir.mtime(dstFile))).equal(+dstFile.updated_at)
+      should((await syncDir.mtime(dstFile)).getTime()).equal((new Date(dstFile.updated_at)).getTime())
       should(await syncDir.readFile(dstFile)).equal('foobar')
     })
 
@@ -501,7 +501,7 @@ describe('Local', function () {
         'dst/dir/',
         'src/'
       ])
-      should(+(await syncDir.mtime(dstDir))).equal(+dstDir.updated_at)
+      should((await syncDir.mtime(dstDir)).getTime()).equal((new Date(dstDir.updated_at)).getTime())
     })
 
     it('throws ENOENT on missing source', async function () {

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -39,10 +39,6 @@ async function mergeSideEffects ({merge, pouch} /*: * */, mergeCall /*: () => Pr
     // which makes them hard to compare.
     delete doc._rev
 
-    // Pouch serializes dates as strings, but input docs generally have Date
-    // objects. Casting makes assertions easier in most cases.
-    doc.updated_at = new Date(doc.updated_at)
-
     return doc
   })
 
@@ -208,7 +204,7 @@ describe('Merge', function () {
         should(sideEffects).deepEqual({
           savedDocs: [
             _.defaults({
-              updated_at: new Date(doc.updated_at) // FIXME: Stop mixing dates & strings
+              updated_at: doc.updated_at
             }, doc)
           ],
           resolvedConflicts: []
@@ -468,7 +464,7 @@ describe('Merge', function () {
             size: mergedLocalUpdate.size,
             // no remote since file was dissociated
             tags: initial.tags, // could only have been updated from a remote update
-            updated_at: new Date(mergedLocalUpdate.updated_at) // FIXME: Stop mixing dates & strings
+            updated_at: mergedLocalUpdate.updated_at
           }
         ],
         resolvedConflicts: [
@@ -780,7 +776,7 @@ describe('Merge', function () {
           sides: {local: 3, remote: 2},
           size: was.size,
           tags: was.tags,
-          updated_at: new Date(was.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: was.updated_at
         }
         const dst = {
           _id: dstId,
@@ -789,14 +785,14 @@ describe('Merge', function () {
           moveFrom: _.defaults({
             _rev: was._rev,
             moveTo: dstId,
-            updated_at: was.updated_at // FIXME: Stop mixing dates & strings
+            updated_at: was.updated_at
           }, src),
           path: dstPath,
           remote: doc.remote,
           sides: {local: 1},
           size: doc.size,
           tags: doc.tags,
-          updated_at: new Date(doc.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: doc.updated_at
         }
         should(sideEffects).deepEqual({
           savedDocs: [src, dst],
@@ -968,7 +964,7 @@ describe('Merge', function () {
           sides: {local: 1, remote: 2},
           size: baz.size,
           tags: baz.tags,
-          updated_at: new Date(baz.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: baz.updated_at
         }
         const dst = {
           _id: qux._id,
@@ -982,7 +978,7 @@ describe('Merge', function () {
           sides: {local: 1, remote: 2},
           size: qux.size,
           tags: [],
-          updated_at: new Date(qux.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: qux.updated_at
         }
         should(sideEffects).deepEqual({
           savedDocs: [src, dst],
@@ -1099,7 +1095,7 @@ describe('Merge', function () {
           remote: was.remote,
           sides: {local: 3, remote: 2},
           tags: was.tags,
-          updated_at: new Date(was.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: was.updated_at
         }
         const dst = {
           _id: dstId,
@@ -1112,7 +1108,7 @@ describe('Merge', function () {
           remote: doc.remote,
           sides: {local: 1},
           tags: doc.tags,
-          updated_at: new Date(doc.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: doc.updated_at
         }
 
         should(sideEffects).deepEqual({
@@ -1236,19 +1232,19 @@ describe('Merge', function () {
           remote: duke.remote,
           sides: {local: 1, remote: 2},
           tags: duke.tags,
-          updated_at: new Date(duke.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: duke.updated_at
         }
         const dst = {
           _id: nukem._id,
           docType: nukem.docType,
           moveFrom: _.defaults({
-            updated_at: duke.updated_at // FIXME: Stop mixing dates & strings
+            updated_at: duke.updated_at
           }, src),
           path: nukem.path,
           remote: nukem.remote,
           sides: {local: 1, remote: 2},
           tags: nukem.tags,
-          updated_at: new Date(nukem.updated_at) // FIXME: Stop mixing dates & strings
+          updated_at: nukem.updated_at
         }
         should(sideEffects).deepEqual({
           savedDocs: [src, dst],
@@ -1484,7 +1480,7 @@ describe('Merge', function () {
               .merge({
                 _deleted: true,
                 sides: {local: 3, remote: 2},
-                updated_at: new Date(doc.updated_at)
+                updated_at: doc.updated_at
               })
               .value()
           ],

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -720,9 +720,15 @@ describe('metadata', function () {
       const d1 = new Date('2018-01-18T16:46:18.362Z')
       const d2 = new Date('2018-02-18T16:46:18.362Z')
       const ino = 123
-      should(buildDir(path, {mtime: d1, ctime: d1, ino})).have.property('updated_at', d1)
-      should(buildDir(path, {mtime: d1, ctime: d2, ino})).have.property('updated_at', d2)
-      should(buildDir(path, {mtime: d2, ctime: d1, ino})).have.property('updated_at', d2)
+      should(buildDir(path, {mtime: d1, ctime: d1, ino})).have.property(
+        'updated_at', timestamp.fromDate(d1).toISOString()
+      )
+      should(buildDir(path, {mtime: d1, ctime: d2, ino})).have.property(
+        'updated_at', timestamp.fromDate(d2).toISOString()
+      )
+      should(buildDir(path, {mtime: d2, ctime: d1, ino})).have.property(
+        'updated_at', timestamp.fromDate(d2).toISOString()
+      )
     })
 
     it('accepts remote info', () => {


### PR DESCRIPTION
  `buildFile` and `buildDir` were using Date objects for the
  `updated_at` attribute of the Metadata object they're building.
  This leads to a comparison nightmare in tests as we some times have a
  Date object and some times have an ISO string representation of this
  date.

  Forcing it to an ISO string in the builder solves this issue.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
