### PR TITLE
core/local/steps/incomplete_fixer: Fix path separator

### DIFF
--- a/core/local/steps/incomplete_fixer.js
+++ b/core/local/steps/incomplete_fixer.js
@@ -82,7 +82,7 @@ module.exports = function (buffer /*: Buffer */, opts /*: { syncPath: string , c
           continue
         }
 
-        if (event.oldPath && item.event.path.startsWith(event.oldPath + '/')) {
+        if (event.oldPath && item.event.path.startsWith(event.oldPath + path.sep)) {
           // We have a match, try to rebuild the incomplete event
           try {
             const rebuilt = await rebuildIncompleteEvent(item, event, opts)


### PR DESCRIPTION
Otherwise it definitely won't work on Windows.

This part still needs unit tests anyway (planned in the current iteration), but since we're currently doing manual testing, better catch more complex issues than this one.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
