### PR TITLE
test/support/builders/metadata: Match implementation

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -69,7 +69,7 @@ module.exports = class BaseMetadataBuilder {
   }
 
   unmerged (sideName /*: SideName */) /*: this */ {
-    delete this.sides
+    if (this.doc.docType === 'file') delete this.doc.sides
     if (sideName === 'local') this.noRemote()
     return this.noRev()
   }
@@ -85,7 +85,11 @@ module.exports = class BaseMetadataBuilder {
   }
 
   noRemote () /*: this */ {
-    delete this.doc.remote
+    /*
+     * $FlowFixMe Flow is lying to us when allowing metadata's buildFile and
+     * buildDir to set remote to undefined
+     */
+    this.doc.remote = undefined
     return this
   }
 

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+const mime = require('mime')
 const crypto = require('crypto')
 
 const BaseMetadataBuilder = require('./base')
@@ -12,7 +13,12 @@ import type { Metadata } from '../../../../core/metadata'
 module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   constructor (pouch /*: ?Pouch */, old /*: ?Metadata */) {
     super(pouch, old)
+
+    const mimeType = mime.lookup(this.doc.path)
+
     this.doc.docType = 'file'
+    this.doc.mime = mimeType
+    this.doc.class = mimeType.split('/')[0]
     this.data('')
   }
 

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -270,9 +270,11 @@ describe('Merge', function () {
         should(sideEffects).deepEqual({
           savedDocs: [{
             _id: initialFile._id,
+            class: 'application',
             docType: 'file',
             ino: initialFile.ino,
             md5sum: offUpdate.md5sum,
+            mime: 'application/octet-stream',
             path: initialFile.path,
             sides: {local: 2},
             size: offUpdate.size,
@@ -297,9 +299,11 @@ describe('Merge', function () {
           savedDocs: [
             {
               _id: initial._id,
+              class: 'application',
               docType: initial.docType,
               ino: initial.ino,
               md5sum: secondUpdate.md5sum,
+              mime: 'application/octet-stream',
               path: initial.path,
               remote: synced.remote,
               sides: {local: 4, remote: 2},
@@ -456,9 +460,11 @@ describe('Merge', function () {
         savedDocs: [
           {
             _id: initial._id,
+            class: 'application',
             docType: initial.docType,
             ino: initial.ino,
             md5sum: mergedLocalUpdate.md5sum,
+            mime: 'application/octet-stream',
             path: initial.path,
             sides: {local: 3},
             size: mergedLocalUpdate.size,
@@ -768,8 +774,10 @@ describe('Merge', function () {
         const src = {
           _deleted: true,
           _id: was._id,
+          class: 'application',
           docType: was.docType,
           md5sum: was.md5sum,
+          mime: 'application/octet-stream',
           moveTo: dstId,
           path: was.path,
           remote: was.remote,
@@ -780,8 +788,10 @@ describe('Merge', function () {
         }
         const dst = {
           _id: dstId,
+          class: 'application',
           docType: doc.docType,
           md5sum: doc.md5sum,
+          mime: 'application/octet-stream',
           moveFrom: _.defaults({
             _rev: was._rev,
             moveTo: dstId,
@@ -956,8 +966,10 @@ describe('Merge', function () {
         const src = {
           _deleted: true,
           _id: baz._id,
+          class: 'application',
           docType: baz.docType,
           md5sum: baz.md5sum,
+          mime: 'application/octet-stream',
           moveTo: qux._id,
           path: baz.path,
           remote: baz.remote,
@@ -968,8 +980,10 @@ describe('Merge', function () {
         }
         const dst = {
           _id: qux._id,
+          class: 'application',
           docType: qux.docType,
           md5sum: baz.md5sum,
+          mime: 'application/octet-stream',
           moveFrom: _.defaults({
             updated_at: baz.updated_at // FIXME: Stop mixing dates & strings
           }, src),


### PR DESCRIPTION
  In the metadata module, when building a file or a directory, we use an
  optional `remote` parameter to fill in the `remote` attribute of the
  `Metadata` object being built. The way it is done, if the parameter is
  not passed, we end up with a `remote` attribute with an `undefined`
  value instead of not having the parameter at all.

  Also, when building a directory, we set the `sides` attribute to an
  empty object instead of not having an attribute at all like we do when
  building a file.

The metadata's `buildFile` method creates documents with a class and
  mime attributes which are missing from the metadata test builders thus
  preventing us from comparing them with documents from test builders.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
