### PR TITLE
core/local/watcher: Use Atom watcher by default

### DIFF
--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -35,7 +35,7 @@ function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ 
   if (platform === 'darwin') {
     return 'chokidar'
   }
-  return 'chokidar' // TODO: Use atom watcher
+  return 'atom'
 }
 
 function build (syncPath /*: string */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {


### PR DESCRIPTION
  For testing purposes we enable the new Atom watcher by default again
  on Linux and Windows.
