### PR TITLE
core/local/watcher: Get watcher type from Config

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -151,6 +151,16 @@ module.exports = class Config {
     this.persist()
   }
 
+  get watcherType () {
+    if (!this.config.watcherType) {
+      this.config.watcherType = (
+        userDefinedWatcherType(process.env) ||
+        platformDefaultWatcherType(process.platform)
+      )
+    }
+    return this.config.watcherType
+  }
+
   // Set the pull, push or full mode for this device
   // It will throw an exception if the mode is not compatible with the last
   // mode used!
@@ -190,4 +200,21 @@ module.exports = class Config {
     delete this.config.state
     return Promise.resolve()
   }
+}
+
+function userDefinedWatcherType (env) /*: WatcherType | null */ {
+  const { COZY_FS_WATCHER } = env
+  if (COZY_FS_WATCHER === 'atom') {
+    return 'atom'
+  } else if (COZY_FS_WATCHER === 'chokidar') {
+    return 'chokidar'
+  }
+  return null
+}
+
+function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ {
+  if (platform === 'darwin') {
+    return 'chokidar'
+  }
+  return 'chokidar' // XXX: Should be 'atom' once we go live with the new watcher
 }

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -57,7 +57,7 @@ module.exports = class Local /*:: implements Side */ {
     this.events = events
     this.syncPath = config.syncPath
     this.tmpPath = path.join(this.syncPath, TMP_DIR_NAME)
-    this.watcher = watcher.build(this.syncPath, this.prep, this.pouch, events, ignore)
+    this.watcher = watcher.build(config, this.prep, this.pouch, events, ignore)
     // $FlowFixMe
     this.other = null
     this._trash = trash

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -21,28 +21,9 @@ export interface Watcher {
 }
 */
 
-function userDefinedWatcherType (env) /*: WatcherType | null */ {
-  const { COZY_FS_WATCHER } = env
-  if (COZY_FS_WATCHER === 'atom') {
-    return 'atom'
-  } else if (COZY_FS_WATCHER === 'chokidar') {
-    return 'chokidar'
-  }
-  return null
-}
+function build (config /*: { syncPath: string, watcherType: string } */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
+  const { syncPath, watcherType } = config
 
-function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ {
-  if (platform === 'darwin') {
-    return 'chokidar'
-  }
-  return 'chokidar' // TODO: Use atom watcher
-}
-
-function build (syncPath /*: string */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
-  const watcherType = (
-    userDefinedWatcherType(process.env) ||
-    platformDefaultWatcherType(process.platform)
-  )
   if (watcherType === 'atom') {
     return new AtomWatcher(syncPath, prep, pouch, events, ignore)
   } else {

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -5,6 +5,7 @@ const should = require('should')
 const fse = require('fs-extra')
 const configHelpers = require('../support/helpers/config')
 const { COZY_URL } = require('../support/helpers/cozy')
+const { onPlatform, onPlatforms } = require('../support/helpers/platform')
 
 const Config = require('../../core/config')
 
@@ -201,6 +202,50 @@ describe('Config', function () {
     it('has no client after a reset', function () {
       this.config.reset()
       should(this.config.isValid()).be.false()
+    })
+  })
+
+  describe('WatcherType', function () {
+    it('returns watcher type if any', function () {
+      this.config.config.watcherType = 'fooWatcher'
+      should(this.config.watcherType).equal('fooWatcher')
+    })
+
+    context('when the COZY_FS_WATCHER env variable value is atom', function () {
+      beforeEach(function () {
+        Object.defineProperty(process.env, 'COZY_FS_WATCHER', {
+          value: 'atom'
+        })
+      })
+
+      it('returns atom', function () {
+        should(this.config.watcherType).equal('atom')
+      })
+    })
+
+    context('when the COZY_FS_WATCHER env variable value is something else', function () {
+      beforeEach(function () {
+        Object.defineProperty(process.env, 'COZY_FS_WATCHER', {
+          value: 'something'
+        })
+      })
+
+      it('returns chokidar', function () {
+        should(this.config.watcherType).equal('chokidar')
+      })
+    })
+
+    onPlatform('darwin', function () {
+      it('returns chokidar by default', function () {
+        should(this.config.watcherType).equal('chokidar')
+      })
+    })
+
+    onPlatforms(['linux', 'win32'], function () {
+      // FIXME: It returns 'atom' by default once the new watcher is live
+      it('returns chokidar by default', function () {
+        should(this.config.watcherType).equal('chokidar')
+      })
     })
   })
 


### PR DESCRIPTION
  To simplify testing the new local watcher using Atom Watcher behind
  the scenes, we move the choice of watcher to the Config.
  If a `watcherType` property is defined in `config.json`, we use it,
  otherwise we set with the 2 mechanisms that already existed (i.e. user
  defined watcher via env variable then platform default watcher).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
