### PR TITLE
[WIP] test/unit/merge: Use builders for expected values

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -61,6 +61,12 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  moveTo (id /*: string */) /*: this */ {
+    this.doc.moveTo = id
+    this.doc._deleted = true
+    return this
+  }
+
   /** Make sure the doc is not the same as before. */
   whateverChange () /*: this */ {
     this.doc.tags = this.doc.tags || []
@@ -156,6 +162,11 @@ module.exports = class BaseMetadataBuilder {
       _id,
       _rev: dbBuilders.rev()
     }
+    return this
+  }
+
+  remote (doc /*: RemoteDoc */) /*: this */ {
+    this.doc.remote = doc
     return this
   }
 


### PR DESCRIPTION
  It can get pretty hard to read and maintain expectations when checking
  the results of side effects.
  Using test metadata builders to create the expectations objects can
  help with that.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
