### PR TITLE
test/unit/merge: Check side effects in every tests

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -251,8 +251,8 @@ class Merge {
       }
       metadata.assignMaxDate(doc, was)
       if (doc.size == null) { doc.size = was.size }
-      if (doc.class == null) { doc.class = was.class }
-      if (doc.mime == null) { doc.mime = was.mime }
+      if (doc.class == null) { doc.class = was.class } // FIXME: Seems useless since metadata.buildFile adds it
+      if (doc.mime == null) { doc.mime = was.mime } // FIXME: Seems useless since metadata.buildFile adds it
       if (doc.tags == null) { doc.tags = was.tags || [] }
       if (doc.ino == null) { doc.ino = was.ino }
       if (doc.fileid == null) { doc.fileid = was.fileid }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -179,6 +179,17 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  tags (...tags /*: string[] */) /*: this */ {
+    this.doc.tags = tags
+    return this
+  }
+
+  type (mime /*: string */) /*: this */ {
+    this.doc.class = mime.split('/')[0]
+    this.doc.mime = mime
+    return this
+  }
+
   build () /*: Metadata */ {
     // Don't detect incompatibilities according to syncPath for test data, to
     // prevent environment related failures.

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -19,7 +19,10 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
     this.doc.docType = 'file'
     this.doc.mime = mimeType
     this.doc.class = mimeType.split('/')[0]
-    this.data('')
+
+    if (this.doc.md5sum == null) {
+      this.data('')
+    }
   }
 
   data (data /*: string */) /*: this */ {


### PR DESCRIPTION
Needs #1444 

Every test now takes documents built using the test builders and
  compare the side effects of the merge methods with expected side
  effects.
  Those changes make clear what changes we expect from each method down
  to every document attributes.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
