### PR TITLE
core/merge: Reset sides on every move

### DIFF
--- a/core/move.js
+++ b/core/move.js
@@ -1,7 +1,9 @@
 /* @flow */
 
+const metadata = require('./metadata')
+
 /*::
-import type { Metadata } from './metadata'
+import type { SideName, Metadata } from './metadata'
 */
 
 // Export so the following possible is possible:
@@ -15,7 +17,7 @@ move.child = child
 
 // Modify the given src/dst docs so they can be merged then moved accordingly
 // during sync.
-function move (src /*: Metadata */, dst /*: Metadata */) {
+function move (side /*: SideName */, src /*: Metadata */, dst /*: Metadata */) {
   // moveTo is used for comparison. It's safer to take _id
   // than path for this case, as explained in doc/developer/design.md
   src.moveTo = dst._id
@@ -31,16 +33,17 @@ function move (src /*: Metadata */, dst /*: Metadata */) {
   delete dst.trashed
 
   dst.moveFrom = src
+
+  if (!dst.overwrite) {
+    delete dst._rev
+  }
+  delete dst.sides
+  metadata.markSide(side, dst)
 }
 
 // Same as move() but mark the source as a child move so it will be moved with
 // its ancestor, not by itself, during sync.
-function child (src /*: Metadata */, dst /*: Metadata */) {
+function child (side /*: SideName */, src /*: Metadata */, dst /*: Metadata */) {
   src.childMove = true
-  move(src, dst)
-
-  // TODO: Find out why _rev is removed only from child move destinations and
-  // explain it here. Or in case it would make sense, move it to the move()
-  // function above.
-  delete dst._rev
+  move(side, src, dst)
 }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -989,7 +989,7 @@ describe('Merge', function () {
           }, src),
           path: qux.path,
           remote: qux.remote,
-          sides: {local: 1, remote: 2},
+          sides: {local: 1},
           size: qux.size,
           tags: [],
           updated_at: qux.updated_at
@@ -1256,7 +1256,7 @@ describe('Merge', function () {
           }, src),
           path: nukem.path,
           remote: nukem.remote,
-          sides: {local: 1, remote: 2},
+          sides: {local: 1},
           tags: nukem.tags,
           updated_at: nukem.updated_at
         }

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -14,7 +14,7 @@ describe('move', () => {
       const src = builders.metadata().path('whatever/src').build()
       const dst = _.defaults({path: 'whatever/dst'}, src)
 
-      move.child(src, dst)
+      move.child('local', src, dst)
 
       should(dst).have.propertyByPath('moveFrom', 'childMove').eql(true)
     })


### PR DESCRIPTION
  When moving a file or directory, we delete the source document and
  create a new one in Pouch.
  This new document should only have one side, the one from which the
  document was created, and its version should be 1 since this is a new
  document (n.b. it can end up being higher if the path is being reused
  and we're fixing the sides later).

  We were doing this reset in some situations only. Now, we do it as
  part of the `move` call so it's done in every move.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
