### PR TITLE
core/merge: Don't mark sides already handled by move()

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -248,7 +248,6 @@ class Merge {
         await this.resolveConflictAsync(side, doc, file)
         return
       }
-      metadata.markSide(side, was, was)
       metadata.assignMaxDate(doc, was)
       if (doc.size == null) { doc.size = was.size }
       if (doc.class == null) { doc.class = was.class }
@@ -296,7 +295,6 @@ class Merge {
       return this.resolveConflictAsync(side, doc, folder)
     }
 
-    metadata.markSide(side, was, was)
     metadata.assignMaxDate(doc, was)
     if (doc.tags == null) { doc.tags = was.tags || [] }
     if (doc.ino == null) { doc.ino = was.ino }

--- a/core/merge.js
+++ b/core/merge.js
@@ -248,7 +248,6 @@ class Merge {
         await this.resolveConflictAsync(side, doc, file)
         return
       }
-      metadata.markSide(side, doc, file)
       metadata.markSide(side, was, was)
       metadata.assignMaxDate(doc, was)
       if (doc.size == null) { doc.size = was.size }
@@ -297,7 +296,6 @@ class Merge {
       return this.resolveConflictAsync(side, doc, folder)
     }
 
-    metadata.markSide(side, doc, folder)
     metadata.markSide(side, was, was)
     metadata.assignMaxDate(doc, was)
     if (doc.tags == null) { doc.tags = was.tags || [] }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -781,7 +781,7 @@ describe('Merge', function () {
           moveTo: dstId,
           path: was.path,
           remote: was.remote,
-          sides: {local: 3, remote: 2},
+          sides: {local: 2, remote: 2},
           size: was.size,
           tags: was.tags,
           updated_at: was.updated_at
@@ -973,7 +973,7 @@ describe('Merge', function () {
           moveTo: qux._id,
           path: baz.path,
           remote: baz.remote,
-          sides: {local: 1, remote: 2},
+          sides: {local: 2, remote: 2},
           size: baz.size,
           tags: baz.tags,
           updated_at: baz.updated_at
@@ -1107,7 +1107,7 @@ describe('Merge', function () {
           moveTo: dstId,
           path: was.path,
           remote: was.remote,
-          sides: {local: 3, remote: 2},
+          sides: {local: 2, remote: 2},
           tags: was.tags,
           updated_at: was.updated_at
         }
@@ -1244,7 +1244,7 @@ describe('Merge', function () {
           moveTo: nukem._id,
           path: duke.path,
           remote: duke.remote,
-          sides: {local: 1, remote: 2},
+          sides: {local: 2, remote: 2},
           tags: duke.tags,
           updated_at: duke.updated_at
         }


### PR DESCRIPTION
Since move source & destination sides are already handled in `core/move`.

Completing [#1440](https://github.com/cozy-labs/cozy-desktop/pull/1440).
Courtesy of @taratatach.