### PR TITLE
core/local/steps/dispatch: Detect end of batch

### DIFF
--- a/core/local/steps/buffer.js
+++ b/core/local/steps/buffer.js
@@ -39,19 +39,6 @@ module.exports = class Buffer {
     })
   }
 
-  async forEach (fn /*: (Batch) => void */) /*: Promise<void> */ {
-    while (true) {
-      fn(await this.pop())
-    }
-  }
-
-  async asyncForEach (fn /*: (Batch) => Promise<void> */) /*: Promise<void> */ {
-    while (true) {
-      const batch = await this.pop()
-      await fn(batch)
-    }
-  }
-
   async doMap (fn /*: (Batch) => Batch */, buffer /*: Buffer */) /*: Promise<void> */ {
     while (true) {
       const batch = fn(await this.pop())

--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -11,6 +11,12 @@ import type Buffer from './buffer'
 import type EventEmitter from 'events'
 import type Prep from '../../prep'
 import type Pouch from '../../pouch'
+
+type DispatchOptions = {
+  events: EventEmitter,
+  prep: Prep,
+  pouch: Pouch,
+}
 */
 
 const SIDE = 'local'
@@ -19,11 +25,12 @@ let events, target, pouch, actions
 // Dispatch takes a buffer of AtomWatcherEvents batches, and calls Prep for
 // each event. It needs to fetch the old documents from pouchdb in some cases
 // to have all the data expected by prep/merge.
-module.exports = function (buffer /*: Buffer */, opts /*: { events: EventEmitter, prep: Prep, pouch: Pouch } */) {
+module.exports = function (buffer /*: Buffer */, opts /*: DispatchOptions */) /*: Buffer */ {
   events = opts.events
   target = opts.prep
   pouch = opts.pouch
-  buffer.asyncForEach(async (batch) => {
+
+  return buffer.asyncMap(async (batch) => {
     for (const event of batch) {
       try {
         log.trace({event}, 'dispatch')
@@ -37,6 +44,8 @@ module.exports = function (buffer /*: Buffer */, opts /*: { events: EventEmitter
         console.log('Dispatch error:', err, event) // TODO
       }
     }
+
+    return batch
   })
 }
 


### PR DESCRIPTION
By using an `asyncMap` instead of an `asyncForEach` and by returning
  the resulting buffer, we can detect the end of a batch processing from
  the caller of the step.
  This is very useful to test the step in isolation.

The Buffer's `forEach` and `asyncForEach` methods are not used at all or not
  any more so we can remove them.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
