### PR TITLE
core/merge: Fix side after remote dissociation

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -178,6 +178,7 @@ class Merge {
           // the old file should be dissociated from the remote
           delete file.remote
           if (file.sides) delete file.sides.remote
+          metadata.markSide('local', file, file)
           await this.pouch.put(file)
         }
         return

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -466,7 +466,7 @@ describe('Merge', function () {
             md5sum: mergedLocalUpdate.md5sum,
             mime: 'application/octet-stream',
             path: initial.path,
-            sides: {local: 3},
+            sides: {local: 4},
             size: mergedLocalUpdate.size,
             // no remote since file was dissociated
             tags: initial.tags, // could only have been updated from a remote update


### PR DESCRIPTION
  When trying to merge a remote file update which results in a conflict
  resolution, we dissociate the untouched local document from the remote
  version.
  When doing so, we're actually saving a new version of the document in
  Pouch which will result in a `_rev` increase and should therefore
  result in a local side increase as well.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
