### PR TITLE
core/config: Separate class/module, refactoring, new functions & flow types

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -45,7 +45,7 @@ class App {
   /*::
   lang: string
   basePath: string
-  config: Config
+  config: Config.Config
   pouch: Pouch
   events: EventEmitter
   ignore: Ignore.Ignore
@@ -63,7 +63,7 @@ class App {
     if (basePath == null) { basePath = os.homedir() }
     basePath = path.resolve(basePath)
     this.basePath = path.join(basePath, '.cozy-desktop')
-    this.config = new Config(this.basePath)
+    this.config = new Config.Config(this.basePath)
     this.pouch = new Pouch(this.config)
     this.events = new SyncState()
 

--- a/core/app.js
+++ b/core/app.js
@@ -63,7 +63,7 @@ class App {
     if (basePath == null) { basePath = os.homedir() }
     basePath = path.resolve(basePath)
     this.basePath = path.join(basePath, '.cozy-desktop')
-    this.config = new Config.Config(this.basePath)
+    this.config = Config.load(this.basePath)
     this.pouch = new Pouch(this.config)
     this.events = new SyncState()
 

--- a/core/app.js
+++ b/core/app.js
@@ -12,7 +12,7 @@ const {createGzip} = require('zlib')
 
 require('./globals')
 const pkg = require('../package.json')
-const Config = require('./config')
+const config = require('./config')
 const logger = require('./logger')
 const sentry = require('./sentry')
 const { LOG_FILE, LOG_FILENAME } = logger
@@ -28,6 +28,7 @@ const Registration = require('./remote/registration')
 
 /*::
 import type EventEmitter from 'events'
+import type { Config } from './config'
 import type stream from 'stream'
 import type { Callback } from './utils/func'
 import type { SyncMode } from './sync'
@@ -45,7 +46,7 @@ class App {
   /*::
   lang: string
   basePath: string
-  config: Config.Config
+  config: Config
   pouch: Pouch
   events: EventEmitter
   ignore: Ignore.Ignore
@@ -63,7 +64,7 @@ class App {
     if (basePath == null) { basePath = os.homedir() }
     basePath = path.resolve(basePath)
     this.basePath = path.join(basePath, '.cozy-desktop')
-    this.config = Config.load(this.basePath)
+    this.config = config.load(this.basePath)
     this.pouch = new Pouch(this.config)
     this.events = new SyncState()
 

--- a/core/config.js
+++ b/core/config.js
@@ -135,13 +135,7 @@ class Config {
   }
 
   get watcherType () {
-    if (!this.fileConfig.watcherType) {
-      this.fileConfig.watcherType = (
-        environmentWatcherType(process.env) ||
-        platformDefaultWatcherType(process.platform)
-      )
-    }
-    return this.fileConfig.watcherType
+    return watcherType(this.fileConfig)
   }
 
   // Set the pull, push or full mode for this device
@@ -209,6 +203,14 @@ function loadOrDeleteFile (configPath) {
   }
 }
 
+function watcherType (config = {}, {env, platform} = process) {
+  return (
+    config.watcherType ||
+    environmentWatcherType(process.env) ||
+    platformDefaultWatcherType(process.platform)
+  )
+}
+
 function environmentWatcherType (env /*: {COZY_FS_WATCHER?: string} */ = process.env) /*: WatcherType | null */ {
   const { COZY_FS_WATCHER } = env
   if (COZY_FS_WATCHER === 'atom') {
@@ -231,5 +233,6 @@ module.exports = {
   environmentWatcherType,
   load,
   loadOrDeleteFile,
-  platformDefaultWatcherType
+  platformDefaultWatcherType,
+  watcherType
 }

--- a/core/config.js
+++ b/core/config.js
@@ -209,7 +209,7 @@ function loadOrDeleteFile (configPath) {
   }
 }
 
-function environmentWatcherType (env) /*: WatcherType | null */ {
+function environmentWatcherType (env /*: {COZY_FS_WATCHER?: string} */ = process.env) /*: WatcherType | null */ {
   const { COZY_FS_WATCHER } = env
   if (COZY_FS_WATCHER === 'atom') {
     return 'atom'
@@ -219,7 +219,7 @@ function environmentWatcherType (env) /*: WatcherType | null */ {
   return null
 }
 
-function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ {
+function platformDefaultWatcherType (platform /*: string */ = process.platform) /*: WatcherType */ {
   if (platform === 'darwin') {
     return 'chokidar'
   }
@@ -228,6 +228,8 @@ function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ 
 
 module.exports = {
   Config,
+  environmentWatcherType,
   load,
-  loadOrDeleteFile
+  loadOrDeleteFile,
+  platformDefaultWatcherType
 }

--- a/core/config.js
+++ b/core/config.js
@@ -21,7 +21,7 @@ class Config {
     fse.ensureDirSync(this.dbPath)
     hideOnWindows(basePath)
 
-    this.config = this.read()
+    this.fileConfig = this.read()
   }
 
   // Read the configuration from disk
@@ -40,7 +40,7 @@ class Config {
 
   // Reset the configuration
   reset () {
-    this.config = Object.create(null)
+    this.fileConfig = Object.create(null)
     this.clear()
     this.persist()
   }
@@ -69,7 +69,7 @@ class Config {
 
   // Transform the config to a JSON string
   toJSON () {
-    return JSON.stringify(this.config, null, 2)
+    return JSON.stringify(this.fileConfig, null, 2)
   }
 
   // Get the tmp config path associated with the current config path
@@ -79,31 +79,31 @@ class Config {
 
   // Get the path on the local file system of the synchronized folder
   get syncPath () {
-    return this.config.path
+    return this.fileConfig.path
   }
 
   // Set the path on the local file system of the synchronized folder
   set syncPath (path) {
-    this.config.path = path
+    this.fileConfig.path = path
   }
 
   // Return the URL of the cozy instance
   get cozyUrl () {
-    return this.config.url
+    return this.fileConfig.url
   }
 
   // Set the URL of the cozy instance
   set cozyUrl (url) {
-    this.config.url = url
+    this.fileConfig.url = url
   }
 
   get gui () {
-    return this.config.gui || {}
+    return this.fileConfig.gui || {}
   }
 
   // Return true if a device has been configured
   isValid () {
-    return !!(this.config.creds && this.cozyUrl)
+    return !!(this.fileConfig.creds && this.cozyUrl)
   }
 
   // Return the name of the registered client
@@ -113,10 +113,10 @@ class Config {
 
   // Return config related to the OAuth client
   get client () {
-    if (!this.config.creds) {
+    if (!this.fileConfig.creds) {
       throw new Error(`Device not configured`)
     }
-    return this.config.creds.client
+    return this.fileConfig.creds.client
   }
 
   get version () {
@@ -130,38 +130,38 @@ class Config {
 
   // Set the remote configuration
   set client (options) {
-    this.config.creds = { client: options }
+    this.fileConfig.creds = { client: options }
     this.persist()
   }
 
   get watcherType () {
-    if (!this.config.watcherType) {
-      this.config.watcherType = (
+    if (!this.fileConfig.watcherType) {
+      this.fileConfig.watcherType = (
         userDefinedWatcherType(process.env) ||
         platformDefaultWatcherType(process.platform)
       )
     }
-    return this.config.watcherType
+    return this.fileConfig.watcherType
   }
 
   // Set the pull, push or full mode for this device
   // It will throw an exception if the mode is not compatible with the last
   // mode used!
   saveMode (mode) {
-    const old = this.config.mode
+    const old = this.fileConfig.mode
     if (old === mode) {
       return true
     } else if (old) {
       throw new Error(`Once you set mode to "${old}", you cannot switch to "${mode}"`)
     }
-    this.config.mode = mode
+    this.fileConfig.mode = mode
     this.persist()
   }
 
   // Implement the Storage interface for cozy-client-js oauth
 
   save (key, value) {
-    this.config[key] = value
+    this.fileConfig[key] = value
     if (key === 'creds') {
       // Persist the access token after it has been refreshed
       this.persist()
@@ -170,17 +170,17 @@ class Config {
   }
 
   load (key) {
-    return Promise.resolve(this.config[key])
+    return Promise.resolve(this.fileConfig[key])
   }
 
   delete (key) {
-    const deleted = delete this.config[key]
+    const deleted = delete this.fileConfig[key]
     return Promise.resolve(deleted)
   }
 
   clear () {
-    delete this.config.creds
-    delete this.config.state
+    delete this.fileConfig.creds
+    delete this.fileConfig.state
     return Promise.resolve()
   }
 }

--- a/core/config.js
+++ b/core/config.js
@@ -217,9 +217,9 @@ function loadOrDeleteFile (configPath /*: string */) /*: FileConfig */ {
   }
 }
 
-function watcherType (config /*: FileConfig */ = {}, {env, platform} /*: * */ = process) /*: WatcherType */ {
+function watcherType (fileConfig /*: FileConfig */ = {}, {env, platform} /*: * */ = process) /*: WatcherType */ {
   return (
-    config.watcherType ||
+    fileConfig.watcherType ||
     environmentWatcherType(process.env) ||
     platformDefaultWatcherType(process.platform)
   )

--- a/core/config.js
+++ b/core/config.js
@@ -202,6 +202,10 @@ class Config {
   }
 }
 
+function load (dir /*: string */) /*: Config */ {
+  return new Config(dir)
+}
+
 function userDefinedWatcherType (env) /*: WatcherType | null */ {
   const { COZY_FS_WATCHER } = env
   if (COZY_FS_WATCHER === 'atom') {
@@ -220,5 +224,6 @@ function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ 
 }
 
 module.exports = {
-  Config
+  Config,
+  load
 }

--- a/core/config.js
+++ b/core/config.js
@@ -219,20 +219,19 @@ function loadOrDeleteFile (configPath /*: string */) /*: FileConfig */ {
 
 function watcherType (fileConfig /*: FileConfig */ = {}, {env, platform} /*: * */ = process) /*: WatcherType */ {
   return (
-    fileConfig.watcherType ||
+    fileWatcherType(fileConfig) ||
     environmentWatcherType(process.env) ||
     platformDefaultWatcherType(process.platform)
   )
 }
 
-function environmentWatcherType (env /*: * */ = process.env) /*: WatcherType | null */ {
+function fileWatcherType (fileConfig /*: FileConfig */) /*: ?WatcherType */ {
+  return validateWatcherType(fileConfig.watcherType)
+}
+
+function environmentWatcherType (env /*: * */ = process.env) /*: ?WatcherType */ {
   const { COZY_FS_WATCHER } = env
-  if (COZY_FS_WATCHER === 'atom') {
-    return 'atom'
-  } else if (COZY_FS_WATCHER === 'chokidar') {
-    return 'chokidar'
-  }
-  return null
+  return validateWatcherType(COZY_FS_WATCHER)
 }
 
 function platformDefaultWatcherType (platform /*: string */ = process.platform) /*: WatcherType */ {
@@ -240,6 +239,15 @@ function platformDefaultWatcherType (platform /*: string */ = process.platform) 
     return 'chokidar'
   }
   return 'chokidar' // XXX: Should be 'atom' once we go live with the new watcher
+}
+
+function validateWatcherType (watcherType /*: ?string */) /*: ?WatcherType */ {
+  if (watcherType === 'atom' || watcherType === 'chokidar') {
+    return watcherType
+  } else {
+    log.warn({watcherType}, 'Invalid watcher type')
+    return null
+  }
 }
 
 module.exports = {

--- a/core/config.js
+++ b/core/config.js
@@ -12,7 +12,7 @@ const log = logger({
 
 // Config can keep some configuration parameters in a JSON file,
 // like the devices credentials or the mount path
-module.exports = class Config {
+class Config {
   // Create config file if it doesn't exist.
   constructor (basePath) {
     this.configPath = path.join(basePath, 'config.json')
@@ -217,4 +217,8 @@ function platformDefaultWatcherType (platform /*: string */) /*: WatcherType */ 
     return 'chokidar'
   }
   return 'chokidar' // XXX: Should be 'atom' once we go live with the new watcher
+}
+
+module.exports = {
+  Config
 }

--- a/core/config.js
+++ b/core/config.js
@@ -137,7 +137,7 @@ class Config {
   get watcherType () {
     if (!this.fileConfig.watcherType) {
       this.fileConfig.watcherType = (
-        userDefinedWatcherType(process.env) ||
+        environmentWatcherType(process.env) ||
         platformDefaultWatcherType(process.platform)
       )
     }
@@ -209,7 +209,7 @@ function loadOrDeleteFile (configPath) {
   }
 }
 
-function userDefinedWatcherType (env) /*: WatcherType | null */ {
+function environmentWatcherType (env) /*: WatcherType | null */ {
   const { COZY_FS_WATCHER } = env
   if (COZY_FS_WATCHER === 'atom') {
     return 'atom'

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -21,7 +21,7 @@ const syncDir = require('./sync_dir')
 
 /*::
 import type EventEmitter from 'events'
-import type Config from '../config'
+import type { Config } from '../config'
 import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider'
 import type { Ignore } from '../ignore'
 import type { Metadata } from '../metadata'

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -4,14 +4,13 @@ const AtomWatcher = require('./atom_watcher')
 const ChokidarWatcher = require('./chokidar_watcher')
 
 /*::
+import type { WatcherType } from '../config'
 import type Pouch from '../pouch'
 import type Prep from '../prep'
 import type EventEmitter from 'events'
 import type { Ignore } from '../ignore'
 import type { ChokidarEvent } from './chokidar_event'
 import type { Checksumer } from './checksumer'
-
-type WatcherType = 'atom' | 'chokidar'
 
 export interface Watcher {
   checksumer: Checksumer,
@@ -21,7 +20,7 @@ export interface Watcher {
 }
 */
 
-function build (config /*: { +syncPath: string, +watcherType: string } */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
+function build (config /*: { +syncPath: string, +watcherType: WatcherType } */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
   const { syncPath, watcherType } = config
 
   if (watcherType === 'atom') {

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -21,7 +21,7 @@ export interface Watcher {
 }
 */
 
-function build (config /*: { syncPath: string, watcherType: string } */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
+function build (config /*: { +syncPath: string, +watcherType: string } */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
   const { syncPath, watcherType } = config
 
   if (watcherType === 'atom') {

--- a/core/pouch.js
+++ b/core/pouch.js
@@ -13,7 +13,7 @@ const logger = require('./logger')
 const metadata = require('./metadata')
 
 /*::
-import type Config from './config'
+import type { Config } from './config'
 import type { Metadata } from './metadata'
 import type { Callback } from './utils/func'
 */

--- a/core/prep.js
+++ b/core/prep.js
@@ -9,7 +9,7 @@ const metadata = require('./metadata')
 const { TRASH_DIR_NAME } = require('./remote/constants')
 
 /*::
-import type Config from './config'
+import type { Config } from './config'
 import type { Ignore } from './ignore'
 import type Merge from './merge'
 import type { SideName, Metadata, RemoteRevisionsByID } from './metadata'

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -12,7 +12,7 @@ const logger = require('../logger')
 const { posix } = path
 
 /*::
-import type Config from '../config'
+import type { Config } from '../config'
 import type { Readable } from 'stream'
 import type { RemoteDoc, RemoteDeletion } from './document'
 import type { Warning } from './warning'

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -14,7 +14,7 @@ const { withContentLength } = require('../file_stream_provider')
 
 /*::
 import type EventEmitter from 'events'
-import type Config from '../config'
+import type { Config } from '../config'
 import type { Metadata } from '../metadata'
 import type Pouch from '../pouch'
 import type Prep from '../prep'

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -2,7 +2,7 @@ const fse = require('fs-extra')
 const del = require('del')
 const path = require('path')
 
-const Config = require('../../../core/config')
+const config = require('../../../core/config')
 
 const { COZY_URL } = require('./cozy')
 
@@ -12,7 +12,7 @@ module.exports = {
     this.basePath = path.resolve(`${parent}/test/${+new Date()}`)
     this.syncPath = path.join(this.basePath, 'Cozy Drive')
     fse.ensureDirSync(this.syncPath)
-    this.config = Config.load(path.join(this.basePath, '.cozy-desktop'))
+    this.config = config.load(path.join(this.basePath, '.cozy-desktop'))
     this.config.syncPath = this.syncPath
     this.config.cozyUrl = COZY_URL
   },

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   registerClient () {
-    this.config.config.creds = {
+    this.config.fileConfig.creds = {
       client: {
         clientID: process.env.COZY_CLIENT_ID || 'desktop',
         clientName: 'desktop',

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -12,7 +12,7 @@ module.exports = {
     this.basePath = path.resolve(`${parent}/test/${+new Date()}`)
     this.syncPath = path.join(this.basePath, 'Cozy Drive')
     fse.ensureDirSync(this.syncPath)
-    this.config = new Config(path.join(this.basePath, '.cozy-desktop'))
+    this.config = new Config.Config(path.join(this.basePath, '.cozy-desktop'))
     this.config.syncPath = this.syncPath
     this.config.cozyUrl = COZY_URL
   },

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -12,7 +12,7 @@ module.exports = {
     this.basePath = path.resolve(`${parent}/test/${+new Date()}`)
     this.syncPath = path.join(this.basePath, 'Cozy Drive')
     fse.ensureDirSync(this.syncPath)
-    this.config = new Config.Config(path.join(this.basePath, '.cozy-desktop'))
+    this.config = Config.load(path.join(this.basePath, '.cozy-desktop'))
     this.config.syncPath = this.syncPath
     this.config.cozyUrl = COZY_URL
   },

--- a/test/support/helpers/integration.js
+++ b/test/support/helpers/integration.js
@@ -21,7 +21,7 @@ const { RemoteTestHelpers } = require('./remote')
 
 /*::
 import type cozy from 'cozy-client-js'
-import type Config from '../../../core/config'
+import type { Config } from '../../../core/config'
 import type { Metadata } from '../../../core/metadata'
 import type Pouch from '../../../core/pouch'
 */

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -263,4 +263,50 @@ describe('core/config', function () {
       })
     })
   })
+
+  describe('.environmentWatcherType()', () => {
+    it('depends on the environment', () => {
+      should(Config.environmentWatcherType()).equal(
+        Config.environmentWatcherType(process.env)
+      )
+    })
+
+    describe('when COZY_FS_WATCHER is valid', () => {
+      for (const COZY_FS_WATCHER of ['atom', 'chokidar']) {
+        it(`returns COZY_FS_WATCHER when set to ${JSON.stringify(COZY_FS_WATCHER)}`, () => {
+          const watcherType = Config.environmentWatcherType({COZY_FS_WATCHER})
+          should(watcherType).equal(COZY_FS_WATCHER)
+        })
+      }
+    })
+
+    describe('when COZY_FS_WATCHER is invalid or missing', () => {
+      for (const COZY_FS_WATCHER of ['invalid', '', ' ', undefined]) {
+        it(`is null when COZY_FS_WATCHER is set to ${JSON.stringify(COZY_FS_WATCHER)}`, () => {
+          const watcherType = Config.environmentWatcherType({COZY_FS_WATCHER})
+          should(watcherType).be.null()
+        })
+      }
+    })
+  })
+
+  describe('.platformDefaultWatcherType()', () => {
+    it('depends on the platform', () => {
+      should(Config.platformDefaultWatcherType()).equal(
+        Config.platformDefaultWatcherType(process.platform)
+      )
+    })
+
+    it('is chokidar on Windows', () => {
+      should(Config.platformDefaultWatcherType('win32')).equal('chokidar')
+    })
+
+    it('is chokidar on macOS', () => {
+      should(Config.platformDefaultWatcherType('darwin')).equal('chokidar')
+    })
+
+    it('is chokidar on Linux', () => {
+      should(Config.platformDefaultWatcherType('linux')).equal('chokidar')
+    })
+  })
 })

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -203,9 +203,9 @@ describe('core/config', function () {
     })
 
     describe('#watcherType', function () {
-      it('returns watcher type from file config if any', function () {
-        this.config.fileConfig.watcherType = 'fooWatcher'
-        should(this.config.watcherType).equal('fooWatcher')
+      it('returns valid watcher type from file config if any', function () {
+        this.config.fileConfig.watcherType = 'atom'
+        should(this.config.watcherType).equal('atom')
       })
 
       it('is the same as core/config.watcherType() otherwise', function () {
@@ -241,9 +241,10 @@ describe('core/config', function () {
     describe('when invalid in file config', () => {
       const fileConfig = {watcherType: 'invalid'}
 
-      // FIXME: Should not silently fallback to chokidar
-      it('is still the file config value', () => {
-        should(config.watcherType(fileConfig)).equal(fileConfig.watcherType)
+      it('is the same as when no file config', () => {
+        should(config.watcherType(fileConfig)).equal(
+          config.watcherType({})
+        )
       })
     })
 

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -6,7 +6,7 @@ const fse = require('fs-extra')
 const configHelpers = require('../support/helpers/config')
 const { COZY_URL } = require('../support/helpers/cozy')
 
-const Config = require('../../core/config')
+const config = require('../../core/config')
 
 describe('core/config', function () {
   describe('.Config', () => {
@@ -95,7 +95,7 @@ describe('core/config', function () {
         })
 
         it('returns an object matching the file content', function () {
-          const newConf = Config.loadOrDeleteFile(this.config.configPath)
+          const newConf = config.loadOrDeleteFile(this.config.configPath)
           newConf.should.be.an.Object()
           newConf.url.should.eql(conf.url)
         })
@@ -110,7 +110,7 @@ describe('core/config', function () {
 
         it('throws an error', function () {
           (() => {
-            Config.loadOrDeleteFile(this.config.configPath)
+            config.loadOrDeleteFile(this.config.configPath)
           }).should.throw()
         })
       })
@@ -121,12 +121,11 @@ describe('core/config', function () {
         })
 
         it('returns an empty object', function () {
-          const config = Config.loadOrDeleteFile(this.config.configPath)
-          should(config).deepEqual({})
+          should(config.loadOrDeleteFile(this.config.configPath)).deepEqual({})
         })
 
         it('does not delete it', function () {
-          Config.loadOrDeleteFile(this.config.configPath)
+          config.loadOrDeleteFile(this.config.configPath)
           should(fse.existsSync(this.config.configPath)).be.true()
         })
       })
@@ -138,19 +137,17 @@ describe('core/config', function () {
 
         it('does not throw any errors', function () {
           (() => {
-            Config.loadOrDeleteFile(this.config.configPath)
+            config.loadOrDeleteFile(this.config.configPath)
           }).should.not.throw()
         })
 
         it('returns an empty object', function () {
-          const config = Config.loadOrDeleteFile(this.config.configPath)
-          should(config).be.an.Object()
-          should(config).be.empty()
+          should(config.loadOrDeleteFile(this.config.configPath)).deepEqual({})
         })
 
         it('deletes the file', function () {
           fse.existsSync(this.config.configPath).should.be.true()
-          Config.loadOrDeleteFile(this.config.configPath)
+          config.loadOrDeleteFile(this.config.configPath)
           fse.existsSync(this.config.configPath).should.be.false()
         })
       })
@@ -161,7 +158,7 @@ describe('core/config', function () {
         const url = 'http://cozy.local:8080/'
         this.config.cozyUrl = url
         this.config.persist()
-        let conf = Config.load(path.dirname(this.config.configPath))
+        let conf = config.load(path.dirname(this.config.configPath))
         should(conf.cozyUrl).equal(url)
       })
     })
@@ -212,7 +209,7 @@ describe('core/config', function () {
       })
 
       it('is the same as core/config.watcherType() otherwise', function () {
-        should(this.config.watcherType).equal(Config.watcherType())
+        should(this.config.watcherType).equal(config.watcherType())
       })
     })
 
@@ -237,7 +234,7 @@ describe('core/config', function () {
       const fileConfig = {watcherType: 'atom'}
 
       it('is the file config value', () => {
-        should(Config.watcherType(fileConfig)).equal(fileConfig.watcherType)
+        should(config.watcherType(fileConfig)).equal(fileConfig.watcherType)
       })
     })
 
@@ -246,7 +243,7 @@ describe('core/config', function () {
 
       // FIXME: Should not silently fallback to chokidar
       it('is still the file config value', () => {
-        should(Config.watcherType(fileConfig)).equal(fileConfig.watcherType)
+        should(config.watcherType(fileConfig)).equal(fileConfig.watcherType)
       })
     })
 
@@ -257,7 +254,7 @@ describe('core/config', function () {
         const env = {COZY_FS_WATCHER: 'chokidar'}
 
         it('is the COZY_FS_WATCHER value', () => {
-          should(Config.watcherType(fileConfig, {env, platform})).equal(
+          should(config.watcherType(fileConfig, {env, platform})).equal(
             env.COZY_FS_WATCHER
           )
         })
@@ -267,8 +264,8 @@ describe('core/config', function () {
         const env = {COZY_FS_WATCHER: 'invalid'}
 
         it('is the default for the current platform', () => {
-          should(Config.watcherType(fileConfig, {env, platform})).equal(
-            Config.platformDefaultWatcherType(platform)
+          should(config.watcherType(fileConfig, {env, platform})).equal(
+            config.platformDefaultWatcherType(platform)
           )
         })
       })
@@ -277,8 +274,8 @@ describe('core/config', function () {
         const env = {}
 
         it('is the default for the current platform', () => {
-          should(Config.watcherType(fileConfig, {env, platform})).equal(
-            Config.platformDefaultWatcherType(platform)
+          should(config.watcherType(fileConfig, {env, platform})).equal(
+            config.platformDefaultWatcherType(platform)
           )
         })
       })
@@ -287,15 +284,15 @@ describe('core/config', function () {
 
   describe('.environmentWatcherType()', () => {
     it('depends on the environment', () => {
-      should(Config.environmentWatcherType()).equal(
-        Config.environmentWatcherType(process.env)
+      should(config.environmentWatcherType()).equal(
+        config.environmentWatcherType(process.env)
       )
     })
 
     describe('when COZY_FS_WATCHER is valid', () => {
       for (const COZY_FS_WATCHER of ['atom', 'chokidar']) {
         it(`returns COZY_FS_WATCHER when set to ${JSON.stringify(COZY_FS_WATCHER)}`, () => {
-          const watcherType = Config.environmentWatcherType({COZY_FS_WATCHER})
+          const watcherType = config.environmentWatcherType({COZY_FS_WATCHER})
           should(watcherType).equal(COZY_FS_WATCHER)
         })
       }
@@ -304,7 +301,7 @@ describe('core/config', function () {
     describe('when COZY_FS_WATCHER is invalid or missing', () => {
       for (const COZY_FS_WATCHER of ['invalid', '', ' ', undefined]) {
         it(`is null when COZY_FS_WATCHER is set to ${JSON.stringify(COZY_FS_WATCHER)}`, () => {
-          const watcherType = Config.environmentWatcherType({COZY_FS_WATCHER})
+          const watcherType = config.environmentWatcherType({COZY_FS_WATCHER})
           should(watcherType).be.null()
         })
       }
@@ -313,21 +310,21 @@ describe('core/config', function () {
 
   describe('.platformDefaultWatcherType()', () => {
     it('depends on the platform', () => {
-      should(Config.platformDefaultWatcherType()).equal(
-        Config.platformDefaultWatcherType(process.platform)
+      should(config.platformDefaultWatcherType()).equal(
+        config.platformDefaultWatcherType(process.platform)
       )
     })
 
     it('is chokidar on Windows', () => {
-      should(Config.platformDefaultWatcherType('win32')).equal('chokidar')
+      should(config.platformDefaultWatcherType('win32')).equal('chokidar')
     })
 
     it('is chokidar on macOS', () => {
-      should(Config.platformDefaultWatcherType('darwin')).equal('chokidar')
+      should(config.platformDefaultWatcherType('darwin')).equal('chokidar')
     })
 
     it('is chokidar on Linux', () => {
-      should(Config.platformDefaultWatcherType('linux')).equal('chokidar')
+      should(config.platformDefaultWatcherType('linux')).equal('chokidar')
     })
   })
 })

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -9,43 +9,60 @@ const { onPlatform, onPlatforms } = require('../support/helpers/platform')
 
 const Config = require('../../core/config')
 
-describe('core/config.Config', function () {
-  beforeEach('instanciate config', configHelpers.createConfig)
-  afterEach('clean config directory', configHelpers.cleanConfig)
+describe('core/config', function () {
+  describe('.Config', () => {
+    beforeEach('instanciate config', configHelpers.createConfig)
+    afterEach('clean config directory', configHelpers.cleanConfig)
 
-  describe('read', function () {
-    context('when a tmp config file exists', function () {
-      beforeEach('create tmp config file', function () {
-        fse.ensureFileSync(this.config.tmpConfigPath)
-      })
-      afterEach('remove tmp config file', function () {
-        if (fse.existsSync(this.config.tmpConfigPath)) {
-          fse.unlinkSync(this.config.tmpConfigPath)
-        }
-      })
-
-      context('and it has a valid JSON content', function () {
-        const config = { 'url': 'https://cozy.test/' }
-
-        beforeEach('write valid content', function () {
-          fse.writeFileSync(this.config.tmpConfigPath, JSON.stringify(config, null, 2))
+    describe('read', function () {
+      context('when a tmp config file exists', function () {
+        beforeEach('create tmp config file', function () {
+          fse.ensureFileSync(this.config.tmpConfigPath)
+        })
+        afterEach('remove tmp config file', function () {
+          if (fse.existsSync(this.config.tmpConfigPath)) {
+            fse.unlinkSync(this.config.tmpConfigPath)
+          }
         })
 
-        it('reads the tmp config', function () {
-          should(this.config.read()).match(config)
+        context('and it has a valid JSON content', function () {
+          const config = { 'url': 'https://cozy.test/' }
+
+          beforeEach('write valid content', function () {
+            fse.writeFileSync(this.config.tmpConfigPath, JSON.stringify(config, null, 2))
+          })
+
+          it('reads the tmp config', function () {
+            should(this.config.read()).match(config)
+          })
+
+          it('persists the tmp config file as the new config file', function () {
+            this.config.read()
+
+            const persistedConfig = fse.readJSONSync(this.config.configPath)
+            should(persistedConfig).match(config)
+          })
         })
 
-        it('persists the tmp config file as the new config file', function () {
-          this.config.read()
+        context('and it does not have a valid JSON content', function () {
+          beforeEach('write invalid content', function () {
+            fse.writeFileSync(this.config.tmpConfigPath, '\0')
+            this.config.persist()
+          })
 
-          const persistedConfig = fse.readJSONSync(this.config.configPath)
-          should(persistedConfig).match(config)
+          it('reads the existing config', function () {
+            const config = this.config.read()
+            should(config).be.an.Object()
+            should(config.url).eql(COZY_URL)
+          })
         })
       })
 
-      context('and it does not have a valid JSON content', function () {
-        beforeEach('write invalid content', function () {
-          fse.writeFileSync(this.config.tmpConfigPath, '\0')
+      context('when no tmp config files exist', function () {
+        beforeEach('remove any tmp config file', function () {
+          if (fse.existsSync(this.config.tmpConfigPath)) {
+            fse.unlinkSync(this.config.tmpConfigPath)
+          }
           this.config.persist()
         })
 
@@ -55,210 +72,195 @@ describe('core/config.Config', function () {
           should(config.url).eql(COZY_URL)
         })
       })
+
+      context('when the read config is empty', function () {
+        beforeEach('empty local config', function () {
+          fse.ensureFileSync(this.config.configPath)
+          fse.writeFileSync(this.config.configPath, '')
+        })
+
+        it('creates a new empty one', function () {
+          const config = this.config.read()
+          should(config).be.an.Object()
+          should(config).be.empty()
+        })
+      })
     })
 
-    context('when no tmp config files exist', function () {
-      beforeEach('remove any tmp config file', function () {
-        if (fse.existsSync(this.config.tmpConfigPath)) {
-          fse.unlinkSync(this.config.tmpConfigPath)
-        }
+    describe('safeLoad', function () {
+      context('when the file content is valid JSON', function () {
+        const conf = { 'url': 'https://cozy.test/' }
+
+        beforeEach('write valid content', function () {
+          fse.writeFileSync(this.config.configPath, JSON.stringify(conf, null, 2))
+        })
+
+        it('returns an object matching the file content', function () {
+          const newConf = Config.Config.safeLoad(this.config.configPath)
+          newConf.should.be.an.Object()
+          newConf.url.should.eql(conf.url)
+        })
+      })
+
+      context('when the file does not exist', function () {
+        beforeEach('remove config file', function () {
+          if (fse.existsSync(this.config.configPath)) {
+            fse.unlinkSync(this.config.configPath)
+          }
+        })
+
+        it('throws an error', function () {
+          (() => {
+            Config.Config.safeLoad(this.config.configPath)
+          }).should.throw()
+        })
+      })
+
+      context('when the file is empty', function () {
+        beforeEach('create empty file', function () {
+          fse.writeFileSync(this.config.configPath, '')
+        })
+
+        it('returns an empty object', function () {
+          const config = Config.Config.safeLoad(this.config.configPath)
+          should(config).deepEqual({})
+        })
+
+        it('does not delete it', function () {
+          Config.Config.safeLoad(this.config.configPath)
+          should(fse.existsSync(this.config.configPath)).be.true()
+        })
+      })
+
+      context('when the file content is not valid JSON', function () {
+        beforeEach('write invalid content', function () {
+          fse.writeFileSync(this.config.configPath, '\0')
+        })
+
+        it('does not throw any errors', function () {
+          (() => {
+            Config.Config.safeLoad(this.config.configPath)
+          }).should.not.throw()
+        })
+
+        it('returns an empty object', function () {
+          const config = Config.Config.safeLoad(this.config.configPath)
+          should(config).be.an.Object()
+          should(config).be.empty()
+        })
+
+        it('deletes the file', function () {
+          fse.existsSync(this.config.configPath).should.be.true()
+          Config.Config.safeLoad(this.config.configPath)
+          fse.existsSync(this.config.configPath).should.be.false()
+        })
+      })
+    })
+
+    describe('persist', function () {
+      it('saves last changes made on the config', function () {
+        const url = 'http://cozy.local:8080/'
+        this.config.cozyUrl = url
         this.config.persist()
-      })
-
-      it('reads the existing config', function () {
-        const config = this.config.read()
-        should(config).be.an.Object()
-        should(config.url).eql(COZY_URL)
+        let conf = new Config.Config(path.dirname(this.config.configPath))
+        should(conf.cozyUrl).equal(url)
       })
     })
 
-    context('when the read config is empty', function () {
-      beforeEach('empty local config', function () {
-        fse.ensureFileSync(this.config.configPath)
-        fse.writeFileSync(this.config.configPath, '')
-      })
-
-      it('creates a new empty one', function () {
-        const config = this.config.read()
-        should(config).be.an.Object()
-        should(config).be.empty()
-      })
-    })
-  })
-
-  describe('safeLoad', function () {
-    context('when the file content is valid JSON', function () {
-      const conf = { 'url': 'https://cozy.test/' }
-
-      beforeEach('write valid content', function () {
-        fse.writeFileSync(this.config.configPath, JSON.stringify(conf, null, 2))
-      })
-
-      it('returns an object matching the file content', function () {
-        const newConf = Config.Config.safeLoad(this.config.configPath)
-        newConf.should.be.an.Object()
-        newConf.url.should.eql(conf.url)
+    describe('SyncPath', function () {
+      it('returns the set sync path', function () {
+        this.config.syncPath = '/path/to/sync/dir'
+        should(this.config.syncPath).equal('/path/to/sync/dir')
       })
     })
 
-    context('when the file does not exist', function () {
-      beforeEach('remove config file', function () {
-        if (fse.existsSync(this.config.configPath)) {
-          fse.unlinkSync(this.config.configPath)
-        }
-      })
-
-      it('throws an error', function () {
-        (() => {
-          Config.Config.safeLoad(this.config.configPath)
-        }).should.throw()
+    describe('CozyUrl', function () {
+      it('returns the set Cozy URL', function () {
+        this.config.cozyUrl = 'https://cozy.example.com'
+        should(this.config.cozyUrl).equal('https://cozy.example.com')
       })
     })
 
-    context('when the file is empty', function () {
-      beforeEach('create empty file', function () {
-        fse.writeFileSync(this.config.configPath, '')
+    describe('gui', () => {
+      it('returns an empty hash by default', function () {
+        should(this.config.gui).deepEqual({})
       })
 
-      it('returns an empty object', function () {
-        const config = Config.Config.safeLoad(this.config.configPath)
-        should(config).deepEqual({})
-      })
-
-      it('does not delete it', function () {
-        Config.Config.safeLoad(this.config.configPath)
-        should(fse.existsSync(this.config.configPath)).be.true()
+      it('returns GUI configuration if any', function () {
+        const guiConfig = {foo: 'bar'}
+        this.config.config.gui = guiConfig
+        should(this.config.gui).deepEqual(guiConfig)
       })
     })
 
-    context('when the file content is not valid JSON', function () {
-      beforeEach('write invalid content', function () {
-        fse.writeFileSync(this.config.configPath, '\0')
+    describe('Client', function () {
+      it('can set a client', function () {
+        this.config.client = { clientName: 'test' }
+        should(this.config.isValid()).be.true()
+        should(this.config.client.clientName).equal('test')
       })
 
-      it('does not throw any errors', function () {
-        (() => {
-          Config.Config.safeLoad(this.config.configPath)
-        }).should.not.throw()
-      })
-
-      it('returns an empty object', function () {
-        const config = Config.Config.safeLoad(this.config.configPath)
-        should(config).be.an.Object()
-        should(config).be.empty()
-      })
-
-      it('deletes the file', function () {
-        fse.existsSync(this.config.configPath).should.be.true()
-        Config.Config.safeLoad(this.config.configPath)
-        fse.existsSync(this.config.configPath).should.be.false()
+      it('has no client after a reset', function () {
+        this.config.reset()
+        should(this.config.isValid()).be.false()
       })
     })
-  })
 
-  describe('persist', function () {
-    it('saves last changes made on the config', function () {
-      const url = 'http://cozy.local:8080/'
-      this.config.cozyUrl = url
-      this.config.persist()
-      let conf = new Config.Config(path.dirname(this.config.configPath))
-      should(conf.cozyUrl).equal(url)
-    })
-  })
+    describe('WatcherType', function () {
+      it('returns watcher type if any', function () {
+        this.config.config.watcherType = 'fooWatcher'
+        should(this.config.watcherType).equal('fooWatcher')
+      })
 
-  describe('SyncPath', function () {
-    it('returns the set sync path', function () {
-      this.config.syncPath = '/path/to/sync/dir'
-      should(this.config.syncPath).equal('/path/to/sync/dir')
-    })
-  })
+      context('when the COZY_FS_WATCHER env variable value is atom', function () {
+        beforeEach(function () {
+          Object.defineProperty(process.env, 'COZY_FS_WATCHER', {
+            value: 'atom'
+          })
+        })
 
-  describe('CozyUrl', function () {
-    it('returns the set Cozy URL', function () {
-      this.config.cozyUrl = 'https://cozy.example.com'
-      should(this.config.cozyUrl).equal('https://cozy.example.com')
-    })
-  })
-
-  describe('gui', () => {
-    it('returns an empty hash by default', function () {
-      should(this.config.gui).deepEqual({})
-    })
-
-    it('returns GUI configuration if any', function () {
-      const guiConfig = {foo: 'bar'}
-      this.config.config.gui = guiConfig
-      should(this.config.gui).deepEqual(guiConfig)
-    })
-  })
-
-  describe('Client', function () {
-    it('can set a client', function () {
-      this.config.client = { clientName: 'test' }
-      should(this.config.isValid()).be.true()
-      should(this.config.client.clientName).equal('test')
-    })
-
-    it('has no client after a reset', function () {
-      this.config.reset()
-      should(this.config.isValid()).be.false()
-    })
-  })
-
-  describe('WatcherType', function () {
-    it('returns watcher type if any', function () {
-      this.config.config.watcherType = 'fooWatcher'
-      should(this.config.watcherType).equal('fooWatcher')
-    })
-
-    context('when the COZY_FS_WATCHER env variable value is atom', function () {
-      beforeEach(function () {
-        Object.defineProperty(process.env, 'COZY_FS_WATCHER', {
-          value: 'atom'
+        it('returns atom', function () {
+          should(this.config.watcherType).equal('atom')
         })
       })
 
-      it('returns atom', function () {
-        should(this.config.watcherType).equal('atom')
-      })
-    })
+      context('when the COZY_FS_WATCHER env variable value is something else', function () {
+        beforeEach(function () {
+          Object.defineProperty(process.env, 'COZY_FS_WATCHER', {
+            value: 'something'
+          })
+        })
 
-    context('when the COZY_FS_WATCHER env variable value is something else', function () {
-      beforeEach(function () {
-        Object.defineProperty(process.env, 'COZY_FS_WATCHER', {
-          value: 'something'
+        it('returns chokidar', function () {
+          should(this.config.watcherType).equal('chokidar')
         })
       })
 
-      it('returns chokidar', function () {
-        should(this.config.watcherType).equal('chokidar')
+      onPlatform('darwin', function () {
+        it('returns chokidar by default', function () {
+          should(this.config.watcherType).equal('chokidar')
+        })
+      })
+
+      onPlatforms(['linux', 'win32'], function () {
+        // FIXME: It returns 'atom' by default once the new watcher is live
+        it('returns chokidar by default', function () {
+          should(this.config.watcherType).equal('chokidar')
+        })
       })
     })
 
-    onPlatform('darwin', function () {
-      it('returns chokidar by default', function () {
-        should(this.config.watcherType).equal('chokidar')
+    describe('saveMode', function () {
+      it('sets the pull or push mode', function () {
+        this.config.saveMode('push')
+        should(this.config.config.mode).equal('push')
       })
-    })
 
-    onPlatforms(['linux', 'win32'], function () {
-      // FIXME: It returns 'atom' by default once the new watcher is live
-      it('returns chokidar by default', function () {
-        should(this.config.watcherType).equal('chokidar')
+      it('throws an error for incompatible mode', function () {
+        this.config.saveMode('push')
+        should.throws(() => this.config.saveMode('pull'), /you cannot switch/)
+        should.throws(() => this.config.saveMode('full'), /you cannot switch/)
       })
-    })
-  })
-
-  describe('saveMode', function () {
-    it('sets the pull or push mode', function () {
-      this.config.saveMode('push')
-      should(this.config.config.mode).equal('push')
-    })
-
-    it('throws an error for incompatible mode', function () {
-      this.config.saveMode('push')
-      should.throws(() => this.config.saveMode('pull'), /you cannot switch/)
-      should.throws(() => this.config.saveMode('full'), /you cannot switch/)
     })
   })
 })

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -188,7 +188,7 @@ describe('core/config', function () {
 
       it('returns GUI configuration if any', function () {
         const guiConfig = {foo: 'bar'}
-        this.config.config.gui = guiConfig
+        this.config.fileConfig.gui = guiConfig
         should(this.config.gui).deepEqual(guiConfig)
       })
     })
@@ -208,7 +208,7 @@ describe('core/config', function () {
 
     describe('WatcherType', function () {
       it('returns watcher type if any', function () {
-        this.config.config.watcherType = 'fooWatcher'
+        this.config.fileConfig.watcherType = 'fooWatcher'
         should(this.config.watcherType).equal('fooWatcher')
       })
 
@@ -253,7 +253,7 @@ describe('core/config', function () {
     describe('saveMode', function () {
       it('sets the pull or push mode', function () {
         this.config.saveMode('push')
-        should(this.config.config.mode).equal('push')
+        should(this.config.fileConfig.mode).equal('push')
       })
 
       it('throws an error for incompatible mode', function () {

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -162,7 +162,7 @@ describe('core/config', function () {
         const url = 'http://cozy.local:8080/'
         this.config.cozyUrl = url
         this.config.persist()
-        let conf = new Config.Config(path.dirname(this.config.configPath))
+        let conf = Config.load(path.dirname(this.config.configPath))
         should(conf.cozyUrl).equal(url)
       })
     })

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -96,7 +96,7 @@ describe('core/config', function () {
         })
 
         it('returns an object matching the file content', function () {
-          const newConf = Config.Config.safeLoad(this.config.configPath)
+          const newConf = Config.loadOrDeleteFile(this.config.configPath)
           newConf.should.be.an.Object()
           newConf.url.should.eql(conf.url)
         })
@@ -111,7 +111,7 @@ describe('core/config', function () {
 
         it('throws an error', function () {
           (() => {
-            Config.Config.safeLoad(this.config.configPath)
+            Config.loadOrDeleteFile(this.config.configPath)
           }).should.throw()
         })
       })
@@ -122,12 +122,12 @@ describe('core/config', function () {
         })
 
         it('returns an empty object', function () {
-          const config = Config.Config.safeLoad(this.config.configPath)
+          const config = Config.loadOrDeleteFile(this.config.configPath)
           should(config).deepEqual({})
         })
 
         it('does not delete it', function () {
-          Config.Config.safeLoad(this.config.configPath)
+          Config.loadOrDeleteFile(this.config.configPath)
           should(fse.existsSync(this.config.configPath)).be.true()
         })
       })
@@ -139,19 +139,19 @@ describe('core/config', function () {
 
         it('does not throw any errors', function () {
           (() => {
-            Config.Config.safeLoad(this.config.configPath)
+            Config.loadOrDeleteFile(this.config.configPath)
           }).should.not.throw()
         })
 
         it('returns an empty object', function () {
-          const config = Config.Config.safeLoad(this.config.configPath)
+          const config = Config.loadOrDeleteFile(this.config.configPath)
           should(config).be.an.Object()
           should(config).be.empty()
         })
 
         it('deletes the file', function () {
           fse.existsSync(this.config.configPath).should.be.true()
-          Config.Config.safeLoad(this.config.configPath)
+          Config.loadOrDeleteFile(this.config.configPath)
           fse.existsSync(this.config.configPath).should.be.false()
         })
       })

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -25,21 +25,21 @@ describe('core/config', function () {
         })
 
         context('and it has a valid JSON content', function () {
-          const config = { 'url': 'https://cozy.test/' }
+          const fileConfig = { 'url': 'https://cozy.test/' }
 
           beforeEach('write valid content', function () {
-            fse.writeFileSync(this.config.tmpConfigPath, JSON.stringify(config, null, 2))
+            fse.writeFileSync(this.config.tmpConfigPath, JSON.stringify(fileConfig, null, 2))
           })
 
           it('reads the tmp config', function () {
-            should(this.config.read()).match(config)
+            should(this.config.read()).match(fileConfig)
           })
 
           it('persists the tmp config file as the new config file', function () {
             this.config.read()
 
-            const persistedConfig = fse.readJSONSync(this.config.configPath)
-            should(persistedConfig).match(config)
+            const fileConfigPersisted = fse.readJSONSync(this.config.configPath)
+            should(fileConfigPersisted).match(fileConfig)
           })
         })
 
@@ -50,9 +50,9 @@ describe('core/config', function () {
           })
 
           it('reads the existing config', function () {
-            const config = this.config.read()
-            should(config).be.an.Object()
-            should(config.url).eql(COZY_URL)
+            const fileConfig = this.config.read()
+            should(fileConfig).be.an.Object()
+            should(fileConfig.url).eql(COZY_URL)
           })
         })
       })
@@ -66,9 +66,9 @@ describe('core/config', function () {
         })
 
         it('reads the existing config', function () {
-          const config = this.config.read()
-          should(config).be.an.Object()
-          should(config.url).eql(COZY_URL)
+          const fileConfig = this.config.read()
+          should(fileConfig).be.an.Object()
+          should(fileConfig.url).eql(COZY_URL)
         })
       })
 
@@ -79,25 +79,25 @@ describe('core/config', function () {
         })
 
         it('creates a new empty one', function () {
-          const config = this.config.read()
-          should(config).be.an.Object()
-          should(config).be.empty()
+          const fileConfig = this.config.read()
+          should(fileConfig).be.an.Object()
+          should(fileConfig).be.empty()
         })
       })
     })
 
     describe('safeLoad', function () {
       context('when the file content is valid JSON', function () {
-        const conf = { 'url': 'https://cozy.test/' }
+        const fileConfig = { 'url': 'https://cozy.test/' }
 
         beforeEach('write valid content', function () {
-          fse.writeFileSync(this.config.configPath, JSON.stringify(conf, null, 2))
+          fse.writeFileSync(this.config.configPath, JSON.stringify(fileConfig, null, 2))
         })
 
         it('returns an object matching the file content', function () {
-          const newConf = config.loadOrDeleteFile(this.config.configPath)
-          newConf.should.be.an.Object()
-          newConf.url.should.eql(conf.url)
+          const newFileConfig = config.loadOrDeleteFile(this.config.configPath)
+          newFileConfig.should.be.an.Object()
+          newFileConfig.url.should.eql(fileConfig.url)
         })
       })
 
@@ -158,8 +158,8 @@ describe('core/config', function () {
         const url = 'http://cozy.local:8080/'
         this.config.cozyUrl = url
         this.config.persist()
-        let conf = config.load(path.dirname(this.config.configPath))
-        should(conf.cozyUrl).equal(url)
+        const configLoaded = config.load(path.dirname(this.config.configPath))
+        should(configLoaded.cozyUrl).equal(url)
       })
     })
 

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -9,7 +9,7 @@ const { onPlatform, onPlatforms } = require('../support/helpers/platform')
 
 const Config = require('../../core/config')
 
-describe('Config', function () {
+describe('core/config.Config', function () {
   beforeEach('instanciate config', configHelpers.createConfig)
   afterEach('clean config directory', configHelpers.cleanConfig)
 
@@ -95,7 +95,7 @@ describe('Config', function () {
       })
 
       it('returns an object matching the file content', function () {
-        const newConf = Config.safeLoad(this.config.configPath)
+        const newConf = Config.Config.safeLoad(this.config.configPath)
         newConf.should.be.an.Object()
         newConf.url.should.eql(conf.url)
       })
@@ -110,7 +110,7 @@ describe('Config', function () {
 
       it('throws an error', function () {
         (() => {
-          Config.safeLoad(this.config.configPath)
+          Config.Config.safeLoad(this.config.configPath)
         }).should.throw()
       })
     })
@@ -121,12 +121,12 @@ describe('Config', function () {
       })
 
       it('returns an empty object', function () {
-        const config = Config.safeLoad(this.config.configPath)
+        const config = Config.Config.safeLoad(this.config.configPath)
         should(config).deepEqual({})
       })
 
       it('does not delete it', function () {
-        Config.safeLoad(this.config.configPath)
+        Config.Config.safeLoad(this.config.configPath)
         should(fse.existsSync(this.config.configPath)).be.true()
       })
     })
@@ -138,19 +138,19 @@ describe('Config', function () {
 
       it('does not throw any errors', function () {
         (() => {
-          Config.safeLoad(this.config.configPath)
+          Config.Config.safeLoad(this.config.configPath)
         }).should.not.throw()
       })
 
       it('returns an empty object', function () {
-        const config = Config.safeLoad(this.config.configPath)
+        const config = Config.Config.safeLoad(this.config.configPath)
         should(config).be.an.Object()
         should(config).be.empty()
       })
 
       it('deletes the file', function () {
         fse.existsSync(this.config.configPath).should.be.true()
-        Config.safeLoad(this.config.configPath)
+        Config.Config.safeLoad(this.config.configPath)
         fse.existsSync(this.config.configPath).should.be.false()
       })
     })
@@ -161,7 +161,7 @@ describe('Config', function () {
       const url = 'http://cozy.local:8080/'
       this.config.cozyUrl = url
       this.config.persist()
-      let conf = new Config(path.dirname(this.config.configPath))
+      let conf = new Config.Config(path.dirname(this.config.configPath))
       should(conf.cozyUrl).equal(url)
     })
   })


### PR DESCRIPTION
So we can reuse the extracted `.watcherType()` function to support
AtomWatcher in scenarios/captures.

Also make sure env-based unit test won't break as soon as we change
the default watcher.