### PR TITLE
test: Introduce TestHelpers.init

### DIFF
--- a/dev/repl.js
+++ b/dev/repl.js
@@ -6,7 +6,7 @@ const { start } = require('repl')
 
 require('../core/globals')
 const { App } = require('../core/app')
-const { IntegrationTestHelpers } = require('../test/support/helpers/integration')
+const TestHelpers = require('../test/support/helpers')
 
 const basePath = process.env.COZY_DESKTOP_DIR
 if (basePath == null) throw new Error('COZY_DESKTOP_DIR is undefined')
@@ -23,7 +23,7 @@ The following objects are available:
 if (config.isValid()) {
   app.instanciate()
   cozy = app.remote.watcher.remoteCozy.client
-  helpers = new IntegrationTestHelpers(config, app.pouch, cozy)
+  helpers = TestHelpers.init(app)
   console.log(`  cozy     A cozy-client-js instance, set up with your config
   helpers  See test/helpers/integration.js
 

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -7,7 +7,7 @@ const should = require('should')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const cozy = cozyHelpers.cozy
 
@@ -24,7 +24,7 @@ describe('Add', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
 

--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -6,7 +6,7 @@ const should = require('should')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 describe('Case or encoding change', () => {
   // This test passes on a macOS workstation when using the docker container,
@@ -33,7 +33,7 @@ describe('Case or encoding change', () => {
 
   beforeEach(async function () {
     cozy = cozyHelpers.cozy
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
 
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -10,7 +10,7 @@ const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const builders = new Builders()
 const cozy = cozyHelpers.cozy
@@ -28,7 +28,7 @@ describe('Conflict resolution', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
 
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()

--- a/test/integration/corruption_fixer.js
+++ b/test/integration/corruption_fixer.js
@@ -13,7 +13,7 @@ const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 /*::
 import type { RemoteDoc } from '../../core/remote/document'
 */
@@ -42,7 +42,7 @@ describe('Re-Upload files when the stack report them as broken', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
     builders = new Builders({cozy})
   })

--- a/test/integration/executable.js
+++ b/test/integration/executable.js
@@ -10,12 +10,12 @@ const {
   onPlatforms
 } = require('../support/helpers/platform')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const { platform } = process
 
 describe('Executable handling', () => {
-  let cozy, helpers, pouch, syncDir
+  let cozy, helpers, syncDir
 
   before(configHelpers.createConfig)
   before(configHelpers.registerClient)
@@ -26,9 +26,8 @@ describe('Executable handling', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    pouch = this.pouch
     cozy = cozyHelpers.cozy
-    helpers = new IntegrationTestHelpers(this.config, pouch, cozy)
+    helpers = TestHelpers.init(this)
     syncDir = helpers.local.syncDir
 
     await helpers.local.setupTrash()

--- a/test/integration/full_loop.js
+++ b/test/integration/full_loop.js
@@ -8,7 +8,7 @@ const metadata = require('../../core/metadata')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const cozy = cozyHelpers.cozy
 
@@ -25,7 +25,7 @@ describe('Full watch/merge/sync/repeat loop', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
 

--- a/test/integration/id_conflict.js
+++ b/test/integration/id_conflict.js
@@ -10,7 +10,7 @@ const {
   onPlatforms
 } = require('../support/helpers/platform')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 describe('Identity conflict', () => {
   if (process.env.TRAVIS && (process.platform === 'darwin')) {
@@ -35,7 +35,7 @@ describe('Identity conflict', () => {
 
   beforeEach(async function () {
     cozy = cozyHelpers.cozy
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
 
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -6,7 +6,7 @@ const should = require('should')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const cozy = cozyHelpers.cozy
 
@@ -23,7 +23,7 @@ describe('Sync gets interrupted, initialScan occurs', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
 

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -10,7 +10,7 @@ const dbBuilders = require('../support/builders/db')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const builders = new Builders()
 const cozy = cozyHelpers.cozy
@@ -33,7 +33,7 @@ describe('Move', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     pouch = helpers._pouch
     prep = helpers.prep
 

--- a/test/integration/mtime-update.js
+++ b/test/integration/mtime-update.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const cozy = cozyHelpers.cozy
 
@@ -26,7 +26,7 @@ describe('Update only a file mtime', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
   })
 

--- a/test/integration/permanent_deletion.js
+++ b/test/integration/permanent_deletion.js
@@ -6,7 +6,7 @@ const should = require('should')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const cozy = cozyHelpers.cozy
 
@@ -23,7 +23,7 @@ describe('Permanent deletion remote', () => {
   after(configHelpers.cleanConfig)
 
   beforeEach(function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
   })
 

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -9,7 +9,7 @@ const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 describe('Platform incompatibilities', () => {
   if (process.platform !== 'win32' && process.platform !== 'darwin') {
@@ -31,7 +31,7 @@ describe('Platform incompatibilities', () => {
   beforeEach(async function () {
     cozy = cozyHelpers.cozy
     builders = new Builders({cozy})
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
 
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()

--- a/test/integration/sync_state.js
+++ b/test/integration/sync_state.js
@@ -8,7 +8,7 @@ const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 const builders = new Builders()
 
@@ -25,7 +25,7 @@ describe('Sync state', () => {
   let events, helpers
 
   beforeEach(function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozyHelpers.cozy)
+    helpers = TestHelpers.init(this)
     events = helpers.events
     sinon.spy(events, 'emit')
     // await helpers.local.setupTrash()

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -7,7 +7,7 @@ const should = require('should')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 describe('Trash', () => {
   let cozy, helpers, pouch, prep
@@ -23,7 +23,7 @@ describe('Trash', () => {
 
   beforeEach(async function () {
     cozy = cozyHelpers.cozy
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     pouch = helpers._pouch
     prep = helpers.prep
 

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -8,7 +8,7 @@ const should = require('should')
 const logger = require('../../core/logger')
 
 const Builders = require('../support/builders')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
@@ -29,7 +29,7 @@ describe('Update file', () => {
   beforeEach(async function () {
     builders = new Builders({cozy: cozyHelpers.cozy})
     cozy = cozyHelpers.cozy
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozy)
+    helpers = TestHelpers.init(this)
     pouch = helpers._pouch
     prep = helpers.prep
 

--- a/test/regression/TRELLO_484_local_sort_before_squash.js
+++ b/test/regression/TRELLO_484_local_sort_before_squash.js
@@ -9,7 +9,7 @@ const sinon = require('sinon')
 const { runActions, init } = require('../support/helpers/scenarios')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 const pouchHelpers = require('../support/helpers/pouch')
 
 let helpers
@@ -30,7 +30,7 @@ describe('TRELLO #484: Local sort before squash (https://trello.com/c/RcRmqymw)'
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozyHelpers.cozy)
+    helpers = TestHelpers.init(this)
     prepCalls = []
 
     for (let method of ['addFileAsync', 'putFolderAsync', 'updateFileAsync',

--- a/test/regression/TRELLO_646_move_overridden_before_sync.js
+++ b/test/regression/TRELLO_646_move_overridden_before_sync.js
@@ -10,7 +10,7 @@ const metadata = require('../../core/metadata')
 const { runActions, init } = require('../support/helpers/scenarios')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 const pouchHelpers = require('../support/helpers/pouch')
 
 describe('TRELLO #646: Déplacement écrasé avant synchro (malgré la synchro par lot, https://trello.com/c/Co05qttn)', () => {
@@ -28,7 +28,7 @@ describe('TRELLO #646: Déplacement écrasé avant synchro (malgré la synchro p
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozyHelpers.cozy)
+    helpers = TestHelpers.init(this)
     await helpers.local.setupTrash()
   })
 

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -10,7 +10,7 @@ const should = require('should')
 const { scenarios, loadFSEventFiles, runActions, init } = require('../support/helpers/scenarios')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 const pouchHelpers = require('../support/helpers/pouch')
 const remoteCaptureHelpers = require('../../dev/capture/remote')
 
@@ -36,7 +36,7 @@ describe('Test scenarios', function () {
   after(configHelpers.cleanConfig)
 
   beforeEach(async function () {
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozyHelpers.cozy)
+    helpers = TestHelpers.init(this)
 
     // TODO: helpers.setup()
     await helpers.local.setupTrash()

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -16,6 +16,7 @@ const SyncState = require('../../../core/syncstate')
 
 const conflictHelpers = require('./conflict')
 const { posixifyPath } = require('./context_dir')
+const cozyHelpers = require('./cozy')
 const { LocalTestHelpers } = require('./local')
 const { RemoteTestHelpers } = require('./remote')
 
@@ -24,9 +25,14 @@ import type cozy from 'cozy-client-js'
 import type { Config } from '../../../core/config'
 import type { Metadata } from '../../../core/metadata'
 import type Pouch from '../../../core/pouch'
+
+export type TestHelpersOptions = {
+  config: Config,
+  pouch: Pouch
+}
 */
 
-class IntegrationTestHelpers {
+class TestHelpers {
   /*::
   local: LocalTestHelpers
   remote: RemoteTestHelpers
@@ -39,14 +45,14 @@ class IntegrationTestHelpers {
   _remote: Remote
   */
 
-  constructor (config /*: Config */, pouch /*: Pouch */, cozyClient /*: cozy.Client */) {
+  constructor ({ config, pouch } /*: TestHelpersOptions */) {
     const merge = new Merge(pouch)
     const ignore = new Ignore([])
     this.prep = new Prep(merge, ignore, config)
     this.events = new SyncState()
     this._local = merge.local = new Local(config, this.prep, pouch, this.events, ignore)
     this._remote = merge.remote = new Remote(config, this.prep, pouch, this.events)
-    this._remote.remoteCozy.client = cozyClient
+    this._remote.remoteCozy.client = cozyHelpers.cozy
     this._sync = new Sync(pouch, this._local, this._remote, ignore, this.events)
     this._sync.stopped = false
     this._sync.diskUsage = this._remote.diskUsage
@@ -166,6 +172,9 @@ class IntegrationTestHelpers {
   }
 }
 
+const init /*: (TestHelpersOptions) => TestHelpers */ =
+  opts => new TestHelpers(opts)
+
 module.exports = {
-  IntegrationTestHelpers
+  init
 }

--- a/test/unit/scheduling.js
+++ b/test/unit/scheduling.js
@@ -7,7 +7,7 @@ const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
-const { IntegrationTestHelpers } = require('../support/helpers/integration')
+const TestHelpers = require('../support/helpers')
 
 // XXX: duplicated from remote/watcher
 const HEARTBEAT /*: number */ = parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || 1000 * 60
@@ -27,7 +27,7 @@ describe('Sync', function () {
 
   before('instanciate local, remote & sync', async function () {
     this.sandbox = sinon.sandbox.create()
-    helpers = new IntegrationTestHelpers(this.config, this.pouch, cozyHelpers.cozy)
+    helpers = TestHelpers.init(this)
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
 


### PR DESCRIPTION

- Replaces `new IntegrationTestHelpers()`
- May end up as a facade (similar to Builders)
- Stop pretending cozy client must be injected (may be improved later)
- Instanciation is an implementation detail
- So we can later introduce new factory functions depending on the context

---

- [x] PR is not too big (except for moved file)
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
