### PR TITLE
core: Introduce options for Local, LocalWatcher.build & Remote

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -259,7 +259,7 @@ class App {
     this.merge = new Merge(this.pouch)
     this.prep = new Prep(this.merge, this.ignore, this.config)
     this.local = this.merge.local = new Local(this)
-    this.remote = this.merge.remote = new Remote(this.config, this.prep, this.pouch, this.events)
+    this.remote = this.merge.remote = new Remote(this)
     this.sync = new Sync(this.pouch, this.local, this.remote, this.ignore, this.events)
     this.sync.diskUsage = this.diskUsage
   }

--- a/core/app.js
+++ b/core/app.js
@@ -258,7 +258,7 @@ class App {
     this.ignore = Ignore.loadSync(this.userIgnoreRules())
     this.merge = new Merge(this.pouch)
     this.prep = new Prep(this.merge, this.ignore, this.config)
-    this.local = this.merge.local = new Local(this.config, this.prep, this.pouch, this.events, this.ignore)
+    this.local = this.merge.local = new Local(this)
     this.remote = this.merge.remote = new Remote(this.config, this.prep, this.pouch, this.events)
     this.sync = new Sync(this.pouch, this.local, this.remote, this.ignore, this.events)
     this.sync.diskUsage = this.diskUsage

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -62,13 +62,13 @@ module.exports = class Local /*:: implements Side */ {
   _trash: (Array<string>) => Promise<void>
   */
 
-  constructor ({config, prep, pouch, events, ignore} /*: LocalOptions */) {
-    this.prep = prep
-    this.pouch = pouch
-    this.events = events
-    this.syncPath = config.syncPath
+  constructor (opts /*: LocalOptions */) {
+    this.prep = opts.prep
+    this.pouch = opts.pouch
+    this.events = opts.events
+    this.syncPath = opts.config.syncPath
     this.tmpPath = path.join(this.syncPath, TMP_DIR_NAME)
-    this.watcher = watcher.build(config, this.prep, this.pouch, events, ignore)
+    this.watcher = watcher.build(opts)
     // $FlowFixMe
     this.other = null
     this._trash = trash

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -35,6 +35,17 @@ import type { Watcher } from './watcher'
 const log = logger({
   component: 'LocalWriter'
 })
+
+/*::
+export type LocalOptions = {
+  config: Config,
+  prep: Prep,
+  pouch: Pouch,
+  events: EventEmitter,
+  ignore: Ignore
+}
+*/
+
 // Local is the class that interfaces cozy-desktop with the local filesystem.
 // It uses a watcher, based on chokidar, to listen for file and folder changes.
 // It also applied changes from the remote cozy on the local filesystem.
@@ -51,7 +62,7 @@ module.exports = class Local /*:: implements Side */ {
   _trash: (Array<string>) => Promise<void>
   */
 
-  constructor (config /*: Config */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) {
+  constructor ({config, prep, pouch, events, ignore} /*: LocalOptions */) {
     this.prep = prep
     this.pouch = pouch
     this.events = events

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -18,9 +18,20 @@ export interface Watcher {
   start (): Promise<*>,
   stop (force: ?bool): Promise<*>,
 }
+
+export type LocalWatcherOptions = {
+  +config: {
+    +syncPath: string,
+    +watcherType: WatcherType
+  },
+  events: EventEmitter,
+  ignore: Ignore,
+  pouch: Pouch,
+  prep: Prep
+}
 */
 
-function build (config /*: { +syncPath: string, +watcherType: WatcherType } */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */, ignore /*: Ignore */) /*: Watcher */ {
+function build ({config, prep, pouch, events, ignore} /*: LocalWatcherOptions */) /*: Watcher */ {
   const { syncPath, watcherType } = config
 
   if (watcherType === 'atom') {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -27,6 +27,15 @@ const log = logger({
   component: 'RemoteWriter'
 })
 
+/*::
+export type RemoteOptions = {
+  config: Config,
+  events: EventEmitter,
+  pouch: Pouch,
+  prep: Prep
+}
+*/
+
 class Remote /*:: implements Side */ {
   /*::
   other: FileStreamProvider
@@ -37,7 +46,7 @@ class Remote /*:: implements Side */ {
   warningsPoller: RemoteWarningPoller
   */
 
-  constructor (config /*: Config */, prep /*: Prep */, pouch /*: Pouch */, events /*: EventEmitter */) {
+  constructor ({config, prep, pouch, events} /*: RemoteOptions */) {
     this.pouch = pouch
     this.events = events
     this.remoteCozy = new RemoteCozy(config)

--- a/test/property/runner.js
+++ b/test/property/runner.js
@@ -47,7 +47,13 @@ async function step (state /*: Object */, op /*: Object */) {
       }
       const ignore = new Ignore([])
       const prep = new Prep(merge, ignore, state.config)
-      state.watcher = Watcher.build(state.dir.root, prep, state.pouchdb, events, ignore)
+      state.watcher = Watcher.build({
+        config: state.config,
+        prep,
+        pouch: state.pouchdb,
+        events,
+        ignore
+      })
       state.watcher.start()
       break
     case 'stop_watcher':

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -50,7 +50,7 @@ class TestHelpers {
     const ignore = new Ignore([])
     this.prep = new Prep(merge, ignore, config)
     this.events = new SyncState()
-    this._local = merge.local = new Local(config, this.prep, pouch, this.events, ignore)
+    this._local = merge.local = new Local({config, prep: this.prep, pouch, events: this.events, ignore})
     this._remote = merge.remote = new Remote(config, this.prep, pouch, this.events)
     this._remote.remoteCozy.client = cozyHelpers.cozy
     this._sync = new Sync(pouch, this._local, this._remote, ignore, this.events)

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -51,7 +51,7 @@ class TestHelpers {
     this.prep = new Prep(merge, ignore, config)
     this.events = new SyncState()
     this._local = merge.local = new Local({config, prep: this.prep, pouch, events: this.events, ignore})
-    this._remote = merge.remote = new Remote(config, this.prep, pouch, this.events)
+    this._remote = merge.remote = new Remote({config, prep: this.prep, pouch, events: this.events})
     this._remote.remoteCozy.client = cozyHelpers.cozy
     this._sync = new Sync(pouch, this._local, this._remote, ignore, this.events)
     this._sync.stopped = false

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -25,7 +25,7 @@ describe('Local', function () {
   before('instanciate local', function () {
     this.prep = {}
     this.events = {}
-    this.local = new Local(this.config, this.prep, this.pouch, this.events)
+    this.local = new Local(this)
 
     builders = new Builders({pouch: this.pouch})
     syncDir = new ContextDir(this.syncPath)

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -41,7 +41,7 @@ describe('remote.Remote', function () {
   before('instanciate remote', function () {
     this.prep = sinon.createStubInstance(Prep)
     this.events = new EventEmitter()
-    this.remote = new Remote(this.config, this.prep, this.pouch, this.events)
+    this.remote = new Remote(this)
   })
   beforeEach(deleteAll)
   beforeEach(createTheCouchdbFolder)

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -25,7 +25,7 @@ describe('Remote', function () {
   before('instanciate remote', function () {
     this.prep = sinon.createStubInstance(Prep)
     this.events = new EventEmitter()
-    this.remote = new Remote(this.config, this.prep, this.pouch, this.events)
+    this.remote = new Remote(this)
   })
   beforeEach(deleteAll)
   beforeEach(createTheCouchdbFolder)


### PR DESCRIPTION
- No need to remember params order anymore
- Makes it easier to add new options

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
