### PR TITLE
core/config: watcherType uses env and platform params

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -220,8 +220,8 @@ function loadOrDeleteFile (configPath /*: string */) /*: FileConfig */ {
 function watcherType (fileConfig /*: FileConfig */ = {}, {env, platform} /*: * */ = process) /*: WatcherType */ {
   return (
     fileWatcherType(fileConfig) ||
-    environmentWatcherType(process.env) ||
-    platformDefaultWatcherType(process.platform)
+    environmentWatcherType(env) ||
+    platformDefaultWatcherType(platform)
   )
 }
 


### PR DESCRIPTION
  We pass the process as the second parameter when calling
  `config.watcherType` but this param is destructured to extract its env
  and platform attributes.
  We should be using those in the function body instead of the `process`
  attributes directly (so we can pass different values in tests).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
