### PR TITLE
[CHOKIDAR] core/local: Introduce chokidar step modules

### DIFF
--- a/core/local/chokidar_steps/initial_diff.js
+++ b/core/local/chokidar_steps/initial_diff.js
@@ -1,0 +1,89 @@
+/* @flow */
+
+const chokidarEvent = require('../chokidar_event')
+const logger = require('../../logger')
+const metadata = require('../../metadata')
+
+/*::
+import type { ChokidarEvent } from '../chokidar_event'
+import type EventBuffer from '../event_buffer'
+import type { InitialScan } from './initial_scan'
+import type Pouch from '../../pouch'
+*/
+
+const log = logger({
+  component: 'ChokidarInitialDiff'
+})
+log.chokidar = log.child({
+  component: 'Chokidar'
+})
+
+module.exports = {
+  step,
+  detectOfflineUnlinkEvents
+}
+
+/*::
+export type ChokidarInitialDiffOptions = {
+  buffer: EventBuffer<ChokidarEvent>,
+  initialScan: ?InitialScan,
+  pouch: Pouch
+}
+*/
+
+async function step (rawEvents /*: ChokidarEvent[] */, {buffer, initialScan, pouch} /*: ChokidarInitialDiffOptions */) /*: Promise<?Array<ChokidarEvent>> */ {
+  let events = rawEvents.filter((e) => e.path !== '') // @TODO handle root dir events
+  if (initialScan != null) {
+    const ids = initialScan.ids
+    events.filter((e) => e.type.startsWith('add'))
+          .forEach((e) => ids.push(metadata.id(e.path)))
+
+    const {offlineEvents, unappliedMoves, emptySyncDir} = await detectOfflineUnlinkEvents(initialScan, pouch)
+    events = offlineEvents.concat(events)
+
+    events = events.filter((e) => {
+      return unappliedMoves.indexOf(metadata.id(e.path)) === -1
+    })
+
+    if (emptySyncDir) {
+      // it is possible this is a temporary faillure (too late mounting)
+      // push back the events and wait until next flush.
+      buffer.unflush(rawEvents)
+      if (--initialScan.emptyDirRetryCount === 0) {
+        throw new Error('Syncdir is empty')
+      }
+      return initialScan.resolve()
+    }
+
+    log.debug({initialEvents: events})
+  }
+  return events
+}
+
+const NB_OF_DELETABLE_ELEMENT = 3
+
+async function detectOfflineUnlinkEvents (initialScan /*: InitialScan */, pouch /*: Pouch */) /*: Promise<{offlineEvents: Array<ChokidarEvent>, unappliedMoves: *, emptySyncDir: boolean}> */ {
+  // Try to detect removed files & folders
+  const events /*: Array<ChokidarEvent> */ = []
+  const docs = await pouch.byRecursivePathAsync('')
+  const inInitialScan = (doc) =>
+    initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
+
+  // the Syncdir is empty error only occurs if there was some docs beforehand
+  let emptySyncDir = docs.length > NB_OF_DELETABLE_ELEMENT
+  let unappliedMoves = []
+
+  for (const doc of docs) {
+    if (inInitialScan(doc) || doc.trashed || doc.incompatibilities) {
+      emptySyncDir = false
+    } else if (doc.moveFrom) {
+      // unapplied move
+      unappliedMoves.push(metadata.id(doc.moveFrom.path))
+    } else {
+      log.chokidar.debug({path: doc.path}, 'pretend unlink or unlinkDir')
+      events.unshift(chokidarEvent.pretendUnlinkFromMetadata(doc))
+    }
+  }
+
+  return {offlineEvents: events, unappliedMoves, emptySyncDir}
+}

--- a/core/local/chokidar_steps/initial_scan.js
+++ b/core/local/chokidar_steps/initial_scan.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+/*::
+export type InitialScan = {
+  ids: string[],
+  emptyDirRetryCount: number,
+  flushed: boolean,
+  resolve: () => void
+}
+*/

--- a/core/local/chokidar_steps/prepare_events.js
+++ b/core/local/chokidar_steps/prepare_events.js
@@ -1,0 +1,91 @@
+/* @flow */
+
+const Promise = require('bluebird')
+const fse = require('fs-extra')
+const _ = require('lodash')
+const path = require('path')
+
+const logger = require('../../logger')
+const metadata = require('../../metadata')
+const {sameDate, fromDate} = require('../../timestamp')
+
+/*::
+import type { Checksumer } from '../checksumer'
+import type { ChokidarEvent } from '../chokidar_event'
+import type { InitialScan } from './initial_scan'
+import type { LocalEvent } from '../event'
+import type { Metadata } from '../../metadata'
+import type Pouch from '../../pouch'
+*/
+
+module.exports = {
+  step,
+  oldMetadata
+}
+
+const log = logger({
+  component: 'ChokidarPrepareEvents'
+})
+
+/*::
+export type PrepareEventsOptions = {
+  +checksum: *,
+  initialScan: ?InitialScan,
+  pouch: Pouch,
+  syncPath: string
+}
+*/
+
+async function step (events /*: ChokidarEvent[] */, {checksum, initialScan, pouch, syncPath} /*: PrepareEventsOptions */) /*: Promise<LocalEvent[]> */ {
+  return Promise.map(events, async (e /*: ChokidarEvent */) /*: Promise<?LocalEvent> */ => {
+    const abspath = path.join(syncPath, e.path)
+
+    const e2 /*: Object */ = _.merge({
+      old: await oldMetadata(e, pouch)
+    }, e)
+
+    if (e.type === 'add' || e.type === 'change') {
+      if (initialScan && e2.old &&
+        e2.path === e2.old.path &&
+        sameDate(fromDate(e2.old.updated_at), fromDate(e2.stats.mtime))) {
+        log.trace({path: e.path}, 'Do not compute checksum : mtime & path are unchanged')
+        e2.md5sum = e2.old.md5sum
+      } else {
+        try {
+          e2.md5sum = await checksum(e.path)
+          log.trace({path: e.path, md5sum: e2.md5sum}, 'Checksum complete')
+        } catch (err) {
+          // FIXME: err.code === EISDIR => keep the event? (e.g. rm foo && mkdir foo)
+          // Chokidar reports a change event when a file is replaced by a directory
+          if (err.code.match(/ENOENT/)) {
+            log.debug({path: e.path, ino: e.stats.ino}, 'Checksum failed: file does not exist anymore')
+            e2.wip = true
+          } else {
+            log.error({path: e.path, err}, 'Checksum failed')
+            return null
+          }
+        }
+      }
+    }
+
+    if (e.type === 'addDir') {
+      if (!await fse.exists(abspath)) {
+        log.debug({path: e.path, ino: e.stats.ino}, 'Dir does not exist anymore')
+        e2.wip = true
+      }
+    }
+
+    return e2
+  }, {concurrency: 50})
+  .filter((e /*: ?LocalEvent */) => e != null)
+}
+
+async function oldMetadata (e /*: ChokidarEvent */, pouch /*: Pouch */) /*: Promise<?Metadata> */ {
+  if (e.old) return e.old
+  try {
+    return await pouch.db.get(metadata.id(e.path))
+  } catch (err) {
+    if (err.status !== 404) log.error({path: e.path, err})
+  }
+  return null
+}

--- a/core/local/chokidar_steps/send_to_prep.js
+++ b/core/local/chokidar_steps/send_to_prep.js
@@ -1,0 +1,147 @@
+/* @flow */
+
+const logger = require('../../logger')
+const metadata = require('../../metadata')
+
+/*::
+import type fse from 'fs-extra'
+
+import type {
+  LocalChange,
+  LocalDirAddition,
+  LocalDirDeletion,
+  LocalDirMove,
+  LocalFileAddition,
+  LocalFileDeletion,
+  LocalFileMove,
+  LocalFileUpdate
+} from '../change'
+import type {
+  LocalFileAdded,
+  LocalFileUpdated
+} from '../event'
+import type Pouch from '../../pouch'
+import type Prep from '../../prep'
+
+export type SendToPrepOptions = {
+  pouch: Pouch,
+  prep: Prep
+}
+*/
+
+module.exports = {
+  step
+}
+
+const log = logger({
+  component: 'ChokidarSendToPrep'
+})
+
+const SIDE = 'local'
+
+// @TODO inline this.onXXX in this function
+// @TODO rename LocalChange types to prep.xxxxxx
+async function step (changes /*: LocalChange[] */, {prep, pouch} /*: SendToPrepOptions */) {
+  const errors /*: Error[] */ = []
+  for (let c of changes) {
+    try {
+      if (c.needRefetch) {
+        // $FlowFixMe
+        c.old = await pouch.db.get(metadata.id(c.old.path))
+      }
+      switch (c.type) {
+        // TODO: Inline old LocalWatcher methods
+        case 'DirDeletion':
+          await onUnlinkDir(c, prep)
+          break
+        case 'FileDeletion':
+          await onUnlinkFile(c, prep)
+          break
+        case 'DirAddition':
+          await onAddDir(c, prep)
+          break
+        case 'FileUpdate':
+          await onChange(c, prep)
+          break
+        case 'FileAddition':
+          await onAddFile(c, prep)
+          break
+        case 'FileMove':
+          await onMoveFile(c, prep)
+          if (c.update) await onChange(c.update, prep)
+          break
+        case 'DirMove':
+          await onMoveFolder(c, prep)
+          break
+        case 'Ignored':
+          break
+        default:
+          throw new Error('wrong changes')
+      }
+    } catch (err) {
+      log.error({path: c.path, err})
+      errors.push(err)
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Could not apply all changes to Prep:\n- ${errors.map(e => e.stack).join('\n- ')}`)
+  }
+}
+
+// New file detected
+function onAddFile ({path: filePath, stats, md5sum} /*: LocalFileAddition */, prep /*: Prep */) {
+  const logError = (err) => log.error({err, path: filePath})
+  const doc = metadata.buildFile(filePath, stats, md5sum)
+  log.info({path: filePath}, 'FileAddition')
+  return prep.addFileAsync(SIDE, doc).catch(logError)
+}
+
+async function onMoveFile ({path: filePath, stats, md5sum, old, overwrite} /*: LocalFileMove */, prep /*: Prep */) {
+  const logError = (err) => log.error({err, path: filePath})
+  const doc = metadata.buildFile(filePath, stats, md5sum, old.remote)
+  if (overwrite) doc.overwrite = overwrite
+  log.info({path: filePath, oldpath: old.path}, 'FileMove')
+  return prep.moveFileAsync(SIDE, doc, old).catch(logError)
+}
+
+function onMoveFolder ({path: folderPath, stats, old, overwrite} /*: LocalDirMove */, prep /*: Prep */) {
+  const logError = (err) => log.error({err, path: folderPath})
+  const doc = metadata.buildDir(folderPath, stats, old.remote)
+  // $FlowFixMe we set doc.overwrite to true, it will be replaced by metadata in merge
+  if (overwrite) doc.overwrite = overwrite
+  log.info({path: folderPath, oldpath: old.path}, 'DirMove')
+  return prep.moveFolderAsync(SIDE, doc, old).catch(logError)
+}
+
+// New directory detected
+function onAddDir ({path: folderPath, stats} /*: LocalDirAddition */, prep /*: Prep */) {
+  const doc = metadata.buildDir(folderPath, stats)
+  log.info({path: folderPath}, 'DirAddition')
+  return prep.putFolderAsync(SIDE, doc).catch(err => log.error({err, path: folderPath}))
+}
+
+// File deletion detected
+//
+// It can be a file moved out. So, we wait a bit to see if a file with the
+// same checksum is added and, if not, we declare this file as deleted.
+function onUnlinkFile ({path: filePath} /*: LocalFileDeletion */, prep /*: Prep */) {
+  log.info({path: filePath}, 'FileDeletion')
+  return prep.trashFileAsync(SIDE, {path: filePath}).catch(err => log.error({err, path: filePath}))
+}
+
+// Folder deletion detected
+//
+// We don't want to delete a folder before files inside it. So we wait a bit
+// after chokidar event to declare the folder as deleted.
+function onUnlinkDir ({path: folderPath} /*: LocalDirDeletion */, prep /*: Prep */) {
+  log.info({path: folderPath}, 'DirDeletion')
+  return prep.trashFolderAsync(SIDE, {path: folderPath}).catch(err => log.error({err, path: folderPath}))
+}
+
+// File update detected
+function onChange ({path: filePath, stats, md5sum} /*: LocalFileUpdate|LocalFileAdded|LocalFileUpdated */, prep /*: Prep */) {
+  log.info({path: filePath}, 'FileUpdate')
+  const doc = metadata.buildFile(filePath, stats, md5sum)
+  return prep.updateFileAsync(SIDE, doc)
+}

--- a/core/local/chokidar_watcher.js
+++ b/core/local/chokidar_watcher.js
@@ -22,6 +22,7 @@ import type Pouch from '../pouch'
 import type Prep from '../prep'
 import type { Checksumer } from './checksumer'
 import type { ChokidarEvent } from './chokidar_event'
+import type { InitialScan } from './chokidar_steps/initial_scan'
 import type { LocalEvent } from './event'
 import type { LocalChange } from './change'
 import type EventEmitter from 'events'
@@ -37,15 +38,6 @@ log.chokidar = log.child({
 const SIDE = 'local'
 
 const NB_OF_DELETABLE_ELEMENT = 3
-
-/*::
-type InitialScan = {
-  ids: string[],
-  emptyDirRetryCount: number,
-  flushed: boolean,
-  resolve: () => void
-}
-*/
 
 // This file contains the filesystem watcher that will trigger operations when
 // a file or a folder is added/removed/changed locally.

--- a/core/local/chokidar_watcher.js
+++ b/core/local/chokidar_watcher.js
@@ -10,6 +10,7 @@ const path = require('path')
 const analysis = require('./analysis')
 const checksumer = require('./checksumer')
 const chokidarEvent = require('./chokidar_event')
+const initialDiff = require('./chokidar_steps/initial_diff')
 const LocalEventBuffer = require('./event_buffer')
 const logger = require('../logger')
 const metadata = require('../metadata')
@@ -36,8 +37,6 @@ log.chokidar = log.child({
 })
 
 const SIDE = 'local'
-
-const NB_OF_DELETABLE_ELEMENT = 3
 
 // This file contains the filesystem watcher that will trigger operations when
 // a file or a folder is added/removed/changed locally.
@@ -159,32 +158,9 @@ module.exports = class LocalWatcher {
     syncDir.ensureExistsSync(this)
     this.events.emit('local-start')
 
-    let events = rawEvents.filter((e) => e.path !== '') // @TODO handle root dir events
     const initialScan = this.initialScan
-    if (initialScan != null) {
-      const ids = initialScan.ids
-      events.filter((e) => e.type.startsWith('add'))
-            .forEach((e) => ids.push(metadata.id(e.path)))
-
-      const {offlineEvents, unappliedMoves, emptySyncDir} = await this.detectOfflineUnlinkEvents(initialScan)
-      events = offlineEvents.concat(events)
-
-      events = events.filter((e) => {
-        return unappliedMoves.indexOf(metadata.id(e.path)) === -1
-      })
-
-      if (emptySyncDir) {
-        // it is possible this is a temporary faillure (too late mounting)
-        // push back the events and wait until next flush.
-        this.buffer.unflush(rawEvents)
-        if (--initialScan.emptyDirRetryCount === 0) {
-          throw new Error('Syncdir is empty')
-        }
-        return initialScan.resolve()
-      }
-
-      log.debug({initialEvents: events})
-    }
+    const events = await initialDiff.step(rawEvents, this)
+    if (!events) return
 
     log.trace('Prepare events...')
     const preparedEvents /*: LocalEvent[] */ = await this.prepareEvents(events, initialScan)
@@ -208,32 +184,6 @@ module.exports = class LocalWatcher {
       initialScan.resolve()
       this.initialScan = null
     }
-  }
-
-  async detectOfflineUnlinkEvents (initialScan /*: InitialScan */) /*: Promise<{offlineEvents: Array<ChokidarEvent>, emptySyncDir: boolean}> */ {
-    // Try to detect removed files & folders
-    const events /*: Array<ChokidarEvent> */ = []
-    const docs = await this.pouch.byRecursivePathAsync('')
-    const inInitialScan = (doc) =>
-      initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
-
-    // the Syncdir is empty error only occurs if there was some docs beforehand
-    let emptySyncDir = docs.length > NB_OF_DELETABLE_ELEMENT
-    let unappliedMoves = []
-
-    for (const doc of docs) {
-      if (inInitialScan(doc) || doc.trashed || doc.incompatibilities) {
-        emptySyncDir = false
-      } else if (doc.moveFrom) {
-        // unapplied move
-        unappliedMoves.push(metadata.id(doc.moveFrom.path))
-      } else {
-        log.chokidar.debug({path: doc.path}, 'pretend unlink or unlinkDir')
-        events.unshift(chokidarEvent.pretendUnlinkFromMetadata(doc))
-      }
-    }
-
-    return {offlineEvents: events, unappliedMoves, emptySyncDir}
   }
 
   async oldMetadata (e /*: ChokidarEvent */) /*: Promise<?Metadata> */ {

--- a/core/local/chokidar_watcher.js
+++ b/core/local/chokidar_watcher.js
@@ -11,9 +11,9 @@ const checksumer = require('./checksumer')
 const chokidarEvent = require('./chokidar_event')
 const initialDiff = require('./chokidar_steps/initial_diff')
 const prepareEvents = require('./chokidar_steps/prepare_events')
+const sendToPrep = require('./chokidar_steps/send_to_prep')
 const LocalEventBuffer = require('./event_buffer')
 const logger = require('../logger')
-const metadata = require('../metadata')
 const syncDir = require('./sync_dir')
 
 /*::
@@ -34,8 +34,6 @@ const log = logger({
 log.chokidar = log.child({
   component: 'Chokidar'
 })
-
-const SIDE = 'local'
 
 // This file contains the filesystem watcher that will trigger operations when
 // a file or a folder is added/removed/changed locally.
@@ -172,7 +170,7 @@ module.exports = class LocalWatcher {
     const release = await this.pouch.lock(this)
     let target = -1
     try {
-      await this.sendToPrep(changes)
+      await sendToPrep.step(changes, this)
       target = (await this.pouch.db.changes({limit: 1, descending: true})).last_seq
     } finally {
       this.events.emit('sync-target', target)
@@ -182,56 +180,6 @@ module.exports = class LocalWatcher {
     if (initialScan != null) {
       initialScan.resolve()
       this.initialScan = null
-    }
-  }
-
-  // @TODO inline this.onXXX in this function
-  // @TODO rename LocalChange types to prep.xxxxxx
-  async sendToPrep (changes /*: LocalChange[] */) {
-    const errors /*: Error[] */ = []
-    for (let c of changes) {
-      try {
-        if (c.needRefetch) {
-          // $FlowFixMe
-          c.old = await this.pouch.db.get(metadata.id(c.old.path))
-        }
-        switch (c.type) {
-          // TODO: Inline old LocalWatcher methods
-          case 'DirDeletion':
-            await this.onUnlinkDir(c.path)
-            break
-          case 'FileDeletion':
-            await this.onUnlinkFile(c.path)
-            break
-          case 'DirAddition':
-            await this.onAddDir(c.path, c.stats)
-            break
-          case 'FileUpdate':
-            await this.onChange(c.path, c.stats, c.md5sum)
-            break
-          case 'FileAddition':
-            await this.onAddFile(c.path, c.stats, c.md5sum)
-            break
-          case 'FileMove':
-            await this.onMoveFile(c.path, c.stats, c.md5sum, c.old, c.overwrite)
-            if (c.update) await this.onChange(c.update.path, c.update.stats, c.update.md5sum)
-            break
-          case 'DirMove':
-            await this.onMoveFolder(c.path, c.stats, c.old, c.overwrite)
-            break
-          case 'Ignored':
-            break
-          default:
-            throw new Error('wrong changes')
-        }
-      } catch (err) {
-        log.error({path: c.path, err})
-        errors.push(err)
-      }
-    }
-
-    if (errors.length > 0) {
-      throw new Error(`Could not apply all changes to Prep:\n- ${errors.map(e => e.stack).join('\n- ')}`)
     }
   }
 
@@ -265,64 +213,5 @@ module.exports = class LocalWatcher {
   async checksum (filePath /*: string */) /*: Promise<string> */ {
     const absPath = path.join(this.syncPath, filePath)
     return this.checksumer.push(absPath)
-  }
-
-  /* Changes */
-
-  // New file detected
-  onAddFile (filePath /*: string */, stats /*: fse.Stats */, md5sum /*: string */) {
-    const logError = (err) => log.error({err, path: filePath})
-    const doc = metadata.buildFile(filePath, stats, md5sum)
-    log.info({path: filePath}, 'FileAddition')
-    return this.prep.addFileAsync(SIDE, doc).catch(logError)
-  }
-
-  async onMoveFile (filePath /*: string */, stats /*: fse.Stats */, md5sum /*: string */, old /*: Metadata */, overwrite /*: ?Metadata */) {
-    const logError = (err) => log.error({err, path: filePath})
-    const doc = metadata.buildFile(filePath, stats, md5sum, old.remote)
-    if (overwrite) doc.overwrite = overwrite
-    log.info({path: filePath, oldpath: old.path}, 'FileMove')
-    return this.prep.moveFileAsync(SIDE, doc, old).catch(logError)
-  }
-
-  onMoveFolder (folderPath /*: string */, stats /*: fse.Stats */, old /*: Metadata */, overwrite /*: ?boolean */) {
-    const logError = (err) => log.error({err, path: folderPath})
-    const doc = metadata.buildDir(folderPath, stats, old.remote)
-    // $FlowFixMe we set doc.overwrite to true, it will be replaced by metadata in merge
-    if (overwrite) doc.overwrite = overwrite
-    log.info({path: folderPath, oldpath: old.path}, 'DirMove')
-    return this.prep.moveFolderAsync(SIDE, doc, old).catch(logError)
-  }
-
-  // New directory detected
-  onAddDir (folderPath /*: string */, stats /*: fse.Stats */) {
-    const doc = metadata.buildDir(folderPath, stats)
-    log.info({path: folderPath}, 'DirAddition')
-    return this.prep.putFolderAsync(SIDE, doc).catch(err => log.error({err, path: folderPath}))
-  }
-
-  // File deletion detected
-  //
-  // It can be a file moved out. So, we wait a bit to see if a file with the
-  // same checksum is added and, if not, we declare this file as deleted.
-  onUnlinkFile (filePath /*: string */) {
-    log.info({path: filePath}, 'FileDeletion')
-    return this.prep.trashFileAsync(SIDE, {path: filePath}).catch(err => log.error({err, path: filePath}))
-  }
-
-  // Folder deletion detected
-  //
-  // We don't want to delete a folder before files inside it. So we wait a bit
-  // after chokidar event to declare the folder as deleted.
-  onUnlinkDir (folderPath /*: string */) {
-    log.info({path: folderPath}, 'DirDeletion')
-    return this.prep.trashFolderAsync(SIDE, {path: folderPath}).catch(err => log.error({err, path: folderPath}))
-  }
-
-  // File update detected
-  onChange (filePath /*: string */, stats /*: fse.Stats */, md5sum /*: string */) {
-    log.info({path: filePath}, 'FileUpdate')
-    const doc = metadata.buildFile(filePath, stats, md5sum)
-    return this.prep.updateFileAsync(SIDE, doc)
   }
 }

--- a/test/unit/local/chokidar_steps/initial_diff.js
+++ b/test/unit/local/chokidar_steps/initial_diff.js
@@ -1,0 +1,89 @@
+/* eslint-env mocha */
+
+const should = require('should')
+
+const initialDiff = require('../../../../core/local/chokidar_steps/initial_diff')
+const metadata = require('../../../../core/metadata')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
+const { platform } = process
+
+describe('core/local/chokidar_steps/initial_diff', () => {
+  let builders
+
+  before('instanciate config', configHelpers.createConfig)
+  before('instanciate pouch', pouchHelpers.createDatabase)
+
+  beforeEach('set up builders', function () {
+    builders = new Builders({pouch: this.pouch})
+  })
+
+  after('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  describe('.detectOfflineUnlinkEvents()', function () {
+    beforeEach('reset pouchdb', function (done) {
+      this.pouch.resetDatabase(done)
+    })
+
+    it('detects deleted files and folders', async function () {
+      let folder1 = {
+        _id: 'folder1',
+        path: 'folder1',
+        docType: 'folder'
+      }
+      let folder2 = {
+        _id: 'folder2',
+        path: 'folder2',
+        docType: 'folder'
+      }
+      const folder3 = {
+        _id: '.cozy_trash/folder3',
+        path: '.cozy_trash/folder3',
+        trashed: true,
+        docType: 'folder'
+      }
+      let file1 = {
+        _id: 'file1',
+        path: 'file1',
+        docType: 'file'
+      }
+      let file2 = {
+        _id: 'file2',
+        path: 'file2',
+        docType: 'file'
+      }
+      const file3 = {
+        _id: '.cozy_trash/folder3/file3',
+        path: '.cozy_trash/folder3/file3',
+        trashed: true,
+        docType: 'file'
+      }
+      for (let doc of [folder1, folder2, folder3, file1, file2, file3]) {
+        const {rev} = await this.pouch.db.put(doc)
+        doc._rev = rev
+      }
+      const initialScan = {ids: ['folder1', 'file1'].map(metadata.id)}
+
+      const {offlineEvents} = await initialDiff.detectOfflineUnlinkEvents(initialScan, this.pouch)
+
+      should(offlineEvents).deepEqual([
+        {type: 'unlinkDir', path: 'folder2', old: folder2},
+        {type: 'unlink', path: 'file2', old: file2}
+      ])
+    })
+
+    if (platform === 'win32' || platform === 'darwin') {
+      it('ignores incompatible docs', async function () {
+        await builders.metafile().incompatible().create()
+        const initialScan = {ids: []}
+
+        const {offlineEvents} = await initialDiff.detectOfflineUnlinkEvents(initialScan, this.pouch)
+        should(offlineEvents).deepEqual([])
+      })
+    }
+  })
+})

--- a/test/unit/local/chokidar_steps/prepare_events.js
+++ b/test/unit/local/chokidar_steps/prepare_events.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+
+const should = require('should')
+
+const prepareEvents = require('../../../../core/local/chokidar_steps/prepare_events')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
+describe('core/local/chokidar_steps/prepare_events', () => {
+  let builders
+
+  before('instanciate config', configHelpers.createConfig)
+  before('instanciate pouch', pouchHelpers.createDatabase)
+
+  beforeEach('set up builders', function () {
+    builders = new Builders({pouch: this.pouch})
+  })
+
+  after('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  describe('.oldMetadata()', function () {
+    it('resolves with the metadata whose id matches the event path', async function () {
+      const old = await builders.metadata().create()
+      const resultByEventType = {}
+      for (let type of ['add', 'addDir', 'change', 'unlink', 'unlinkDir']) {
+        resultByEventType[type] = await prepareEvents.oldMetadata({type, path: old.path}, this.pouch)
+      }
+      should(resultByEventType).deepEqual({
+        add: old,
+        addDir: old,
+        change: old,
+        unlink: old,
+        unlinkDir: old
+      })
+    })
+  })
+})

--- a/test/unit/local/chokidar_watcher.js
+++ b/test/unit/local/chokidar_watcher.js
@@ -7,7 +7,6 @@ const should = require('should')
 
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 const Watcher = require('../../../core/local/chokidar_watcher')
-const metadata = require('../../../core/metadata')
 
 const Builders = require('../../support/builders')
 const configHelpers = require('../../support/helpers/config')
@@ -430,68 +429,5 @@ describe('LocalWatcher Tests', function () {
         }, 1800)
       })
     })
-  })
-
-  describe('detectOfflineUnlinkEvents', function () {
-    beforeEach('reset pouchdb', function (done) {
-      this.pouch.resetDatabase(done)
-    })
-
-    it('detects deleted files and folders', async function () {
-      let folder1 = {
-        _id: 'folder1',
-        path: 'folder1',
-        docType: 'folder'
-      }
-      let folder2 = {
-        _id: 'folder2',
-        path: 'folder2',
-        docType: 'folder'
-      }
-      const folder3 = {
-        _id: '.cozy_trash/folder3',
-        path: '.cozy_trash/folder3',
-        trashed: true,
-        docType: 'folder'
-      }
-      let file1 = {
-        _id: 'file1',
-        path: 'file1',
-        docType: 'file'
-      }
-      let file2 = {
-        _id: 'file2',
-        path: 'file2',
-        docType: 'file'
-      }
-      const file3 = {
-        _id: '.cozy_trash/folder3/file3',
-        path: '.cozy_trash/folder3/file3',
-        trashed: true,
-        docType: 'file'
-      }
-      for (let doc of [folder1, folder2, folder3, file1, file2, file3]) {
-        const {rev} = await this.pouch.db.put(doc)
-        doc._rev = rev
-      }
-      const initialScan = {ids: ['folder1', 'file1'].map(metadata.id)}
-
-      const {offlineEvents} = await this.watcher.detectOfflineUnlinkEvents(initialScan)
-
-      should(offlineEvents).deepEqual([
-        {type: 'unlinkDir', path: 'folder2', old: folder2},
-        {type: 'unlink', path: 'file2', old: file2}
-      ])
-    })
-
-    if (platform === 'win32' || platform === 'darwin') {
-      it('ignores incompatible docs', async function () {
-        await builders.metafile().incompatible().create()
-        const initialScan = {ids: []}
-
-        const {offlineEvents} = await this.watcher.detectOfflineUnlinkEvents(initialScan)
-        should(offlineEvents).deepEqual([])
-      })
-    }
   })
 })

--- a/test/unit/local/chokidar_watcher.js
+++ b/test/unit/local/chokidar_watcher.js
@@ -129,23 +129,6 @@ describe('LocalWatcher Tests', function () {
     })
   })
 
-  describe('#oldMetadata()', () => {
-    it('resolves with the metadata whose id matches the event path', async function () {
-      const old = await builders.metadata().create()
-      const resultByEventType = {}
-      for (let type of ['add', 'addDir', 'change', 'unlink', 'unlinkDir']) {
-        resultByEventType[type] = await this.watcher.oldMetadata({type, path: old.path})
-      }
-      should(resultByEventType).deepEqual({
-        add: old,
-        addDir: old,
-        change: old,
-        unlink: old,
-        unlinkDir: old
-      })
-    })
-  })
-
   describe('onAddFile', () => {
     if (process.env.APPVEYOR) {
       it('is unstable on AppVeyor')


### PR DESCRIPTION
First step to make chokidar steps easier to understand/refactor.
This mostly implies moving/extracting stuff to separate files & injecting dependencies that used to be available directly as `ChokidarWatcher` properties.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
