### PR TITLE
core/merge: Compare remotes only when not null

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -220,7 +220,7 @@ class Merge {
         log.info({path}, 'up to date')
         return null
       } else {
-        if (doc.remote._id !== folder.remote._id) {
+        if (doc.remote && doc.remote._id !== folder.remote._id) {
           await this.resolveConflictAsync(side, folder, folder)
         }
         return this.pouch.put(doc)

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -456,7 +456,11 @@ function buildDir (fpath /*: string */, stats /*: Stats */, remote /*: ?Metadata
     remote
   }
   if (stats.fileid) { doc.fileid = stats.fileid }
-  return doc
+
+  return _.chain(doc)
+    .cloneDeep()
+    .omitBy(_.isUndefined)
+    .value()
 }
 
 const EXECUTABLE_MASK = 1 << 6
@@ -478,7 +482,11 @@ function buildFile (filePath /*: string */, stats /*: Stats */, md5sum /*: strin
   }
   if (stats.mode && (+stats.mode & EXECUTABLE_MASK) !== 0) { doc.executable = true }
   if (stats.fileid) { doc.fileid = stats.fileid }
-  return doc
+
+  return _.chain(doc)
+    .cloneDeep()
+    .omitBy(_.isUndefined)
+    .value()
 }
 
 const CONFLICT_PATTERN = '-conflict-\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}.\\d{3}Z'

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -37,12 +37,10 @@ module.exports = class BaseMetadataBuilder {
         _id: metadata.id('foo'),
         docType: 'folder', // To make flow happy (overridden by subclasses)
         path: 'foo',
-        remote: {
-          _id: dbBuilders.id(),
-          _rev: dbBuilders.rev()
-        },
         tags: [],
         sides: {},
+        // $FlowFixMe: metadata's buildFile and buildDir allow it while types don't
+        remote: undefined,
         updated_at: timestamp.current().toISOString()
       }
     }
@@ -57,6 +55,7 @@ module.exports = class BaseMetadataBuilder {
 
   moveFrom (was /*: Metadata */) /*: this */ {
     this.doc.moveFrom = _.defaultsDeep({ moveTo: this.doc._id }, was)
+    if (this.doc.remote == null) this.doc.remote = was.remote
     this.noRev()
     return this
   }
@@ -166,6 +165,7 @@ module.exports = class BaseMetadataBuilder {
 
   upToDate () /*: this */ {
     this.doc.sides = {local: 2, remote: 2}
+    if (this.doc.remote == null) this.remoteId(dbBuilders.id())
     return this
   }
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -200,7 +200,10 @@ module.exports = class BaseMetadataBuilder {
     // prevent environment related failures.
     metadata.assignPlatformIncompatibilities(this.doc, '')
 
-    return _.cloneDeep(this.doc)
+    return _.chain(this.doc)
+      .cloneDeep()
+      .omitBy(_.isUndefined)
+      .value()
   }
 
   async create () /*: Promise<Metadata> */ {

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -183,8 +183,8 @@ describe('Merge', function () {
 
     onPlatforms(['win32', 'darwin'], () => {
       it('resolves an identity conflict with an existing file', async function () {
-        await builders.metafile().path('bar').create()
-        const doc = builders.metafile().path('BAR').build()
+        await builders.metafile().path('bar').upToDate().create()
+        const doc = builders.metafile().path('BAR').remoteId(dbBuilders.id()).build()
 
         const sideEffects = await mergeSideEffects(this, () =>
           this.merge.addFileAsync(this.side, _.cloneDeep(doc))
@@ -784,12 +784,12 @@ describe('Merge', function () {
         await builders
           .metadir()
           .path('alfred')
-          .sides({ [this.side]: 1 })
+          .sides({ local: 1 })
           .create()
         Alfred = await builders
           .metadir()
           .path('Alfred')
-          .sides({ [otherSide(this.side)]: 1 })
+          .sides({ remote: 1 })
           .remoteId(dbBuilders.id())
           .build()
       })
@@ -797,13 +797,13 @@ describe('Merge', function () {
       onPlatforms(['win32', 'darwin'], () => {
         it('resolves the conflict', async function () {
           const sideEffects = await mergeSideEffects(this, () =>
-            this.merge.putFolderAsync(this.side, _.cloneDeep(Alfred))
+            this.merge.putFolderAsync('local', _.cloneDeep(Alfred))
           )
 
           should(sideEffects).deepEqual({
             savedDocs: [],
             resolvedConflicts: [
-              [this.side, _.pick(Alfred, ['path', 'remote'])]
+              ['local', _.pick(Alfred, ['path', 'remote'])]
             ]
           })
         })
@@ -812,14 +812,14 @@ describe('Merge', function () {
       onPlatform('linux', () => {
         it('saves the doc as a new doc', async function () {
           const sideEffects = await mergeSideEffects(this, () =>
-            this.merge.putFolderAsync(this.side, _.cloneDeep(Alfred))
+            this.merge.putFolderAsync('local', _.cloneDeep(Alfred))
           )
 
           should(sideEffects).deepEqual({
             savedDocs: [
               _.defaultsDeep(
                 {
-                  sides: { [this.side]: 1 }
+                  sides: { local: 1 }
                 },
                 Alfred
               )
@@ -914,7 +914,7 @@ describe('Merge', function () {
               sides: { [this.side]: 1 },
               moveFrom: movedSrc
             },
-            _.pick(was, ['size', 'ino']),
+            _.pick(was, ['size', 'ino', 'remote']),
             doc
           )
         ],
@@ -1081,7 +1081,6 @@ describe('Merge', function () {
         .path('SRC/FILE2')
         .moveFrom(orig)
         .sides({ [this.side]: 3, [otherSide(this.side)]: 2 })
-        .remoteId(dbBuilders.id())
         .create()
       const doc = await builders
         .metafile()
@@ -1116,6 +1115,7 @@ describe('Merge', function () {
               sides: { [this.side]: 1 },
               moveFrom: movedSrc
             },
+            _.pick(orig, ['remote']),
             doc
             // TODO: Compare _revs
           )
@@ -1170,6 +1170,7 @@ describe('Merge', function () {
               sides: { local: 1 },
               moveFrom: movedSrc
             },
+            _.pick(orig, ['remote']),
             doc
             // TODO: Compare _revs
           )
@@ -1316,6 +1317,7 @@ describe('Merge', function () {
                 sides: { [this.side]: 1 },
                 moveFrom: movedSrc
               },
+              _.pick(was, ['remote']),
               doc
               // TODO: Compare _revs
             )
@@ -1365,7 +1367,7 @@ describe('Merge', function () {
               sides: { [this.side]: 1 },
               moveFrom: movedSrc
             },
-            _.pick(was, ['ino']),
+            _.pick(was, ['ino', 'remote']),
             doc
             // TODO: Compare _revs
           )
@@ -1692,6 +1694,7 @@ describe('Merge', function () {
         .metadir()
         .path('src')
         .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
+        .remoteId(dbBuilders.id())
         .create()
       const srcFile = await builders
         .metafile()
@@ -1699,12 +1702,12 @@ describe('Merge', function () {
         .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
         .remoteId(dbBuilders.id())
         .create()
-      const oldDst = builders
+      const oldDst = await builders
         .metadir()
         .path('dst')
         .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
         .remoteId(dbBuilders.id())
-        .build()
+        .create()
       const dstFile = await builders
         .metafile()
         .path('dst/file')
@@ -1745,6 +1748,7 @@ describe('Merge', function () {
               moveFrom: movedSrcDir,
               overwrite: oldDst
             },
+            _.pick(srcDir, ['remote']),
             _.omit(dstDir, ['_rev']) // TODO: Compare _revs
           ),
           _.omit(movedSrcFile, ['_rev']), // TODO: Compare _revs
@@ -2198,6 +2202,7 @@ describe('Merge', function () {
         const was = await builders
           .metadata()
           .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
+          .remoteId(dbBuilders.id())
           .create()
         const doc = builders
           .metadata(was)

--- a/test/unit/pouch.js
+++ b/test/unit/pouch.js
@@ -322,8 +322,8 @@ describe('Pouch', function () {
 
       beforeEach(async function () {
         const builders = new Builders({pouch: this.pouch})
-        dir = await builders.metadir().path('dir-with-remote-id').create()
-        file = await builders.metafile().path('file-with-remote-id').create()
+        dir = await builders.metadir().path('dir-with-remote-id').upToDate().create()
+        file = await builders.metafile().path('file-with-remote-id').upToDate().create()
       })
 
       it('resolves with docs matching the given remoteIds, in the same order', async function () {

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -217,9 +217,8 @@ describe('remote.Remote', function () {
         }
       }
       await this.remote.addFileAsync(doc)
-      should.exist(doc.remote._id)
-      should.exist(doc.remote._rev)
-      should.exist(doc._deleted)
+      should(doc._deleted).be.true()
+      should(doc).not.have.property('remote')
     })
   })
 
@@ -332,9 +331,8 @@ describe('remote.Remote', function () {
           }
         }
         await this.remote.overwriteFileAsync(doc)
-        should.exist(doc.remote._id)
-        should.exist(doc.remote._rev)
-        should.exist(doc._deleted)
+        should(doc._deleted).be.true()
+        should(doc).not.have.property('remote')
       })
     })
   }


### PR DESCRIPTION
When merging an update or the creation of a directory at a path where
  a directory already exist, we check if their remote ids are equal to
  determine if we should update the existing document or resolve a
  conflict.
  However, in the situation where the both the existing document and new
  document are local only, we don't have a `remote` attribute and trying
  to compare their ids will throw an error for trying to access an
  attribute on `undefined`.

  We just make sure that a `remote` attribute exists on the new
  document before comparing the ids because the document's `remote`
  attribute will be assigned the existing's document's `remote`
  attribute if it exists.

In order to test this, we needed to have coherent `remote` attribute values in test documents.

Indeed, local documents which have not been synchronised should not have a
  `remote` attribute. On the other hand, remote documents and
  synchronised documents should always have one.

  We make sure the test document builders don't assign a `remote` value
  by default and that tests assign one when necessary.
Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
