### PR TITLE
core/config: Default to atom watcher

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,6 @@ clone_depth: 10
 environment:
   MOCHA_TIMEOUT: "60000"
   NO_BREAKPOINTS: "1"
-  COZY_FS_WATCHER: "chokidar"
   matrix:
       - BUILD_JOB: "short_tests"
       - BUILD_JOB: "scenarios_build"

--- a/core/config.js
+++ b/core/config.js
@@ -238,7 +238,7 @@ function platformDefaultWatcherType (platform /*: string */ = process.platform) 
   if (platform === 'darwin') {
     return 'chokidar'
   }
-  return 'chokidar' // XXX: Should be 'atom' once we go live with the new watcher
+  return 'atom'
 }
 
 function validateWatcherType (watcherType /*: ?string */) /*: ?WatcherType */ {

--- a/dev/ci/scenarios.sh
+++ b/dev/ci/scenarios.sh
@@ -4,9 +4,5 @@ set -ex
 
 . "./dev/ci/start_xvfb.sh"
 
-# FIXME Scenario tests use ChokidarEvents and onFlush
-# So, they are not yet compatible with atom/watcher
-export COZY_FS_WATCHER=chokidar
-
 yarn install:electron
 yarn test:scenarios --timeout $MOCHA_TIMEOUT --forbid-only

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -317,7 +317,7 @@ describe('core/config', function () {
     })
 
     it('is chokidar on Windows', () => {
-      should(config.platformDefaultWatcherType('win32')).equal('chokidar')
+      should(config.platformDefaultWatcherType('win32')).equal('atom')
     })
 
     it('is chokidar on macOS', () => {
@@ -325,7 +325,7 @@ describe('core/config', function () {
     })
 
     it('is chokidar on Linux', () => {
-      should(config.platformDefaultWatcherType('linux')).equal('chokidar')
+      should(config.platformDefaultWatcherType('linux')).equal('atom')
     })
   })
 })


### PR DESCRIPTION
Except on macOS where the default is still chokidar.

This is a temporary change that will be reverted, to make testing easier.
But it will soon make its way into production.

It is expected to break the CI, so we can progressively merge the required fixes.