### PR TITLE
core/local/steps/buffer: Drop empty batches

### DIFF
--- a/core/local/steps/await_write_finish.js
+++ b/core/local/steps/await_write_finish.js
@@ -35,9 +35,7 @@ function sendReadyBatches (waiting /*: WaitingItem[] */, out /*: Buffer */) {
     }
     const item = waiting.shift()
     clearTimeout(item.timeout)
-    if (item.events.length > 0) {
-      out.push(item.events)
-    }
+    out.push(item.events)
   }
 }
 

--- a/core/local/steps/buffer.js
+++ b/core/local/steps/buffer.js
@@ -23,6 +23,8 @@ module.exports = class Buffer {
   }
 
   push (batch /*: Batch */) /*: void */ {
+    if (batch.length === 0) return
+
     if (this._resolve) {
       this._resolve(batch)
       this._resolve = null

--- a/core/local/steps/initial_diff.js
+++ b/core/local/steps/initial_diff.js
@@ -144,9 +144,7 @@ function sendReadyBatches (waiting /*: WaitingItem[] */, out /*: Buffer */) {
     }
     const item = waiting.shift()
     clearTimeout(item.timeout)
-    if (item.batch.length > 0) {
-      out.push(item.batch)
-    }
+    out.push(item.batch)
   }
 }
 

--- a/test/unit/local/steps/buffer.js
+++ b/test/unit/local/steps/buffer.js
@@ -48,9 +48,11 @@ describe('core/local/steps/Buffer', function () {
         await should(buffer.pop()).be.fulfilledWith(batch)
       })
 
-      it('accepts empty batches', async () => {
-        const batch = []
+      it('drops empty batches', async () => {
+        const emptyBatch = []
+        const batch = builders.nonEmptyBatch()
 
+        buffer.push(emptyBatch)
         buffer.push(batch)
 
         await should(buffer.pop()).be.fulfilledWith(batch)


### PR DESCRIPTION
No need to pass them around and run useless code.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
