### PR TITLE
test/support/helpers: Load default ignore rules

### DIFF
--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -46,7 +46,7 @@ class TestHelpers {
 
   constructor ({ config, pouch } /*: TestHelpersOptions */) {
     const merge = new Merge(pouch)
-    const ignore = new Ignore([])
+    const ignore = (new Ignore([])).addDefaultRules()
     const prep = new Prep(merge, ignore, config)
     const events = new SyncState()
     const localHelpers = new LocalTestHelpers({config, prep, pouch, events, ignore})


### PR DESCRIPTION
Otherwise tests will fail with AtomWatcher since it doesn't have
an `ignored` option like chokidar.

This doesn't prevent us to keep using the chokidar option.

Courtesy of @taratatach.

**Needs #1476**

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
