### PR TITLE
core/ignore: Don't confuse relative path with Windows drive letter

### DIFF
--- a/core/ignore.js
+++ b/core/ignore.js
@@ -105,6 +105,13 @@ function match (path /*: string */, isFolder /*: boolean */, pattern /*: IgnoreP
   if (parent === '.') {
     return false
   }
+  // On Windows, the various `path.*()` functions don't play well with
+  // relative paths where the top-level file or directory name includes a
+  // forbidden `:` character and looks like a drive letter, even without a
+  // separator. Better make sure we don't end up in an infinite loop.
+  if (parent === path) {
+    return false
+  }
   return match(parent, true, pattern)
 }
 

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 const { Ignore, loadSync } = require('../../core/ignore')
 const metadata = require('../../core/metadata')
 
+const { onPlatform } = require('../support/helpers/platform')
 const TmpDir = require('../support/helpers/TmpDir')
 
 describe('Ignore', function () {
@@ -263,6 +264,22 @@ describe('Ignore', function () {
       })
       const ignore = new Ignore(['Foo'])
       ignore.isIgnored({ relativePath: 'foo', isFolder: false }).should.be.true()
+    })
+  })
+
+  describe('#isIgnored()', () => {
+    onPlatform('win32', () => {
+      context('when at least one rule to match against', () => {
+        const ignore = new Ignore(['at least one rule'])
+
+        for (const relativePath of ['c:', 'd:whatever', 'e:\\whatever', 'f:what\\ever']) {
+          context(`with relative path ${JSON.stringify(relativePath)}`, () => {
+            it('does not confuse the path start with a Windows drive letter', () => {
+              ignore.isIgnored({relativePath}).should.be.false()
+            })
+          })
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
On Windows, the various `path.*()` functions don't play well with
relative paths where the top-level file or directory name includes a
forbidden `:` character and looks like a drive letter, even without a
separator. Better make sure we don't end up in an infinite loop.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
