### PR TITLE
test/support/helpers/scenarios: .init() fileid support

### DIFF
--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -160,7 +160,7 @@ async function runLocalAtom (scenario, atomCapture, helpers) {
     if (process.platform === 'win32' && atomCapture.name.match(/win32/)) {
       relpathFix = (relpath) => relpath.replace(/\//g, '\\')
     }
-    await init(scenario, helpers.pouch, helpers.local.syncDir.abspath, relpathFix)
+    await init(scenario, helpers.pouch, helpers.local.syncDir.abspath, relpathFix, true)
   }
 
   await runActions(scenario, helpers.local.syncDir.abspath, {skipWait: true})

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -130,6 +130,15 @@ module.exports.loadRemoteChangesFiles = (scenario) => {
   })
 }
 
+const getInode = async ({path, ino, trashed, trueino}) => {
+  if (trashed || !trueino) {
+    return ino
+  } else {
+    const stats = await fse.stat(path)
+    return stats.ino
+  }
+}
+
 module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
   debug('[init]')
   const remoteDocsToTrash = []
@@ -150,9 +159,9 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
       if (!trashed) {
         debug(`- create local dir: ${localPath}`)
         await fse.ensureDir(abspath(localPath))
-        if (trueino) ino = (await fse.stat(abspath(localPath))).ino
       }
 
+      ino = await getInode({path: abspath(localPath), ino, trashed, trueino})
       const doc = {
         _id: metadata.id(localPath),
         docType: 'folder',
@@ -189,9 +198,9 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
       if (!trashed) {
         debug(`- create local file: ${localPath}`)
         await fse.outputFile(abspath(localPath), content)
-        if (trueino) ino = (await fse.stat(abspath(localPath))).ino
       }
 
+      ino = await getInode({path: abspath(localPath), ino, trashed, trueino})
       const doc = {
         _id: metadata.id(localPath),
         md5sum,

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -130,8 +130,8 @@ module.exports.loadRemoteChangesFiles = (scenario) => {
   })
 }
 
-const getInode = async ({path, fakeIno, trashed, trueino}) => {
-  if (trashed || !trueino) {
+const getInode = async ({path, fakeIno, trashed, useRealInodes}) => {
+  if (trashed || !useRealInodes) {
     return fakeIno
   } else {
     const stats = await fse.stat(path)
@@ -139,7 +139,7 @@ const getInode = async ({path, fakeIno, trashed, trueino}) => {
   }
 }
 
-module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
+module.exports.init = async (scenario, pouch, abspath, relpathFix, useRealInodes) => {
   debug('[init]')
   const remoteDocsToTrash = []
   for (let {path: relpath, ino: fakeIno, trashed, content} of scenario.init) {
@@ -161,7 +161,7 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
         await fse.ensureDir(abspath(localPath))
       }
 
-      const ino = await getInode({path: abspath(localPath), fakeIno, trashed, trueino})
+      const ino = await getInode({path: abspath(localPath), fakeIno, trashed, useRealInodes})
       const doc = {
         _id: metadata.id(localPath),
         docType: 'folder',
@@ -200,7 +200,7 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
         await fse.outputFile(abspath(localPath), content)
       }
 
-      const ino = await getInode({path: abspath(localPath), fakeIno, trashed, trueino})
+      const ino = await getInode({path: abspath(localPath), fakeIno, trashed, useRealInodes})
       const doc = {
         _id: metadata.id(localPath),
         md5sum,

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -130,9 +130,9 @@ module.exports.loadRemoteChangesFiles = (scenario) => {
   })
 }
 
-const getInode = async ({path, ino, trashed, trueino}) => {
+const getInode = async ({path, fakeIno, trashed, trueino}) => {
   if (trashed || !trueino) {
-    return ino
+    return fakeIno
   } else {
     const stats = await fse.stat(path)
     return stats.ino
@@ -142,7 +142,7 @@ const getInode = async ({path, ino, trashed, trueino}) => {
 module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
   debug('[init]')
   const remoteDocsToTrash = []
-  for (let {path: relpath, ino, trashed, content} of scenario.init) {
+  for (let {path: relpath, ino: fakeIno, trashed, content} of scenario.init) {
     debug(relpath)
     const isOutside = relpath.startsWith('../outside')
     let remoteParent
@@ -161,7 +161,7 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
         await fse.ensureDir(abspath(localPath))
       }
 
-      ino = await getInode({path: abspath(localPath), ino, trashed, trueino})
+      const ino = await getInode({path: abspath(localPath), fakeIno, trashed, trueino})
       const doc = {
         _id: metadata.id(localPath),
         docType: 'folder',
@@ -200,7 +200,7 @@ module.exports.init = async (scenario, pouch, abspath, relpathFix, trueino) => {
         await fse.outputFile(abspath(localPath), content)
       }
 
-      ino = await getInode({path: abspath(localPath), ino, trashed, trueino})
+      const ino = await getInode({path: abspath(localPath), fakeIno, trashed, trueino})
       const doc = {
         _id: metadata.id(localPath),
         md5sum,


### PR DESCRIPTION
Will fix 9 scenarios on Windows with new atom watcher.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
