### PR TITLE
core/local/steps/initial_diff: Detect path reuse

### DIFF
--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -9,100 +9,106 @@ const pouchHelpers = require('../../../support/helpers/pouch')
 const Buffer = require('../../../../core/local/steps/buffer')
 const initialDiff = require('../../../../core/local/steps/initial_diff')
 
-describe('local/steps/initial_diff.loop()', () => {
+describe('local/steps/initial_diff', () => {
   let builders
-  let buffer
 
   before('instanciate config', configHelpers.createConfig)
   beforeEach('instanciate pouch', pouchHelpers.createDatabase)
   beforeEach('populate pouch with documents', function () {
     builders = new Builders({pouch: this.pouch})
-    buffer = new Buffer()
   })
   afterEach('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
 
-  it('detects documents moved while client was stopped', async function () {
-    await builders.metadir().path('foo').ino(1).create()
-    await builders.metafile().path('fizz').ino(2).create()
+  describe('.loop()', () => {
+    let buffer
 
-    const state = await initialDiff.initialState({ pouch: this.pouch })
+    beforeEach('populate pouch with documents', function () {
+      buffer = new Buffer()
+    })
 
-    const bar = builders.event().action('scan').kind('directory').path('bar').ino(1).build()
-    const buzz = builders.event().action('scan').kind('file').path('buzz').ino(2).build()
-    buffer.push([bar, buzz])
-    buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
+    it('detects documents moved while client was stopped', async function () {
+      await builders.metadir().path('foo').ino(1).create()
+      await builders.metafile().path('fizz').ino(2).create()
 
-    const events = await buffer.pop()
-    should(events).deepEqual([
-      builders.event(bar).action('renamed').oldPath('foo').build(),
-      builders.event(buzz).action('renamed').oldPath('fizz').build()
-    ])
-  })
+      const state = await initialDiff.initialState({ pouch: this.pouch })
 
-  it('detects documents moved while client is doing initial scan', async function () {
-    await builders.metadir().path('foo').ino(1).create()
-    await builders.metafile().path('foo/baz').ino(2).create()
-    await builders.metadir().path('bar').ino(3).create()
+      const bar = builders.event().action('scan').kind('directory').path('bar').ino(1).build()
+      const buzz = builders.event().action('scan').kind('file').path('buzz').ino(2).build()
+      buffer.push([bar, buzz])
+      buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
 
-    const state = await initialDiff.initialState({ pouch: this.pouch })
+      const events = await buffer.pop()
+      should(events).deepEqual([
+        builders.event(bar).action('renamed').oldPath('foo').build(),
+        builders.event(buzz).action('renamed').oldPath('fizz').build()
+      ])
+    })
 
-    const foo = builders.event().action('scan').kind('directory').path('foo').ino(1).build()
-    const barbaz = builders.event().action('created').kind('file').path('bar/baz').ino(2).build()
-    buffer.push([foo, barbaz])
-    const bar = builders.event().action('scan').kind('directory').path('bar').ino(3).build()
-    buffer.push([
-      bar,
-      builders.event().action('scan').kind('file').path('bar/baz').ino(2).build()
-    ])
-    buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
+    it('detects documents moved while client is doing initial scan', async function () {
+      await builders.metadir().path('foo').ino(1).create()
+      await builders.metafile().path('foo/baz').ino(2).create()
+      await builders.metadir().path('bar').ino(3).create()
 
-    const events = [].concat(
-      await buffer.pop(),
-      await buffer.pop()
-    )
-    should(events).deepEqual([
-      foo,
-      builders.event(barbaz).action('renamed').oldPath('foo/baz').build(),
-      bar
-    ])
-  })
+      const state = await initialDiff.initialState({ pouch: this.pouch })
 
-  it('detects documents replaced by another one of a different kind while client was stopped', async function () {
-    await builders.metadir().path('foo').ino(1).create()
-    await builders.metafile().path('bar').ino(2).create()
-    await builders.metadir().path('fizz').ino(3).create()
-    await builders.metafile().path('buzz').ino(4).create()
+      const foo = builders.event().action('scan').kind('directory').path('foo').ino(1).build()
+      const barbaz = builders.event().action('created').kind('file').path('bar/baz').ino(2).build()
+      buffer.push([foo, barbaz])
+      const bar = builders.event().action('scan').kind('directory').path('bar').ino(3).build()
+      buffer.push([
+        bar,
+        builders.event().action('scan').kind('file').path('bar/baz').ino(2).build()
+      ])
+      buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
 
-    const state = await initialDiff.initialState({ pouch: this.pouch })
+      const events = [].concat(
+        await buffer.pop(),
+        await buffer.pop()
+      )
+      should(events).deepEqual([
+        foo,
+        builders.event(barbaz).action('renamed').oldPath('foo/baz').build(),
+        bar
+      ])
+    })
 
-    const foo = builders.event().action('scan').kind('file').path('foo').ino(2).build()
-    const buzz = builders.event().action('scan').kind('directory').path('buzz').ino(3).build()
-    buffer.push([foo, buzz])
-    buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
+    it('detects documents replaced by another one of a different kind while client was stopped', async function () {
+      await builders.metadir().path('foo').ino(1).create()
+      await builders.metafile().path('bar').ino(2).create()
+      await builders.metadir().path('fizz').ino(3).create()
+      await builders.metafile().path('buzz').ino(4).create()
 
-    const events = await buffer.pop()
-    should(events).deepEqual([
-      builders.event(foo).action('renamed').oldPath('bar').build(),
-      builders.event(buzz).action('renamed').oldPath('fizz').build()
-    ])
-  })
+      const state = await initialDiff.initialState({ pouch: this.pouch })
 
-  it('detects documents removed while client was stopped', async function () {
-    await builders.metadir().path('foo').ino(1).create()
-    await builders.metafile().path('bar').ino(2).create()
+      const foo = builders.event().action('scan').kind('file').path('foo').ino(2).build()
+      const buzz = builders.event().action('scan').kind('directory').path('buzz').ino(3).build()
+      buffer.push([foo, buzz])
+      buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
 
-    const state = await initialDiff.initialState({ pouch: this.pouch })
+      const events = await buffer.pop()
+      should(events).deepEqual([
+        builders.event(foo).action('renamed').oldPath('bar').build(),
+        builders.event(buzz).action('renamed').oldPath('fizz').build()
+      ])
+    })
 
-    const initial = builders.event().action('initial-scan-done').build()
-    buffer.push([initial])
-    buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
+    it('detects documents removed while client was stopped', async function () {
+      await builders.metadir().path('foo').ino(1).create()
+      await builders.metafile().path('bar').ino(2).create()
 
-    const events = await buffer.pop()
-    should(events).deepEqual([
-      builders.event().action('deleted').kind('file').path('bar').build(),
-      builders.event().action('deleted').kind('directory').path('foo').build(),
-      initial
-    ])
+      const state = await initialDiff.initialState({ pouch: this.pouch })
+
+      const initial = builders.event().action('initial-scan-done').build()
+      buffer.push([initial])
+      buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
+
+      const events = await buffer.pop()
+      should(events).deepEqual([
+        builders.event().action('deleted').kind('file').path('bar').build(),
+        builders.event().action('deleted').kind('directory').path('foo').build(),
+        initial
+      ])
+    })
   })
 })


### PR DESCRIPTION
  Generate a `deleted` event for a document whose associated file is
  missing only if there is no other document at the same path.
  Otherwise we won't create a document for the new file.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
