### PR TITLE
core/local/atom_watcher: Modulify & fix .stepsInitialState()

### DIFF
--- a/core/local/atom_watcher.js
+++ b/core/local/atom_watcher.js
@@ -84,7 +84,7 @@ const stepsInitialState = opts =>
     {}
   )
 
-module.exports = class AtomWatcher {
+class AtomWatcher {
   /*::
   pouch: Pouch
   events: EventEmitter
@@ -150,4 +150,8 @@ module.exports = class AtomWatcher {
     }
     this.producer.stop()
   }
+}
+
+module.exports = {
+  AtomWatcher
 }

--- a/core/local/atom_watcher.js
+++ b/core/local/atom_watcher.js
@@ -74,7 +74,7 @@ const producer = opts => {
   }
 }
 
-const stepsInitialState = opts =>
+const stepsInitialState = (opts /*: * */) =>
   Promise.reduce(
     async (state, step) =>
       step.initialState
@@ -153,5 +153,6 @@ class AtomWatcher {
 }
 
 module.exports = {
-  AtomWatcher
+  AtomWatcher,
+  stepsInitialState
 }

--- a/core/local/atom_watcher.js
+++ b/core/local/atom_watcher.js
@@ -74,14 +74,14 @@ const producer = opts => {
   }
 }
 
-const stepsInitialState = (opts /*: * */) =>
+const stepsInitialState = (state /*: Object */, opts /*: * */) /*: Promise<Object> */ =>
   Promise.reduce(
-    async (state, step) =>
-      step.initialState
-        ? Object.assign(state, await step.initialState(opts))
-        : state,
     steps,
-    {}
+    async (prevState, step) =>
+      step.initialState
+        ? _.assign(prevState, await step.initialState(opts))
+        : prevState,
+    state
   )
 
 class AtomWatcher {
@@ -126,7 +126,7 @@ class AtomWatcher {
       this._runningReject = reject
     })
     this.events.emit('local-start')
-    this.state = await stepsInitialState(this)
+    await stepsInitialState(this.state, this)
     this.producer.start()
     const scanDone = new Promise((resolve) => {
       this.events.on('initial-scan-done', resolve)

--- a/core/local/steps/initial_diff.js
+++ b/core/local/steps/initial_diff.js
@@ -33,6 +33,7 @@ const DELAY = 200
 const STEP_NAME = 'initialDiff'
 
 module.exports = {
+  STEP_NAME,
   loop,
   initialState
 }

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const AtomWatcher = require('./atom_watcher')
+const { AtomWatcher } = require('./atom_watcher')
 const ChokidarWatcher = require('./chokidar_watcher')
 
 /*::

--- a/dev/capture/local.js
+++ b/dev/capture/local.js
@@ -10,7 +10,7 @@ const sinon = require('sinon')
 
 const Config = require('../../core/config')
 const { Ignore } = require('../../core/ignore')
-const AtomWatcher = require('../../core/local/atom_watcher')
+const { AtomWatcher } = require('../../core/local/atom_watcher')
 const Pouch = require('../../core/pouch')
 const Prep = require('../../core/prep')
 const fixturesHelpers = require('../../test/support/helpers/scenarios')

--- a/test/unit/local/atom_watcher.js
+++ b/test/unit/local/atom_watcher.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+/* @flow */
+
+const should = require('should')
+
+const AtomWatcher = require('../../../core/local/atom_watcher')
+const initialDiff = require('../../../core/local/steps/initial_diff')
+
+const configHelpers = require('../../support/helpers/config')
+const pouchHelpers = require('../../support/helpers/pouch')
+
+console.log(initialDiff.STEP_NAME)
+
+describe('core/local/atom_watcher', () => {
+  before('instanciate config', configHelpers.createConfig)
+  before('instanciate pouch', pouchHelpers.createDatabase)
+  after('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  describe('.stepsInitialState()', () => {
+    it('includes initial diff state key', async function () {
+      const state = {}
+      const initialState = await AtomWatcher.stepsInitialState(state, this)
+      should(state).have.property(initialDiff.STEP_NAME)
+      should(initialState).have.property(initialDiff.STEP_NAME)
+    })
+  })
+})


### PR DESCRIPTION
Modulification was needed so we can export the function.
So we can test it.
So we can reproduce the issue.
So we can fix it.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
