### PR TITLE
core/merge: Revert dir local move + remote add = conflict

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -220,9 +220,6 @@ class Merge {
         log.info({path}, 'up to date')
         return null
       } else {
-        if (doc.remote._id !== folder.remote._id) {
-          await this.resolveConflictAsync(side, folder, folder)
-        }
         return this.pouch.put(doc)
       }
     }

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -321,24 +321,8 @@ describe('Conflict resolution', () => {
     })
   })
 
-  describe('merging local dir move then remote dir addition to the same destination', () => {
-    it('renames one of them', async () => {
-      await helpers.local.syncDir.ensureDir('src')
-      await helpers.local.scan()
-      await helpers.syncAll()
-      await helpers.pullAndSyncAll()
-      // FIXME: Initial tree helper?
-      await cozy.files.createDirectory({name: 'dst'})
-      await helpers.local.syncDir.move('src', 'dst')
-
-      await fullSyncStartingFrom('local')
-
-      should(await helpers.trees()).deepEqual(bothSides([
-        'dst-conflict-.../',
-        'dst/'
-      ]))
-    })
-  })
+  // FIXME: merging local dir move then remote dir addition to the same
+  // destination doesn't trigger a conflict although it should.
 
   describe('remote', () => {
     beforeEach('set up conflict', async () => {


### PR DESCRIPTION
Was #1416 / commit 3971c0ef35fc710a662666ef7964a2bd21715531.

For some edge cases, the result is worse than without the fix.
We don't have time to investigate yet, so better revert & bring it back later.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
