### PR TITLE
core/local: Improve logging in atom watcher & steps

### DIFF
--- a/.jq
+++ b/.jq
@@ -103,8 +103,8 @@ def issues: clean | select(is_issue);
 def path(pattern):
   clean | select(
     (
-      (.path // (.doc | .path) // (.change | .doc | .path) // (.idConflict | .newDoc | .path)),
-      (.oldpath // (.was | .path) // (.idConflict | .existingDoc | .path)),
+      (.path // (.doc | .path) // (.change | .doc | .path) // (.idConflict | .newDoc | .path) // (.event | .path)),
+      (.oldpath // (.was | .path) // (.idConflict | .existingDoc | .path) // (.event | .oldPath)),
       ""
     )
       | strings

--- a/core/local/atom_watcher.js
+++ b/core/local/atom_watcher.js
@@ -70,7 +70,7 @@ const producer = opts => {
   } else if (process.platform === 'win32') {
     return new WinProducer(opts)
   } else {
-    throw new Error('The experimental watcher is not available on this platform')
+    throw new Error('The atom watcher is not available on this platform')
   }
 }
 
@@ -135,7 +135,10 @@ class AtomWatcher {
       let target = -1
       try {
         target = (await this.pouch.db.changes({limit: 1, descending: true})).last_seq
-      } catch (err) { /* ignore err */ }
+      } catch (err) {
+        log.warn({err})
+        /* ignore err */
+      }
       this.events.emit('sync-target', target)
       this.events.emit('local-end')
     })

--- a/core/local/steps/add_checksum.js
+++ b/core/local/steps/add_checksum.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const logger = require('../../logger')
 const log = logger({
-  component: 'addChecksum'
+  component: 'atom/addChecksum'
 })
 
 /*::
@@ -43,7 +43,7 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: C
         // keep the event. Maybe it was one if its parents directory that was
         // moved, and then we can refine the event later (in incompleteFixer).
         event.incomplete = true
-        log.info({err, event}, 'Cannot compute checksum')
+        log.debug({err, event}, 'Cannot compute checksum')
       }
     }
     return events

--- a/core/local/steps/add_infos.js
+++ b/core/local/steps/add_infos.js
@@ -6,7 +6,7 @@ const { id } = require('../../metadata')
 const stater = require('../stater')
 const logger = require('../../logger')
 const log = logger({
-  component: 'addInfos'
+  component: 'atom/addInfos'
 })
 
 /*::
@@ -42,7 +42,7 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string } */) /*: Buffe
           }
         }
       } catch (err) {
-        log.info({err, event}, 'Cannot get infos')
+        log.debug({err, event}, 'Cannot get infos')
         event.incomplete = true
       }
       batch.push(event)

--- a/core/local/steps/await_write_finish.js
+++ b/core/local/steps/await_write_finish.js
@@ -3,7 +3,7 @@
 const Buffer = require('./buffer')
 const logger = require('../../logger')
 const log = logger({
-  component: 'awaitWriteFinish'
+  component: 'atom/awaitWriteFinish'
 })
 
 // Wait this delay (in milliseconds) after the last event for a given file
@@ -114,6 +114,6 @@ async function awaitWriteFinish (buffer /*: Buffer */, out /*: Buffer */) {
 function loop (buffer /*: Buffer */, opts /*: {} */) /*: Buffer */ {
   const out = new Buffer()
   awaitWriteFinish(buffer, out)
-    .catch(err => log.error({err}))
+    .catch(err => { log.error({err}) })
   return out
 }

--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -3,7 +3,7 @@
 const { buildDir, buildFile, id } = require('../../metadata')
 const logger = require('../../logger')
 const log = logger({
-  component: 'dispatch'
+  component: 'atom/dispatch'
 })
 
 /*::
@@ -48,11 +48,11 @@ function step (opts /*: DispatchOptions */) {
         if (event.action === 'initial-scan-done') {
           actions.initialScanDone(opts)
         } else {
-          // $FlowFixMe
           await actions[event.action + event.kind](event, opts)
         }
       } catch (err) {
-        console.log('Dispatch error:', err, event) // TODO
+        log.error({err, event})
+        // TODO: Error handling
       }
     }
     return batch
@@ -93,6 +93,7 @@ actions = {
     try {
       old = await fetchOldDoc(pouch, id(event.oldPath))
     } catch (err) {
+      log.debug({err, event}, 'Assuming move can be handled as addition')
       // A renamed event where the source does not exist can be seen as just an
       // add. It can happen on Linux when a file is added when the client is
       // stopped, and is moved before it was scanned.
@@ -109,6 +110,7 @@ actions = {
     try {
       old = await fetchOldDoc(pouch, id(event.oldPath))
     } catch (err) {
+      log.debug({err, event}, 'Assuming move can be handled as addition')
       // A renamed event where the source does not exist can be seen as just an
       // add. It can happen on Linux when a dir is added when the client is
       // stopped, and is moved before it was scanned.
@@ -125,6 +127,7 @@ actions = {
     try {
       old = await fetchOldDoc(pouch, event._id)
     } catch (err) {
+      log.debug({err, event}, 'Assuming already deleted')
       // The file was already marked as deleted in pouchdb
       // => we can ignore safely this event
       return
@@ -137,6 +140,7 @@ actions = {
     try {
       old = await fetchOldDoc(pouch, event._id)
     } catch (err) {
+      log.debug({err, event}, 'Assuming already deleted')
       // The dir was already marked as deleted in pouchdb
       // => we can ignore safely this event
       return

--- a/core/local/steps/incomplete_fixer.js
+++ b/core/local/steps/incomplete_fixer.js
@@ -6,7 +6,7 @@ const stater = require('../stater')
 const metadata = require('../../metadata')
 const logger = require('../../logger')
 const log = logger({
-  component: 'incompleteFixer'
+  component: 'atom/incompleteFixer'
 })
 
 // Drop incomplete events after this delay (in milliseconds).
@@ -109,7 +109,7 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: C
           incompletes.splice(i, 1)
           break
         } catch (err) {
-          log.error({err}, 'Could not rebuild incomplete event')
+          log.error({err, event, item}, 'Could not rebuild incomplete event')
           // If we have an error, there is probably not much that we can do
         }
       }

--- a/core/local/steps/linux_producer.js
+++ b/core/local/steps/linux_producer.js
@@ -9,7 +9,7 @@ const watcher = require('@atom/watcher')
 
 const logger = require('../../logger')
 const log = logger({
-  component: 'LinuxProducer'
+  component: 'atom/LinuxProducer'
 })
 
 /*::
@@ -87,6 +87,7 @@ module.exports = class LinuxProducer /*:: implements Producer */ {
           kind: 'unknown'
         })
       } catch (err) {
+        log.error({err, path: path.join(relPath, entry)})
         // TODO error handling
       }
     }

--- a/core/local/steps/scan_folder.js
+++ b/core/local/steps/scan_folder.js
@@ -2,7 +2,7 @@
 
 const logger = require('../../logger')
 const log = logger({
-  component: 'scanFolder'
+  component: 'atom/scanFolder'
 })
 
 /*::
@@ -26,7 +26,7 @@ function loop (buffer /*: Buffer */, opts /*: { scan: Scanner } */) /*: Buffer *
       }
       if (event.action === 'created' && event.kind === 'directory') {
         opts.scan(event.path)
-          .catch((err) => log.info({err, event}, 'Error on scan'))
+          .catch((err) => log.error({err, event}, 'Error on scan'))
       }
     }
     return batch

--- a/core/local/steps/win_detect_move.js
+++ b/core/local/steps/win_detect_move.js
@@ -4,7 +4,7 @@ const { id } = require('../../metadata')
 const Buffer = require('./buffer')
 const logger = require('../../logger')
 const log = logger({
-  component: 'winDetectMove'
+  component: 'atom/winDetectMove'
 })
 
 // Wait at most this delay (in milliseconds) to see if it's a move.
@@ -61,7 +61,7 @@ async function winDetectMove (buffer, out, pouch) {
           const was = await pouch.db.get(id(event.path))
           deleted.set(was.fileid, event.path)
         } catch (err) {
-          // Ignore the error
+          log.debug({err, event}, 'No metadata. Ignoring.')
         } finally {
           release()
         }

--- a/core/local/steps/win_producer.js
+++ b/core/local/steps/win_producer.js
@@ -10,7 +10,7 @@ const watcher = require('@atom/watcher')
 const stater = require('../stater')
 const logger = require('../../logger')
 const log = logger({
-  component: 'WinProducer'
+  component: 'atom/WinProducer'
 })
 
 /*::
@@ -71,6 +71,7 @@ module.exports = class WinProducer /*:: implements Producer */ {
           kind: stater.kind(stats)
         })
       } catch (err) {
+        log.error({err, path: path.join(relPath, entry)})
         // TODO error handling
       }
     }


### PR DESCRIPTION
- Prefix loggers with `atom/`
- Ensure no error is swallowed
- Handle .event|.path in jq's path() filter
- Fix *experimental* wording
- Log expected/ignorable errors at the debug level
- Log non-critical but unexpected ones at the warn level
- Make sure event and other useful data are logged when available
- At least log path whenever possible if no event is available
- Use logger instead of console.log()
- Remove useless $FlowFixMe notice
- Don't return log.error() result in callback

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
