### PR TITLE
test: Reclassify ./unit/scheduling as ./integration/scheduling

### DIFF
--- a/test/integration/scheduling.js
+++ b/test/integration/scheduling.js
@@ -16,14 +16,14 @@ const HEARTBEAT /*: number */ = parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || 
 
 const builders = new Builders()
 
-describe('Sync', function () {
+describe('Scheduling', function () {
   before('instanciate config', configHelpers.createConfig)
   before('register OAuth client', configHelpers.registerClient)
   before('instanciate pouch', pouchHelpers.createDatabase)
   before('delete all', cozyHelpers.deleteAll)
   after('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
-  after('clean  local', () => helpers.local.clean())
+  after('clean local', () => helpers.local.clean())
 
   let helpers
 


### PR DESCRIPTION
It is not a unit test since it tests many components together.
Also fixed test name to match file & to prevent confusion with Sync unit tests.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
