### PR TITLE
test/support/helpers/local: Fix atom steps init in #simulateAtomEvents()

### DIFF
--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -147,7 +147,7 @@ class LocalTestHelpers {
     const { watcher } = this.side
     if (!(watcher instanceof atomWatcher.AtomWatcher)) {
       throw new Error(
-        'Cannot only use Local#simulateAtomEvents() with AtomWatcher'
+        'Can only use LocalTestHelpers#simulateAtomEvents() with AtomWatcher'
       )
     }
     await atomWatcher.stepsInitialState(watcher.state, watcher)


### PR DESCRIPTION
Fixes `TypeError: Cannot match against 'undefined' or 'null'` everywhere
when running scenarios with atom watcher/captures.

Thanks @taratatach for identifying the issue!

Requires checking the watcher type to make flow happy.
The `$FlowFixMe` notice is still needed because of the magic batch.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
