### PR TITLE
core/config: Only log watcher type as invalid when it is actually set

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -245,7 +245,7 @@ function validateWatcherType (watcherType /*: ?string */) /*: ?WatcherType */ {
   if (watcherType === 'atom' || watcherType === 'chokidar') {
     return watcherType
   } else {
-    log.warn({watcherType}, 'Invalid watcher type')
+    if (watcherType) log.warn({watcherType}, 'Invalid watcher type')
     return null
   }
 }


### PR DESCRIPTION
Fixes flooding useless error messages in test logs.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
