### PR TITLE
Run scenarios captures on their creation platform only

### DIFF
--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -115,4 +115,10 @@ module.exports = class AtomWatcherEventBuilder {
     this._event.noIgnore = true
     return this
   }
+
+  incomplete () /*: this */ {
+    this._event.incomplete = true
+    this.noStats()
+    return this
+  }
 }

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -98,7 +98,9 @@ module.exports.loadAtomCaptures = scenario => {
   const eventFiles = glob.sync(path.join(path.dirname(scenario.path), 'atom', '*.json*'))
   const disabledEventsFile = (name) => {
     if (process.platform === 'win32' && name.indexOf('win32') === -1) {
-      return 'darwin/linux test'
+      return 'linux test'
+    } else if (process.platform === 'linux' && name.indexOf('win32') >= 0) {
+      return 'win32 test'
     } else if (name.endsWith(disabledExtension)) {
       return 'disabled case'
     }

--- a/test/unit/local/steps/incomplete_fixer.js
+++ b/test/unit/local/steps/incomplete_fixer.js
@@ -1,0 +1,116 @@
+/* eslint-env mocha */
+/* @flow */
+
+const _ = require('lodash')
+const path = require('path')
+
+const should = require('should')
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+const { ContextDir } = require('../../../support/helpers/context_dir')
+
+const metadata = require('../../../../core/metadata')
+const Buffer = require('../../../../core/local/steps/buffer')
+const incompleteFixer = require('../../../../core/local/steps/incomplete_fixer')
+
+const completedEvent = event =>
+  _.pick(event, ['_id', 'path', 'kind', 'md5sum', 'action', 'incomplete'])
+
+const completionChanges = async (buffer) => buffer.pop().map(completedEvent)
+
+describe('local/steps/initialDiff', () => {
+  let builders
+  let syncDir
+  let buffer
+  let options
+  let initialScanDone
+
+  const CHECKSUM = 'checksum'
+  const checksumer = {
+    push: path => CHECKSUM,
+    kill: () => {}
+  }
+
+  before('instanciate config', configHelpers.createConfig)
+  before(function () {
+    options = { syncPath: this.config.syncPath, checksumer }
+    syncDir = new ContextDir(this.config.syncPath)
+  })
+  beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+  beforeEach('populate pouch with documents', function () {
+    builders = new Builders({pouch: this.pouch})
+    buffer = new Buffer()
+    initialScanDone = builders.event().action('initial-scan-done').path('').build()
+  })
+  afterEach('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  context('without any complete "renamed" event', () => {
+    it('drops incomplete events', async function () {
+      const events = [
+        builders.event().incomplete().action('created').path('foo1').build(),
+        builders.event().incomplete().action('modified').path('foo2').build(),
+        builders.event().incomplete().action('deleted').path('foo3').build(),
+        builders.event().incomplete().action('scan').path('foo4').build()
+      ]
+      buffer.push(_.cloneDeep(events))
+      buffer.push(_.cloneDeep([initialScanDone]))
+
+      const completedBuffer = await incompleteFixer.loop(buffer, options)
+      should(await completedBuffer.pop()).deepEqual([initialScanDone])
+    })
+  })
+
+  context('with a complete "renamed" event in the batch', () => {
+    it('leaves complete events untouched', async function () {
+      const events = [
+        builders.event().action('created').path('file').build(),
+        builders.event().action('renamed').oldPath('file').path('foo').build()
+      ]
+      buffer.push(_.cloneDeep(events))
+
+      const completedBuffer = await incompleteFixer.loop(buffer, options)
+      should(await completedBuffer.pop()).deepEqual(events)
+    })
+
+    it('rebuilds the first incomplete event matching the "renamed" event old path', async function () {
+      const events = [
+        builders.event().incomplete().kind('file').action('created').path('src/foo1').build(),
+        builders.event().incomplete().kind('file').action('modified').path('src/foo2').build(),
+        builders.event().incomplete().kind('file').action('deleted').path('src/foo3').build(),
+        builders.event().incomplete().kind('file').action('renamed').oldPath('src/foo4').path('foo').build(),
+        builders.event().incomplete().kind('file').action('scan').path('src/foo5').build()
+      ]
+      const renamed = builders.event().kind('directory').action('renamed').oldPath('src').path('dst').build()
+      buffer.push(_.cloneDeep(events))
+      buffer.push(_.cloneDeep([renamed, initialScanDone]))
+
+      // Create actual files in `dst/` since their parent folder has been moved
+      const files = events.map(event => {
+        const newPath = event.path.replace('src', 'dst')
+        if (event.kind === 'directory') {
+          return syncDir.ensureDir(newPath)
+        } else if (event.kind === 'file' && event.action !== 'deleted') {
+          return syncDir.outputFile(newPath, 'content')
+        }
+      })
+      await Promise.all(files)
+
+      const completedBuffer = await incompleteFixer.loop(buffer, options)
+
+      const changes = await completionChanges(completedBuffer)
+      should(changes).deepEqual([
+        completedEvent(renamed),
+        completedEvent(initialScanDone),
+        {
+          _id: metadata.id(path.normalize('dst/foo1')),
+          path: path.normalize('dst/foo1'),
+          kind: 'file',
+          md5sum: CHECKSUM,
+          action: 'created'
+        }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Based on #1487 

The new atom watcher doesn't generate/handle events the same way on
Windows and GNU/Linux, so better not mix captures & platforms.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
