### PR TITLE
test/support/helpers/scenarios: Enable atom captures for current platform only

### DIFF
--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -98,7 +98,9 @@ module.exports.loadAtomCaptures = scenario => {
   const eventFiles = glob.sync(path.join(path.dirname(scenario.path), 'atom', '*.json*'))
   const disabledEventsFile = (name) => {
     if (process.platform === 'win32' && name.indexOf('win32') === -1) {
-      return 'darwin/linux test'
+      return 'linux test'
+    } else if (process.platform === 'linux' && name.indexOf('win32') >= 0) {
+      return 'win32 test'
     } else if (name.endsWith(disabledExtension)) {
       return 'disabled case'
     }


### PR DESCRIPTION
The new atom watcher doesn't generate/handle events the same way on
Windows and GNU/Linux, so better not mix captures & platforms.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
