### PR TITLE
core/local/steps/incomplete_fixer: Extract .step()

### DIFF
--- a/core/local/steps/incomplete_fixer.js
+++ b/core/local/steps/incomplete_fixer.js
@@ -18,7 +18,7 @@ const DELAY = 3000
 
 /*::
 import type Buffer from './buffer'
-import type { AtomWatcherEvent } from './event'
+import type { AtomWatcherEvent, Batch } from './event'
 import type { Checksumer } from '../checksumer'
 
 type IncompleteItem = {
@@ -28,7 +28,8 @@ type IncompleteItem = {
 */
 
 module.exports = {
-  loop
+  loop,
+  step
 }
 
 function wasRenamedSuccessively (previousIncomplete /*: IncompleteItem */, nextEvent /*: AtomWatcherEvent */) /*: boolean %checks */ {
@@ -69,7 +70,11 @@ async function rebuildIncompleteEvent (item /*: IncompleteItem */, event /*: Ato
 // Cf test/property/local_watcher/swedish_krona.json
 function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: Checksumer } */) /*: Buffer */ {
   const incompletes = []
-  return buffer.asyncMap(async (events) => {
+  return buffer.asyncMap(step(incompletes, opts))
+}
+
+function step (incompletes /*: IncompleteItem[] */, opts /*: IncompleteFixerOptions */) {
+  return async (events /*: Batch */) /*: Promise<Batch> */ => {
     // Filter out the incomplete events
     const batch = []
     for (const event of events) {
@@ -116,5 +121,5 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: C
     }
 
     return batch
-  })
+  }
 }

--- a/core/local/steps/incomplete_fixer.js
+++ b/core/local/steps/incomplete_fixer.js
@@ -25,6 +25,11 @@ type IncompleteItem = {
   event: AtomWatcherEvent,
   timestamp: number,
 }
+
+type IncompleteFixerOptions = {
+  syncPath: string,
+  checksumer: Checksumer
+}
 */
 
 module.exports = {
@@ -68,7 +73,7 @@ async function rebuildIncompleteEvent (item /*: IncompleteItem */, event /*: Ato
 // fs.stats if we have a file here.
 //
 // Cf test/property/local_watcher/swedish_krona.json
-function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: Checksumer } */) /*: Buffer */ {
+function loop (buffer /*: Buffer */, opts /*: IncompleteFixerOptions */) /*: Buffer */ {
   const incompletes = []
   return buffer.asyncMap(step(incompletes, opts))
 }

--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -115,4 +115,10 @@ module.exports = class AtomWatcherEventBuilder {
     this._event.noIgnore = true
     return this
   }
+
+  incomplete () /*: this */ {
+    this._event.incomplete = true
+    delete this._event.md5sum
+    return this.noStats()
+  }
 }

--- a/test/unit/local/steps/incomplete_fixer.js
+++ b/test/unit/local/steps/incomplete_fixer.js
@@ -1,0 +1,58 @@
+/* eslint-env mocha */
+/* @flow */
+
+const should = require('should')
+const sinon = require('sinon')
+
+const Buffer = require('../../../../core/local/steps/buffer')
+const incompleteFixer = require('../../../../core/local/steps/incomplete_fixer')
+
+const Builders = require('../../../support/builders')
+
+const builders = new Builders()
+
+describe('core/local/steps/incomplete_fixer', () => {
+  const syncPath = __dirname
+
+  let checksumer
+
+  beforeEach(() => {
+    checksumer = {
+      push: sinon.stub().resolves(),
+      kill: sinon.stub()
+    }
+  })
+
+  describe('.loop()', () => {
+    it('pushes a fixed event into the output buffer', async () => {
+      const createdEvent = builders.event()
+        .kind('file')
+        .action('created')
+        .path('missing')
+        .incomplete()
+        .build()
+      const renamedEvent = builders.event()
+        .kind(createdEvent.kind)
+        .action('renamed')
+        .oldPath(createdEvent.path)
+        .path(__filename)
+        .build()
+      const inputBuffer = new Buffer()
+      const outputBuffer = incompleteFixer.loop(inputBuffer, {syncPath, checksumer})
+
+      inputBuffer.push([createdEvent])
+      inputBuffer.push([renamedEvent])
+
+      should(await outputBuffer.pop()).deepEqual([
+        {
+          _id: renamedEvent._id,
+          action: 'renamed',
+          kind: 'file',
+          oldPath: createdEvent.path,
+          path: renamedEvent.path,
+          stats: renamedEvent.stats
+        }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Minimal builders change + `.loop()` test (nominal case) so we can extract `.step()` and test it more thoroughly without having to deal with buffers.

The code was carefully refactored in order not to conflict with upcoming #1494.
Also, although it will conflict, rebasing #1487 should be relatively easy too.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
