### PR TITLE
core/local/steps: Improve Atom Watcher logs

### DIFF
--- a/core/local/steps/add_checksum.js
+++ b/core/local/steps/add_checksum.js
@@ -1,10 +1,14 @@
 /* @flow */
 
+const _ = require('lodash')
 const path = require('path')
 
 const logger = require('../../logger')
+
+const STEP_NAME = 'addChecksum'
+
 const log = logger({
-  component: 'atom/addChecksum'
+  component: `atom/${STEP_NAME}`
 })
 
 /*::
@@ -42,7 +46,7 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: C
         // Even if the file is no longer at the expected path, we want to
         // keep the event. Maybe it was one if its parents directory that was
         // moved, and then we can refine the event later (in incompleteFixer).
-        event.incomplete = true
+        _.set(event, ['incomplete', STEP_NAME], err.message)
         log.debug({err, event}, 'Cannot compute checksum')
       }
     }

--- a/core/local/steps/add_infos.js
+++ b/core/local/steps/add_infos.js
@@ -1,12 +1,16 @@
 /* @flow */
 
+const _ = require('lodash')
 const path = require('path')
 
 const { id } = require('../../metadata')
 const stater = require('../stater')
 const logger = require('../../logger')
+
+const STEP_NAME = 'addInfos'
+
 const log = logger({
-  component: 'atom/addInfos'
+  component: `atom/${STEP_NAME}`
 })
 
 /*::
@@ -38,12 +42,15 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string } */) /*: Buffe
             event.kind = stater.kind(event.stats)
           } else { // deleted
             // If kind is unknown, we say it's a file arbitrary
-            event.kind = event.kind === 'directory' ? 'directory' : 'file'
+            if (event.kind !== 'directory' && event.kind !== 'file') {
+              _.set(event, [STEP_NAME, 'kindConvertedFrom'], event.kind)
+              event.kind = 'file'
+            }
           }
         }
       } catch (err) {
         log.debug({err, event}, 'Cannot get infos')
-        event.incomplete = true
+        _.set(event, ['incomplete', STEP_NAME], err.message)
       }
       batch.push(event)
     }

--- a/core/local/steps/filter_ignored.js
+++ b/core/local/steps/filter_ignored.js
@@ -1,10 +1,18 @@
 /* @flow */
 
+const logger = require('../../logger')
+
 /*::
 import type Buffer from './buffer'
 import type { AtomWatcherEvent } from './event'
 import type { Ignore } from '../../ignore'
 */
+
+const STEP_NAME = 'filterIgnored'
+
+const log = logger({
+  component: `atom/${STEP_NAME}`
+})
 
 module.exports = {
   loop
@@ -28,9 +36,10 @@ function buildNotIgnored (ignoreRules /*: Ignore */) /*: ((AtomWatcherEvent) => 
     if (event.noIgnore) {
       return true
     }
-    return !ignoreRules.isIgnored({
-      relativePath: event.path,
-      isFolder: event.kind === 'directory'
-    })
+    const relativePath = event.path
+    const isFolder = event.kind === 'directory'
+    const isIgnored = ignoreRules.isIgnored({relativePath, isFolder})
+    if (isIgnored) log.debug({event}, 'Ignored')
+    return !isIgnored
   }
 }

--- a/core/local/steps/linux_producer.js
+++ b/core/local/steps/linux_producer.js
@@ -94,7 +94,7 @@ module.exports = class LinuxProducer /*:: implements Producer */ {
     if (entries.length === 0) {
       return
     }
-    log.debug({entries}, 'scan')
+    log.trace({path: relPath}, `Scanned ${entries.length} item(s) in dir`)
     this.buffer.push(entries)
     for (const entry of entries) {
       if (entry.stats && entry.stats.isDirectory()) {
@@ -104,7 +104,7 @@ module.exports = class LinuxProducer /*:: implements Producer */ {
   }
 
   process (batch /*: Array<*> */) {
-    log.info({batch}, 'process')
+    log.trace(`Processing ${batch.length} event(s)`)
     // Atom/watcher emits events with an absolute path, but it's more
     // convenient for us to use a relative path.
     for (const event of batch) {

--- a/core/local/steps/scan_folder.js
+++ b/core/local/steps/scan_folder.js
@@ -1,8 +1,11 @@
 /* @flow */
 
 const logger = require('../../logger')
+
+const STEP_NAME = 'scanFolder'
+
 const log = logger({
-  component: 'atom/scanFolder'
+  component: `atom/${STEP_NAME}`
 })
 
 /*::
@@ -26,7 +29,7 @@ function loop (buffer /*: Buffer */, opts /*: { scan: Scanner } */) /*: Buffer *
       }
       if (event.action === 'created' && event.kind === 'directory') {
         opts.scan(event.path)
-          .catch((err) => log.error({err, event}, 'Error on scan'))
+          .catch((err) => { log.error({err, event}, 'Error on scan') })
       }
     }
     return batch

--- a/core/local/steps/win_producer.js
+++ b/core/local/steps/win_producer.js
@@ -78,7 +78,7 @@ module.exports = class WinProducer /*:: implements Producer */ {
     if (entries.length === 0) {
       return
     }
-    log.debug({entries}, 'scan')
+    log.trace({path: relPath}, `Scanned ${entries.length} item(s) in dir`)
     this.buffer.push(entries)
     for (const entry of entries) {
       if (entry.stats && entry.stats.directory) {
@@ -88,7 +88,7 @@ module.exports = class WinProducer /*:: implements Producer */ {
   }
 
   process (batch /*: Array<*> */) {
-    log.info({batch}, 'process')
+    log.trace(`Processing ${batch.length} event(s)`)
     // Atom/watcher emits events with an absolute path, but it's more
     // convenient for us to use a relative path.
     for (const event of batch) {

--- a/test/unit/local/steps/await_write_finish.js
+++ b/test/unit/local/steps/await_write_finish.js
@@ -72,7 +72,34 @@ describe('core/local/steps/await_write_finish.loop()', () => {
         buffer.push([Object.assign({}, event)])
       })
       const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
-      should(await enhancedBuffer.pop()).eql([originalBatch[0]])
+      should(await enhancedBuffer.pop()).eql([
+        {
+          // 3rd modified -> created
+          action: 'created',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                // 2nd modified -> created
+                action: 'created',
+                awaitWriteFinish: {
+                  previousEvents: [
+                    {
+                      // 1st created
+                      action: 'created',
+                      kind: 'file',
+                      path: __filename
+                    }
+                  ]
+                },
+                kind: 'file',
+                path: __filename
+              }
+            ]
+          },
+          kind: 'file',
+          path: __filename
+        }
+      ])
       should(await heuristicIsEmpty(enhancedBuffer)).be.true()
     })
 
@@ -135,7 +162,24 @@ describe('core/local/steps/await_write_finish.loop()', () => {
     })
     const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
     should(await enhancedBuffer.pop()).eql([originalBatch[1]])
-    should(await enhancedBuffer.pop()).eql([originalBatch[0]])
+    should(await enhancedBuffer.pop()).eql([
+      {
+        // 3rd modified -> created
+        action: 'created',
+        awaitWriteFinish: {
+          previousEvents: [
+            {
+              // 1st created
+              action: 'created',
+              kind: 'file',
+              path: __filename
+            }
+          ]
+        },
+        kind: 'file',
+        path: __filename
+      }
+    ])
     should(await heuristicIsEmpty(enhancedBuffer)).be.true()
   })
 })

--- a/test/unit/local/steps/incomplete_fixer.js
+++ b/test/unit/local/steps/incomplete_fixer.js
@@ -91,6 +91,10 @@ describe('core/local/steps/incomplete_fixer', () => {
             {
               _id: metadata.id(src),
               action: 'deleted',
+              incompleteFixer: {
+                incompleteEvent: renamedEvent,
+                completingEvent: deletedEvent
+              },
               kind: renamedEvent.kind,
               path: src
             }
@@ -134,6 +138,10 @@ describe('core/local/steps/incomplete_fixer', () => {
             {
               _id: metadata.id(dst2),
               action: 'renamed',
+              incompleteFixer: {
+                incompleteEvent: firstRenamedEvent,
+                completingEvent: secondRenamedEvent
+              },
               kind: 'file',
               md5sum,
               oldPath: src,

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -138,8 +138,8 @@ describe('local/steps/initial_diff', () => {
     })
 
     it('detects documents removed while client was stopped', async function () {
-      await builders.metadir().path('foo').ino(1).create()
-      await builders.metafile().path('bar').ino(2).create()
+      const foo = await builders.metadir().path('foo').ino(1).create()
+      const bar = await builders.metafile().path('bar').ino(2).create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
 
@@ -148,8 +148,20 @@ describe('local/steps/initial_diff', () => {
 
       const events = await buffer.pop()
       should(events).deepEqual([
-        builders.event().action('deleted').kind('file').path('bar').build(),
-        builders.event().action('deleted').kind('directory').path('foo').build(),
+        {
+          _id: bar._id,
+          action: 'deleted',
+          initialDiff: {notFound: {kind: 'file', path: bar.path}},
+          kind: 'file',
+          path: bar.path
+        },
+        {
+          _id: foo._id,
+          action: 'deleted',
+          initialDiff: {notFound: {kind: 'directory', path: foo.path}},
+          kind: 'directory',
+          path: foo.path
+        },
         initialScanDone
       ])
     })


### PR DESCRIPTION
- Unify STEP_NAME's
- Aggregate event context instead of logging it along the way to make
  it easier to read, to follow and to understand
- Log at the dispatch step only to limit the amount of log lines

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
