### PR TITLE
core/local/steps/incomplete_fixer: Overwrite event

### DIFF
--- a/core/local/steps/incomplete_fixer.js
+++ b/core/local/steps/incomplete_fixer.js
@@ -154,7 +154,7 @@ function step (incompletes /*: IncompleteItem[] */, opts /*: IncompleteFixerOpti
             // We have a match, try to rebuild the incomplete event
             const rebuilt = await rebuildIncompleteEvent(item, event, opts)
             log.debug({path: rebuilt.path, action: rebuilt.action}, 'rebuilt event')
-            if (rebuilt.action === 'renamed' && rebuilt.path === event.path) {
+            if (rebuilt.path === event.path) {
               batch.splice(batch.indexOf(event), 1, rebuilt)
             } else {
               batch.push(rebuilt)


### PR DESCRIPTION
When rebuilding an incomplete event, if the completing event and the
  rebuilt one share the same path, we should completely replace the
  completing event since it's now obsolete.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
