### PR TITLE
core/local/steps: Log batches in producers

### DIFF
--- a/core/local/steps/linux_producer.js
+++ b/core/local/steps/linux_producer.js
@@ -91,10 +91,10 @@ module.exports = class LinuxProducer /*:: implements Producer */ {
         // TODO error handling
       }
     }
+    log.trace({path: relPath, batch: entries}, 'scan')
     if (entries.length === 0) {
       return
     }
-    log.trace({path: relPath}, `Scanned ${entries.length} item(s) in dir`)
     this.buffer.push(entries)
     for (const entry of entries) {
       if (entry.stats && entry.stats.isDirectory()) {
@@ -104,7 +104,7 @@ module.exports = class LinuxProducer /*:: implements Producer */ {
   }
 
   process (batch /*: Array<*> */) {
-    log.trace(`Processing ${batch.length} event(s)`)
+    log.trace({batch}, 'process')
     // Atom/watcher emits events with an absolute path, but it's more
     // convenient for us to use a relative path.
     for (const event of batch) {

--- a/core/local/steps/win_producer.js
+++ b/core/local/steps/win_producer.js
@@ -75,10 +75,10 @@ module.exports = class WinProducer /*:: implements Producer */ {
         // TODO error handling
       }
     }
+    log.trace({path: relPath, batch: entries}, 'scan')
     if (entries.length === 0) {
       return
     }
-    log.trace({path: relPath}, `Scanned ${entries.length} item(s) in dir`)
     this.buffer.push(entries)
     for (const entry of entries) {
       if (entry.stats && entry.stats.directory) {
@@ -88,7 +88,7 @@ module.exports = class WinProducer /*:: implements Producer */ {
   }
 
   process (batch /*: Array<*> */) {
-    log.trace(`Processing ${batch.length} event(s)`)
+    log.trace({batch}, 'process')
     // Atom/watcher emits events with an absolute path, but it's more
     // convenient for us to use a relative path.
     for (const event of batch) {


### PR DESCRIPTION
At least temporarily, until we're confident enough to remove it.
I feel like we could regret not having them while debugging.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
