### PR TITLE
core/local/steps/win_detect_move: Test & refactor

### DIFF
--- a/core/local/steps/win_detect_move.js
+++ b/core/local/steps/win_detect_move.js
@@ -97,7 +97,7 @@ async function winDetectMove (buffer, out, pouch) {
               // FIXME: Make up new event with attached old one
               _.set(event, [STEP_NAME, 'aggregatedEvents'], {
                 deletedEvent: e,
-                createdEvent: event
+                createdEvent: _.clone(event)
               })
               event.action = 'renamed'
               event.oldPath = e.path

--- a/core/local/steps/win_detect_move.js
+++ b/core/local/steps/win_detect_move.js
@@ -32,9 +32,6 @@ module.exports = {
   loop
 }
 
-// TODO add unit tests and logs
-// TODO check that a file/dir created and removed just after is not seen as a move
-
 // On windows, ReadDirectoryChangesW emits a deleted and an added events when
 // a file or directory is moved. This step merges the two events to a single
 // renamed event.
@@ -94,7 +91,6 @@ async function winDetectMove (buffer, out, pouch) {
           for (let j = 0; j < l; j++) {
             const e = pending[i].events[j]
             if (e.action === 'deleted' && e.path === path) {
-              // FIXME: Make up new event with attached old one
               _.set(event, [STEP_NAME, 'aggregatedEvents'], {
                 deletedEvent: e,
                 createdEvent: _.clone(event)

--- a/test/unit/local/steps/win_detect_move.js
+++ b/test/unit/local/steps/win_detect_move.js
@@ -1,0 +1,204 @@
+/* eslint-env mocha */
+/* @flow */
+
+const Promise = require('bluebird')
+const _ = require('lodash')
+const should = require('should')
+
+const Buffer = require('../../../../core/local/steps/buffer')
+const winDetectMove = require('../../../../core/local/steps/win_detect_move')
+const metadata = require('../../../../core/metadata')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
+if (process.platform === 'win32') {
+  describe('core/local/steps/win_detect_move', () => {
+    let builders
+
+    before('instanciate config', configHelpers.createConfig)
+    beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+    afterEach('clean pouch', pouchHelpers.cleanDatabase)
+    after('clean config directory', configHelpers.cleanConfig)
+
+    beforeEach(function () {
+      builders = new Builders(this)
+    })
+
+    describe('.loop()', () => {
+      let inputBuffer, outputBuffer
+
+      beforeEach(function () {
+        inputBuffer = new Buffer()
+        outputBuffer = winDetectMove.loop(inputBuffer, this)
+      })
+
+      const inputBatch = events => inputBuffer.push(events)
+      const outputBatch = () => outputBuffer.pop()
+
+      const metadataBuilderByKind = kind => {
+        switch (kind) {
+          case 'file': return builders.metafile()
+          case 'directory': return builders.metadir()
+          default: throw new Error(`Cannot find metadata builder for ${JSON.stringify(kind)}`)
+        }
+      }
+
+      for (const kind of ['file', 'directory']) {
+        describe(`deleted ${kind} (matching doc)`, () => {
+          const srcIno = 1
+          const srcPath = 'src'
+          let deletedEvent
+
+          beforeEach(async () => {
+            await metadataBuilderByKind(kind).path(srcPath).ino(srcIno).create()
+            deletedEvent = builders.event().action('deleted').kind(kind)
+              .path(srcPath).build()
+          })
+
+          describe(`+ created ${kind} (same path, different fileid)`, () => {
+            const differentIno = srcIno + 1
+            let createdEvent
+
+            beforeEach(async () => {
+              createdEvent = builders.event().action('created').kind(kind)
+                .path(srcPath).ino(differentIno).build()
+
+              inputBatch([deletedEvent, createdEvent])
+            })
+
+            it(`is a replaced ${kind} (not aggregated)`, async function () {
+              should(await outputBatch()).deepEqual([
+                deletedEvent,
+                createdEvent
+              ])
+            })
+          })
+
+          describe(`+ created ${kind} (different path, same fileid)`, () => {
+            const dstPath = 'dst'
+            let createdEvent
+
+            beforeEach(async () => {
+              createdEvent = builders.event().action('created').kind(kind)
+                .path(dstPath).ino(srcIno).build()
+
+              inputBatch([deletedEvent, createdEvent])
+            })
+
+            it(`is a renamed ${kind} (aggregated)`, async function () {
+              should(await outputBatch()).deepEqual([
+                {
+                  _id: metadata.id(dstPath),
+                  action: 'renamed',
+                  kind,
+                  oldPath: srcPath,
+                  path: dstPath,
+                  stats: createdEvent.stats,
+                  winDetectMove: {aggregatedEvents: {createdEvent, deletedEvent}}
+                }
+              ])
+            })
+          })
+
+          describe(`+ created ${kind} (temporary path, incomplete)`, () => {
+            const tmpPath = 'tmp'
+            let createdTmpEvent
+
+            beforeEach(async () => {
+              createdTmpEvent = builders.event().action('created').kind(kind)
+                .path(tmpPath).incomplete().build()
+              // XXX: ino?
+              inputBatch([deletedEvent, createdTmpEvent])
+            })
+
+            describe(`+ deleted ${kind} (temporary path, missing doc)`, () => {
+              let deletedTmpEvent
+
+              beforeEach(async () => {
+                deletedTmpEvent = builders.event().action('deleted').kind(kind)
+                  .path(tmpPath).build()
+                inputBatch([deletedTmpEvent])
+              })
+
+              describe(`+ created ${kind} (different path, same fileid)`, () => {
+                const dstPath = 'dst'
+                let createdDstEvent
+
+                beforeEach(async () => {
+                  createdDstEvent = builders.event().action('created').kind(kind)
+                    .path(dstPath).ino(srcIno).build()
+                  inputBatch([createdDstEvent])
+                })
+
+                it(`is a temporary ${kind} (not aggregated) + a renamed ${kind} (aggregated)`, async () => {
+                  const outputBatches = await Promise.mapSeries(
+                    _.range(3),
+                    outputBatch
+                  )
+                  should(outputBatches).deepEqual([
+                    [
+                      createdTmpEvent
+                    ],
+                    [
+                      _.defaults({
+                        winDetectMove: {docNotFound: 'missing'}
+                      }, deletedTmpEvent)
+                    ],
+                    [
+                      {
+                        _id: metadata.id(dstPath),
+                        action: 'renamed',
+                        kind,
+                        oldPath: srcPath,
+                        path: dstPath,
+                        stats: createdDstEvent.stats,
+                        winDetectMove: {
+                          aggregatedEvents: {
+                            deletedEvent,
+                            createdEvent: createdDstEvent
+                          }
+                        }
+                      }
+                    ]
+                  ])
+                })
+              })
+            })
+          })
+        })
+
+        describe(`created ${kind} (incomplete)`, () => {
+          let createdEvent
+
+          beforeEach(async () => {
+            createdEvent = builders.event().action('created').kind(kind)
+              .ino(1).build()
+          })
+
+          describe(`+ deleted ${kind} (same path, missing doc)`, () => {
+            let deletedEvent
+
+            beforeEach(async () => {
+              deletedEvent = builders.event().action('deleted').kind(kind)
+                .path(createdEvent.path).build()
+
+              inputBatch([createdEvent, deletedEvent])
+            })
+
+            it(`is a temporary ${kind} (not aggregated)`, async function () {
+              should(await outputBatch()).deepEqual([
+                createdEvent,
+                _.defaults(
+                  {winDetectMove: {docNotFound: 'missing'}},
+                  deletedEvent
+                )
+              ])
+            })
+          })
+        })
+      }
+    })
+  })
+}

--- a/test/unit/local/steps/win_detect_move.js
+++ b/test/unit/local/steps/win_detect_move.js
@@ -34,7 +34,7 @@ if (process.platform === 'win32') {
         outputBuffer = winDetectMove.loop(inputBuffer, this)
       })
 
-      const inputBatch = events => inputBuffer.push(events)
+      const inputBatch = events => inputBuffer.push(_.cloneDeep(events))
       const outputBatch = () => outputBuffer.pop()
 
       const metadataBuilderByKind = kind => {


### PR DESCRIPTION
**Needs #1505**
   
It would be interesting to isolate the various side-effects (existing
metadata lookup, timeouts...) and identify their possible combinations
with the correponding race conditions. But this may require quite a lot
of refactoring. So this PR only test event combos, not timing. Still
better than nothing.

Extracted a few functions from implementation.
Also fixed a circular reference in debug data attached to events.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
