### PR TITLE
core/local/steps: Fix AtomWatcherEvent#stats type

### DIFF
--- a/core/local/steps/event.js
+++ b/core/local/steps/event.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 /*::
-import type { Stats } from 'fs'
+import type { Stats } from '../stater'
 
 export type EventAction =
   | 'created'

--- a/core/local/steps/linux_producer.js
+++ b/core/local/steps/linux_producer.js
@@ -8,6 +8,8 @@ const Promise = require('bluebird')
 const watcher = require('@atom/watcher')
 
 const logger = require('../../logger')
+const stater = require('../stater')
+
 const log = logger({
   component: 'atom/LinuxProducer'
 })
@@ -97,7 +99,7 @@ module.exports = class LinuxProducer /*:: implements Producer */ {
     log.trace({path: relPath}, `Scanned ${entries.length} item(s) in dir`)
     this.buffer.push(entries)
     for (const entry of entries) {
-      if (entry.stats && entry.stats.isDirectory()) {
+      if (entry.stats && stater.isDirectory(entry.stats)) {
         await this.scan(entry.path)
       }
     }


### PR DESCRIPTION
Type was fs.Stats instead of `fs.Stats|WinStats`.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
