### PR TITLE
test/support/builders: Use realistic test stats

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -7,6 +7,7 @@ const metadata = require('../../../../core/metadata')
 const timestamp = require('../../../../core/timestamp')
 
 const dbBuilders = require('../db')
+const statsBuilder = require('../stats')
 
 /*::
 import type fs from 'fs-extra'
@@ -111,6 +112,9 @@ module.exports = class BaseMetadataBuilder {
   }
 
   ino (ino /*: number */) /*: this */ {
+    if (process.platform === 'win32') {
+      this.doc.fileid = statsBuilder.fileIdFromNumber(ino)
+    }
     this.doc.ino = ino
     return this
   }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -119,11 +119,6 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  fileid (fileid /*: string */) /*: this */ {
-    this.doc.fileid = fileid
-    return this
-  }
-
   stats ({ino, mtime, ctime} /*: fs.Stats */) /*: this */ {
     return this.ino(ino).updatedAt(timestamp.maxDate(mtime, ctime))
   }

--- a/test/support/builders/stats.js
+++ b/test/support/builders/stats.js
@@ -1,0 +1,122 @@
+/* @flow */
+
+const fs = require('fs')
+const _ = require('lodash')
+
+/*::
+import type { Stats, WinStats } from '../../../core/local/stater'
+import type { EventKind } from '../../../core/local/steps/event'
+
+export interface StatsBuilder {
+  ino (number): StatsBuilder,
+  kind (EventKind): StatsBuilder,
+  build (): Stats
+}
+*/
+
+const nonExecutableModeSync = path => fs.statSync(path).mode & (0 << 6)
+
+const defaultDirMode = nonExecutableModeSync(__dirname)
+const defaultFileMode = nonExecutableModeSync(__filename)
+const defaultDate = () => new Date()
+const commonDefaults = () => ({
+  ino: 1,
+  size: 0,
+  atime: defaultDate(),
+  mtime: defaultDate(),
+  ctime: defaultDate()
+})
+
+/** Build a Node.js fs.Stats object */
+class DefaultStatsBuilder {
+  /*::
+  stats: fs.Stats
+  */
+
+  constructor (oldStats /*: ?fs.Stats */) {
+    this.stats = oldStats
+      ? _.clone(oldStats)
+      : Object.assign(
+        new fs.Stats(),
+        {
+          mode: defaultFileMode,
+          birthtime: defaultDate()
+        },
+        commonDefaults()
+      )
+  }
+
+  ino (newIno /*: number */) /*: this */ {
+    this.stats.ino = newIno
+    return this
+  }
+
+  kind (newKind /*: EventKind */) /*: this */ {
+    this.stats.mode = newKind === 'file'
+      ? defaultFileMode
+      : defaultDirMode
+    return this
+  }
+
+  build () {
+    return this.stats
+  }
+}
+
+/** A fileid in @gyselroth/windows-fsstat is represented as a 16 digits
+ * hexadecimal string.
+ */
+const fileIdFromNumber = (n /*: number */) =>
+  '0x' + n.toString(16).toUpperCase().padStart(16, '0')
+
+/** Build a @gyselroth/windows-fsstat object */
+class WinStatsBuilder {
+  /*::
+  winStats: WinStats
+  */
+
+  constructor (oldStats /*: ?WinStats */) {
+    this.winStats = oldStats
+      ? _.clone(oldStats)
+      : Object.assign(
+        ({
+          fileid: fileIdFromNumber(commonDefaults().ino),
+          directory: false,
+          symbolicLink: false
+        } /*: Object */),
+        commonDefaults()
+      )
+  }
+
+  ino (newIno /*: number */) /*: this */ {
+    this.winStats.fileid = fileIdFromNumber(newIno)
+    this.winStats.ino = newIno
+    return this
+  }
+
+  kind (newKind /*: EventKind */) /*: this */ {
+    this.winStats.directory = newKind === 'directory'
+    this.winStats.symbolicLink = newKind === 'symlink'
+    return this
+  }
+
+  build () {
+    return this.winStats
+  }
+}
+
+const forPlatform = (platform = process.platform) =>
+  platform === 'win32'
+    ? new WinStatsBuilder()
+    : new DefaultStatsBuilder()
+
+const fromStats = (baseStats /*: ?(WinStats | fs.Stats) */) => {
+  if (baseStats instanceof fs.Stats) return new DefaultStatsBuilder(baseStats)
+  if (baseStats != null) return new WinStatsBuilder(baseStats)
+  return forPlatform()
+}
+
+module.exports = {
+  fileIdFromNumber,
+  fromStats
+}

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -31,8 +31,8 @@ describe('local/steps/initial_diff', () => {
       should(state).have.property(initialDiff.STEP_NAME, {
         waiting: [],
         byInode: new Map([
-          [foo.ino, { path: foo.path, kind: kind(foo) }],
-          [fizz.ino, { path: fizz.path, kind: kind(fizz) }]
+          [foo.fileid || foo.ino, { path: foo.path, kind: kind(foo) }],
+          [fizz.fileid || fizz.ino, { path: fizz.path, kind: kind(fizz) }]
         ]),
         byPath: new Map()
       })

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -39,6 +39,10 @@ async function mergeSideEffects ({merge, pouch} /*: * */, mergeCall /*: () => Pr
     // which makes them hard to compare.
     delete doc._rev
 
+    // Don't include fileids in assertions: they are specific to Windows and
+    // not really useful at the Merge level.
+    delete doc.fileid
+
     return doc
   })
 
@@ -173,7 +177,7 @@ describe('Merge', function () {
                 tags: ['bar', 'baz'],
                 sides: { [this.side]: 3, [otherSide(this.side)]: 2 }
               },
-              _.omit(file, ['_rev'])
+              _.omit(file, ['_rev', 'fileid'])
             )
           ],
           resolvedConflicts: []
@@ -312,7 +316,7 @@ describe('Merge', function () {
                 sides: { local: 2 }
               },
               _.pick(offUpdate, ['md5sum', 'size', 'updated_at']),
-              _.omit(initialFile, ['_rev', 'remote']) // FIXME: Compare _revs, stop mixing undefined and missing remote
+              _.omit(initialFile, ['_rev', 'fileid', 'remote']) // FIXME: Compare _revs, stop mixing undefined and missing remote
             )
           ],
           resolvedConflicts: []
@@ -355,7 +359,7 @@ describe('Merge', function () {
                 sides: { [this.side]: 4 }
               },
               _.pick(secondUpdate, ['md5sum', 'size', 'updated_at']),
-              _.omit(firstUpdate, ['_rev']) // TODO: Compare _revs
+              _.omit(firstUpdate, ['_rev', 'fileid']) // TODO: Compare _revs
             )
           ],
           resolvedConflicts: []
@@ -486,7 +490,7 @@ describe('Merge', function () {
               sides: { [this.side]: 3, remote: 2 }
             },
             _.pick(doc, ['tags', 'updated_at']),
-            _.omit(file, ['_rev']) // TODO: Compare _revs
+            _.omit(file, ['_rev', 'fileid']) // TODO: Compare _revs
           )
         ],
         resolvedConflicts: []
@@ -511,7 +515,7 @@ describe('Merge', function () {
               sides: { [this.side]: 3, remote: 2 }
             },
             _.pick(doc, ['md5sum', 'size', 'tags', 'updated_at']),
-            _.omit(file, ['_rev']) // TODO: Compare _revs
+            _.omit(file, ['_rev', 'fileid']) // TODO: Compare _revs
           )
         ],
         resolvedConflicts: []
@@ -569,7 +573,7 @@ describe('Merge', function () {
               sides: { local: 4 }
             },
             // TODO: Compare _revs
-            _.omit(mergedLocalUpdate, ['_rev', 'remote']) // We're dissociating the local doc from the remote doc
+            _.omit(mergedLocalUpdate, ['_rev', 'fileid', 'remote']) // We're dissociating the local doc from the remote doc
           )
         ],
         resolvedConflicts: [
@@ -908,7 +912,7 @@ describe('Merge', function () {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev', 'fileid']), // TODO: Compare _revs
           _.defaults(
             {
               sides: { [this.side]: 1 },
@@ -1359,7 +1363,7 @@ describe('Merge', function () {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev', 'fileid']), // TODO: Compare _revs
           _.defaults(
             {
               sides: { [this.side]: 1 },


### PR DESCRIPTION
**Needs #1504**

Introduces new `StatsBuilder`.
Which builds `WinStats` & generates fileids from test inode numbers.
So we can reuse it in `AtomwatcherEventBuilder` & `BaseMetadataBuilder`.
And make sure our test data actually match our production data.

Since fileids have more precision than inode numbers, it could make sense to
generate inode numbers from fileids instead of the opposite.
But the current way prevent breaking many tests.
And the other one would mostly be relevant to test precision issues.
Which we don't test yet anyway.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
