### PR TITLE
test/integration/corruption_fixer: Disable test

### DIFF
--- a/test/integration/corruption_fixer.js
+++ b/test/integration/corruption_fixer.js
@@ -84,7 +84,7 @@ describe('Re-Upload files when the stack report them as broken', () => {
     should(helpers.local.syncDir.existsSync(fileName)).be.false()
   })
 
-  it('If the metadata in pouchdb are ok, fix once', async () => {
+  it.skip('If the metadata in pouchdb are ok, fix once', async () => {
     // HACK: to get in the same state than if this desktop had uploaded a file which got corrupted
     const fileName = 'file-corrupted-fixable'
 


### PR DESCRIPTION
This test is failing due to the new in-memory cache in cozy-stack:
https://github.com/cozy/cozy-stack/commit/581ba9ccbe33475f1dd68bbc2f0f85c8d4ea89e5

The corruption fixer is in production since 5 months, so it is probably
not fixing a lot of files anymore & may be dropped soon.

Courtesy of @taratatach

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
