### PR TITLE
Avoid recomputing checksums

### DIFF
--- a/core/local/steps/add_checksum.js
+++ b/core/local/steps/add_checksum.js
@@ -40,7 +40,9 @@ function loop (buffer /*: Buffer */, opts /*: { syncPath: string , checksumer: C
             event.kind === 'file') {
           log.debug({path: event.path, action: event.action}, 'checksum')
           const absPath = path.join(opts.syncPath, event.path)
-          event.md5sum = await opts.checksumer.push(absPath)
+          if (!event.md5sum) {
+            event.md5sum = await opts.checksumer.push(absPath)
+          }
         }
       } catch (err) {
         // Even if the file is no longer at the expected path, we want to

--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -91,6 +91,16 @@ module.exports = class AtomWatcherEventBuilder {
     return this
   }
 
+  mtime (newMtime /*: Date */) /*: this */ {
+    this._ensureStatsBuilder().mtime(newMtime)
+    return this
+  }
+
+  ctime (newCtime /*: Date */) /*: this */ {
+    this._ensureStatsBuilder().ctime(newCtime)
+    return this
+  }
+
   noStats () /*: this */ {
     delete this._event.stats
     delete this._statsBuilder

--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -10,6 +10,7 @@ const statsBuilder = require('./stats')
 
 /*::
 import type { Stats } from 'fs'
+import type { Metadata } from '../../../core/metadata'
 import type { AtomWatcherEvent, EventAction, EventKind, Batch } from '../../../core/local/steps/event'
 import type { StatsBuilder } from './stats'
 */
@@ -18,6 +19,10 @@ function randomPick /*:: <T> */ (elements /*: Array<T> */) /*: T */{
   const l = elements.length
   const i = Math.floor(Math.random() * l)
   return elements[i]
+}
+
+function kind (doc /*: Metadata */) /*: EventKind */ {
+  return doc.docType === 'folder' ? 'directory' : doc.docType
 }
 
 module.exports = class AtomWatcherEventBuilder {
@@ -47,6 +52,19 @@ module.exports = class AtomWatcherEventBuilder {
         .fromStats(this._event.stats)
         .kind(this._event.kind)
     return this._statsBuilder
+  }
+
+  fromDoc (doc /*: Metadata */) /*: this */ {
+    const updatedAt = new Date(doc.updated_at)
+
+    let builder =
+      this
+        .kind(kind(doc))
+        .path(doc.path)
+        .ctime(updatedAt)
+        .mtime(updatedAt)
+    if (doc.ino) builder = builder.ino(doc.ino)
+    return builder
   }
 
   build () /*: AtomWatcherEvent */ {

--- a/test/support/builders/stats.js
+++ b/test/support/builders/stats.js
@@ -10,6 +10,8 @@ import type { EventKind } from '../../../core/local/steps/event'
 export interface StatsBuilder {
   ino (number): StatsBuilder,
   kind (EventKind): StatsBuilder,
+  mtime (Date) : StatsBuilder,
+  ctime (Date) : StatsBuilder,
   build (): Stats
 }
 */
@@ -58,6 +60,16 @@ class DefaultStatsBuilder {
     return this
   }
 
+  mtime (newMtime /*: Date */) /*: this */ {
+    this.stats.mtime = newMtime
+    return this
+  }
+
+  ctime (newCtime /*: Date */) /*: this */ {
+    this.stats.ctime = newCtime
+    return this
+  }
+
   build () {
     return this.stats
   }
@@ -97,6 +109,16 @@ class WinStatsBuilder {
   kind (newKind /*: EventKind */) /*: this */ {
     this.winStats.directory = newKind === 'directory'
     this.winStats.symbolicLink = newKind === 'symlink'
+    return this
+  }
+
+  mtime (newMtime /*: Date */) /*: this */ {
+    this.winStats.mtime = newMtime
+    return this
+  }
+
+  ctime (newCtime /*: Date */) /*: this */ {
+    this.winStats.ctime = newCtime
     return this
   }
 

--- a/test/unit/local/steps/add_checksum.js
+++ b/test/unit/local/steps/add_checksum.js
@@ -51,6 +51,27 @@ describe('core/local/steps/add_checksum.loop()', () => {
       .and.length(batch.length)
     should.not.exist(enhancedBatch[0].md5sum)
   })
+  it('should not compute checksum if already present', async () => {
+    const batch = [
+      {
+        action: 'scan',
+        kind: 'file',
+        path: __filename,
+        md5sum: 'checksum'
+      }
+    ]
+    const buffer = new Buffer()
+    buffer.push(batch)
+    const enhancedBuffer = addChecksum.loop(buffer, {
+      checksumer: checksumer.init(),
+      syncPath: ''
+    })
+    const enhancedBatch = await enhancedBuffer.pop()
+    should(enhancedBatch)
+      .be.an.Array()
+      .and.length(batch.length)
+    should(enhancedBatch[0]).have.property('md5sum', 'checksum')
+  })
   it('should work for every action', async () => {
     const batch = [
       {


### PR DESCRIPTION
When an event matches an existing document's ino, path and last update
  time, we can safely assume the checksum hasn't changed and set it on
  the event.

When an event already has a checksum, it's not necessary to recompute
  it in this step.
  This will speed up the initial scan by avoiding lots of checksum
  computations.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
