### PR TITLE
core/metadata: Fix .buildDir() sides

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -452,7 +452,6 @@ function buildDir (fpath /*: string */, stats /*: Stats */, remote /*: ?Metadata
     docType: 'folder',
     updated_at: timestamp.fromDate(timestamp.maxDate(stats.mtime, stats.ctime)).toISOString(),
     ino: stats.ino,
-    sides: {},
     remote
   }
   if (stats.fileid) { doc.fileid = stats.fileid }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -34,7 +34,7 @@ module.exports = class BaseMetadataBuilder {
       this.old = old
       this.doc = _.cloneDeep(old)
     } else {
-      this.doc = {
+      const doc /*: Object */ = {
         _id: metadata.id('foo'),
         docType: 'folder', // To make flow happy (overridden by subclasses)
         path: 'foo',
@@ -43,9 +43,9 @@ module.exports = class BaseMetadataBuilder {
           _rev: dbBuilders.rev()
         },
         tags: [],
-        sides: {},
         updated_at: timestamp.current().toISOString()
       }
+      this.doc = doc
     }
   }
 
@@ -210,10 +210,10 @@ module.exports = class BaseMetadataBuilder {
 
     const doc = this.build()
     // Update doc until _rev matches the highest side
+    doc.sides = doc.sides || {local: 1}
     const desiredRevNumber = Math.max(
-      1,
-      this.doc.sides.local || 0,
-      this.doc.sides.remote || 0
+      doc.sides.local || 0,
+      doc.sides.remote || 0
     )
     let revNumber = 0
     while (revNumber < desiredRevNumber) {


### PR DESCRIPTION
Otherwise .markSide() will mess up because sides != null.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
