### PR TITLE
ci/travis: Run integration tests with atom watcher on Linux

### DIFF
--- a/dev/ci/tests.sh
+++ b/dev/ci/tests.sh
@@ -4,10 +4,6 @@ set -ex
 
 . "./dev/ci/start_xvfb.sh"
 
-# FIXME Integration tests use ChokidarEvents and onFlush
-# So, they are not yet compatible with atom/watcher
-export COZY_FS_WATCHER=chokidar
-
 yarn install:all
 yarn build:elm
 yarn lint

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -13,7 +13,7 @@ const TestHelpers = require('../support/helpers')
 const cozy = cozyHelpers.cozy
 
 describe('Sync gets interrupted, initialScan occurs', () => {
-  if (config.watcherType() === 'atom' && process.platform === 'win32') {
+  if (config.watcherType() === 'atom') {
     it.skip('is not supported yet')
     return
   }


### PR DESCRIPTION

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
