### PR TITLE
test/support/builders/atom_watcher_event: Fix #path()

### DIFF
--- a/test/support/builders/atom_watcher_event.js
+++ b/test/support/builders/atom_watcher_event.js
@@ -90,7 +90,7 @@ module.exports = class AtomWatcherEventBuilder {
 
   path (newPath /*: string */) /*: this */ {
     this._event.path = path.normalize(newPath)
-    this._event._id = metadata.id(newPath)
+    this._event._id = metadata.id(this._event.path)
     return this
   }
 


### PR DESCRIPTION
So atom event ids are normalized the same way as paths in tests.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
