### PR TITLE
test: Fix scenarios initial diff state issue

### DIFF
--- a/core/local/steps/event.js
+++ b/core/local/steps/event.js
@@ -38,7 +38,15 @@ const KINDS /*: EventKind[] */ = [
   'file', 'directory', 'symlink', 'unknown'
 ]
 
+const INITIAL_SCAN_DONE = {
+  action: 'initial-scan-done',
+  kind: 'unknown',
+  path: '.',
+  noIgnore: true
+}
+
 module.exports = {
   ACTIONS,
+  INITIAL_SCAN_DONE,
   KINDS
 }

--- a/core/local/steps/producer.js
+++ b/core/local/steps/producer.js
@@ -7,6 +7,7 @@ const Promise = require('bluebird')
 const watcher = require('@atom/watcher')
 
 const Buffer = require('./buffer')
+const { INITIAL_SCAN_DONE } = require('./event')
 const stater = require('../stater')
 const logger = require('../../logger')
 
@@ -84,8 +85,7 @@ module.exports = class Producer {
     // moved. Wait a bit to ensure that the corresponding renamed events have
     // been emited.
     await Promise.delay(1000)
-    const scanDone = { action: 'initial-scan-done', kind: 'unknown', path: '.', noIgnore: true }
-    this.buffer.push([scanDone])
+    this.buffer.push([INITIAL_SCAN_DONE])
   }
 
   async scan (relPath /*: string */) {

--- a/test/integration/mtime-update.js
+++ b/test/integration/mtime-update.js
@@ -63,6 +63,7 @@ describe('Update only a file mtime', () => {
         stats
       }])
     } else {
+      await helpers.local.simulateAtomStart()
       await helpers.local.simulateAtomEvents([
         [
           {

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -155,6 +155,7 @@ function injectChokidarBreakpoints (eventsFile) {
 }
 
 async function runLocalAtom (scenario, atomCapture, helpers) {
+  await helpers.local.simulateAtomStart()
   if (scenario.init) {
     let relpathFix = _.identity
     if (process.platform === 'win32' && atomCapture.name.match(/win32/)) {


### PR DESCRIPTION
So initial diff doesn't end up with state before initial scan while
we're testing live captures in scenarios.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
