### PR TITLE
test/scenarios/create_dirs: Fix linux Atom capture

### DIFF
--- a/test/scenarios/create_dirs/atom/linux.json
+++ b/test/scenarios/create_dirs/atom/linux.json
@@ -2,8 +2,15 @@
   [
     {
       "action": "created",
-      "kind": "file",
+      "kind": "directory",
       "path": "foo"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "directory",
+      "path": "foo/bar"
     }
   ],
   [
@@ -18,19 +25,19 @@
         "gid": 1000,
         "rdev": 0,
         "blksize": 4096,
-        "ino": 2,
+        "ino": 20582718,
         "size": 4096,
         "blocks": 8,
-        "atimeMs": 1550661717194.0144,
-        "mtimeMs": 1550661717194.0144,
-        "ctimeMs": 1550661717194.0144,
-        "birthtimeMs": 1550661717194.0144,
-        "atime": "2019-02-20T11:21:57.194Z",
-        "mtime": "2019-02-20T11:21:57.194Z",
-        "ctime": "2019-02-20T11:21:57.194Z",
-        "birthtime": "2019-02-20T11:21:57.194Z"
+        "atimeMs": 1554187261625.9788,
+        "mtimeMs": 1554187261624.9788,
+        "ctimeMs": 1554187261625.9788,
+        "birthtimeMs": 1554187261625.9788,
+        "atime": "2019-04-02T06:41:01.626Z",
+        "mtime": "2019-04-02T06:41:01.625Z",
+        "ctime": "2019-04-02T06:41:01.626Z",
+        "birthtime": "2019-04-02T06:41:01.626Z"
       },
-      "kind": "unknown"
+      "kind": "directory"
     }
   ]
 ]


### PR DESCRIPTION
  The capture contained events for files while we are actually creating
  directories.
  This lead to errors raised in the addChecksum step.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
