### PR TITLE
core/local/steps/producer: Fix incomplete scan race condition

### DIFF
--- a/core/local/steps/producer.js
+++ b/core/local/steps/producer.js
@@ -108,10 +108,8 @@ module.exports = class Producer {
       }
     }
     log.trace({path: relPath, batch: entries}, 'scan')
-    if (entries.length === 0) {
-      return
-    }
     this.buffer.push(entries)
+
     for (const entry of entries) {
       if (entry.stats && stater.isDirectory(entry.stats)) {
         await this.scan(entry.path)


### PR DESCRIPTION
A race condition could occur between readdir and stat in
  producer.scan().
  If the listed item is deleted before we can get its stats, we now
  issue an incomplete scan event instead of logging an error, thus
  avoiding possible deletion of the document via the deleted event
  issued by initialDiff and then recreation via the renamed event issued
  later by the producer (possibly aggregated by winDetectMove).

Greatly helped by @sebn 	

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
