### PR TITLE
core/merge: Save missing fileids on up-to-date scanned docs 

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -122,6 +122,7 @@ module.exports = {
   buildDir,
   buildFile,
   upToDate,
+  outOfDateSide,
   createConflictingDoc,
   conflictRegExp,
   shouldIgnore
@@ -336,6 +337,18 @@ function upToDate (doc /*: Metadata */) /*: Metadata */ {
   const rev = Math.max(clone.sides.local, clone.sides.remote)
 
   return _.assign(clone, { errors: undefined, sides: { local: rev, remote: rev } })
+}
+
+function outOfDateSide (doc /*: Metadata */) /*: ?SideName */ {
+  const localRev = _.get(doc, 'sides.local', 0)
+  const remoteRev = _.get(doc, 'sides.remote', 0)
+  if ((localRev === 0 || remoteRev === 0) && doc._deleted) {
+    return null
+  } else if (localRev > remoteRev) {
+    return 'remote'
+  } else if (remoteRev > localRev) {
+    return 'local'
+  }
 }
 
 // Ensure new timestamp is never older than the previous one

--- a/core/sync.js
+++ b/core/sync.js
@@ -361,16 +361,10 @@ class Sync {
   // Select which side will apply the change
   // It returns the side, its name, and also the last rev applied by this side
   selectSide (doc /*: Metadata */) {
-    let localRev = doc.sides.local || 0
-    let remoteRev = doc.sides.remote || 0
-    if ((localRev === 0 || remoteRev === 0) && doc._deleted) {
-      return []
-    } else if (localRev > remoteRev) {
-      return [this.remote, 'remote', remoteRev]
-    } else if (remoteRev > localRev) {
-      return [this.local, 'local', localRev]
-    } else {
-      return []
+    switch (metadata.outOfDateSide(doc)) {
+      case 'local': return [this.local, 'local', doc.sides.local || 0]
+      case 'remote': return [this.remote, 'remote', doc.sides.remote || 0]
+      default: return []
     }
   }
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -25,6 +25,7 @@ const {
   buildFile,
   invariants,
   upToDate,
+  outOfDateSide,
   createConflictingDoc,
   conflictRegExp
 } = metadata
@@ -803,6 +804,35 @@ describe('metadata', function () {
       doc.errors = 1
 
       should(upToDate(doc).errors).be.undefined()
+    })
+  })
+
+  describe('outOfDateSide', () => {
+    let builders
+    beforeEach(() => {
+      builders = new Builders({pouch: this.pouch})
+    })
+
+    it('returns nothing if sides are not set', () => {
+      const doc1 = builders.metadata().sides({}).build()
+      should(outOfDateSide(doc1)).be.undefined()
+      const doc2 = builders.metadata().sides().build()
+      should(outOfDateSide(doc2)).be.undefined()
+    })
+
+    it('returns nothing if sides are equal', () => {
+      const doc = builders.metadata().sides({ local: 1, remote: 1 }).build()
+      should(outOfDateSide(doc)).be.undefined()
+    })
+
+    it('returns "local" if the local side is smaller than the remote one', () => {
+      const doc = builders.metadata().sides({ local: 1, remote: 2 }).build()
+      should(outOfDateSide(doc)).equal('local')
+    })
+
+    it('returns "remote" if the remote side is smaller than the local one', () => {
+      const doc = builders.metadata().sides({ local: 2, remote: 1 }).build()
+      should(outOfDateSide(doc)).equal('remote')
     })
   })
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -810,7 +810,7 @@ describe('metadata', function () {
   describe('outOfDateSide', () => {
     let builders
     beforeEach(() => {
-      builders = new Builders({pouch: this.pouch})
+      builders = new Builders()
     })
 
     it('returns nothing if sides are not set', () => {


### PR DESCRIPTION

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
