### PR TITLE
core/local/steps/dispatch: Lock around event dispatch

### DIFF
--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -14,7 +14,10 @@ const log = logger({
 
 /*::
 import type Buffer from './buffer'
-import type { Batch } from './event'
+import type {
+  AtomWatcherEvent,
+  Batch
+} from './event'
 import type { WinDetectMoveState } from './win_detect_move'
 import type EventEmitter from 'events'
 import type Prep from '../../prep'
@@ -52,14 +55,7 @@ function step (opts /*: DispatchOptions */) {
   return async (batch /*: Batch */) => {
     for (const event of batch) {
       try {
-        log.trace({event}, 'dispatch')
-        if (event.action === 'initial-scan-done') {
-          actions.initialScanDone(opts)
-        } else if (event.action === 'ignored') {
-          actions.ignored(event)
-        } else {
-          await actions[event.action + event.kind](event, opts)
-        }
+        await dispatchEvent(event, opts)
       } catch (err) {
         log.error({err, event})
       } finally {
@@ -69,6 +65,17 @@ function step (opts /*: DispatchOptions */) {
       }
     }
     return batch
+  }
+}
+
+async function dispatchEvent (event /*: AtomWatcherEvent */, opts /*: DispatchOptions */) {
+  log.trace({event}, 'dispatch')
+  if (event.action === 'initial-scan-done') {
+    actions.initialScanDone(opts)
+  } else if (event.action === 'ignored') {
+    actions.ignored(event)
+  } else {
+    await actions[event.action + event.kind](event, opts)
   }
 }
 

--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -7,9 +7,10 @@ const { buildDir, buildFile, id } = require('../../metadata')
 const logger = require('../../logger')
 
 const STEP_NAME = 'dispatch'
+const component = `atom/${STEP_NAME}`
 
 const log = logger({
-  component: `atom/${STEP_NAME}`
+  component
 })
 
 /*::

--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -76,7 +76,13 @@ async function dispatchEvent (event /*: AtomWatcherEvent */, opts /*: DispatchOp
   } else if (event.action === 'ignored') {
     actions.ignored(event)
   } else {
-    await actions[event.action + event.kind](event, opts)
+    // Lock to prevent Merge/Sync conflicts
+    const release = await opts.pouch.lock(component)
+    try {
+      await actions[event.action + event.kind](event, opts)
+    } finally {
+      release()
+    }
   }
 }
 


### PR DESCRIPTION
To prevent Merge/Sync conflicts.
This will probably make performances worse.
Sync should probably lock around single changes, not batches.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [x] it includes relevant documentation
