### PR TITLE
core/metadata: Fix previous dir conflict suffix

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -517,7 +517,7 @@ function createConflictingDoc (doc /*: Metadata */) /*: Metadata */ {
   let ext = path.extname(doc.path)
   let dir = path.dirname(doc.path)
   let base = path.basename(doc.path, ext)
-  const previousConflictingName = conflictRegExp('(.*)').exec(base)
+  const previousConflictingName = conflictRegExp('(.*)').exec(doc.path)
   const filename = previousConflictingName
     ? previousConflictingName[1]
     : base

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -905,6 +905,18 @@ describe('metadata', function () {
       should(secondConflict.path).be.a.String().and.match(pathRegExp)
       should(path.extname(secondConflict.path)).equal(ext)
     })
+    it('should not mistake a previous conflict timezone for a file extension', () => {
+      const base = 'dirname'
+      const firstConflictSuffix = '-conflict-1970-01-01T13_37_00.666Z'
+      const doc = {path: `${base}${firstConflictSuffix}`}
+
+      const secondConflict = createConflictingDoc(doc)
+
+      should(secondConflict.path)
+        .be.a.String()
+        .and.match(conflictRegExp(base))
+        .and.not.containEql(firstConflictSuffix)
+    })
   })
 
   describe('shouldIgnore', () => {


### PR DESCRIPTION
Do not mistake a previous conflict timezone for a file extension.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
