### PR TITLE
core/local/steps/await_write_finish: Aggregate in batch

### DIFF
--- a/core/local/steps/await_write_finish.js
+++ b/core/local/steps/await_write_finish.js
@@ -63,18 +63,24 @@ function countFileWriteEvents (events /*: AtomWatcherEvent[] */) /*: number */ {
 function debounce (waiting /*: WaitingItem[] */, events /*: AtomWatcherEvent[] */) {
   for (let i = 0; i < events.length; i++) {
     const event = events[i]
+
     if (event.incomplete) {
       continue
     }
+
     if (event.kind === 'file' && ['modified', 'deleted'].includes(event.action)) {
       for (let j = 0; j < waiting.length; j++) {
         const w = waiting[j]
+
         if (w.nbCandidates === 0) { continue }
+
         for (let k = 0; k < w.events.length; k++) {
           const e = w.events[k]
+
           if (['created', 'modified'].includes(e.action) && e.path === event.path) {
             w.events.splice(k, 1)
             w.nbCandidates--
+
             if (event.action === 'modified') {
               _.update(event, [STEP_NAME, 'previousEvents'], previousEvents =>
                 _.concat(_.toArray(previousEvents), [e])
@@ -82,6 +88,7 @@ function debounce (waiting /*: WaitingItem[] */, events /*: AtomWatcherEvent[] *
               // Preserve the action from the first event (it can be a created file)
               event.action = e.action
             }
+
             if (event.action === 'deleted' && e.action === 'created') {
               // It's just a temporary file that we can ignore
               log.debug(
@@ -91,6 +98,7 @@ function debounce (waiting /*: WaitingItem[] */, events /*: AtomWatcherEvent[] *
               events.splice(i, 1)
               i--
             }
+
             break
           }
         }

--- a/test/unit/local/steps/await_write_finish.js
+++ b/test/unit/local/steps/await_write_finish.js
@@ -1,9 +1,12 @@
 /* eslint-env mocha */
 /* @flow */
 
+const _ = require('lodash')
 const should = require('should')
+
 const awaitWriteFinish = require('../../../../core/local/steps/await_write_finish')
 const Buffer = require('../../../../core/local/steps/buffer')
+const stater = require('../../../../core/local/stater')
 
 const lastEventToCheckEmptyness = {
   action: 'initial-scan-done',
@@ -25,99 +28,12 @@ async function heuristicIsEmpty (buffer) {
 }
 
 describe('core/local/steps/await_write_finish.loop()', () => {
-  it('should reduce created→deleted to empty', async () => {
-    const buffer = new Buffer()
-    const originalBatch = [
-      {
-        action: 'created',
-        kind: 'file',
-        path: __filename
-      },
-      {
-        action: 'deleted',
-        kind: 'file',
-        path: __filename
-      },
-      lastEventToCheckEmptyness
-    ]
-    originalBatch.forEach(event => {
-      buffer.push([Object.assign({}, event)])
-    })
-    const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
-    should(await heuristicIsEmpty(enhancedBuffer)).be.true()
-  })
-
-  describe('created→modified→modified with or without deleted', () => {
-    it('should reduce created→modified→modified to created', async () => {
+  context('with many batches', () => {
+    it('should reduce created→deleted to empty', async () => {
       const buffer = new Buffer()
       const originalBatch = [
         {
           action: 'created',
-          kind: 'file',
-          path: __filename
-        },
-        {
-          action: 'modified',
-          kind: 'file',
-          path: __filename
-        },
-        {
-          action: 'modified',
-          kind: 'file',
-          path: __filename
-        },
-        lastEventToCheckEmptyness
-      ]
-      originalBatch.forEach(event => {
-        buffer.push([Object.assign({}, event)])
-      })
-      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
-      should(await enhancedBuffer.pop()).eql([
-        {
-          // 3rd modified -> created
-          action: 'created',
-          awaitWriteFinish: {
-            previousEvents: [
-              {
-                // 2nd modified -> created
-                action: 'created',
-                awaitWriteFinish: {
-                  previousEvents: [
-                    {
-                      // 1st created
-                      action: 'created',
-                      kind: 'file',
-                      path: __filename
-                    }
-                  ]
-                },
-                kind: 'file',
-                path: __filename
-              }
-            ]
-          },
-          kind: 'file',
-          path: __filename
-        }
-      ])
-      should(await heuristicIsEmpty(enhancedBuffer)).be.true()
-    })
-
-    it('should reduce created→modified→modified→deleted to empty', async () => {
-      const buffer = new Buffer()
-      const originalBatch = [
-        {
-          action: 'created',
-          kind: 'file',
-          path: __filename
-        },
-        {
-          action: 'modified',
-          kind: 'file',
-          path: __filename
-        },
-        {
-          action: 'modified',
           kind: 'file',
           path: __filename
         },
@@ -134,52 +50,445 @@ describe('core/local/steps/await_write_finish.loop()', () => {
       const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
       should(await heuristicIsEmpty(enhancedBuffer)).be.true()
     })
+
+    it('should reduce modified→deleted to deleted', async () => {
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'deleted',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      originalBatch.forEach(event => {
+        buffer.push([Object.assign({}, event)])
+      })
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([
+        originalBatch[1]
+      ])
+      should(await heuristicIsEmpty(enhancedBuffer)).be.true()
+    })
+
+    describe('created→modified→modified with or without deleted', () => {
+      it('should reduce created→modified→modified to created', async () => {
+        const buffer = new Buffer()
+        const originalBatch = [
+          {
+            action: 'created',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          lastEventToCheckEmptyness
+        ]
+        originalBatch.forEach(event => {
+          buffer.push([Object.assign({}, event)])
+        })
+        const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+        should(await enhancedBuffer.pop()).eql([
+          {
+            // 3rd modified -> created
+            action: 'created',
+            awaitWriteFinish: {
+              previousEvents: [
+                {
+                  // 2nd modified -> created
+                  action: 'created',
+                  awaitWriteFinish: {
+                    previousEvents: [
+                      {
+                        // 1st created
+                        action: 'created',
+                        kind: 'file',
+                        path: __filename
+                      }
+                    ]
+                  },
+                  kind: 'file',
+                  path: __filename
+                }
+              ]
+            },
+            kind: 'file',
+            path: __filename
+          }
+        ])
+        should(await heuristicIsEmpty(enhancedBuffer)).be.true()
+      })
+
+      it('should reduce created→modified→modified→deleted to empty', async () => {
+        const buffer = new Buffer()
+        const originalBatch = [
+          {
+            action: 'created',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'deleted',
+            kind: 'file',
+            path: __filename
+          },
+          lastEventToCheckEmptyness
+        ]
+        originalBatch.forEach(event => {
+          buffer.push([Object.assign({}, event)])
+        })
+        const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+        should(await heuristicIsEmpty(enhancedBuffer)).be.true()
+      })
+    })
+
+    it('should reduce modified→modified to latest modified', async () => {
+      const fileStats = await stater.stat(__filename)
+      const stats1 = {
+        ...fileStats,
+        size: 1
+      }
+      const stats2 = {
+        ...fileStats,
+        size: 2
+      }
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename,
+          stats: stats1
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename,
+          stats: stats2
+        },
+        lastEventToCheckEmptyness
+      ]
+      originalBatch.forEach(event => {
+        buffer.push([Object.assign({}, event)])
+      })
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([
+        {
+          action: 'modified',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                action: 'modified',
+                kind: 'file',
+                path: __filename,
+                stats: stats1
+              }
+            ]
+          },
+          kind: 'file',
+          path: __filename,
+          stats: stats2
+        }
+      ])
+      should(await heuristicIsEmpty(enhancedBuffer)).be.true()
+    })
+
+    it('should not squash incomplete events', async () => {
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename,
+          incomplete: true
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      originalBatch.forEach(event => {
+        buffer.push([Object.assign({}, event)])
+      })
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([originalBatch[1]])
+      should(await enhancedBuffer.pop()).eql([
+        {
+          // 3rd modified -> created
+          action: 'created',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                // 1st created -> created
+                action: 'created',
+                kind: 'file',
+                path: __filename
+              }
+            ]
+          },
+          kind: 'file',
+          path: __filename
+        }
+      ])
+      should(await heuristicIsEmpty(enhancedBuffer)).be.true()
+    })
   })
 
-  it('should not squash incomplete events', async () => {
-    const buffer = new Buffer()
-    const originalBatch = [
-      {
-        action: 'created',
-        kind: 'file',
-        path: __filename
-      },
-      {
-        action: 'modified',
-        kind: 'file',
-        path: __filename,
-        incomplete: true
-      },
-      {
-        action: 'modified',
-        kind: 'file',
-        path: __filename
-      },
-      lastEventToCheckEmptyness
-    ]
-    originalBatch.forEach(event => {
-      buffer.push([Object.assign({}, event)])
-    })
-    const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
-    should(await enhancedBuffer.pop()).eql([originalBatch[1]])
-    should(await enhancedBuffer.pop()).eql([
-      {
-        // 3rd modified -> created
-        action: 'created',
-        awaitWriteFinish: {
-          previousEvents: [
-            {
-              // 1st created
-              action: 'created',
-              kind: 'file',
-              path: __filename
-            }
-          ]
+  context('with one batch', () => {
+    it('should reduce created→deleted to empty', async () => {
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
         },
-        kind: 'file',
-        path: __filename
+        {
+          action: 'deleted',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      buffer.push(_.cloneDeep(originalBatch))
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([
+        lastEventToCheckEmptyness
+      ])
+    })
+
+    it('should reduce modified→deleted to deleted', async () => {
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'deleted',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      buffer.push(_.cloneDeep(originalBatch))
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([
+        originalBatch[1],
+        lastEventToCheckEmptyness
+      ])
+    })
+
+    describe('created→modified→modified with or without deleted', () => {
+      it('should reduce created→modified→modified to created', async () => {
+        const buffer = new Buffer()
+        const originalBatch = [
+          {
+            action: 'created',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          lastEventToCheckEmptyness
+        ]
+        buffer.push(_.cloneDeep(originalBatch))
+        const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+        should(await enhancedBuffer.pop()).eql([
+          {
+            // 3rd modified -> created
+            action: 'created',
+            awaitWriteFinish: {
+              previousEvents: [
+                {
+                  // 2nd modified -> created
+                  action: 'created',
+                  awaitWriteFinish: {
+                    previousEvents: [
+                      {
+                        // 1st created
+                        action: 'created',
+                        kind: 'file',
+                        path: __filename
+                      }
+                    ]
+                  },
+                  kind: 'file',
+                  path: __filename
+                }
+              ]
+            },
+            kind: 'file',
+            path: __filename
+          },
+          lastEventToCheckEmptyness
+        ])
+      })
+
+      it('should reduce created→modified→modified→deleted to empty', async () => {
+        const buffer = new Buffer()
+        const originalBatch = [
+          {
+            action: 'created',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'modified',
+            kind: 'file',
+            path: __filename
+          },
+          {
+            action: 'deleted',
+            kind: 'file',
+            path: __filename
+          },
+          lastEventToCheckEmptyness
+        ]
+        buffer.push(_.cloneDeep(originalBatch))
+        const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+        should(await enhancedBuffer.pop()).eql([
+          lastEventToCheckEmptyness
+        ])
+      })
+    })
+
+    it('should reduce modified→modified to latest modified', async () => {
+      const fileStats = await stater.stat(__filename)
+      const stats1 = {
+        ...fileStats,
+        size: 1
       }
-    ])
-    should(await heuristicIsEmpty(enhancedBuffer)).be.true()
+      const stats2 = {
+        ...fileStats,
+        size: 2
+      }
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename,
+          stats: stats1
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename,
+          stats: stats2
+        },
+        lastEventToCheckEmptyness
+      ]
+      buffer.push(_.cloneDeep(originalBatch))
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([
+        {
+          action: 'modified',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                action: 'modified',
+                kind: 'file',
+                path: __filename,
+                stats: stats1
+              }
+            ]
+          },
+          kind: 'file',
+          path: __filename,
+          stats: stats2
+        },
+        lastEventToCheckEmptyness
+      ])
+    })
+
+    it('should not squash incomplete events', async () => {
+      const buffer = new Buffer()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename,
+          incomplete: true
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      buffer.push(_.cloneDeep(originalBatch))
+      const enhancedBuffer = awaitWriteFinish.loop(buffer, {})
+      should(await enhancedBuffer.pop()).eql([
+        {
+          // 3rd modified -> created
+          action: 'created',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                // 1st created
+                action: 'created',
+                kind: 'file',
+                path: __filename
+              }
+            ]
+          },
+          kind: 'file',
+          path: __filename
+        },
+        originalBatch[1],
+        lastEventToCheckEmptyness
+      ])
+    })
   })
 })

--- a/test/unit/local/steps/await_write_finish.js
+++ b/test/unit/local/steps/await_write_finish.js
@@ -109,19 +109,11 @@ describe('core/local/steps/await_write_finish.loop()', () => {
               previousEvents: [
                 {
                   // 2nd modified -> created
-                  action: 'created',
-                  awaitWriteFinish: {
-                    previousEvents: [
-                      {
-                        // 1st created
-                        action: 'created',
-                        kind: 'file',
-                        path: __filename
-                      }
-                    ]
-                  },
-                  kind: 'file',
-                  path: __filename
+                  action: 'created'
+                },
+                {
+                  // 1st created
+                  action: 'created'
                 }
               ]
             },
@@ -202,9 +194,15 @@ describe('core/local/steps/await_write_finish.loop()', () => {
             previousEvents: [
               {
                 action: 'modified',
-                kind: 'file',
-                path: __filename,
-                stats: stats1
+                stats: _.pick(stats1, [
+                  'ino',
+                  'fileid',
+                  'size',
+                  'atime',
+                  'mtime',
+                  'ctime',
+                  'birthtime'
+                ])
               }
             ]
           },
@@ -250,9 +248,7 @@ describe('core/local/steps/await_write_finish.loop()', () => {
             previousEvents: [
               {
                 // 1st created -> created
-                action: 'created',
-                kind: 'file',
-                path: __filename
+                action: 'created'
               }
             ]
           },
@@ -341,19 +337,11 @@ describe('core/local/steps/await_write_finish.loop()', () => {
               previousEvents: [
                 {
                   // 2nd modified -> created
-                  action: 'created',
-                  awaitWriteFinish: {
-                    previousEvents: [
-                      {
-                        // 1st created
-                        action: 'created',
-                        kind: 'file',
-                        path: __filename
-                      }
-                    ]
-                  },
-                  kind: 'file',
-                  path: __filename
+                  action: 'created'
+                },
+                {
+                  // 1st created
+                  action: 'created'
                 }
               ]
             },
@@ -432,9 +420,15 @@ describe('core/local/steps/await_write_finish.loop()', () => {
             previousEvents: [
               {
                 action: 'modified',
-                kind: 'file',
-                path: __filename,
-                stats: stats1
+                stats: _.pick(stats1, [
+                  'ino',
+                  'fileid',
+                  'size',
+                  'atime',
+                  'mtime',
+                  'ctime',
+                  'birthtime'
+                ])
               }
             ]
           },
@@ -477,9 +471,7 @@ describe('core/local/steps/await_write_finish.loop()', () => {
             previousEvents: [
               {
                 // 1st created
-                action: 'created',
-                kind: 'file',
-                path: __filename
+                action: 'created'
               }
             ]
           },


### PR DESCRIPTION
The step would only work if the first event on which we'll aggregate
  others was in a previous batch.
  If a lot of writes happen quickly we'll see batches of modified
  events for the same file / directory and we want to aggregate those
  to limit the number of changes to merge and sync.

  To do that, we go over the events of the current batch and aggregate
  them before trying to aggregate them with waiting events.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
