### PR TITLE
core/local/steps/initial_diff: Ignore events for unapplied moves

### DIFF
--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -3,8 +3,6 @@
 
 const should = require('should')
 
-const config = require('../../core/config')
-
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
@@ -13,11 +11,6 @@ const TestHelpers = require('../support/helpers')
 const cozy = cozyHelpers.cozy
 
 describe('Sync gets interrupted, initialScan occurs', () => {
-  if (config.watcherType() === 'atom') {
-    it.skip('is not supported yet')
-    return
-  }
-
   let helpers
 
   before(configHelpers.createConfig)


### PR DESCRIPTION
If a document was moved remotely and we merged the change but did not
  get to apply it locally (e.g. the client was stopped during the
  process), we will receive scan events for the source of the move when
  we start the client again (i.e. the file has not been moved).

  If we let those scan events go all the way to dispatch, we'll end up
  creating a new document remotely with the source of the previous move
  (i.e. the source document does not exist in pouch anymore so we can
  know it's been moved during Merge).

  To avoid this, we ignore those events if we can find a document with
  the same kind and ino during the initial diff and that document has a
  movement marker (i.e. moveFrom).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
