### PR TITLE
gui: Fix MacOSX installer icons positions

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,14 @@ asarUnpack:
 - gui/scripts/**
 directories:
   buildResources: gui/assets
+dmg:
+  contents:
+    - x: 110
+      y: 150
+    - x: 440
+      y: 150
+      type: link
+      path: '/Applications'
 win:
   target:
   - nsis


### PR DESCRIPTION
  Vertically center App and Applications folder icons in the MacOSX dmg
  installer.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
