### PR TITLE
core/local/steps/initial_diff: Fix renamed events #1555

### DIFF
--- a/core/local/steps/initial_diff.js
+++ b/core/local/steps/initial_diff.js
@@ -48,7 +48,8 @@ const log = logger({
 module.exports = {
   STEP_NAME,
   loop,
-  initialState
+  initialState,
+  clearState
 }
 
 // Some files and directories can have been deleted while cozy-desktop was
@@ -89,6 +90,18 @@ async function initialState (opts /*: { pouch: Pouch } */) /*: Promise<InitialDi
   return {
     [STEP_NAME]: { waiting, scannedPaths, byInode }
   }
+}
+
+function clearState (state /*: InitialDiffState */) {
+  const { [STEP_NAME]: { waiting, scannedPaths, byInode } } = state
+
+  for (const item of waiting) {
+    clearTimeout(item.timeout)
+  }
+
+  state[STEP_NAME].waiting = []
+  scannedPaths.clear()
+  byInode.clear()
 }
 
 async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: Pouch */, state /*: InitialDiffState */) /*: Promise<void> */ {
@@ -164,8 +177,7 @@ async function initialDiff (buffer /*: Buffer */, out /*: Buffer */, pouch /*: P
             })
           }
         }
-        byInode.clear()
-        scannedPaths.clear()
+        clearState(state)
       }
       batch.push(event)
     }

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -31,6 +31,7 @@ describe('local/steps/initial_diff', () => {
       const state = await initialDiff.initialState(this)
       should(state).have.property(initialDiff.STEP_NAME, {
         waiting: [],
+        scannedPaths: new Set(),
         byInode: new Map([
           [foo.fileid || foo.ino, {
             path: foo.path,
@@ -43,8 +44,7 @@ describe('local/steps/initial_diff', () => {
             updated_at: fizz.updated_at,
             md5sum: fizz.md5sum
           }]
-        ]),
-        byPath: new Map()
+        ])
       })
     })
   })

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -33,7 +33,7 @@ describe('local/steps/initial_diff', () => {
       const state = await initialDiff.initialState(this)
       should(state).have.property(initialDiff.STEP_NAME, {
         waiting: [],
-        renamed: [],
+        renamedEvents: [],
         scannedPaths: new Set(),
         byInode: new Map([
           [foo.fileid || foo.ino, foo],
@@ -47,11 +47,11 @@ describe('local/steps/initial_diff', () => {
     it('removes every item from all initialDiff state collections', function () {
       const doc = builders.metadata().path('foo').ino(1).build()
       const waiting = [{ batch: [], nbCandidates: 0, timeout: setTimeout(() => {}, 0) }]
-      const renamed = [{ oldPath: 'bar', path: 'foo' }]
+      const renamedEvents = [builders.event().path('foo').oldPath('bar').build()]
       const scannedPaths = new Set(['foo'])
       const byInode = new Map([[doc.fileid || doc.ino || '', doc]]) // Flow thinks doc.ino can be null
       const state = {
-        [initialDiff.STEP_NAME]: { waiting, renamed, scannedPaths, byInode }
+        [initialDiff.STEP_NAME]: { waiting, renamedEvents, scannedPaths, byInode }
       }
 
       initialDiff.clearState(state)
@@ -59,7 +59,7 @@ describe('local/steps/initial_diff', () => {
       should(state).deepEqual({
         [initialDiff.STEP_NAME]: {
           waiting: [],
-          renamed: [],
+          renamedEvents: [],
           scannedPaths: new Set(),
           byInode: new Map()
         }

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -36,32 +36,24 @@ describe('local/steps/initial_diff', () => {
         renamed: [],
         scannedPaths: new Set(),
         byInode: new Map([
-          [foo.fileid || foo.ino, {
-            path: foo.path,
-            kind: kind(foo),
-            updated_at: foo.updated_at
-          }],
-          [fizz.fileid || fizz.ino, {
-            path: fizz.path,
-            kind: kind(fizz),
-            updated_at: fizz.updated_at,
-            md5sum: fizz.md5sum
-          }]
+          [foo.fileid || foo.ino, foo],
+          [fizz.fileid || fizz.ino, fizz]
         ])
       })
     })
   })
 
   describe('.clearState()', () => {
-    const waiting = [{ batch: [], nbCandidates: 0, timeout: setTimeout(() => {}, 0) }]
-    const renamed = [{ oldPath: 'bar', path: 'foo' }]
-    const scannedPaths = new Set(['foo'])
-    const byInode = new Map([[1, { path: 'foo', kind: 'file', updated_at: (new Date()).toString() }]])
-    const state = {
-      [initialDiff.STEP_NAME]: { waiting, renamed, scannedPaths, byInode }
-    }
-
     it('removes every item from all initialDiff state collections', function () {
+      const doc = builders.metadata().path('foo').ino(1).build()
+      const waiting = [{ batch: [], nbCandidates: 0, timeout: setTimeout(() => {}, 0) }]
+      const renamed = [{ oldPath: 'bar', path: 'foo' }]
+      const scannedPaths = new Set(['foo'])
+      const byInode = new Map([[doc.fileid || doc.ino || '', doc]]) // Flow thinks doc.ino can be null
+      const state = {
+        [initialDiff.STEP_NAME]: { waiting, renamed, scannedPaths, byInode }
+      }
+
       initialDiff.clearState(state)
 
       should(state).deepEqual({
@@ -194,7 +186,7 @@ describe('local/steps/initial_diff', () => {
         {
           _id: foo._id,
           action: 'deleted',
-          initialDiff: {notFound: _.defaults({kind: kind(foo)}, _.pick(foo, ['path', 'updated_at']))},
+          initialDiff: {notFound: _.defaults({kind: kind(foo)}, _.pick(foo, ['path', 'md5sum', 'updated_at']))},
           kind: 'directory',
           path: foo.path
         },

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -49,6 +49,27 @@ describe('local/steps/initial_diff', () => {
     })
   })
 
+  describe('.clearState()', () => {
+    const waiting = [{ batch: [], nbCandidates: 0, timeout: setTimeout(() => {}, 0) }]
+    const scannedPaths = new Set(['foo'])
+    const byInode = new Map([[1, { path: 'foo', kind: 'file', updated_at: (new Date()).toString() }]])
+    const state = {
+      [initialDiff.STEP_NAME]: { waiting, scannedPaths, byInode }
+    }
+
+    it('removes every item from all initialDiff state collections', function () {
+      initialDiff.clearState(state)
+
+      should(state).deepEqual({
+        [initialDiff.STEP_NAME]: {
+          waiting: [],
+          scannedPaths: new Set(),
+          byInode: new Map()
+        }
+      })
+    })
+  })
+
   describe('.loop()', () => {
     let buffer
     let initialScanDone


### PR DESCRIPTION
When transforming `scan` events into `renamed` events during the
  initial scan, we don't know if some of the moved documents are
  children of moved directories.
  This is a problem because when dispatching them, we won't find any
  document corresponding to their oldPath in Pouch since they would have
  been moved just before.

  To make sure all stopped client moves are correctly detected and
  merged, we keep track of `renamed` events that are issued by the
  initialDiff step or the watcher during the initial scan and use them
  to correct any of their children's movements.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
