### PR TITLE
core/remote/change: Fix deleted-created sort

### DIFF
--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -269,8 +269,10 @@ const sorter = (a, b) => {
   if (areParentChild(deletedId(b), deletedId(a))) return aFirst
   if (areParentChild(deletedId(a), deletedId(b))) return bFirst
 
-  if (deletedId(a) === createdId(b)) return aFirst
-  if (deletedId(b) === createdId(a)) return bFirst
+  if (deletedId(a) && createdId(b) && deletedId(a) === createdId(b))
+    return aFirst
+  if (deletedId(b) && createdId(a) && deletedId(b) === createdId(a))
+    return bFirst
 
   // otherwise, order by add path
   if (lower(createdId(a), createdId(b))) return aFirst

--- a/test/unit/remote/change.js
+++ b/test/unit/remote/change.js
@@ -18,4 +18,28 @@ describe('remote change sort', () => {
     remoteChange.sort(a)
     a.should.deepEqual([parent, child])
   })
+
+  describe('sorts deleted before created for the same path', () => {
+    const deleted = {
+      doc: { path: 'parent/file' },
+      type: 'FileDeletion'
+    }
+
+    const created = {
+      doc: { path: 'parent/file' },
+      type: 'FileAddition'
+    }
+
+    it('when deleted comes before created', () => {
+      const changes = [deleted, created]
+      remoteChange.sort(changes)
+      changes.should.deepEqual([deleted, created])
+    })
+
+    it('when created comes before deleted', () => {
+      const changes = [created, deleted]
+      remoteChange.sort(changes)
+      changes.should.deepEqual([deleted, created])
+    })
+  })
 })

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -174,11 +174,10 @@ describe('RemoteWatcher', function() {
       await this.watcher.pullMany(remoteDocs)
 
       apply.callCount.should.equal(2)
-      // Changes are sorted before applying (first one was given
-      // Metadata since it is valid, while second one got the original
-      // RemoteDeletion)
-      should(apply.args[0][0].doc).deepEqual(validMetadata(remoteDocs[0]))
-      should(apply.args[1][0].doc).deepEqual(remoteDocs[1])
+      // Changes are sorted before applying (first one got the original
+      // RemoteDeletion, while second one was given Metadata since it is valid)
+      should(apply.args[0][0].doc).deepEqual(remoteDocs[1])
+      should(apply.args[1][0].doc).deepEqual(validMetadata(remoteDocs[0]))
     })
 
     context('when apply() rejects some file/dir', function() {
@@ -200,12 +199,12 @@ describe('RemoteWatcher', function() {
         await this.watcher.pullMany(remoteDocs).catch(() => {})
         should(apply).have.been.calledTwice()
         should(apply.args[0][0]).have.properties({
-          type: 'FileAddition',
-          doc: validMetadata(remoteDocs[0])
-        })
-        should(apply.args[1][0]).have.properties({
           type: 'IgnoredChange',
           doc: remoteDocs[1]
+        })
+        should(apply.args[1][0]).have.properties({
+          type: 'FileAddition',
+          doc: validMetadata(remoteDocs[0])
         })
       })
 


### PR DESCRIPTION
  To re-order changes coming from the remote changesFeed, we use the
  javascript `sort()` function which compares 2 elements at a time,
  elements `a` and `b`.
  In our custom sorter, to make sure changes which delete (i.e. in Pouch
  terms) a specific id come before changes which create the same id, we
  have 2 comparisons following each other :
  - first we check if change `a` deletes the id created by change `b`
  - second, if the first comparison was falsy, we check if change `b`
  deletes the id created by change `a`

  Due to the way to compute the id deleted or created by a change, if
  `b` deletes the id and `a` creates it (i.e. we should be in the second
  comparison case), the first comparison we return a truthy value and
  the creation will come first, leading to conflicts in Merge later.

  To make sure our comparisons are valid, we need to make sure we
  compare ids which are not null (e.g. we should not try to compare the
  created id of a change if that change actually deletes it).

  Expected changes in test/unit/remote/watcher.js were re-ordered to
  reflect the new expected order (deletions first).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
