### PR TITLE
git: Prevent CRLF for *.js files on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+# JavaScript files with carriage returns would break prettier on Windows
+*.js text eol=lf
 # Make sure running scripts doesn't fail on Windows + Docker because of CRLF
 *.sh text eol=lf


### PR DESCRIPTION
Because core.autocrlf=true breaks prettier.

---

- [x] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes tests matching the implementation changes
- [x] it includes relevant documentation
