### PR TITLE
dev/remote/automated_registration: Pass string URLs to request

### DIFF
--- a/dev/remote/automated_registration.js
+++ b/dev/remote/automated_registration.js
@@ -105,7 +105,7 @@ const automatedRegistration = (
   passphrase /*: string */,
   storage /*: * */
 ) /*: Registration */ => {
-  const cozyUrl = path => new url.URL(path, cozyBaseUrl)
+  const cozyUrl = path => new url.URL(path, cozyBaseUrl).toString()
   const saveCredentials = async redirectUrl => {
     log.debug('Saving credentials...')
     await client({ url: redirectUrl })


### PR DESCRIPTION
Otherwise, for some yet undiscovered reason, a third-party dependency
seems to be passing a broken URL object to electron-proxy-agent which
then messes up HTTPS with port 80.

Used to be a string before refactoring anyway.
Not even sure `request*` & `*fetch` can handle an URL object either.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
