### PR TITLE
core: Use our own rev to determine changes to apply

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -84,6 +84,7 @@ type RemoteRev = string
 export type RemoteRevisionsByID = { [RemoteID] : RemoteRev}
 
 export type MetadataSidesInfo = {
+  target: number,
   remote?: number,
   local?: number
 }
@@ -161,6 +162,8 @@ module.exports = {
   sameBinary,
   markSide,
   incSides,
+  side,
+  target,
   wasSynced,
   buildDir,
   buildFile,
@@ -374,16 +377,12 @@ function extractRevNumber(doc /*: Metadata|{_rev: string} */) {
 }
 
 // Return true if the remote file is up-to-date for this document
-function isUpToDate(side /*: SideName */, doc /*: Metadata */) {
-  let currentRev = doc.sides[side] || 0
-  let lastRev = extractRevNumber(doc)
-  return currentRev === lastRev
+function isUpToDate(sideName /*: SideName */, doc /*: Metadata */) {
+  return side(doc, sideName) === target(doc)
 }
 
-function isAtLeastUpToDate(side /*: SideName */, doc /*: Metadata */) {
-  let currentRev = doc.sides[side] || 0
-  let lastRev = extractRevNumber(doc)
-  return currentRev >= lastRev
+function isAtLeastUpToDate(sideName /*: SideName */, doc /*: Metadata */) {
+  return side(doc, sideName) >= target(doc)
 }
 
 function markAsUnsyncable(side /*: SideName */, doc /*: Metadata */) {
@@ -397,12 +396,14 @@ function markAsNew(doc /*: Metadata */) {
 }
 
 function markAsUpToDate(doc /*: Metadata */) {
-  let rev = extractRevNumber(doc) + 1
-  for (let s of ['local', 'remote']) {
-    doc.sides[s] = rev
+  const newTarget = target(doc) + 1
+  doc.sides = {
+    target: newTarget,
+    local: newTarget,
+    remote: newTarget
   }
   delete doc.errors
-  return rev
+  return newTarget
 }
 
 function upToDate(doc /*: Metadata */) /*: Metadata */ {
@@ -411,7 +412,7 @@ function upToDate(doc /*: Metadata */) /*: Metadata */ {
 
   return _.assign(clone, {
     errors: undefined,
-    sides: { local: rev, remote: rev }
+    sides: { rev, local: rev, remote: rev }
   })
 }
 
@@ -547,29 +548,30 @@ function markSide(
   doc /*: Metadata */,
   prev /*: ?Metadata */
 ) /*: Metadata */ {
-  let rev = 0
-  if (prev) {
-    rev = extractRevNumber(prev)
-  }
+  const prevSides = prev && prev.sides
+  const prevTarget = target(prev)
+
   if (doc.sides == null) {
-    const was = prev && prev.sides
-    doc.sides = clone(was || {})
+    doc.sides = clone(prevSides || { target: prevTarget })
   }
-  doc.sides[side] = ++rev
+  doc.sides[side] = prevTarget + 1
+  doc.sides.target = prevTarget + 1
   return doc
 }
 
-function incSides(doc /*: {sides?: MetadataSidesInfo} */) /*: void */ {
+function incSides(doc /*: Metadata */) /*: void */ {
   doc.sides = {
+    target: target(doc) + 1,
     local: side(doc, 'local') + 1,
     remote: side(doc, 'remote') + 1
   }
 }
 
-function side(
-  doc /*: {sides?: MetadataSidesInfo} */,
-  sideName /*: SideName */
-) /*: number */ {
+function target(doc /*: ?Metadata */) /*: number */ {
+  return (doc && doc.sides && doc.sides.target) || 0
+}
+
+function side(doc /*: Metadata */, sideName /*: SideName */) /*: number */ {
   return (doc.sides || {})[sideName] || 0
 }
 

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -167,7 +167,6 @@ module.exports = {
   wasSynced,
   buildDir,
   buildFile,
-  upToDate,
   outOfDateSide,
   createConflictingDoc,
   CONFLICT_REGEXP,
@@ -404,16 +403,6 @@ function markAsUpToDate(doc /*: Metadata */) {
   }
   delete doc.errors
   return newTarget
-}
-
-function upToDate(doc /*: Metadata */) /*: Metadata */ {
-  const clone = _.clone(doc)
-  const rev = Math.max(clone.sides.local, clone.sides.remote)
-
-  return _.assign(clone, {
-    errors: undefined,
-    sides: { rev, local: rev, remote: rev }
-  })
 }
 
 function outOfDateSide(doc /*: Metadata */) /*: ?SideName */ {

--- a/core/move.js
+++ b/core/move.js
@@ -40,8 +40,7 @@ function move(side /*: SideName */, src /*: Metadata */, dst /*: Metadata */) {
   if (!dst.overwrite) {
     delete dst._rev
   }
-  delete dst.sides
-  metadata.markSide(side, dst)
+  metadata.markSide(side, dst, src)
 }
 
 // Same as move() but mark the source as a child move so it will be moved with

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -83,7 +83,7 @@ class Pouch {
   byRemoteIdAsync: (id: string) => Promise<*>
   byRemoteIdMaybeAsync: (id: string) => Promise<*>
   addAllViewsAsync: () => Promise<*>
-  getPreviousRevAsync: (id: string, shortRev: ?number) => Promise<Metadata>
+  getPreviousRevAsync: (id: string, revDiff: number) => Promise<Metadata>
   getLocalSeqAsync: () => Promise<number>
   setLocalSeqAsync: (number) => Promise<*>
   getRemoteSeqAsync: () => string
@@ -386,7 +386,7 @@ class Pouch {
   /* Helpers */
 
   // Retrieve a previous doc revision from its id
-  getPreviousRev(id, shortRev, callback) {
+  getPreviousRev(id, revDiff, callback) {
     let options = {
       revs: true,
       revs_info: true,
@@ -398,8 +398,8 @@ class Pouch {
       } else {
         let { ids } = infos[0].ok._revisions
         let { start } = infos[0].ok._revisions
-        let revId = ids[start - shortRev]
-        let rev = `${shortRev}-${revId}`
+        let revId = ids[start - revDiff]
+        let rev = `${revDiff}-${revId}`
         return this.db.get(id, { rev }, function(err, doc) {
           if (err) {
             log.debug(infos[0].doc)

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -7,6 +7,7 @@ const PouchDB = require('pouchdb')
 const uuid = require('uuid/v4')
 
 const { PouchError } = require('./error')
+const metadata = require('../metadata')
 
 /*::
 import type { Pouch } from './'
@@ -53,7 +54,23 @@ const MIGRATION_RESULT_NOOP = 'MigrationNoop'
 const MIGRATION_RESULT_COMPLETE = 'MigrationComplete'
 const MIGRATION_RESULT_FAILED = 'MigrationFailed'
 
-const migrations /*: Migration[] */ = []
+const migrations /*: Migration[] */ = [
+  {
+    baseSchemaVersion: SCHEMA_INITIAL_VERSION,
+    targetSchemaVersion: 1,
+    description: 'Adding sides.target with value of _rev',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(doc => doc.sides == null || doc.sides.target == null)
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        doc.sides = doc.sides || {}
+        doc.sides.target = metadata.extractRevNumber(doc)
+        return doc
+      })
+    }
+  }
+]
 
 class MigrationFailedError extends Error {
   /*::

--- a/core/sync.js
+++ b/core/sync.js
@@ -351,8 +351,11 @@ class Sync {
       log.debug({ path: doc.path }, `Applying else for ${doc.docType} change`)
       let old
       try {
-        old = await this.pouch.getPreviousRevAsync(doc._id, rev)
-      } catch (_) {
+        old = await this.pouch.getPreviousRevAsync(
+          doc._id,
+          doc.sides.target - rev
+        )
+      } catch (err) {
         await this.doOverwrite(side, doc)
       }
 
@@ -515,8 +518,9 @@ class Sync {
         await this.pouch.put({
           ...unsynced,
           sides: {
-            [side]: metadata.extractRevNumber(doc) + 1,
-            [other]: unsynced.sides[other] + 1
+            target: unsynced.sides.target + 1, // increase target because of new merge
+            [side]: doc.sides.target,
+            [other]: unsynced.sides[other] + 1 // increase side to mark change as applied
           }
         })
       } else {

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -43,7 +43,12 @@ describe('Add', () => {
       await helpers.remote.pullChanges()
 
       should(helpers.putDocs('path', '_deleted', 'trashed', 'sides')).deepEqual(
-        [{ path: path.normalize('parent/file'), sides: { remote: 1 } }]
+        [
+          {
+            path: path.normalize('parent/file'),
+            sides: { target: 1, remote: 1 }
+          }
+        ]
       )
 
       await helpers.syncAll()

--- a/test/integration/full_loop.js
+++ b/test/integration/full_loop.js
@@ -45,7 +45,7 @@ describe('Full watch/merge/sync/repeat loop', () => {
 
     const doc = await helpers.pouch.db.get(metadata.id('file'))
     should(doc.ino).be.a.Number()
-    should(doc.sides).deepEqual({ local: 2, remote: 2 })
+    should(doc.sides).deepEqual({ target: 2, local: 2, remote: 2 })
     await helpers._local.watcher.stop()
   })
 })

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -173,7 +173,11 @@ module.exports = class BaseMetadataBuilder {
   }
 
   upToDate() /*: this */ {
-    this.doc.sides = { rev: 2, local: 2, remote: 2 }
+    this.doc.sides = {
+      ...this.doc.sides,
+      target: (this.doc.sides && this.doc.sides.target) || 1
+    }
+    metadata.markAsUpToDate(this.doc)
     return this
   }
 
@@ -183,7 +187,7 @@ module.exports = class BaseMetadataBuilder {
   }
 
   changedSide(side /*: SideName */) /*: this */ {
-    metadata.markSide(side, this.doc, this.old)
+    metadata.markSide(side, this.doc, this.doc)
     return this
   }
 

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -212,7 +212,7 @@ module.exports.init = async (
         updated_at: lastModifiedDate,
         path: localPath,
         tags: [],
-        sides: { local: 2, remote: 2 }
+        sides: { target: 2, local: 2, remote: 2 }
       }
       stater.assignInoAndFileId(doc, stats)
 
@@ -269,7 +269,7 @@ module.exports.init = async (
         path: localPath,
         size: content.length,
         tags: [],
-        sides: { local: 2, remote: 2 }
+        sides: { target: 2, local: 2, remote: 2 }
       }
       stater.assignInoAndFileId(doc, stats)
       if (!isOutside) {

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -189,6 +189,7 @@ describe('Local', function() {
         docType: 'file',
         md5sum: 'deadcafe',
         sides: {
+          target: 1,
           local: 1
         }
       }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -68,6 +68,14 @@ async function mergeSideEffects(
   }
 }
 
+function increasedSides(sides, sideName, count) {
+  return {
+    ...sides,
+    target: sides.target + count,
+    [sideName]: sides[sideName] + count
+  }
+}
+
 describe('Merge', function() {
   let builders
 
@@ -100,7 +108,7 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 1 }
+              sides: { target: 1, [this.side]: 1 }
             },
             doc
           )
@@ -122,8 +130,6 @@ describe('Merge', function() {
       })
 
       it('saves the new file with the correct side number', async function() {
-        const expectedRevNumber = 4 // create + delete + create + update side
-
         const doc = builders
           .metafile()
           .path(path)
@@ -138,8 +144,7 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber }
-                // TODO: Compare _revs
+                sides: { target: 1, [this.side]: 1 }
               },
               doc
             )
@@ -180,7 +185,7 @@ describe('Merge', function() {
             _.defaults(
               {
                 tags: ['bar', 'baz'],
-                sides: { [this.side]: 3, [otherSide(this.side)]: 2 }
+                sides: increasedSides(file.sides, this.side, 1)
               },
               _.omit(file, ['_rev', 'fileid'])
             )
@@ -231,7 +236,7 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: { [this.side]: 1 }
+                sides: { target: 1, [this.side]: 1 }
               },
               doc
             )
@@ -306,15 +311,16 @@ describe('Merge', function() {
           })
 
           it('migrates the existing file', async function() {
-            const expectedRevNumber =
-              metadata.extractRevNumber(existingFile) + 1
-
             await this.merge.addFileAsync('local', _.cloneDeep(sameFile))
 
             const savedFile = await this.pouch.db.get(existingFile._id)
             should(savedFile).have.properties({
               fileid: sameFile.fileid,
-              sides: { local: expectedRevNumber, remote: expectedRevNumber }
+              sides: {
+                target: existingFile.sides.target + 1,
+                local: existingFile.sides.local + 1,
+                remote: existingFile.sides.remote + 1
+              }
             })
           })
         })
@@ -413,7 +419,7 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: { local: 2 }
+                sides: increasedSides(initialFile.sides, 'local', 1)
               },
               _.pick(offUpdate, ['md5sum', 'size', 'updated_at']),
               _.omit(initialFile, ['_rev', 'fileid', 'remote']) // FIXME: Compare _revs, stop mixing undefined and missing remote
@@ -456,7 +462,7 @@ describe('Merge', function() {
           savedDocs: [
             _.defaultsDeep(
               {
-                sides: { [this.side]: 4 }
+                sides: increasedSides(firstUpdate.sides, 'local', 1)
               },
               _.pick(secondUpdate, ['md5sum', 'size', 'updated_at']),
               _.omit(firstUpdate, ['_rev', 'fileid']) // TODO: Compare _revs
@@ -567,7 +573,7 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 1 }
+              sides: { target: 1, [this.side]: 1 }
             },
             doc
           )
@@ -590,7 +596,7 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 3, remote: 2 }
+              sides: increasedSides(file.sides, this.side, 1)
             },
             _.pick(doc, ['tags', 'updated_at']),
             _.omit(file, ['_rev', 'fileid']) // TODO: Compare _revs
@@ -615,7 +621,7 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 3, remote: 2 }
+              sides: increasedSides(file.sides, this.side, 1)
             },
             _.pick(doc, ['md5sum', 'size', 'tags', 'updated_at']),
             _.omit(file, ['_rev', 'fileid']) // TODO: Compare _revs
@@ -673,9 +679,11 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { local: 4 }
+              sides: {
+                target: mergedLocalUpdate.sides.target + 1,
+                local: mergedLocalUpdate.sides.local + 1
+              }
             },
-            // TODO: Compare _revs
             _.omit(mergedLocalUpdate, ['_rev', 'fileid', 'remote']) // We're dissociating the local doc from the remote doc
           )
         ],
@@ -778,7 +786,7 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 1 }
+              sides: { target: 1, [this.side]: 1 }
             },
             doc
           )
@@ -807,9 +815,9 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 2 }
+              sides: increasedSides(old.sides, this.side, 1)
             },
-            _.omit(doc, ['_rev']) // TODO: Compare _revs
+            _.omit(doc, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -829,7 +837,6 @@ describe('Merge', function() {
       })
 
       it('saves the new folder with the correct side number', async function() {
-        const expectedRevNumber = 4 // create + delete + create + update side
         const doc = builders
           .metadir()
           .path(path)
@@ -843,9 +850,9 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber }
+                sides: { target: 1, [this.side]: 1 }
               },
-              _.omit(doc, ['_rev']) // TODO: Compare _revs
+              _.omit(doc, ['_rev'])
             )
           ],
           resolvedConflicts: []
@@ -938,7 +945,7 @@ describe('Merge', function() {
               savedDocs: [
                 _.defaultsDeep(
                   {
-                    sides: { [this.side]: 1 }
+                    sides: { target: 1, [this.side]: 1 }
                   },
                   Alfred
                 )
@@ -988,14 +995,13 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedSrc
             },
-            _.pick(doc, ['_id', 'path', 'updated_at']),
-            _.omit(was, ['_rev']) // TODO: Compare _revs
+            _.omit(doc, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -1014,9 +1020,9 @@ describe('Merge', function() {
         .remoteId(dbBuilders.id())
         .create()
       const doc = builders
-        .metafile()
+        .metafile(was)
         .path('FOO/NEW-MISSING-FIELDS.JPG')
-        .data('image')
+        .noRev()
         .build()
 
       const sideEffects = await mergeSideEffects(this, () =>
@@ -1032,14 +1038,14 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev', 'fileid']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev', 'fileid']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedSrc
             },
             _.pick(was, ['size', 'ino']),
-            doc
+            _.omit(doc, ['fileid'])
           )
         ],
         resolvedConflicts: []
@@ -1091,12 +1097,12 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
                 _id: dstId,
                 path: dstPath,
-                sides: { [this.side]: 1 },
+                sides: { target: 1, [this.side]: 1 },
                 moveFrom: movedSrc
               },
               doc
@@ -1121,8 +1127,6 @@ describe('Merge', function() {
       })
 
       it('saves the new file with the correct side', async function() {
-        const expectedRevNumber = 4 // create + delete + create + update side
-
         const was = await builders
           .metafile()
           .path('SRC_FILE')
@@ -1152,14 +1156,13 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(was.sides, this.side, 1),
                 moveFrom: movedSrc
               },
               doc
-              // TODO: Compare _revs
             )
           ],
           resolvedConflicts: []
@@ -1176,10 +1179,9 @@ describe('Merge', function() {
         .sides({ local: 1 })
         .create()
       const doc = builders
-        .metafile()
+        .metafile(was)
         .path('FOO/NEW')
-        .data('content')
-        .tags('courge', 'quux')
+        .noRev()
         .build()
 
       const sideEffects = await mergeSideEffects(this, () =>
@@ -1190,17 +1192,16 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { local: 2 },
+              sides: increasedSides(was.sides, 'local', 1),
               _deleted: true
             },
-            _.omit(was, ['_rev']) // TODO: Compare _revs
+            _.omit(was, ['_rev'])
           ),
           _.defaults(
             {
-              sides: { local: 1 }
+              sides: { target: 1, local: 1 }
             },
             doc
-            // TODO: Compare _revs
           )
         ],
         resolvedConflicts: []
@@ -1208,6 +1209,12 @@ describe('Merge', function() {
     })
 
     it('does not identify the child move of a file following another unsynced move as an addition', async function() {
+      const src = await builders
+        .metadir()
+        .path('SRC')
+        .upToDate()
+        .remoteId(dbBuilders.id())
+        .create()
       const orig = await builders
         .metafile()
         .path('SRC/FILE')
@@ -1244,18 +1251,17 @@ describe('Merge', function() {
             _id: 'DST',
             path: 'DST',
             docType: 'folder',
-            sides: { [this.side]: 1 },
+            sides: { rev: 1, [this.side]: 1 },
             tags: [],
             updated_at: doc.updated_at // XXX: It might fail if it takes longer to run moveFileAsync
           },
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedSrc
             },
             doc
-            // TODO: Compare _revs
           )
         ],
         resolvedConflicts: []
@@ -1276,7 +1282,7 @@ describe('Merge', function() {
         .sides({ local: 1 })
         .create()
       const doc = await builders
-        .metafile()
+        .metafile(was)
         .path('DST/FILE2')
         .build()
 
@@ -1298,18 +1304,17 @@ describe('Merge', function() {
             _id: 'DST',
             path: 'DST',
             docType: 'folder',
-            sides: { local: 1 },
+            sides: { rev: 1, local: 1 },
             tags: [],
             updated_at: doc.updated_at // XXX: It might fail if it takes longer to run moveFileAsync
           },
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev']),
           _.defaults(
             {
-              sides: { local: 1 },
+              sides: increasedSides(was.sides, 'local', 1),
               moveFrom: movedSrc
             },
-            doc
-            // TODO: Compare _revs
+            _.omit(doc, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -1318,8 +1323,6 @@ describe('Merge', function() {
 
     onPlatforms(['win32', 'darwin'], () => {
       it('does not identify an identical renaming as a conflict', async function() {
-        const expectedRevNumber = 5 // up to date + delete + create + update side
-
         const banana = await builders
           .metafile()
           .path('banana')
@@ -1344,18 +1347,17 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(banana.sides, this.side, 1),
                 path: BANANA.path,
                 moveFrom: _.defaults(
                   {
-                    sides: { [this.side]: 2, [otherSide(this.side)]: 2 },
                     moveTo: BANANA._id,
                     _deleted: true
                   },
                   banana
                 )
               },
-              _.omit(banana, ['_rev']) // TODO: Compare _revs
+              _.omit(banana, ['_rev'])
             )
           ],
           resolvedConflicts: []
@@ -1394,8 +1396,6 @@ describe('Merge', function() {
 
     onPlatform('linux', () => {
       it('does not identify an identical renaming as a conflict', async function() {
-        const expectedRevNumber = 1 // new unsynced document
-
         const banana = await builders
           .metafile()
           .path('banana')
@@ -1425,14 +1425,13 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(banana.sides, this.side, 1),
                 moveFrom: movedSrc
               },
               BANANA
-              // TODO: Compare _revs
             )
           ],
           resolvedConflicts: []
@@ -1451,7 +1450,7 @@ describe('Merge', function() {
           .path('QUX')
           .create()
         const doc = builders
-          .metafile()
+          .metafile(was)
           .path('qux')
           .build()
 
@@ -1472,14 +1471,13 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: 1 },
+                sides: increasedSides(was.sides, this.side, 1),
                 moveFrom: movedSrc
               },
-              doc
-              // TODO: Compare _revs
+              _.omit(doc, ['_rev'])
             )
           ],
           resolvedConflicts: []
@@ -1507,7 +1505,7 @@ describe('Merge', function() {
         .remoteId(dbBuilders.id())
         .create()
       const doc = builders
-        .metadir()
+        .metadir(was)
         .path('FOOBAR/NEW')
         .tags('courge', 'quux')
         .build()
@@ -1529,15 +1527,14 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev', 'fileid']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev', 'fileid']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedSrc
             },
             _.pick(was, ['ino']),
-            doc
-            // TODO: Compare _revs
+            _.omit(doc, ['_rev', 'fileid'])
           )
         ],
         resolvedConflicts: []
@@ -1590,16 +1587,15 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
                 _id: dstId,
                 path: dstPath,
-                sides: { [this.side]: 1 },
+                sides: increasedSides(was.sides, this.side, 1),
                 moveFrom: movedSrc
               },
               doc
-              // TODO: Compare _revs
             )
           ],
           resolvedConflicts: [[this.side, _.pick(doc, ['path', 'remote'])]]
@@ -1619,8 +1615,6 @@ describe('Merge', function() {
       })
 
       it('saves the new directory with the correct side', async function() {
-        const expectedRevNumber = 4 // create + delete + create + update side
-
         const was = await builders
           .metadir()
           .path('SRC_DIR')
@@ -1650,15 +1644,14 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(was.sides, this.side, 1),
                 moveFrom: movedSrc
               },
               _.pick(was, ['ino']),
               doc
-              // TODO: Compare _revs
             )
           ],
           resolvedConflicts: []
@@ -1701,15 +1694,14 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedSrc,
               overwrite: existing
             },
             doc
-            // TODO: Compare _revs
           )
         ],
         resolvedConflicts: []
@@ -1718,8 +1710,6 @@ describe('Merge', function() {
 
     onPlatforms(['win32', 'darwin'], () => {
       it('does not identify an identical renaming as a conflict', async function() {
-        const expectedRevNumber = 5 // up to date + delete + create + update side
-
         const apple = await builders
           .metadir()
           .path('apple')
@@ -1744,10 +1734,9 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(apple.sides, this.side, 1),
                 moveFrom: _.defaults(
                   {
-                    sides: { [this.side]: 2, [otherSide(this.side)]: 2 },
                     moveTo: APPLE._id,
                     _deleted: true
                   },
@@ -1755,7 +1744,6 @@ describe('Merge', function() {
                 )
               },
               APPLE
-              // TODO: Compare _revs
             )
           ],
           resolvedConflicts: []
@@ -1795,8 +1783,6 @@ describe('Merge', function() {
 
     onPlatform('linux', () => {
       it('does not identify an identical renaming as a conflict', async function() {
-        const expectedRevNumber = 1 // new unsynced document
-
         const apple = await builders
           .metadir()
           .path('apple')
@@ -1826,14 +1812,13 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(apple.sides, this.side, 1),
                 moveFrom: movedSrc
               },
               APPLE
-              // TODO: Compare _revs
             )
           ],
           resolvedConflicts: []
@@ -1874,10 +1859,10 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: 1 },
+                sides: increasedSides(duke.sides, this.side, 1),
                 moveFrom: movedSrc
               },
               nukem
@@ -1900,12 +1885,12 @@ describe('Merge', function() {
         .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
         .remoteId(dbBuilders.id())
         .create()
-      const oldDst = builders
+      const oldDst = await builders
         .metadir()
         .path('dst')
         .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
         .remoteId(dbBuilders.id())
-        .build()
+        .create()
       const dstFile = await builders
         .metafile()
         .path('dst/file')
@@ -1913,7 +1898,7 @@ describe('Merge', function() {
         .remoteId(dbBuilders.id())
         .create()
       const dstDir = builders
-        .metadir()
+        .metadir(srcDir)
         .path('dst')
         .overwrite(oldDst)
         .build()
@@ -1943,23 +1928,23 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrcDir, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrcDir, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(srcDir.sides, this.side, 1),
               moveFrom: movedSrcDir,
               overwrite: oldDst
             },
-            _.omit(dstDir, ['_rev']) // TODO: Compare _revs
+            _.omit(dstDir, ['_rev'])
           ),
-          _.omit(movedSrcFile, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrcFile, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(srcFile.sides, this.side, 1),
               moveFrom: movedSrcFile
             },
             _.pick(srcFile, ['remote']),
-            _.omit(dstFile, ['_rev']) // TODO: Compare _revs
+            _.omit(dstFile, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -1988,9 +1973,9 @@ describe('Merge', function() {
         .remoteId(dbBuilders.id())
         .create()
       const doc = builders
-        .metadir()
+        .metadir(was)
         .path('DESTINATION')
-        .sides({ [this.side]: 2, [otherSide(this.side)]: 2 })
+        .changedSide(this.side)
         .remoteId(dbBuilders.id())
         .build()
 
@@ -2029,30 +2014,30 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedDir, ['_rev']), // TODO: Compare _revs
+          _.omit(movedDir, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedDir
             },
-            doc
+            _.omit(doc, ['_rev'])
           ),
-          _.omit(movedSubfile, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSubfile, ['_rev']),
           _.defaults(
             {
               _id: metadata.id(movedPath(subfile)),
               path: movedPath(subfile),
-              sides: { [this.side]: 1 },
+              sides: increasedSides(subfile.sides, this.side, 1),
               moveFrom: movedSubfile
             },
             _.omit(subfile, ['_rev'])
           ),
-          _.omit(movedSubdir, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSubdir, ['_rev']),
           _.defaults(
             {
               _id: metadata.id(movedPath(subdir)),
               path: movedPath(subdir),
-              sides: { [this.side]: 1 },
+              sides: increasedSides(subdir.sides, this.side, 1),
               moveFrom: movedSubdir
             },
             _.omit(subdir, ['_rev'])
@@ -2075,7 +2060,7 @@ describe('Merge', function() {
         .sides({ [this.side]: 1 })
         .create()
       const doc = builders
-        .metadir()
+        .metadir(was)
         .path('MOVED_DIR')
         .build()
 
@@ -2098,28 +2083,28 @@ describe('Merge', function() {
       )
       should(sideEffects).deepEqual({
         savedDocs: [
-          _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+          _.omit(movedSrc, ['_rev']),
           _.defaults(
             {
-              sides: { [this.side]: 1 },
+              sides: increasedSides(was.sides, this.side, 1),
               moveFrom: movedSrc
             },
-            doc
+            _.omit(doc, ['_rev'])
           ),
           _.defaults(
             {
-              sides: { [this.side]: 2 },
+              sides: increasedSides(unsyncedFile.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(unsyncedFile, ['_rev']) // TODO: Compare _revs
+            _.omit(unsyncedFile, ['_rev'])
           ),
           _.defaults(
             {
               _id: metadata.id(movedPath(unsyncedFile)),
               path: movedPath(unsyncedFile),
-              sides: { [this.side]: 1 }
+              sides: { target: 1, [this.side]: 1 }
             },
-            _.omit(unsyncedFile, ['_rev']) // TODO: Compare _revs
+            _.omit(unsyncedFile, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -2138,8 +2123,6 @@ describe('Merge', function() {
       })
 
       it('saves the new directory with the correct side', async function() {
-        const expectedRevNumber = 4 // create + delete + create + update side
-
         const was = await builders
           .metadir()
           .path('SRC_DIR')
@@ -2147,7 +2130,7 @@ describe('Merge', function() {
           .remoteId(dbBuilders.id())
           .create()
         const doc = builders
-          .metadir()
+          .metadir(was)
           .path(path)
           .build()
 
@@ -2168,13 +2151,13 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedSrc, ['_rev']), // TODO: Compare _revs
+            _.omit(movedSrc, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(was.sides, this.side, 1),
                 moveFrom: movedSrc
               },
-              doc
+              _.omit(doc, ['_rev'])
             )
           ],
           resolvedConflicts: []
@@ -2195,8 +2178,6 @@ describe('Merge', function() {
       })
 
       it('saves the new child with the correct side', async function() {
-        const expectedRevNumber = 4 // create + delete + create + update side
-
         const was = await builders
           .metadir()
           .path('SRC_DIR')
@@ -2240,23 +2221,23 @@ describe('Merge', function() {
         )
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.omit(movedDir, ['_rev']), // TODO: Compare _revs
+            _.omit(movedDir, ['_rev']),
             _.defaults(
               {
-                sides: { [this.side]: 1 },
+                sides: increasedSides(was.sides, this.side, 1),
                 moveFrom: movedDir
               },
               doc
             ),
-            _.omit(movedChild, ['_rev']), // TODO: Compare _revs
+            _.omit(movedChild, ['_rev']),
             _.defaults(
               {
                 _id: metadata.id(movedPath(child)),
                 path: movedPath(child),
-                sides: { [this.side]: expectedRevNumber },
+                sides: increasedSides(child.sides, this.side, 1),
                 moveFrom: movedChild
               },
-              _.omit(child, ['_rev']) // TODO: Compare _revs
+              _.omit(child, ['_rev'])
             )
           ],
           resolvedConflicts: []
@@ -2296,9 +2277,12 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [otherSide(this.side)]: 3 } // XXX: Why not resetting the side here?
+              sides: {
+                target: was.sides.target + 1,
+                [otherSide(this.side)]: was.sides[otherSide(this.side)] + 1
+              }
             },
-            _.omit(was, ['trashed', '_rev']) // TODO: Compare _revs
+            _.omit(was, ['trashed', '_rev'])
           )
         ],
         resolvedConflicts: []
@@ -2323,10 +2307,10 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 2 }, // FIXME: Is that really necessary??
+              sides: increasedSides(doc.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(doc, ['_rev']) // TODO: Compare _revs
+            _.omit(doc, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -2350,10 +2334,10 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 2 }, // FIXME: Is that really necessary??
+              sides: increasedSides(doc.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(doc, ['_rev']) // TODO: Compare _revs
+            _.omit(doc, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -2391,31 +2375,31 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: { [this.side]: 2 }, // FIXME: Is that really necessary??
+              sides: increasedSides(subsubsubfile.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(subsubsubfile, ['_rev']) // TODO: Compare _revs
+            _.omit(subsubsubfile, ['_rev'])
           ),
           _.defaults(
             {
-              sides: { [this.side]: 2 }, // FIXME: Is that really necessary??
+              sides: increasedSides(subsubdir.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(subsubdir, ['_rev']) // TODO: Compare _revs
+            _.omit(subsubdir, ['_rev'])
           ),
           _.defaults(
             {
-              sides: { [this.side]: 2 }, // FIXME: Is that really necessary??
+              sides: increasedSides(subdir.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(subdir, ['_rev']) // TODO: Compare _revs
+            _.omit(subdir, ['_rev'])
           ),
           _.defaults(
             {
-              sides: { [this.side]: 2 }, // FIXME: Is that really necessary??
+              sides: increasedSides(doc.sides, this.side, 1),
               _deleted: true
             },
-            _.omit(doc, ['_rev']) // TODO: Compare _revs
+            _.omit(doc, ['_rev'])
           )
         ],
         resolvedConflicts: []
@@ -2443,10 +2427,10 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                _deleted: true,
-                sides: { [this.side]: 3, [otherSide(this.side)]: 2 }
+                sides: increasedSides(was.sides, this.side, 1),
+                _deleted: true
               },
-              _.omit(was, ['_rev']) // TODO: Compare _revs
+              _.omit(was, ['_rev'])
             )
           ],
           resolvedConflicts: []

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -17,6 +17,7 @@ const {
   invalidChecksum,
   invalidPath,
   markSide,
+  markAsUpToDate,
   detectIncompatibilities,
   sameBinary,
   sameFile,
@@ -24,7 +25,6 @@ const {
   buildDir,
   buildFile,
   invariants,
-  upToDate,
   outOfDateSide,
   createConflictingDoc,
   CONFLICT_REGEXP
@@ -928,7 +928,7 @@ describe('metadata', function() {
     })
   })
 
-  describe('upToDate', () => {
+  describe('markAsUpToDate', () => {
     let doc
     beforeEach(async () => {
       const builders = new Builders({ pouch: this.pouch })
@@ -939,26 +939,36 @@ describe('metadata', function() {
         .build()
     })
 
-    it('returns a clone of the doc', () => {
-      const clone = upToDate(doc)
+    it('increments the doc target', () => {
+      const previousTarget = doc.sides.target
 
-      should(clone._id).eql(doc._id)
-      should(clone.path).eql(doc.path)
+      markAsUpToDate(doc)
 
-      doc.path = '/new/doc/path'
-      should(clone.path).not.eql(doc.path)
+      should(doc.sides.target).eql(previousTarget + 1)
     })
 
-    it('returns a doc with both sides equal', () => {
-      const clone = upToDate(doc)
+    it('returns the new target', () => {
+      const target = markAsUpToDate(doc)
 
-      should(clone.sides.local).eql(clone.sides.remote)
+      should(target)
+        .be.a.Number()
+        .and.eql(doc.sides.target)
+    })
+
+    it('sets both sides to the new target', () => {
+      markAsUpToDate(doc)
+
+      should(doc.sides.local)
+        .eql(doc.sides.remote)
+        .and.eql(doc.sides.target)
     })
 
     it('removes errors', () => {
       doc.errors = 1
 
-      should(upToDate(doc).errors).be.undefined()
+      markAsUpToDate(doc)
+
+      should(doc.errors).be.undefined()
     })
   })
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -769,17 +769,19 @@ describe('metadata', function() {
         const doc = metadata[`build${kind}`](path, stats)
 
         markSide('local', doc)
-        should(doc).have.properties({ sides: { local: 1 } })
+        should(doc).have.properties({ sides: { target: 1, local: 1 } })
       })
 
       it(`increments the side from the _rev of an already existing ${kind}`, async function() {
         const prev = metadata[`build${kind}`](path, stats)
-        prev.sides = { local: 3, remote: 5 }
+        prev.sides = { target: 5, local: 3, remote: 5 }
         prev._rev = '5-0123'
         const doc = metadata[`build${kind}`](path, stats)
 
         markSide('local', doc, prev)
-        should(doc).have.properties({ sides: { local: 6, remote: 5 } })
+        should(doc).have.properties({
+          sides: { target: 6, local: 6, remote: 5 }
+        })
       })
     }
   })
@@ -791,18 +793,24 @@ describe('metadata', function() {
     }
 
     it('increments both sides by 1 in-place', () => {
-      should(docAfterIncSides({})).deepEqual({ sides: { local: 1, remote: 1 } })
-      should(docAfterIncSides({ sides: { local: 1 } })).deepEqual({
-        sides: { local: 2, remote: 1 }
+      should(docAfterIncSides({})).deepEqual({
+        sides: { target: 1, local: 1, remote: 1 }
       })
-      should(docAfterIncSides({ sides: { remote: 1 } })).deepEqual({
-        sides: { local: 1, remote: 2 }
+      should(docAfterIncSides({ sides: { target: 1, local: 1 } })).deepEqual({
+        sides: { target: 2, local: 2, remote: 1 }
       })
-      should(docAfterIncSides({ sides: { local: 2, remote: 2 } })).deepEqual({
-        sides: { local: 3, remote: 3 }
+      should(docAfterIncSides({ sides: { target: 1, remote: 1 } })).deepEqual({
+        sides: { target: 2, local: 1, remote: 2 }
       })
-      should(docAfterIncSides({ sides: { local: 3, remote: 2 } })).deepEqual({
-        sides: { local: 4, remote: 3 }
+      should(
+        docAfterIncSides({ sides: { target: 2, local: 2, remote: 2 } })
+      ).deepEqual({
+        sides: { target: 3, local: 3, remote: 3 }
+      })
+      should(
+        docAfterIncSides({ sides: { target: 3, local: 3, remote: 2 } })
+      ).deepEqual({
+        sides: { target: 4, local: 4, remote: 3 }
       })
     })
   })

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -109,8 +109,16 @@ describe('Sync', function() {
 
   describe('sync', function() {
     it('waits for and applies available changes', async function() {
-      const doc1 = { _id: 'doc1', docType: 'file', sides: { local: 1 } }
-      const doc2 = { _id: 'doc2', docType: 'folder', sides: { remote: 1 } }
+      const doc1 = {
+        _id: 'doc1',
+        docType: 'file',
+        sides: { target: 1, local: 1 }
+      }
+      const doc2 = {
+        _id: 'doc2',
+        docType: 'folder',
+        sides: { target: 1, remote: 1 }
+      }
       await this.pouch.db.put(doc1)
       await this.pouch.db.put(doc2)
       const apply = sinon.stub(this.sync, 'apply')
@@ -131,6 +139,7 @@ describe('Sync', function() {
           _id: 'ignored',
           docType: 'folder',
           sides: {
+            target: 1,
             local: 1
           }
         }
@@ -147,8 +156,9 @@ describe('Sync', function() {
           _id: 'foo',
           docType: 'folder',
           sides: {
-            local: 1,
-            remote: 1
+            target: 2,
+            local: 2,
+            remote: 2
           }
         }
       }
@@ -164,6 +174,7 @@ describe('Sync', function() {
           _id: 'foo',
           path: 'foo',
           sides: {
+            target: 2,
             local: 2,
             remote: 1
           },
@@ -184,6 +195,7 @@ describe('Sync', function() {
           docType: 'file',
           md5sum: '0000000000000000000000000000000000000000',
           sides: {
+            target: 3,
             local: 3,
             remote: 2
           },
@@ -196,8 +208,9 @@ describe('Sync', function() {
         _id: 'foo/bar',
         docType: 'file',
         sides: {
-          local: 1,
-          remote: 1
+          target: 4,
+          local: 4,
+          remote: 4
         }
       })
     })
@@ -210,6 +223,7 @@ describe('Sync', function() {
           docType: 'folder',
           tags: [],
           sides: {
+            target: 1,
             local: 1
           }
         }
@@ -226,6 +240,7 @@ describe('Sync', function() {
         md5sum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
         docType: 'file',
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -239,6 +254,7 @@ describe('Sync', function() {
         md5sum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
         docType: 'file',
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -246,6 +262,7 @@ describe('Sync', function() {
       doc._rev = created.rev
       doc.md5sum = '389dd709c94a6a7ea56e1d55cbf65eef31b9bc5e'
       doc.sides = {
+        target: 2,
         local: 2,
         remote: 1
       }
@@ -303,18 +320,21 @@ describe('Sync', function() {
         md5sum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
         docType: 'file',
         sides: {
-          local: 1
+          target: 2,
+          local: 2,
+          remote: 2
         }
       }
       const created = await this.pouch.db.put(doc)
       doc._rev = created.rev
       doc.tags = ['courge']
       doc.sides = {
-        local: 2,
-        remote: 1
+        target: 3,
+        local: 3,
+        remote: 2
       }
       await this.pouch.db.put(doc)
-      await this.sync.applyDoc(doc, this.remote, 'remote', 1)
+      await this.sync.applyDoc(doc, this.remote, 'remote', 2)
       this.remote.overwriteFileAsync.called.should.be.false()
       let ufm = this.remote.updateFileMetadataAsync
       ufm.calledWith(doc).should.be.true()
@@ -329,6 +349,7 @@ describe('Sync', function() {
         docType: 'file',
         tags: ['qux'],
         sides: {
+          target: 3,
           local: 3,
           remote: 2
         }
@@ -340,6 +361,7 @@ describe('Sync', function() {
         docType: 'file',
         tags: ['qux'],
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -360,6 +382,7 @@ describe('Sync', function() {
         docType: 'file',
         tags: ['qux'],
         sides: {
+          target: 3,
           local: 3,
           remote: 2
         }
@@ -372,6 +395,7 @@ describe('Sync', function() {
         docType: 'file',
         tags: ['qux'],
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -392,6 +416,7 @@ describe('Sync', function() {
         docType: 'file',
         tags: ['qux'],
         sides: {
+          target: 3,
           local: 3,
           remote: 2
         }
@@ -403,6 +428,7 @@ describe('Sync', function() {
         docType: 'file',
         tags: ['qux'],
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -437,6 +463,7 @@ describe('Sync', function() {
         _deleted: true,
         docType: 'file',
         sides: {
+          target: 2,
           local: 1,
           remote: 2
         }
@@ -452,6 +479,7 @@ describe('Sync', function() {
         _deleted: true,
         docType: 'file',
         sides: {
+          target: 2,
           local: 2
         }
       }
@@ -465,6 +493,7 @@ describe('Sync', function() {
         _rev: '1-abcdef0123456789',
         docType: 'folder',
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -479,6 +508,7 @@ describe('Sync', function() {
         docType: 'folder',
         tags: ['qux'],
         sides: {
+          target: 2,
           local: 1,
           remote: 2
         }
@@ -496,6 +526,7 @@ describe('Sync', function() {
         docType: 'folder',
         tags: ['qux'],
         sides: {
+          target: 3,
           local: 3,
           remote: 2
         }
@@ -507,6 +538,7 @@ describe('Sync', function() {
         docType: 'folder',
         tags: ['qux'],
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -524,6 +556,7 @@ describe('Sync', function() {
         _deleted: true,
         docType: 'folder',
         sides: {
+          target: 2,
           local: 1,
           remote: 2
         }
@@ -539,6 +572,7 @@ describe('Sync', function() {
         _deleted: true,
         docType: 'folder',
         sides: {
+          target: 2,
           local: 2
         }
       }
@@ -552,6 +586,7 @@ describe('Sync', function() {
       let doc = {
         _id: 'first/failure',
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -563,7 +598,7 @@ describe('Sync', function() {
       const actual = await this.pouch.db.get(doc._id)
       should(actual.errors).equal(1)
       should(actual._rev).not.equal(doc._rev)
-      should(actual.sides).deepEqual({ local: 2 })
+      should(actual.sides).deepEqual({ target: 2, local: 2 })
       should(metadata.isUpToDate('local', actual)).be.true()
     })
 
@@ -572,10 +607,9 @@ describe('Sync', function() {
         _id: 'second/failure',
         errors: 1,
         sides: {
-          // XXX: Use dumb values so we don't need to save Pouch doc multiple
-          //      times to get a matching rev.
-          local: 0,
-          remote: 2
+          target: 4,
+          local: 2,
+          remote: 4
         }
       }
       let infos = await this.pouch.db.put(doc)
@@ -588,7 +622,7 @@ describe('Sync', function() {
       const actual = await this.pouch.db.get(doc._id)
       should(actual.errors).equal(2)
       should(actual._rev).not.equal(doc._rev)
-      should(actual.sides).deepEqual({ local: 0, remote: 3 })
+      should(actual.sides).deepEqual({ target: 5, local: 2, remote: 5 })
       should(metadata.isUpToDate('remote', actual)).be.true()
     })
 
@@ -597,7 +631,8 @@ describe('Sync', function() {
         _id: 'third/failure',
         errors: 3,
         sides: {
-          remote: 1
+          target: 4,
+          remote: 4
         }
       }
       const infos = await this.pouch.db.put(doc)
@@ -617,22 +652,22 @@ describe('Sync', function() {
       const updateRevs = ({ sync }, doc) =>
         sync.updateRevs(_.cloneDeep(doc), syncSide)
 
-      let doc, upToDate, syncedRev, mergedRev
+      let doc, upToDate, syncedTarget, mergedTarget
 
       beforeEach(async function() {
         upToDate = await builders
           .metadata()
-          .upToDate()
+          .upToDate() // 2, 2
           .create()
-        syncedRev = upToDate.sides[syncSide]
-        mergedRev = upToDate.sides[mergedSide] + 1
+        syncedTarget = upToDate.sides[syncSide] // 2
+        mergedTarget = upToDate.sides[mergedSide] + 1 // 3
         doc = await builders
           .metadata(upToDate)
           .sides({
-            [syncSide]: syncedRev,
-            [mergedSide]: mergedRev
+            [syncSide]: syncedTarget, // 2
+            [mergedSide]: mergedTarget // 3
           })
-          .create()
+          .create() // rev == 3
       })
 
       context('without changes merged during Sync', function() {
@@ -641,9 +676,7 @@ describe('Sync', function() {
 
           const updated = await this.pouch.db.get(doc._id)
           should(metadata.outOfDateSide(updated)).be.undefined()
-          should(metadata.extractRevNumber(updated)).equal(
-            metadata.extractRevNumber(doc) + 1
-          )
+          should(metadata.target(updated)).equal(metadata.target(doc) + 1)
         })
       })
 
@@ -657,12 +690,12 @@ describe('Sync', function() {
               await builders
                 .metadata(doc)
                 .sides({
-                  [syncSide]: syncedRev,
-                  [mergedSide]: mergedRev + extraChanges
+                  [syncSide]: syncedTarget, // 2
+                  [mergedSide]: mergedTarget + extraChanges // 3 + extra
                 })
-                .create()
+                .create() // rev == 3 + extra
 
-              await updateRevs(this, doc)
+              await updateRevs(this, doc) // rev == 4, syncSide == 3, mergedSide == 4 + extra - 1
 
               updated = await this.pouch.db.get(doc._id)
             })
@@ -672,14 +705,14 @@ describe('Sync', function() {
             })
 
             it('keeps the changes difference between sides', () => {
-              should(updated.sides[mergedSide]).equal(
-                updated.sides[syncSide] + extraChanges
+              should(metadata.side(updated, mergedSide)).equal(
+                metadata.side(updated, syncSide) + extraChanges
               )
             })
 
             it(`keeps the doc rev coherent with its ${mergedSide} side`, async function() {
-              should(metadata.extractRevNumber(updated)).equal(
-                updated.sides[mergedSide]
+              should(metadata.target(updated)).equal(
+                metadata.side(updated, mergedSide)
               )
             })
           }
@@ -695,6 +728,7 @@ describe('Sync', function() {
         _rev: '1-0123456789',
         docType: 'file',
         sides: {
+          target: 1,
           remote: 1
         }
       }
@@ -707,6 +741,7 @@ describe('Sync', function() {
         _rev: '3-0123456789',
         docType: 'file',
         sides: {
+          target: 3,
           remote: 3,
           local: 2
         }
@@ -723,6 +758,7 @@ describe('Sync', function() {
         _rev: '1-0123456789',
         docType: 'file',
         sides: {
+          target: 1,
           local: 1
         }
       }
@@ -735,6 +771,7 @@ describe('Sync', function() {
         _rev: '4-0123456789',
         docType: 'file',
         sides: {
+          target: 4,
           remote: 3,
           local: 4
         }
@@ -751,6 +788,7 @@ describe('Sync', function() {
         _rev: '5-0123456789',
         docType: 'file',
         sides: {
+          target: 5,
           remote: 5,
           local: 5
         }
@@ -768,6 +806,7 @@ describe('Sync', function() {
         _deleted: true,
         docType: 'file',
         sides: {
+          target: 5,
           local: 5
         }
       }
@@ -784,6 +823,7 @@ describe('Sync', function() {
         _deleted: true,
         docType: 'file',
         sides: {
+          target: 5,
           remote: 5
         }
       }


### PR DESCRIPTION
We don't control the Pouch's `_rev` attribute set on each document.
When we move a document, the destination will be a new document  in
Pouch. This means its `_rev` will probably start with 1 (it can be
higher if the path has previously existed but it does not matter
here).

Since our mechanism to determine which changes need to be applied on
which side is based on the `_rev` value (i.e. its short rev or
beginning number to be precise) and the `sides` we maintain, we
cannot keep the existing `sides` value since they will probably not be
correlated with the new `_rev` anymore.
This means we're losing information when doing a move.

This loss prevents us from being able to merge some combinations of
changes.
e.g. With the client stopped:
1. add document to a folder locally
2. move that folder remotely
3. launch client to synchronize changes

The file will be moved as a child of the moved directory and its
`sides` attribute will contain `{ remote: 1 }` (i.e. we're losing the
local addition information).
In this situation, we're not able to move the file since it doesn't
exist remotely and we don't have any remote id for it and we won't try
to upload it to the Cozy since we see a remotely created file.

By maintaining our own `rev` attribute, we're able to keep a
correlation between the `rev` and the `sides` values even when moving
a document.
In our previous example, we'll be easily able to mark the file as created
locally in the new directory.

We decided to add this `rev` attribute inside the `sides` attribute
since they work together.
The `MetadataSidesInfos` type looks like this now:
```
{
  rev: number,
  local?: number,
  remote?: number
}
```

Out faked docs coherence was also improved by:
- Improving Metdata builder's `upToDate()` method to take into account
  existing sides (i.e. if doc is based on another one)
- Using builder's helper methods to set sides whenever possible
- Avoiding faking movements when possible (to avoid unnecessary side
  effects when running the move method we're testing)

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
