### PR TITLE
gui/js/proxy: Fix .config() & tests

### DIFF
--- a/gui/js/proxy.js
+++ b/gui/js/proxy.js
@@ -4,13 +4,14 @@ const ElectronProxyAgent = require('electron-proxy-agent')
 const url = require('url')
 const http = require('http')
 const https = require('https')
+const process = require('process')
 const yargs = require('yargs')
 
 const log = require('../../core/app').logger({
   component: 'GUI:proxy'
 })
 
-const config = (argv = yargs.argv) => {
+const config = (argv = process.argv) => {
   const config = yargs
     .env('COZY_DRIVE')
     .conflicts('proxy-script', 'proxy-rules')

--- a/test/unit/gui/proxy.js
+++ b/test/unit/gui/proxy.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const http = require('http')
 const https = require('https')
 const path = require('path')
+const process = require('process')
 const should = require('should')
 const { URL } = require('url')
 
@@ -20,6 +21,10 @@ describe('gui/js/proxy', function() {
 
   describe('.config()', () => {
     let config
+
+    it('is equivalent to .config(process.argv)', () => {
+      should(proxy.config()).deepEqual(proxy.config(process.argv))
+    })
 
     describe('with no command-line option', () => {
       beforeEach(() => {

--- a/test/unit/gui/proxy.js
+++ b/test/unit/gui/proxy.js
@@ -86,10 +86,7 @@ describe('gui/js/proxy', function() {
         done()
       })
     }
-    const revertProxySideEffects = () => {
-      session.defaultSession.setCertificateVerifyProc(null)
-      // TODO: Find a way to revert allowNTLMCredentialsForDomains()
-      // TODO: Find a way to revert setProxy()
+    const revertProxySideEffects = done => {
       global.fetch = proxySideEffects.originalFetch
       http.request = proxySideEffects.originalHttpRequest
       https.request = proxySideEffects.originalHttpsRequest
@@ -100,6 +97,9 @@ describe('gui/js/proxy', function() {
       ]) {
         app.removeAllListeners(event)
       }
+      session.defaultSession.setCertificateVerifyProc(null)
+      session.defaultSession.allowNTLMCredentialsForDomains('')
+      session.defaultSession.setProxy({}, done)
     }
 
     afterEach(revertProxySideEffects)


### PR DESCRIPTION
When refactoring `gui/js/proxy` to make it testable, we actually broke
command-line arguments parsing. Which means app didn't start anymore.

Once fixed, some tests started breaking because the proxy setup was not
completely reverted in `test/unit/gui/proxy`.

Now everything should be back to normal.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
