### PR TITLE
[WIP] test: Use same networking environment as production

### DIFF
--- a/gui/js/proxy.js
+++ b/gui/js/proxy.js
@@ -22,7 +22,6 @@ const config = (argv = process.argv) => {
       'Rules indicating which URLs should bypass the proxy settings. ' +
         'See https://github.com/electron/electron/blob/master/docs/api/session.md#sessetproxyconfig-callback'
     )
-    .default('proxy-ntlm-domains', '*')
     .describe(
       'proxy-ntlm-domains',
       'A comma-separated list of servers for which integrated authentication is enabled. ' +

--- a/test/support/hooks/index.js
+++ b/test/support/hooks/index.js
@@ -10,3 +10,4 @@
  */
 
 require('./logging')
+require('./proxy')

--- a/test/support/hooks/proxy.js
+++ b/test/support/hooks/proxy.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+
+const { app, session } = require('electron')
+const proxy = require('../../../gui/js/proxy')
+const { APPVEYOR, TRAVIS } = process.env
+
+const userAgentHost = APPVEYOR ? 'AppVeyor' : TRAVIS ? 'Travis' : 'local'
+const userAgent = `Cozy-Desktop-${process.platform}-dev-${userAgentHost}`
+
+before(done => {
+  proxy.setup(app, proxy.config(), session, userAgent, () => done())
+})

--- a/test/unit/gui/proxy.js
+++ b/test/unit/gui/proxy.js
@@ -14,7 +14,7 @@ describe('gui/js/proxy', function() {
   const emptyConfig = {
     'login-by-realm': undefined,
     'proxy-bypassrules': undefined,
-    'proxy-ntlm-domains': '*',
+    'proxy-ntlm-domains': undefined,
     'proxy-rules': undefined,
     'proxy-script': undefined
   }


### PR DESCRIPTION
Including:

- proxy & NTLM support
- monkey-patched standard libs
- unmaintained dependencies

So we can spot issues on CI.

No need to call `app.on('ready', ...)`: electron-mocha is already
wrapping the test suite inside it.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [x] it includes relevant documentation
