### PR TITLE
core/app: Temporarily disable Sentry

### DIFF
--- a/core/sentry.js
+++ b/core/sentry.js
@@ -11,6 +11,10 @@ const log = logger({
 
 const _ = require('lodash')
 
+// FIXME: We were getting far too many Sentry messages.
+// So it is disabled for now, until we find a solution.
+process.env.COZY_NO_SENTRY = '1'
+
 module.exports = {
   setup,
   flag,


### PR DESCRIPTION
To stop spamming infra. Until we find a solution.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes tests matching the implementation changes
- [ ] it includes relevant documentation
