### PR TITLE
core/local: Rename Buffer to Channel

### DIFF
--- a/core/local/atom_watcher.js
+++ b/core/local/atom_watcher.js
@@ -112,14 +112,14 @@ class AtomWatcher {
       opts
     )
     // Here, we build a chain of steps. Each step can be seen as an actor that
-    // communicates with the next one via a buffer. The first step is called
+    // communicates with the next one via a Channel. The first step is called
     // the producer: even if the chain is ready at the end of this constructor,
     // the producer won't start pushing batches of events until it is started.
-    let buffer = steps.reduce(
-      (buf, step) => step.loop(buf, stepOptions),
-      this.producer.buffer
+    const channel = steps.reduce(
+      (chan, step) => step.loop(chan, stepOptions),
+      this.producer.channel
     )
-    dispatch.loop(buffer, stepOptions)
+    dispatch.loop(channel, stepOptions)
   }
 
   async start() {

--- a/core/local/steps/add_checksum.js
+++ b/core/local/steps/add_checksum.js
@@ -12,7 +12,7 @@ const log = logger({
 })
 
 /*::
-import type Buffer from './buffer'
+import type Channel from './channel'
 import type { Checksumer } from '../checksumer'
 */
 
@@ -30,10 +30,10 @@ module.exports = {
 //   smarter
 // TODO the 2 optimizations ↑
 function loop(
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: { syncPath: string , checksumer: Checksumer } */
-) /*: Buffer */ {
-  return buffer.asyncMap(async events => {
+) /*: Channel */ {
+  return channel.asyncMap(async events => {
     for (const event of events) {
       try {
         if (event.incomplete) {

--- a/core/local/steps/add_infos.js
+++ b/core/local/steps/add_infos.js
@@ -14,7 +14,7 @@ const log = logger({
 })
 
 /*::
-import type Buffer from './buffer'
+import type Channel from './channel'
 */
 
 module.exports = {
@@ -23,10 +23,10 @@ module.exports = {
 
 // This step adds some basic informations about events: _id, docType and stats.
 function loop(
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: { syncPath: string } */
-) /*: Buffer */ {
-  return buffer.asyncMap(async events => {
+) /*: Channel */ {
+  return channel.asyncMap(async events => {
     const batch = []
     for (const event of events) {
       if (event.kind === 'symlink') {

--- a/core/local/steps/await_write_finish.js
+++ b/core/local/steps/await_write_finish.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 
-const Buffer = require('./buffer')
+const Channel = require('./channel')
 const logger = require('../../logger')
 
 const STEP_NAME = 'awaitWriteFinish'
@@ -33,7 +33,7 @@ module.exports = {
 
 // TODO add unit tests and logs
 
-function sendReadyBatches(waiting /*: WaitingItem[] */, out /*: Buffer */) {
+function sendReadyBatches(waiting /*: WaitingItem[] */, out /*: Channel */) {
   while (waiting.length > 0) {
     if (waiting[0].nbCandidates !== 0) {
       break
@@ -208,12 +208,12 @@ function debounce(
 // events for files, as we can have several of them in a short lapse of time,
 // and computing the checksum several times in a row for the same file is not a
 // good idea.
-async function awaitWriteFinish(buffer /*: Buffer */, out /*: Buffer */) {
+async function awaitWriteFinish(channel /*: Channel */, out /*: Channel */) {
   const waiting /*: WaitingItem[] */ = []
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const events = aggregateBatch(await buffer.pop())
+    const events = aggregateBatch(await channel.pop())
     let nbCandidates = countFileWriteEvents(events)
     debounce(waiting, events)
 
@@ -230,9 +230,9 @@ async function awaitWriteFinish(buffer /*: Buffer */, out /*: Buffer */) {
 }
 
 // eslint-disable-next-line no-unused-vars
-function loop(buffer /*: Buffer */, opts /*: {} */) /*: Buffer */ {
-  const out = new Buffer()
-  awaitWriteFinish(buffer, out).catch(err => {
+function loop(channel /*: Channel */, opts /*: {} */) /*: Channel */ {
+  const out = new Channel()
+  awaitWriteFinish(channel, out).catch(err => {
     log.error({ err })
   })
   return out

--- a/core/local/steps/channel.js
+++ b/core/local/steps/channel.js
@@ -3,16 +3,14 @@
 const Promise = require('bluebird')
 
 /*::
-import type { AtomWatcherEvent, Batch } from './event'
+import type { Batch } from './event'
 */
 
-// Buffer is a data structure for propagating batches of events from a FS
+// Channel is a data structure for propagating batches of events from a FS
 // watcher to the Pouch database, via several steps. It's expected that we have
-// only one class/function that pushes in the buffer, and only one
-// class/function that takes batches from the buffer.
-//
-// FIXME: Rename Buffer to prevent confusion with the built-in type.
-module.exports = class Buffer {
+// only one class/function that pushes in the channel, and only one
+// class/function that takes batches from the channel.
+module.exports = class Channel {
   /*::
   _resolve: ?Promise<Batch>
   _buffer: Array<Batch>
@@ -45,36 +43,36 @@ module.exports = class Buffer {
 
   async doMap(
     fn /*: (Batch) => Batch */,
-    buffer /*: Buffer */
+    channel /*: Channel */
   ) /*: Promise<void> */ {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const batch = fn(await this.pop())
-      buffer.push(batch)
+      channel.push(batch)
     }
   }
 
-  map(fn /*: (Batch) => Batch */) /*: Buffer */ {
-    const buffer = new Buffer()
-    this.doMap(fn, buffer)
-    return buffer
+  map(fn /*: (Batch) => Batch */) /*: Channel */ {
+    const channel = new Channel()
+    this.doMap(fn, channel)
+    return channel
   }
 
   async doAsyncMap(
     fn /*: (Batch) => Promise<Batch> */,
-    buffer /*: Buffer */
+    channel /*: Channel */
   ) /*: Promise<void> */ {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const batch = await this.pop()
       const after = await fn(batch)
-      buffer.push(after)
+      channel.push(after)
     }
   }
 
-  asyncMap(fn /*: (Batch) => Promise<Batch> */) /*: Buffer */ {
-    const buffer = new Buffer()
-    this.doAsyncMap(fn, buffer)
-    return buffer
+  asyncMap(fn /*: (Batch) => Promise<Batch> */) /*: Channel */ {
+    const channel = new Channel()
+    this.doAsyncMap(fn, channel)
+    return channel
   }
 }

--- a/core/local/steps/dispatch.js
+++ b/core/local/steps/dispatch.js
@@ -14,7 +14,7 @@ const log = logger({
 })
 
 /*::
-import type Buffer from './buffer'
+import type Channel from './channel'
 import type {
   AtomWatcherEvent,
   Batch
@@ -43,11 +43,14 @@ module.exports = {
   step
 }
 
-// Dispatch takes a buffer of AtomWatcherEvents batches, and calls Prep for
+// Dispatch takes a Channel of AtomWatcherEvents batches, and calls Prep for
 // each event. It needs to fetch the old documents from pouchdb in some cases
 // to have all the data expected by prep/merge.
-function loop(buffer /*: Buffer */, opts /*: DispatchOptions */) /*: Buffer */ {
-  return buffer.asyncMap(opts.onAtomEvents || step(opts))
+function loop(
+  channel /*: Channel */,
+  opts /*: DispatchOptions */
+) /*: Channel */ {
+  return channel.asyncMap(opts.onAtomEvents || step(opts))
 }
 
 function step(opts /*: DispatchOptions */) {

--- a/core/local/steps/filter_ignored.js
+++ b/core/local/steps/filter_ignored.js
@@ -3,7 +3,7 @@
 const logger = require('../../logger')
 
 /*::
-import type Buffer from './buffer'
+import type Channel from './channel'
 import type { AtomWatcherEvent } from './event'
 import type { Ignore } from '../../ignore'
 */
@@ -24,12 +24,12 @@ module.exports = {
 // watchers), but it needs to be put after the AddInfos step as the docType is
 // required to know if the event can be ignored.
 function loop(
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: { ignore: Ignore } */
-) /*: Buffer */ {
+) /*: Channel */ {
   const notIgnored = buildNotIgnored(opts.ignore)
 
-  return buffer.map(batch => {
+  return channel.map(batch => {
     return batch.filter(notIgnored)
   })
 }

--- a/core/local/steps/incomplete_fixer.js
+++ b/core/local/steps/incomplete_fixer.js
@@ -18,7 +18,7 @@ const log = logger({
 const DELAY = 3000
 
 /*::
-import type Buffer from './buffer'
+import type Channel from './channel'
 import type { AtomWatcherEvent, Batch } from './event'
 import type { Checksumer } from '../checksumer'
 
@@ -154,11 +154,11 @@ function buildDeletedFromRenamed(
 //
 // Cf test/property/local_watcher/swedish_krona.json
 function loop(
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: IncompleteFixerOptions */
-) /*: Buffer */ {
+) /*: Channel */ {
   const incompletes = []
-  return buffer.asyncMap(step(incompletes, opts))
+  return channel.asyncMap(step(incompletes, opts))
 }
 
 function step(

--- a/core/local/steps/initial_diff.js
+++ b/core/local/steps/initial_diff.js
@@ -5,7 +5,7 @@ const path = require('path')
 
 const logger = require('../../logger')
 const { id } = require('../../metadata')
-const Buffer = require('./buffer')
+const Channel = require('./channel')
 
 /*::
 import type Pouch from '../../pouch'
@@ -57,11 +57,11 @@ module.exports = {
 // what was in pouchdb and the events from the local watcher to find what was
 // deleted.
 function loop(
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: { pouch: Pouch, state: InitialDiffState } */
-) /*: Buffer */ {
-  const out = new Buffer()
-  initialDiff(buffer, out, opts.pouch, opts.state).catch(err => {
+) /*: Channel */ {
+  const out = new Channel()
+  initialDiff(channel, out, opts.pouch, opts.state).catch(err => {
     log.error({ err })
   })
   return out
@@ -107,14 +107,14 @@ function clearState(state /*: InitialDiffState */) {
 }
 
 async function initialDiff(
-  buffer /*: Buffer */,
-  out /*: Buffer */,
+  channel /*: Channel */,
+  out /*: Channel */,
   pouch /*: Pouch */,
   state /*: InitialDiffState */
 ) /*: Promise<void> */ {
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const events = await buffer.pop()
+    const events = await channel.pop()
     const {
       [STEP_NAME]: { waiting, renamedEvents, scannedPaths, byInode }
     } = state
@@ -226,7 +226,7 @@ async function initialDiff(
   }
 }
 
-function sendReadyBatches(waiting /*: WaitingItem[] */, out /*: Buffer */) {
+function sendReadyBatches(waiting /*: WaitingItem[] */, out /*: Channel */) {
   while (waiting.length > 0) {
     if (waiting[0].nbCandidates !== 0) {
       break

--- a/core/local/steps/overwrite.js
+++ b/core/local/steps/overwrite.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 
-const Buffer = require('./buffer')
+const Channel = require('./channel')
 const logger = require('../../logger')
 
 /*::
@@ -136,7 +136,7 @@ const step = async (batch /*: Batch */, opts /*: OverwriteOptions */) => {
   }
 }
 
-const _loop = async (buffer, out, opts) => {
+const _loop = async (channel, out, opts) => {
   const output = pending => {
     clearTimeout(pending.timeout)
     out.push(pending.events)
@@ -146,7 +146,7 @@ const _loop = async (buffer, out, opts) => {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const events = await buffer.pop()
+    const events = await channel.pop()
     const {
       state: { [STEP_NAME]: state }
     } = opts
@@ -163,10 +163,10 @@ const _loop = async (buffer, out, opts) => {
   }
 }
 
-const loop = (buffer /*: Buffer */, opts /*: OverwriteOptions */) => {
-  const out = new Buffer()
+const loop = (channel /*: Channel */, opts /*: OverwriteOptions */) => {
+  const out = new Channel()
 
-  _loop(buffer, out, opts).catch(err => {
+  _loop(channel, out, opts).catch(err => {
     log.error({ err })
   })
 

--- a/core/local/steps/producer.js
+++ b/core/local/steps/producer.js
@@ -6,7 +6,7 @@ const path = require('path')
 const Promise = require('bluebird')
 const watcher = require('@atom/watcher')
 
-const Buffer = require('./buffer')
+const Channel = require('./channel')
 const { INITIAL_SCAN_DONE } = require('./event')
 const logger = require('../../logger')
 const defaultStater = require('../stater')
@@ -45,12 +45,12 @@ const log = logger({
 //   and update events.
 module.exports = class Producer {
   /*::
-  buffer: Buffer
+  channel: Channel
   syncPath: string
   watcher: *
   */
   constructor(opts /*: { syncPath : string } */) {
-    this.buffer = new Buffer()
+    this.channel = new Channel()
     this.syncPath = opts.syncPath
     this.watcher = null
     autoBind(this)
@@ -91,7 +91,7 @@ module.exports = class Producer {
     // moved. Wait a bit to ensure that the corresponding renamed events have
     // been emited.
     await Promise.delay(1000)
-    this.buffer.push([INITIAL_SCAN_DONE])
+    this.channel.push([INITIAL_SCAN_DONE])
   }
 
   async scan(
@@ -121,7 +121,7 @@ module.exports = class Producer {
       }
     }
     log.trace({ path: relPath, batch: entries }, 'scan')
-    this.buffer.push(entries)
+    this.channel.push(entries)
 
     for (const entry of entries) {
       if (entry.stats && stater.isDirectory(entry.stats)) {
@@ -140,7 +140,7 @@ module.exports = class Producer {
         event.oldPath = path.relative(this.syncPath, event.oldPath)
       }
     }
-    this.buffer.push(batch)
+    this.channel.push(batch)
   }
 
   stop() {

--- a/core/local/steps/scan_folder.js
+++ b/core/local/steps/scan_folder.js
@@ -9,7 +9,7 @@ const log = logger({
 })
 
 /*::
-import type Buffer from './buffer'
+import type Channel from './channel'
 import type { Scanner } from './producer'
 */
 
@@ -22,10 +22,10 @@ module.exports = {
 // when this happens, we scan the directory to see if it contains files and
 // sub-directories.
 function loop(
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: { scan: Scanner } */
-) /*: Buffer */ {
-  return buffer.asyncMap(async batch => {
+) /*: Channel */ {
+  return channel.asyncMap(async batch => {
     for (const event of batch) {
       if (event.incomplete) {
         continue

--- a/core/local/steps/win_identical_renaming.js
+++ b/core/local/steps/win_identical_renaming.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 
-const Buffer = require('./buffer')
+const Channel = require('./channel')
 const logger = require('../../logger')
 
 /*::
@@ -121,7 +121,7 @@ const step = async (
   }
 }
 
-const _loop = async (buffer, out, opts) => {
+const _loop = async (channel, out, opts) => {
   const output = pending => {
     clearTimeout(pending.timeout)
     out.push(pending.events)
@@ -131,7 +131,7 @@ const _loop = async (buffer, out, opts) => {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const events = await buffer.pop()
+    const events = await channel.pop()
     const {
       state: { [STEP_NAME]: state }
     } = opts
@@ -149,12 +149,12 @@ const _loop = async (buffer, out, opts) => {
 }
 
 const loop = (
-  buffer /*: Buffer */,
+  channel /*: Channel */,
   opts /*: WinIdenticalRenamingOptions */
 ) => {
-  const out = new Buffer()
+  const out = new Channel()
 
-  _loop(buffer, out, opts).catch(err => {
+  _loop(channel, out, opts).catch(err => {
     log.error({ err })
   })
 

--- a/dev/capture/local.js
+++ b/dev/capture/local.js
@@ -171,13 +171,13 @@ const runAndRecordAtomEvents = async scenario => {
 
   try {
     await watcher.start()
-    const { buffer } = watcher.producer
-    const actualPush = buffer.push
+    const { channel } = watcher.producer
+    const actualPush = channel.push
     // $FlowFixMe
-    buffer.push = batch => {
+    channel.push = batch => {
       batch.forEach(replaceFSEventIno)
       capturedBatches.push(_.cloneDeep(batch))
-      actualPush.call(buffer, batch)
+      actualPush.call(channel, batch)
     }
     await fixturesHelpers.runActions(scenario, abspath).delay(1000)
     return saveFSEventsToFile(scenario, capturedBatches, 'atom')

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -166,7 +166,7 @@ class LocalTestHelpers {
     const watcher = this._ensureAtomWatcher()
     for (const batch of batches.concat([simulationCompleteBatch])) {
       // $FlowFixMe
-      watcher.producer.buffer.push(batch)
+      watcher.producer.channel.push(batch)
     }
     await this.startSimulation()
   }
@@ -174,7 +174,7 @@ class LocalTestHelpers {
   async simulateAtomStart() {
     const watcher = this._ensureAtomWatcher()
     await atomWatcher.stepsInitialState(watcher.state, watcher)
-    watcher.producer.buffer.push([INITIAL_SCAN_DONE])
+    watcher.producer.channel.push([INITIAL_SCAN_DONE])
   }
 
   _ensureAtomWatcher() /*: atomWatcher.AtomWatcher */ {

--- a/test/unit/local/steps/add_checksum.js
+++ b/test/unit/local/steps/add_checksum.js
@@ -8,7 +8,7 @@
 const should = require('should')
 const checksumer = require('../../../../core/local/checksumer')
 const addChecksum = require('../../../../core/local/steps/add_checksum')
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 
 describe('core/local/steps/add_checksum.loop()', () => {
   it('should add checksum within a file event', async () => {
@@ -19,13 +19,13 @@ describe('core/local/steps/add_checksum.loop()', () => {
         path: __filename
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
-    const enhancedBuffer = addChecksum.loop(buffer, {
+    const channel = new Channel()
+    channel.push(batch)
+    const enhancedChannel = addChecksum.loop(channel, {
       checksumer: checksumer.init(),
       syncPath: ''
     })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch)
       .be.an.Array()
       .and.length(batch.length)
@@ -40,13 +40,13 @@ describe('core/local/steps/add_checksum.loop()', () => {
         path: __dirname
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
-    const enhancedBuffer = addChecksum.loop(buffer, {
+    const channel = new Channel()
+    channel.push(batch)
+    const enhancedChannel = addChecksum.loop(channel, {
       checksumer: checksumer.init(),
       syncPath: ''
     })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch)
       .be.an.Array()
       .and.length(batch.length)
@@ -62,13 +62,13 @@ describe('core/local/steps/add_checksum.loop()', () => {
         md5sum: 'checksum'
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
-    const enhancedBuffer = addChecksum.loop(buffer, {
+    const channel = new Channel()
+    channel.push(batch)
+    const enhancedChannel = addChecksum.loop(channel, {
       checksumer: checksumer.init(),
       syncPath: ''
     })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch)
       .be.an.Array()
       .and.length(batch.length)
@@ -102,19 +102,19 @@ describe('core/local/steps/add_checksum.loop()', () => {
       kind: 'file',
       path: __filename
     }
-    const buffer = new Buffer()
-    buffer.push([
+    const channel = new Channel()
+    channel.push([
       createdEvent,
       modifiedEvent,
       scanEvent,
       renamedEvent,
       ignoredEvent
     ])
-    const enhancedBuffer = addChecksum.loop(buffer, {
+    const enhancedChannel = addChecksum.loop(channel, {
       checksumer: checksumer.init(),
       syncPath: ''
     })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).deepEqual([
       {
         ...createdEvent,

--- a/test/unit/local/steps/add_infos.js
+++ b/test/unit/local/steps/add_infos.js
@@ -7,7 +7,7 @@ import type { AtomWatcherEvent } from '../../../../core/local/steps/event'
 
 const should = require('should')
 const addInfos = require('../../../../core/local/steps/add_infos')
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 
 describe('core/local/steps/add_infos.loop()', () => {
   it('should returns an enhanced batch with infos', async () => {
@@ -18,12 +18,12 @@ describe('core/local/steps/add_infos.loop()', () => {
         path: __filename
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
-    const enhancedBuffer = addInfos.loop(buffer, {
+    const channel = new Channel()
+    channel.push(batch)
+    const enhancedChannel = addInfos.loop(channel, {
       syncPath: ''
     })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch)
       .be.an.Array()
       .and.have.length(batch.length)
@@ -52,12 +52,12 @@ describe('core/local/steps/add_infos.loop()', () => {
         path: __dirname
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
-    const enhancedBuffer = addInfos.loop(buffer, {
+    const channel = new Channel()
+    channel.push(batch)
+    const enhancedChannel = addInfos.loop(channel, {
       syncPath: ''
     })
-    const [scanEvent, ...otherEvents] = await enhancedBuffer.pop()
+    const [scanEvent, ...otherEvents] = await enhancedChannel.pop()
     should(scanEvent).eql({
       action: batch[0].action,
       kind: 'directory',

--- a/test/unit/local/steps/filter_ignored.js
+++ b/test/unit/local/steps/filter_ignored.js
@@ -6,7 +6,7 @@ const { onPlatforms } = require('../../../support/helpers/platform')
 const Builders = require('../../../support/builders')
 
 const { Ignore } = require('../../../../core/ignore')
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 const filterIgnored = require('../../../../core/local/steps/filter_ignored')
 
 onPlatforms(['linux', 'win32'], () => {
@@ -14,10 +14,10 @@ onPlatforms(['linux', 'win32'], () => {
     const builders = new Builders()
 
     let ignore
-    let buffer
+    let channel
 
     beforeEach(() => {
-      buffer = new Buffer()
+      channel = new Channel()
 
       const patterns = ['*.bck', 'tmp/', 'folder/']
       ignore = new Ignore(patterns)
@@ -25,7 +25,7 @@ onPlatforms(['linux', 'win32'], () => {
 
     context('without any batches of events', () => {
       it('does not throw any errors', () => {
-        should(() => filterIgnored.loop(buffer, { ignore })).not.throw()
+        should(() => filterIgnored.loop(channel, { ignore })).not.throw()
       })
     })
 
@@ -81,13 +81,13 @@ onPlatforms(['linux', 'win32'], () => {
             batch.push(ignoredEvents[i])
           }
         }
-        buffer.push(batch)
+        channel.push(batch)
       })
 
       it('keeps only the relevant events in order', async () => {
-        const filteredBuffer = filterIgnored.loop(buffer, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, { ignore })
 
-        const relevantEvents = await filteredBuffer.pop()
+        const relevantEvents = await filteredChannel.pop()
         should(relevantEvents).deepEqual(notIgnoredEvents)
       })
     })
@@ -118,29 +118,29 @@ onPlatforms(['linux', 'win32'], () => {
           .build()
       ]
       beforeEach(() => {
-        buffer.push([ignoredEvents[0], notIgnoredEvents[0]])
-        buffer.push([ignoredEvents[1], notIgnoredEvents[1]])
+        channel.push([ignoredEvents[0], notIgnoredEvents[0]])
+        channel.push([ignoredEvents[1], notIgnoredEvents[1]])
       })
 
-      it('returns a buffer without events for filtered paths', async () => {
+      it('returns a channel without events for filtered paths', async () => {
         let relevantEvents
 
-        const filteredBuffer = filterIgnored.loop(buffer, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, { ignore })
 
-        relevantEvents = await filteredBuffer.pop()
+        relevantEvents = await filteredChannel.pop()
         should(relevantEvents).not.containDeep(ignoredEvents)
-        relevantEvents = await filteredBuffer.pop()
+        relevantEvents = await filteredChannel.pop()
         should(relevantEvents).not.containDeep(ignoredEvents)
       })
 
       it('keeps the order of batches with relevant events', async () => {
         let relevantEvents
 
-        const filteredBuffer = filterIgnored.loop(buffer, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, { ignore })
 
-        relevantEvents = await filteredBuffer.pop()
+        relevantEvents = await filteredChannel.pop()
         should(relevantEvents).containDeepOrdered([notIgnoredEvents[0]])
-        relevantEvents = await filteredBuffer.pop()
+        relevantEvents = await filteredChannel.pop()
         should(relevantEvents).containDeepOrdered([notIgnoredEvents[1]])
       })
     })
@@ -157,13 +157,13 @@ onPlatforms(['linux', 'win32'], () => {
         .kind('file')
         .build()
       beforeEach(() => {
-        buffer.push([directoryEvent, fileEvent])
+        channel.push([directoryEvent, fileEvent])
       })
 
       it('filters out folder events only', async () => {
-        const filteredBuffer = filterIgnored.loop(buffer, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, { ignore })
 
-        const relevantEvents = await filteredBuffer.pop()
+        const relevantEvents = await filteredChannel.pop()
         should(relevantEvents).deepEqual([fileEvent])
       })
     })

--- a/test/unit/local/steps/incomplete_fixer.js
+++ b/test/unit/local/steps/incomplete_fixer.js
@@ -12,7 +12,7 @@ const configHelpers = require('../../../support/helpers/config')
 
 const metadata = require('../../../../core/metadata')
 const stater = require('../../../../core/local/stater')
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 const incompleteFixer = require('../../../../core/local/steps/incomplete_fixer')
 
 const CHECKSUM = 'checksum'
@@ -36,7 +36,7 @@ describe('core/local/steps/incomplete_fixer', () => {
   after('cleanup config', configHelpers.cleanConfig)
 
   describe('.loop()', () => {
-    it('pushes the result of step() into the output buffer', async function() {
+    it('pushes the result of step() into the output Channel', async function() {
       const { syncPath } = this
 
       const src = 'missing'
@@ -56,16 +56,16 @@ describe('core/local/steps/incomplete_fixer', () => {
         .oldPath(src)
         .path(dst)
         .build()
-      const inputBuffer = new Buffer()
-      const outputBuffer = incompleteFixer.loop(inputBuffer, {
+      const inputChannel = new Channel()
+      const outputChannel = incompleteFixer.loop(inputChannel, {
         syncPath,
         checksumer
       })
 
-      inputBuffer.push([createdEvent])
-      inputBuffer.push([renamedEvent])
+      inputChannel.push([createdEvent])
+      inputChannel.push([renamedEvent])
 
-      should(await outputBuffer.pop()).deepEqual(
+      should(await outputChannel.pop()).deepEqual(
         await incompleteFixer.step(
           [{ event: createdEvent, timestamp: Date.now() }],
           { syncPath, checksumer }

--- a/test/unit/local/steps/initial_diff.js
+++ b/test/unit/local/steps/initial_diff.js
@@ -9,7 +9,7 @@ const Builders = require('../../../support/builders')
 const configHelpers = require('../../../support/helpers/config')
 const pouchHelpers = require('../../../support/helpers/pouch')
 
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 const initialDiff = require('../../../../core/local/steps/initial_diff')
 const metadata = require('../../../../core/metadata')
 
@@ -94,13 +94,13 @@ describe('local/steps/initial_diff', () => {
   })
 
   describe('.loop()', () => {
-    let buffer
+    let channel
     let initialScanDone
 
-    const inputBatch = batch => buffer.push(_.cloneDeep(batch))
+    const inputBatch = batch => channel.push(_.cloneDeep(batch))
 
     beforeEach(function() {
-      buffer = new Buffer()
+      channel = new Channel()
       initialScanDone = builders
         .event()
         .action('initial-scan-done')
@@ -140,7 +140,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([barScan, buzzScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -210,8 +210,11 @@ describe('local/steps/initial_diff', () => {
         .build()
       inputBatch([barScan, barBazScan, initialScanDone])
 
-      buffer = initialDiff.loop(buffer, { pouch: this.pouch, state })
-      const events = [].concat(await buffer.pop(), await buffer.pop())
+      channel = initialDiff.loop(channel, {
+        pouch: this.pouch,
+        state
+      })
+      const events = [].concat(await channel.pop(), await channel.pop())
 
       should(events).deepEqual([
         fooScan,
@@ -267,7 +270,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([fooScan, buzzScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -320,7 +323,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([fooScan, barScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -363,7 +366,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([fooScan, barScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -392,7 +395,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -455,7 +458,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([stillEmptyFileScan, sameContentFileScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -491,7 +494,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([dirScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([dirScan, initialScanDone])
@@ -529,7 +532,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([updatedMetadataScan, updatedContentScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -582,7 +585,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([fooScan, fizzScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -643,7 +646,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([parent2Scan, foo2Scan, bar2Scan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([
@@ -717,7 +720,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([parent2Scan, foo2Scan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       const deletedPath = path.normalize('parent-2/foo-2/bar')
@@ -793,7 +796,7 @@ describe('local/steps/initial_diff', () => {
       inputBatch([parent2Scan, fooScan, initialScanDone])
 
       const events = await initialDiff
-        .loop(buffer, { pouch: this.pouch, state })
+        .loop(channel, { pouch: this.pouch, state })
         .pop()
 
       should(events).deepEqual([

--- a/test/unit/local/steps/overwrite.js
+++ b/test/unit/local/steps/overwrite.js
@@ -4,7 +4,7 @@
 const _ = require('lodash')
 const should = require('should')
 
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 const overwrite = require('../../../../core/local/steps/overwrite')
 
 const Builders = require('../../../support/builders')
@@ -18,7 +18,7 @@ import type {
 
 describe('core/local/steps/overwrite', () => {
   describe('.loop()', () => {
-    let builders, inputBuffer, outputBuffer
+    let builders, inputChannel, outputChannel
 
     beforeEach(() => {
       builders = new Builders()
@@ -39,8 +39,8 @@ describe('core/local/steps/overwrite', () => {
           .ino(3)
           .build()
       }
-      inputBuffer = new Buffer()
-      outputBuffer = overwrite.loop(inputBuffer, {
+      inputChannel = new Channel()
+      outputChannel = overwrite.loop(inputChannel, {
         pouch: {
           byIdMaybeAsync: async id => _.cloneDeep(docs[id])
         },
@@ -48,8 +48,8 @@ describe('core/local/steps/overwrite', () => {
       })
     })
 
-    const inputBatch = batch => inputBuffer.push(_.cloneDeep(batch))
-    const outputBatch = () => outputBuffer.pop()
+    const inputBatch = batch => inputChannel.push(_.cloneDeep(batch))
+    const outputBatch = () => outputChannel.pop()
 
     it('ignores deleted file (dst/file) followed by renamed file (src/file → dst/file) with different ino', async () => {
       const deletedEvent = builders

--- a/test/unit/local/steps/scan_folder.js
+++ b/test/unit/local/steps/scan_folder.js
@@ -4,7 +4,7 @@
 const should = require('should')
 const sinon = require('sinon')
 const scanFolder = require('../../../../core/local/steps/scan_folder')
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 
 describe('core/local/steps/scan_folder.loop()', () => {
   it('should call the producer scan for action `created` only', async () => {
@@ -45,11 +45,11 @@ describe('core/local/steps/scan_folder.loop()', () => {
         path: __dirname
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
+    const channel = new Channel()
+    channel.push(batch)
     const scan = sinon.stub().resolves()
-    const enhancedBuffer = scanFolder.loop(buffer, { scan })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedChannel = scanFolder.loop(channel, { scan })
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.length(batch.length)
     should(scan).be.calledOnce()
   })
@@ -72,11 +72,11 @@ describe('core/local/steps/scan_folder.loop()', () => {
         path: __dirname
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
+    const channel = new Channel()
+    channel.push(batch)
     const scan = sinon.stub().resolves()
-    const enhancedBuffer = scanFolder.loop(buffer, { scan })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedChannel = scanFolder.loop(channel, { scan })
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.length(batch.length)
     should(scan).be.calledThrice()
   })
@@ -99,11 +99,11 @@ describe('core/local/steps/scan_folder.loop()', () => {
         path: __dirname
       }
     ]
-    const buffer = new Buffer()
-    buffer.push(batch)
+    const channel = new Channel()
+    channel.push(batch)
     const scan = sinon.stub().resolves()
-    const enhancedBuffer = scanFolder.loop(buffer, { scan })
-    const enhancedBatch = await enhancedBuffer.pop()
+    const enhancedChannel = scanFolder.loop(channel, { scan })
+    const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.length(batch.length)
     should(scan).be.calledTwice()
   })

--- a/test/unit/local/steps/win_detect_move.js
+++ b/test/unit/local/steps/win_detect_move.js
@@ -6,7 +6,7 @@ const _ = require('lodash')
 const path = require('path')
 const should = require('should')
 
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 const winDetectMove = require('../../../../core/local/steps/win_detect_move')
 const metadata = require('../../../../core/metadata')
 
@@ -30,16 +30,16 @@ if (process.platform === 'win32') {
     })
 
     describe('.loop()', () => {
-      let inputBuffer, outputBuffer
+      let inputChannel, outputChannel
 
       beforeEach(async function() {
         this.state = await winDetectMove.initialState()
-        inputBuffer = new Buffer()
-        outputBuffer = winDetectMove.loop(inputBuffer, this)
+        inputChannel = new Channel()
+        outputChannel = winDetectMove.loop(inputChannel, this)
       })
 
-      const inputBatch = events => inputBuffer.push(_.cloneDeep(events))
-      const outputBatch = () => outputBuffer.pop()
+      const inputBatch = events => inputChannel.push(_.cloneDeep(events))
+      const outputBatch = () => outputChannel.pop()
 
       const metadataBuilderByKind = kind => {
         switch (kind) {

--- a/test/unit/local/steps/win_identical_renaming.js
+++ b/test/unit/local/steps/win_identical_renaming.js
@@ -4,7 +4,7 @@
 const _ = require('lodash')
 const should = require('should')
 
-const Buffer = require('../../../../core/local/steps/buffer')
+const Channel = require('../../../../core/local/steps/channel')
 const winIdenticalRenaming = require('../../../../core/local/steps/win_identical_renaming')
 
 const Builders = require('../../../support/builders')
@@ -19,7 +19,7 @@ import type {
 if (process.platform === 'win32') {
   describe('core/local/steps/win_identical_renaming', () => {
     describe('.loop()', () => {
-      let builders, inputBuffer, outputBuffer
+      let builders, inputChannel, outputChannel
 
       beforeEach(() => {
         builders = new Builders()
@@ -33,8 +33,8 @@ if (process.platform === 'win32') {
             .path('file')
             .build()
         }
-        inputBuffer = new Buffer()
-        outputBuffer = winIdenticalRenaming.loop(inputBuffer, {
+        inputChannel = new Channel()
+        outputChannel = winIdenticalRenaming.loop(inputChannel, {
           pouch: {
             byIdMaybeAsync: async id => _.cloneDeep(docs[id])
           },
@@ -42,8 +42,8 @@ if (process.platform === 'win32') {
         })
       })
 
-      const inputBatch = batch => inputBuffer.push(_.cloneDeep(batch))
-      const outputBatch = () => outputBuffer.pop()
+      const inputBatch = batch => inputChannel.push(_.cloneDeep(batch))
+      const outputBatch = () => outputChannel.pop()
 
       describe('broken case-only renaming', () => {
         it('fixes renamed directory (DIR -> DIR) matching dir to (dir -> DIR) after .DELAY', async () => {


### PR DESCRIPTION
- Prevents naming confusion with built-in global Buffer
- Prevents using the built-in in case of missing import
- Type is actually some kind of *buffered channel*, but sticking to the
  simpler `Channel` name since we don't have many of them.

---

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
