### PR TITLE
core: Improve logging

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -693,9 +693,12 @@ class Merge {
         (doc.sides && !metadata.isUpToDate(side, doc))
       ) {
         log.warn(
-          { path: folder.path },
-          `${doc.path}: cannot be deleted with ${folder.path}: ` +
-            `${doc.docType} was modified on the ${otherSide(side)} side`
+          {
+            path: doc.path,
+            ancestorPath: folder.path,
+            otherSide: otherSide(side)
+          },
+          'Cannot be deleted with ancestor: document was modified on the other side.'
         )
         log.info({ path: doc.path }, 'Dissociating from remote...')
         delete doc.remote

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -249,15 +249,15 @@ function ensureValidPath(doc /*: {path: string} */) {
 function invariants(doc /*: Metadata */) {
   let err
   if (!doc.sides) {
-    err = new Error(`${doc._id} has no sides`)
+    err = new Error(`Metadata has no sides`)
   } else if (doc.sides.remote && !doc.remote) {
-    err = new Error(`${doc._id} has 'sides.remote' but no remote`)
+    err = new Error(`Metadata has 'sides.remote' but no remote`)
   } else if (doc.docType === 'file' && doc.md5sum == null) {
-    err = new Error(`${doc._id} is a file without checksum`)
+    err = new Error(`File metadata has no checksum`)
   }
 
   if (err) {
-    log.error({ err, sentry: true }, err.message)
+    log.error({ err, path: doc.path, sentry: true }, err.message)
     throw err
   }
 


### PR DESCRIPTION
Don't include ids or the whole docs in error messages.
To make errors easier to read/group when debugging.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
