### PR TITLE
core/remote/watcher: Assume offline on FetchError only

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -152,6 +152,7 @@ const sendErrorToMainWindow = msg => {
     desktop.stopSync().catch(err => log.error(err))
     return // no notification
   } else {
+    msg = translate('Dashboard Synchronization impossible')
     trayWindow.send('sync-error', msg)
   }
   const notif = new Notification({ title: 'Cozy Drive', body: msg })

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -6,6 +6,8 @@ const sinon = require('sinon')
 
 const fse = require('fs-extra')
 const _ = require('lodash')
+const { FetchError } = require('electron-fetch')
+
 const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
@@ -372,7 +374,7 @@ describe('Conflict resolution', () => {
 
     describe('retry', () => {
       beforeEach('simulate stack failure', () => {
-        sinon.stub(cozy.files, 'updateAttributesById').throws('FetchError')
+        sinon.stub(cozy.files, 'updateAttributesById').throws(new FetchError())
       })
 
       it('success', async () => {

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -3,6 +3,7 @@
 
 const EventEmitter = require('events')
 const sinon = require('sinon')
+const { FetchError } = require('electron-fetch')
 
 const Prep = require('../../../core/prep')
 const { Remote } = require('../../../core/remote')
@@ -37,7 +38,7 @@ describe('Remote', function() {
     it('The remote can be started when offline ', async function() {
       let fetchStub = sinon
         .stub(global, 'fetch')
-        .rejects(new Error('net::ERR_INTERNET_DISCONNECTED'))
+        .rejects(new FetchError('net::ERR_INTERNET_DISCONNECTED'))
       let eventsSpy = sinon.spy(this.events, 'emit')
       await this.remote.start().started
       eventsSpy.should.have.been.calledWith('offline')

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -26,6 +26,7 @@ describe('Remote', function() {
   before('instanciate pouch', pouchHelpers.createDatabase)
   before('instanciate remote', function() {
     this.prep = sinon.createStubInstance(Prep)
+    this.prep.config = this.config
     this.events = new EventEmitter()
     this.remote = new Remote(this)
   })

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -123,8 +123,6 @@ describe('RemoteWatcher', function() {
       this.pouch.getRemoteSeqAsync.resolves(lastLocalSeq)
       this.watcher.pullMany.resolves()
       this.remoteCozy.changes.resolves(changes)
-
-      return this.watcher.watch()
     })
 
     afterEach(function() {
@@ -134,13 +132,15 @@ describe('RemoteWatcher', function() {
       this.pouch.getRemoteSeqAsync.restore()
     })
 
-    it('pulls the changed files/dirs', function() {
+    it('pulls the changed files/dirs', async function() {
+      await this.watcher.watch()
       this.watcher.pullMany.should.be
         .calledOnce()
         .and.be.calledWithExactly(changes.docs)
     })
 
-    it('updates the last update sequence in local db', function() {
+    it('updates the last update sequence in local db', async function() {
+      await this.watcher.watch()
       this.pouch.setRemoteSeqAsync.should.be
         .calledOnce()
         .and.be.calledWithExactly(lastRemoteSeq)


### PR DESCRIPTION
So the sync status doesn't "blink" on invariant violations for example.

Also made sure technical error messages were not shown to the user anymore.

Teamwork with @taratatach :heart: 

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
