### PR TITLE
[WIP] core: Improve common Cozy errors handling

### DIFF
--- a/core/logger.js
+++ b/core/logger.js
@@ -6,6 +6,10 @@ const os = require('os')
 const path = require('path')
 const _ = require('lodash')
 
+/*::
+export type Logger = bunyan.Logger
+*/
+
 const LOG_DIR = path.join(
   process.env.COZY_DESKTOP_DIR || os.homedir(),
   '.cozy-desktop'

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -45,7 +45,6 @@ type CommonCozyErrorHandlingOptions = {
 
 type CommonCozyErrorHandlingResult =
   | 'offline'
-  | 'unhandled'
 */
 
 const handleCommonCozyErrors = (
@@ -68,7 +67,8 @@ const handleCommonCozyErrors = (
       return 'offline'
     }
   } else {
-    return 'unhandled'
+    log.error({ err })
+    throw err
   }
 }
 

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -2,6 +2,7 @@
 
 const autoBind = require('auto-bind')
 const CozyClient = require('cozy-client-js').Client
+const { FetchError } = require('electron-fetch')
 const _ = require('lodash')
 const path = require('path')
 
@@ -12,12 +13,15 @@ const {
   keepFiles,
   parentDirIds
 } = require('./document')
+const userActionRequired = require('./user_action_required')
 const logger = require('../logger')
 
 const { posix } = path
 
 /*::
+import type EventEmitter from 'events'
 import type { Config } from '../config'
+import type { Logger } from '../logger'
 import type { Readable } from 'stream'
 import type { RemoteDoc, RemoteDeletion } from './document'
 import type { Warning } from './warning'
@@ -31,6 +35,41 @@ function DirectoryNotFound(path /*: string */, cozyURL /*: string */) {
   this.name = 'DirectoryNotFound'
   this.message = `Directory ${path} was not found on Cozy ${cozyURL}`
   this.stack = new Error().stack
+}
+
+/*::
+type CommonCozyErrorHandlingOptions = {
+  events: EventEmitter,
+  log: Logger
+}
+
+type CommonCozyErrorHandlingResult =
+  | 'offline'
+  | 'unhandled'
+*/
+
+const handleCommonCozyErrors = (
+  err /*: Error */,
+  { events, log } /*: CommonCozyErrorHandlingOptions */
+) /*: CommonCozyErrorHandlingResult */ => {
+  if (err instanceof FetchError) {
+    if (err.status === 400) {
+      log.error({ err }, 'Client has been revoked')
+      throw new Error('Client has been revoked')
+    } else if (err.status === 402) {
+      log.error({ err }, 'User action required')
+      throw userActionRequired.includeJSONintoError(err)
+    } else if (err.status === 403) {
+      log.error({ err }, 'Client has wrong permissions (lack disk-usage)')
+      throw new Error('Client has wrong permissions (lack disk-usage)')
+    } else {
+      log.warn({ err }, 'Assuming offline')
+      events.emit('offline')
+      return 'offline'
+    }
+  } else {
+    return 'unhandled'
+  }
 }
 
 // A remote Cozy instance.
@@ -259,7 +298,8 @@ class RemoteCozy {
 
 module.exports = {
   DirectoryNotFound,
-  RemoteCozy
+  RemoteCozy,
+  handleCommonCozyErrors
 }
 
 async function getChangesFeed(

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -125,11 +125,7 @@ class RemoteWatcher {
     }
 
     for (const err of errors) {
-      const result = handleCommonCozyErrors(err, { events: this.events, log })
-      if (result === 'unhandled') {
-        log.error({ err })
-        throw err
-      }
+      handleCommonCozyErrors(err, { events: this.events, log })
       // No need to handle 'offline' result since next pollings will switch
       // back to 'online' as soon as the changesfeed can be fetched.
     }

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -3,14 +3,13 @@
 const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const _ = require('lodash')
-const { FetchError } = require('electron-fetch')
 
 const logger = require('../logger')
 const metadata = require('../metadata')
 const { MergeMissingParentError } = require('../merge')
 const remoteChange = require('./change')
+const { handleCommonCozyErrors } = require('./cozy')
 const { inRemoteTrash } = require('./document')
-const userActionRequired = require('./user_action_required')
 
 /*::
 import type EventEmitter from 'events'
@@ -126,19 +125,13 @@ class RemoteWatcher {
     }
 
     for (const err of errors) {
-      if (err.status === 400) {
-        log.error({ err }, 'Client has been revoked')
-        throw new Error('Client has been revoked')
-      } else if (err.status === 402) {
-        log.error({ err }, 'User action required')
-        throw userActionRequired.includeJSONintoError(err)
-      } else if (err instanceof FetchError) {
-        log.error({ err }, 'Assuming offline')
-        this.events.emit('offline')
-      } else {
+      const result = handleCommonCozyErrors(err, { events: this.events, log })
+      if (result === 'unhandled') {
         log.error({ err })
         throw err
       }
+      // No need to handle 'offline' result since next pollings will switch
+      // back to 'online' as soon as the changesfeed can be fetched.
     }
   }
 

--- a/core/sync.js
+++ b/core/sync.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 const { MAX_SYNC_ATTEMPTS } = require('./constants')
 const logger = require('./logger')
 const metadata = require('./metadata')
-const userActionRequired = require('./remote/user_action_required')
+const { handleCommonCozyErrors } = require('./remote/cozy')
 const { HEARTBEAT } = require('./remote/watcher')
 const { otherSide } = require('./side')
 const measureTime = require('./perftools')
@@ -436,19 +436,11 @@ class Sync {
     try {
       await this.diskUsage()
     } catch (err) {
-      if (err.status === 400) {
-        log.error({ err }, 'Client has been revoked')
-        throw new Error('Client has been revoked')
-      } else if (err.status === 402) {
-        log.error({ err }, 'User action required')
-        throw userActionRequired.includeJSONintoError(err)
-      } else if (err.status === 403) {
-        log.error({ err }, 'Client has wrong permissions (lack disk-usage)')
-        throw new Error('Client has wrong permissions (lack disk-usage)')
-      } else {
+      const result = handleCommonCozyErrors(err, { events: this.events, log })
+      // FIXME: Handle non-Fetch errors as offline to match previous behavior.
+      // This should be fixed in a subsequent commit.
+      if (result === 'offline' || result === 'unhandled') {
         // The client is offline, wait that it can connect again to the server
-        log.warn({ path }, 'Client is offline')
-        this.events.emit('offline')
         // eslint-disable-next-line no-constant-condition
         while (true) {
           try {

--- a/core/sync.js
+++ b/core/sync.js
@@ -437,9 +437,7 @@ class Sync {
       await this.diskUsage()
     } catch (err) {
       const result = handleCommonCozyErrors(err, { events: this.events, log })
-      // FIXME: Handle non-Fetch errors as offline to match previous behavior.
-      // This should be fixed in a subsequent commit.
-      if (result === 'offline' || result === 'unhandled') {
+      if (result === 'offline') {
         // The client is offline, wait that it can connect again to the server
         // eslint-disable-next-line no-constant-condition
         while (true) {

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -1,6 +1,8 @@
 /* eslint-env mocha */
 /* @flow weak */
 
+const { FetchError } = require('electron-fetch')
+const faker = require('faker')
 const _ = require('lodash')
 const path = require('path')
 const should = require('should')
@@ -11,13 +13,89 @@ const {
   TRASH_DIR_ID,
   TRASH_DIR_NAME
 } = require('../../../core/remote/constants')
-const { DirectoryNotFound, RemoteCozy } = require('../../../core/remote/cozy')
+const {
+  DirectoryNotFound,
+  RemoteCozy,
+  handleCommonCozyErrors
+} = require('../../../core/remote/cozy')
 
 const configHelpers = require('../../support/helpers/config')
 const { COZY_URL, builders, deleteAll } = require('../../support/helpers/cozy')
 const CozyStackDouble = require('../../support/doubles/cozy_stack')
 
 const cozyStackDouble = new CozyStackDouble()
+
+describe('core/remote/cozy', () => {
+  describe('.handleCommonCozyErrors()', () => {
+    let events, log
+
+    beforeEach(() => {
+      events = { emit: sinon.spy() }
+      log = { error: sinon.spy(), warn: sinon.spy() }
+    })
+
+    const randomMessage = faker.random.words
+
+    context('on FetchError status 400', () => {
+      const err = new FetchError(randomMessage())
+      err.status = 400
+      const expectedMessage = 'Client has been revoked'
+
+      it(`throws an Error with the exact "${expectedMessage}" message to notify the GUI`, () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw()
+      })
+    })
+
+    context('on FetchError status 402', () => {
+      const status = 402
+      const message = randomMessage()
+      const err = new FetchError(
+        JSON.stringify([{ status: status.toString(), message }])
+      )
+      err.status = status
+
+      it('throws an error decorated with JSON parsed from the original message', () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw({ status, message })
+      })
+    })
+
+    context('on FetchError status 403', () => {
+      const err = new FetchError(randomMessage())
+      err.status = 403
+
+      it('throws a permissions error', () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw(/permissions/)
+      })
+    })
+
+    context('on any other FetchError', () => {
+      const err = new FetchError(randomMessage())
+
+      it('emits "offline" to notify the GUI', () => {
+        handleCommonCozyErrors(err, { events, log })
+        should(events.emit).have.been.calledWith('offline')
+      })
+
+      it('returns "offline" to allow custom behavior', () => {
+        should(handleCommonCozyErrors(err, { events, log })).eql('offline')
+      })
+    })
+
+    context('on any other error', () => {
+      const err = new Error(randomMessage())
+
+      it('returns "unhandled" to allow custom behavior', () => {
+        should(handleCommonCozyErrors(err, { events, log })).eql('unhandled')
+      })
+    })
+  })
+})
 
 describe('RemoteCozy', function() {
   before(() => cozyStackDouble.start())

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -90,8 +90,10 @@ describe('core/remote/cozy', () => {
     context('on any other error', () => {
       const err = new Error(randomMessage())
 
-      it('returns "unhandled" to allow custom behavior', () => {
-        should(handleCommonCozyErrors(err, { events, log })).eql('unhandled')
+      it('throws the error', () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw(err)
       })
     })
   })


### PR DESCRIPTION
- Extracted from `RemoteWatcher` and `Sync`
- Mostly keeping the current behavior, although:
    * Using the `RemoteCozy` logger could make sense
    * handling 'offline' result only in `Sync` is weird

Possible breaking change: non-Fetch errors on disk-usage request in
`Sync` don't trigger an offline/online round trip anymore.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
