### PR TITLE
core/sentry: Bring back monitoring

### DIFF
--- a/core/sentry.js
+++ b/core/sentry.js
@@ -11,10 +11,6 @@ const log = logger({
 
 const _ = require('lodash')
 
-// FIXME: We were getting far too many Sentry messages.
-// So it is disabled for now, until we find a solution.
-process.env.COZY_NO_SENTRY = '1'
-
 module.exports = {
   setup,
   flag,


### PR DESCRIPTION
This reverts commit d4a29001ec09780f9dc6d8f2e2dbce33156e2702.
