### PR TITLE
core: Ignore "System Volume Information/" by default

### DIFF
--- a/core/config/.cozyignore
+++ b/core/config/.cozyignore
@@ -42,6 +42,7 @@ Icon
 *.sw[px]
 
 # Windows
+System Volume Information/
 Thumbs.db
 ehthumbs.db
 $Recycle.bin


### PR DESCRIPTION
- We better not touch it on Windows
- We may not have the necessary permissions anyway

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
