### PR TITLE
core: Improve common Cozy errors handling

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -45,7 +45,6 @@ type CommonCozyErrorHandlingOptions = {
 
 type CommonCozyErrorHandlingResult =
   | 'offline'
-  | 'unhandled'
 */
 
 const handleCommonCozyErrors = (
@@ -68,7 +67,8 @@ const handleCommonCozyErrors = (
       return 'offline'
     }
   } else {
-    return 'unhandled'
+    log.error({ err })
+    throw err
   }
 }
 

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -47,14 +47,16 @@ type CommonCozyErrorHandlingResult =
   | 'offline'
 */
 
+const COZY_CLIENT_REVOKED_MESSAGE = 'Client has been revoked'
+
 const handleCommonCozyErrors = (
   err /*: Error */,
   { events, log } /*: CommonCozyErrorHandlingOptions */
 ) /*: CommonCozyErrorHandlingResult */ => {
   if (err instanceof FetchError) {
     if (err.status === 400) {
-      log.error({ err }, 'Client has been revoked')
-      throw new Error('Client has been revoked')
+      log.error({ err })
+      throw new Error(COZY_CLIENT_REVOKED_MESSAGE)
     } else if (err.status === 402) {
       log.error({ err }, 'User action required')
       throw userActionRequired.includeJSONintoError(err)
@@ -298,6 +300,7 @@ class RemoteCozy {
 
 module.exports = {
   DirectoryNotFound,
+  COZY_CLIENT_REVOKED_MESSAGE,
   RemoteCozy,
   handleCommonCozyErrors
 }

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -125,11 +125,7 @@ class RemoteWatcher {
     }
 
     for (const err of errors) {
-      const result = handleCommonCozyErrors(err, { events: this.events, log })
-      if (result === 'unhandled') {
-        log.error({ err })
-        throw err
-      }
+      handleCommonCozyErrors(err, { events: this.events, log })
       // No need to handle 'offline' result since next pollings will switch
       // back to 'online' as soon as the changesfeed can be fetched.
     }

--- a/core/remote/watcher.js
+++ b/core/remote/watcher.js
@@ -3,13 +3,12 @@
 const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const _ = require('lodash')
-const { FetchError } = require('electron-fetch')
 
 const metadata = require('../metadata')
 const { MergeMissingParentError } = require('../merge')
 const remoteChange = require('./change')
+const { handleCommonCozyErrors } = require('./cozy')
 const { inRemoteTrash } = require('./document')
-const userActionRequired = require('./user_action_required')
 const logger = require('../utils/logger')
 
 /*::
@@ -126,19 +125,13 @@ class RemoteWatcher {
     }
 
     for (const err of errors) {
-      if (err.status === 400) {
-        log.error({ err }, 'Client has been revoked')
-        throw new Error('Client has been revoked')
-      } else if (err.status === 402) {
-        log.error({ err }, 'User action required')
-        throw userActionRequired.includeJSONintoError(err)
-      } else if (err instanceof FetchError) {
-        log.error({ err }, 'Assuming offline')
-        this.events.emit('offline')
-      } else {
+      const result = handleCommonCozyErrors(err, { events: this.events, log })
+      if (result === 'unhandled') {
         log.error({ err })
         throw err
       }
+      // No need to handle 'offline' result since next pollings will switch
+      // back to 'online' as soon as the changesfeed can be fetched.
     }
   }
 

--- a/core/sync.js
+++ b/core/sync.js
@@ -438,9 +438,7 @@ class Sync {
       await this.diskUsage()
     } catch (err) {
       const result = handleCommonCozyErrors(err, { events: this.events, log })
-      // FIXME: Handle non-Fetch errors as offline to match previous behavior.
-      // This should be fixed in a subsequent commit.
-      if (result === 'offline' || result === 'unhandled') {
+      if (result === 'offline') {
         // The client is offline, wait that it can connect again to the server
         // eslint-disable-next-line no-constant-condition
         while (true) {

--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -6,6 +6,10 @@ const os = require('os')
 const path = require('path')
 const _ = require('lodash')
 
+/*::
+export type Logger = bunyan.Logger
+*/
+
 const LOG_DIR = path.join(
   process.env.COZY_DESKTOP_DIR || os.homedir(),
   '.cozy-desktop'

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -1,6 +1,8 @@
 /* eslint-env mocha */
 /* @flow weak */
 
+const { FetchError } = require('electron-fetch')
+const faker = require('faker')
 const _ = require('lodash')
 const path = require('path')
 const should = require('should')
@@ -11,13 +13,89 @@ const {
   TRASH_DIR_ID,
   TRASH_DIR_NAME
 } = require('../../../core/remote/constants')
-const { DirectoryNotFound, RemoteCozy } = require('../../../core/remote/cozy')
+const {
+  DirectoryNotFound,
+  RemoteCozy,
+  handleCommonCozyErrors
+} = require('../../../core/remote/cozy')
 
 const configHelpers = require('../../support/helpers/config')
 const { COZY_URL, builders, deleteAll } = require('../../support/helpers/cozy')
 const CozyStackDouble = require('../../support/doubles/cozy_stack')
 
 const cozyStackDouble = new CozyStackDouble()
+
+describe('core/remote/cozy', () => {
+  describe('.handleCommonCozyErrors()', () => {
+    let events, log
+
+    beforeEach(() => {
+      events = { emit: sinon.spy() }
+      log = { error: sinon.spy(), warn: sinon.spy() }
+    })
+
+    const randomMessage = faker.random.words
+
+    context('on FetchError status 400', () => {
+      const err = new FetchError(randomMessage())
+      err.status = 400
+      const expectedMessage = 'Client has been revoked'
+
+      it(`throws an Error with the exact "${expectedMessage}" message to notify the GUI`, () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw()
+      })
+    })
+
+    context('on FetchError status 402', () => {
+      const status = 402
+      const message = randomMessage()
+      const err = new FetchError(
+        JSON.stringify([{ status: status.toString(), message }])
+      )
+      err.status = status
+
+      it('throws an error decorated with JSON parsed from the original message', () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw({ status, message })
+      })
+    })
+
+    context('on FetchError status 403', () => {
+      const err = new FetchError(randomMessage())
+      err.status = 403
+
+      it('throws a permissions error', () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw(/permissions/)
+      })
+    })
+
+    context('on any other FetchError', () => {
+      const err = new FetchError(randomMessage())
+
+      it('emits "offline" to notify the GUI', () => {
+        handleCommonCozyErrors(err, { events, log })
+        should(events.emit).have.been.calledWith('offline')
+      })
+
+      it('returns "offline" to allow custom behavior', () => {
+        should(handleCommonCozyErrors(err, { events, log })).eql('offline')
+      })
+    })
+
+    context('on any other error', () => {
+      const err = new Error(randomMessage())
+
+      it('returns "unhandled" to allow custom behavior', () => {
+        should(handleCommonCozyErrors(err, { events, log })).eql('unhandled')
+      })
+    })
+  })
+})
 
 describe('RemoteCozy', function() {
   before(() => cozyStackDouble.start())

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -90,8 +90,10 @@ describe('core/remote/cozy', () => {
     context('on any other error', () => {
       const err = new Error(randomMessage())
 
-      it('returns "unhandled" to allow custom behavior', () => {
-        should(handleCommonCozyErrors(err, { events, log })).eql('unhandled')
+      it('throws the error', () => {
+        should(() => {
+          handleCommonCozyErrors(err, { events, log })
+        }).throw(err)
       })
     })
   })


### PR DESCRIPTION
- Extracted from `RemoteWatcher` and `Sync`
- Mostly keeping the current behavior, except...
- Non-Fetch errors on disk-usage request in `Sync` don't trigger an offline/online round trip anymore.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
