### PR TITLE
local/atom/filter_ignored: Handle renamed paths

### DIFF
--- a/core/local/atom/filter_ignored.js
+++ b/core/local/atom/filter_ignored.js
@@ -15,6 +15,7 @@ const log = logger({
 })
 
 module.exports = {
+  STEP_NAME,
   loop
 }
 

--- a/core/local/atom/filter_ignored.js
+++ b/core/local/atom/filter_ignored.js
@@ -1,10 +1,13 @@
 /* @flow */
 
+const _ = require('lodash')
+
 const logger = require('../../logger')
+const metadata = require('../../metadata')
 
 /*::
 import type Channel from './channel'
-import type { AtomEvent } from './event'
+import type { AtomEvent, EventKind } from './event'
 import type { Ignore } from '../../ignore'
 */
 
@@ -28,24 +31,68 @@ function loop(
   channel /*: Channel */,
   opts /*: { ignore: Ignore } */
 ) /*: Channel */ {
-  const notIgnored = buildNotIgnored(opts.ignore)
+  const isIgnored = (path /*: string */, kind /*: EventKind */) =>
+    opts.ignore.isIgnored({
+      relativePath: path,
+      isFolder: kind === 'directory'
+    })
 
-  return channel.map(batch => {
-    return batch.filter(notIgnored)
+  return channel.map(events => {
+    const batch = []
+
+    for (const event of events) {
+      if (event.noIgnore) {
+        batch.push(event)
+        continue
+      }
+
+      const isPathIgnored = isIgnored(event.path, event.kind)
+
+      if (event.action === 'renamed' && event.oldPath != null) {
+        const isOldPathIgnored = isIgnored(event.oldPath, event.kind)
+
+        if (isOldPathIgnored && isPathIgnored) {
+          log.debug({ event }, 'Ignored via .cozyignore')
+        } else if (isPathIgnored) {
+          const deletedEvent = movedToIgnoredPath(event)
+          batch.push(deletedEvent)
+        } else if (isOldPathIgnored) {
+          const createdEvent = movedFromIgnoredPath(event)
+          batch.push(createdEvent)
+        } else {
+          batch.push(event)
+        }
+      } else if (isPathIgnored) {
+        log.debug({ event }, 'Ignored via .cozyignore')
+      } else {
+        batch.push(event)
+      }
+    }
+
+    return batch
   })
 }
 
-function buildNotIgnored(
-  ignoreRules /*: Ignore */
-) /*: ((AtomEvent) => boolean) */ {
-  return (event /*: AtomEvent */) /*: boolean */ => {
-    if (event.noIgnore) {
-      return true
-    }
-    const relativePath = event.path
-    const isFolder = event.kind === 'directory'
-    const isIgnored = ignoreRules.isIgnored({ relativePath, isFolder })
-    if (isIgnored) log.debug({ event }, 'Ignored')
-    return !isIgnored
+function movedFromIgnoredPath(event /*: AtomEvent */) /*: AtomEvent */ {
+  const createdEvent = {
+    ...event,
+    action: 'created'
   }
+  _.set(createdEvent, [STEP_NAME, 'movedFromIgnoredPath'], createdEvent.oldPath)
+  delete createdEvent.oldPath
+
+  return createdEvent
+}
+
+function movedToIgnoredPath(event /*: AtomEvent */) /*: AtomEvent */ {
+  const deletedEvent = {
+    ...event,
+    action: 'deleted'
+  }
+  _.set(deletedEvent, [STEP_NAME, 'movedToIgnoredPath'], deletedEvent.path)
+  deletedEvent._id = metadata.id(deletedEvent.oldPath)
+  deletedEvent.path = deletedEvent.oldPath
+  delete deletedEvent.oldPath
+
+  return deletedEvent
 }

--- a/test/scenarios/manage_moves_with_ignored_src_or_dst/atom/linux.json
+++ b/test/scenarios/manage_moves_with_ignored_src_or_dst/atom/linux.json
@@ -1,0 +1,30 @@
+[
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "file1.tmp"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "file1.tmp"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "file1",
+      "oldPath": "file1.tmp"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "file2.tmp",
+      "oldPath": "file2"
+    }
+  ]
+]

--- a/test/scenarios/manage_moves_with_ignored_src_or_dst/scenario.js
+++ b/test/scenarios/manage_moves_with_ignored_src_or_dst/scenario.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  side: 'local',
+  init: [{ ino: 2, path: 'file2', content: 'was not ignored' }],
+  actions: [
+    { type: 'create_file', path: 'file1.tmp' },
+    { type: 'wait', ms: 1500 },
+    { type: 'mv', src: 'file1.tmp', dst: 'file1' },
+    { type: 'mv', src: 'file2', dst: 'file2.tmp' }
+  ],
+  expected: {
+    localTree: ['file1', 'file2.tmp'],
+    remoteTree: ['file1'],
+    remoteTrash: ['file2']
+  }
+} /*: Scenario */)


### PR DESCRIPTION
Until now, the `filterIgnored` module was ignoring events based on
  their `path` attribute only.
  However, `renamed` events also have an `oldPath` attribute. Movements
  can happen from or to an ignored location and this should be handled
  as follows:
  - ignored to not ignored: event should be considered as a `created`
    event at the not ignored destination path, the `path` attribute
  - not ignored to ignored: event should be considered as a `deleted`
    event at the not ignored source path, the `oldPath` attribute
  - not ignored to not ignored: event is untouched
  - ignored to ignored: event is completely ignored

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
