### PR TITLE
core: Merge ./constants into ./sync

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-const MAX_SYNC_ATTEMPTS = 3
-
-module.exports = {
-  MAX_SYNC_ATTEMPTS
-}

--- a/core/sync.js
+++ b/core/sync.js
@@ -6,7 +6,6 @@ const Promise = require('bluebird')
 const { dirname } = require('path')
 const _ = require('lodash')
 
-const { MAX_SYNC_ATTEMPTS } = require('./constants')
 const metadata = require('./metadata')
 const userActionRequired = require('./remote/user_action_required')
 const { HEARTBEAT } = require('./remote/watcher')
@@ -27,6 +26,8 @@ import type { Side } from './side' // eslint-disable-line
 const log = logger({
   component: 'Sync'
 })
+
+const MAX_SYNC_ATTEMPTS = 3
 
 const TRASHING_DELAY = 1000
 


### PR DESCRIPTION
- No need for a module for a single constant...
- It is only used in Sync anyway.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
