### PR TITLE
core/local/atom/producer: Do not #scan() ignored files/dirs

### DIFF
--- a/core/config/.cozyignore
+++ b/core/config/.cozyignore
@@ -3,6 +3,9 @@
 # all hidden files
 .*
 
+# Cozy
+.system-tmp-cozy-drive/
+
 # Dropbox
 .dropbox
 .dropbox.attr

--- a/core/ignore.js
+++ b/core/ignore.js
@@ -132,7 +132,6 @@ const defaultRulesPath = resolve(__dirname, './config/.cozyignore')
 class Ignore {
   /*::
   patterns: IgnorePattern[]
-  match: (string, boolean, IgnorePattern) => boolean
   */
 
   // Load patterns for detecting ignored files and folders

--- a/core/local/atom/producer.js
+++ b/core/local/atom/producer.js
@@ -22,6 +22,12 @@ const log = logger({
   component: 'atom/Producer'
 })
 
+const isIgnored = ({ path, kind }, ignore) =>
+  ignore.isIgnored({
+    relativePath: path,
+    isFolder: kind === 'directory'
+  })
+
 // This class is a producer: it watches the filesystem and the events are
 // created here.
 //
@@ -118,7 +124,9 @@ module.exports = class Producer {
         }
         if (stats) scanEvent.stats = stats
         if (incomplete) scanEvent.incomplete = incomplete
-        entries.push(scanEvent)
+        if (!isIgnored(scanEvent, this.ignore)) {
+          entries.push(scanEvent)
+        }
       } catch (err) {
         log.error({ err, path: path.join(relPath, entry) })
       }

--- a/core/local/atom/producer.js
+++ b/core/local/atom/producer.js
@@ -12,6 +12,7 @@ const defaultStater = require('../stater')
 const logger = require('../../utils/logger')
 
 /*::
+import type { Ignore } from '../../ignore'
 import type { AtomEvent } from './event'
 
 export type Scanner = (string) => Promise<void>
@@ -47,11 +48,13 @@ module.exports = class Producer {
   /*::
   channel: Channel
   syncPath: string
+  ignore: Ignore
   watcher: *
   */
-  constructor(opts /*: { syncPath : string } */) {
+  constructor(opts /*: { syncPath: string, ignore: Ignore } */) {
     this.channel = new Channel()
     this.syncPath = opts.syncPath
+    this.ignore = opts.ignore
     this.watcher = null
     autoBind(this)
   }

--- a/test/unit/local/atom/producer.js
+++ b/test/unit/local/atom/producer.js
@@ -8,6 +8,7 @@ const fs = require('fs')
 const path = require('path')
 
 const Producer = require('../../../../core/local/atom/producer')
+const { Ignore } = require('../../../../core/ignore')
 const stater = require('../../../../core/local/stater')
 
 const { ContextDir } = require('../../../support/helpers/context_dir')
@@ -17,14 +18,14 @@ onPlatforms(['linux', 'win32'], () => {
   describe('core/local/atom/producer', () => {
     let syncDir
     let syncPath
+    let ignore
     let producer
 
     beforeEach(() => {
       syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'Cozy Drive.test-'))
       syncDir = new ContextDir(syncPath)
-      producer = new Producer({
-        syncPath
-      })
+      ignore = new Ignore([])
+      producer = new Producer({ syncPath, ignore })
     })
 
     describe('scan()', () => {


### PR DESCRIPTION
So we don't try to scan:

- `.system-tmp-cozy-drive/` contents
- Windows system files/dirs

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
