### PR TITLE
core/metadata: No ancestors duplication in conflict names

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -607,7 +607,7 @@ function createConflictingDoc(doc /*: Metadata */) /*: Metadata */ {
   let ext = path.extname(doc.path)
   let dir = path.dirname(doc.path)
   let base = path.basename(doc.path, ext)
-  const previousConflictingName = conflictRegExp('(.*)').exec(doc.path)
+  const previousConflictingName = conflictRegExp('(.*)').exec(base)
   const filename = previousConflictingName ? previousConflictingName[1] : base
   // 180 is an arbitrary limit to avoid having files with too long names
   const notToLongFilename = filename.slice(0, 180)

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -606,12 +606,13 @@ function createConflictingDoc(doc /*: Metadata */) /*: Metadata */ {
   let date = fsutils.validName(new Date().toISOString())
   let ext = path.extname(doc.path)
   let dir = path.dirname(doc.path)
-  let base = path.basename(doc.path, ext)
-  const previousConflictingName = conflictRegExp('(.*)').exec(base)
-  const filename = previousConflictingName ? previousConflictingName[1] : base
-  // 180 is an arbitrary limit to avoid having files with too long names
-  const notToLongFilename = filename.slice(0, 180)
-  dst.path = `${path.join(dir, notToLongFilename)}-conflict-${date}${ext}`
+  let basename = path.basename(doc.path)
+  const previousConflictingName = conflictRegExp('(.*)').exec(basename)
+  const filename = previousConflictingName
+    ? previousConflictingName[1]
+    : path.basename(basename, ext)
+  const notTooLongFilename = filename.slice(0, 180)
+  dst.path = `${path.join(dir, notTooLongFilename)}-conflict-${date}${ext}`
   assignId(dst)
   return dst
 }

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -1082,6 +1082,21 @@ describe('metadata', function() {
         .and.match(conflictRegExp(base))
         .and.not.containEql(firstConflictSuffix)
     })
+    it('should not duplicate its ancestors', () => {
+      const doc = { path: 'parent/dir/file.ext' }
+      const newDoc = createConflictingDoc(doc)
+      should(newDoc.path).not.containEql('parent/dir/parent/dir')
+    })
+
+    it('should not duplicate the ancestors of a previous conflict', () => {
+      const ext = `.pdf`
+      const base = `docname`
+      const doc = {
+        path: `parent/dir/${base}-conflict-1970-01-01T13_37_00.666Z${ext}`
+      }
+      const newDoc = createConflictingDoc(doc)
+      should(newDoc.path).not.containEql('parent/dir/parent/dir')
+    })
   })
 
   describe('shouldIgnore', () => {


### PR DESCRIPTION
  If a file, already in conflict, should be renamed because of a
  conflicting document and has ancestors, then those ancestors should
  not be duplicated in the generated path.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
