### PR TITLE
travis/linux: Add job for stopped client scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,11 @@ jobs:
           os: linux
           env:
               - CC=gcc-8 CXX=g++-8
+        - <<: *test_scenarios
+          os: linux
+          name: stopped client scenarios
+          env:
+              - STOPPED_CLIENT=1
         - &dist
           stage: test
           script: ./dev/ci/dist.sh

--- a/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
+++ b/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
@@ -3,6 +3,9 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  disabled: {
+    stopped: 'Does not work with AtomWatcher yet.'
+  },
   init: [
     { ino: 1, path: 'a/' },
     { ino: 2, path: 'a/file-a' },

--- a/test/scenarios/move_dir_and_update_subfile/scenario.js
+++ b/test/scenarios/move_dir_and_update_subfile/scenario.js
@@ -3,6 +3,9 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  disabled: {
+    stopped: 'Broken by a regression on AtomWatcher. To be fixed soon.'
+  },
   init: [
     { ino: 1, path: 'src/' },
     { ino: 2, path: 'src/file', content: 'initial content' }

--- a/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
+++ b/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
@@ -3,6 +3,9 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  disabled: {
+    stopped: 'Does not work with AtomWatcher yet.'
+  },
   init: [
     { ino: 1, path: 'a', content: 'content a' },
     { ino: 2, path: 'b', content: 'content b' }

--- a/test/scenarios/move_overwriting_dir/scenario.js
+++ b/test/scenarios/move_overwriting_dir/scenario.js
@@ -6,7 +6,8 @@ module.exports = ({
   side: 'local',
   disabled: {
     'atom/linux': 'Does not work with AtomWatcher yet.',
-    'atom/win32': 'Does not work with AtomWatcher yet.'
+    'atom/win32': 'Does not work with AtomWatcher yet.',
+    stopped: 'Does not work with AtomWatcher yet.'
   },
   init: [
     { ino: 1, path: 'dst/' },

--- a/test/scenarios/move_overwriting_file/scenario.js
+++ b/test/scenarios/move_overwriting_file/scenario.js
@@ -3,6 +3,9 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  disabled: {
+    stopped: 'Does not work with AtomWatcher yet.'
+  },
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'dst/file' },

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -64,7 +64,7 @@ describe('Test scenarios', function() {
       it.skip(`test/scenarios/${
         scenario.name
       }/local/  (skip remote only test)`, () => {})
-    } else {
+    } else if (process.env[stoppedEnvVar] == null) {
       for (let atomCapture of loadAtomCaptures(scenario)) {
         const localTestName = `test/scenarios/${scenario.name}/atom/${
           atomCapture.name
@@ -105,7 +105,7 @@ describe('Test scenarios', function() {
           })
         }
       }
-
+    } else {
       const stoppedTestName = `test/scenarios/${scenario.name}/local/stopped`
       const stoppedTestSkipped = shouldSkipLocalStopped(scenario)
       if (stoppedTestSkipped) {
@@ -118,6 +118,7 @@ describe('Test scenarios', function() {
       }
     }
 
+    if (process.env[stoppedEnvVar]) continue
     const remoteTestName = `test/scenarios/${scenario.name}/remote/`
     const remoteTestSkipped = shouldSkipRemote(scenario)
     if (remoteTestSkipped) {

--- a/test/scenarios/trash_dir_with_content/scenario.js
+++ b/test/scenarios/trash_dir_with_content/scenario.js
@@ -11,6 +11,11 @@ module.exports = ({
     { ino: 5, path: 'parent/dir/subdir/file' },
     { ino: 6, path: 'parent/other_dir/' }
   ],
+  disabled: {
+    stopped:
+      'Remote trash content is ok on initial scan & ko on live change. ' +
+      'Disable the initial scan scenario until we fix the live case.'
+  },
   actions: [{ type: 'trash', path: 'parent/dir' }],
   expected: {
     tree: ['parent/', 'parent/other_dir/'],


### PR DESCRIPTION
Minimal test harness so we can quickly fix #1638 without breaking something else.

Other improvements can come up in a future PR regarding travis jobs & the scenario runner.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
