### PR TITLE
core/merge: Transform child move if file was created on other side

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -481,10 +481,10 @@ class Merge {
       let dst = _.cloneDeep(doc)
       dst._id = makeDestinationID(doc)
       dst.path = doc.path.replace(was.path, folder.path)
-      if (src.sides && src.sides[side] && !src.sides[otherSide(side)]) {
-        metadata.markAsUnsyncable(side, src)
-        metadata.markAsNew(dst)
-        metadata.markSide(side, dst)
+
+      const singleSide = metadata.detectSingleSide(src)
+      if (singleSide) {
+        move.convertToDestinationAddition(singleSide, src, dst)
       } else {
         move.child(side, src, dst)
       }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -39,15 +39,17 @@ const mime = require('mime')
 const deepDiff = require('deep-diff').diff
 const path = require('path')
 
+const logger = require('./utils/logger')
+const timestamp = require('./utils/timestamp')
+const fsutils = require('./utils/fs')
+
 const {
   detectPathIncompatibilities,
   detectPathLengthIncompatibility
 } = require('./incompatibilities/platform')
 const { DIR_TYPE, FILE_TYPE } = require('./remote/constants')
-const logger = require('./utils/logger')
-const timestamp = require('./utils/timestamp')
+const { SIDE_NAMES, otherSide } = require('./side')
 
-const fsutils = require('./utils/fs')
 /*::
 import type fs from 'fs'
 import type { PlatformIncompatibility } from './incompatibilities/platform'
@@ -160,6 +162,7 @@ module.exports = {
   sameFile,
   sameFileIgnoreRev,
   sameBinary,
+  detectSingleSide,
   markSide,
   incSides,
   side,
@@ -562,6 +565,16 @@ function target(doc /*: ?Metadata */) /*: number */ {
 
 function side(doc /*: Metadata */, sideName /*: SideName */) /*: number */ {
   return (doc.sides || {})[sideName] || 0
+}
+
+function detectSingleSide(doc /*: Metadata */) /*: ?SideName */ {
+  if (doc.sides) {
+    for (const sideName of SIDE_NAMES) {
+      if (doc.sides[sideName] && !doc.sides[otherSide(sideName)]) {
+        return sideName
+      }
+    }
+  }
 }
 
 function wasSynced(doc /*: Metadata */) /*: boolean */ {

--- a/core/move.js
+++ b/core/move.js
@@ -17,6 +17,7 @@ import type { SideName } from './side'
 
 module.exports = move
 move.child = child
+move.convertToDestinationAddition = convertToDestinationAddition
 
 // Modify the given src/dst docs so they can be merged then moved accordingly
 // during sync.
@@ -48,4 +49,19 @@ function move(side /*: SideName */, src /*: Metadata */, dst /*: Metadata */) {
 function child(side /*: SideName */, src /*: Metadata */, dst /*: Metadata */) {
   src.childMove = true
   move(side, src, dst)
+}
+
+function convertToDestinationAddition(
+  side /*: SideName */,
+  src /*: Metadata */,
+  dst /*: Metadata */
+) {
+  // Delete source
+  if (src.moveTo) delete src.moveTo
+  metadata.markAsUnsyncable(side, src)
+
+  // Create destination
+  if (dst.moveFrom) delete dst.moveFrom
+  metadata.markAsNew(dst)
+  metadata.markSide(side, dst)
 }

--- a/core/side.js
+++ b/core/side.js
@@ -10,6 +10,8 @@ export type SideName =
   | "remote";
 */
 
+const SIDE_NAMES /*: Set<SideName> */ = new Set(['local', 'remote'])
+
 function otherSide(side /*: SideName */) /*: SideName */ {
   switch (side) {
     case 'local':
@@ -22,5 +24,6 @@ function otherSide(side /*: SideName */) /*: SideName */ {
 }
 
 module.exports = {
+  SIDE_NAMES,
   otherSide
 }

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -366,6 +366,50 @@ describe('Move', () => {
           ]
         })
       })
+
+      it('on initial scan with parent move', async () => {
+        should(await helpers.local.tree()).deepEqual([
+          'parent/',
+          'parent/dst/',
+          'parent/src/',
+          'parent/src/dir/',
+          'parent/src/dir/empty-subdir/',
+          'parent/src/dir/file',
+          'parent/src/dir/subdir/',
+          'parent/src/dir/subdir/file'
+        ])
+        const was = await pouch.byRemoteIdAsync(dir._id)
+        await helpers._remote.moveFolderAsync(
+          {
+            ...was,
+            path: path.normalize('parent/dst/dir')
+          },
+          was
+        )
+        await helpers.pullAndSyncAll()
+        should(await helpers.trees('metadata', 'remote')).deepEqual({
+          remote: [
+            'parent/',
+            'parent/dst/',
+            'parent/dst/dir/',
+            'parent/dst/dir/empty-subdir/',
+            'parent/dst/dir/file',
+            'parent/dst/dir/subdir/',
+            'parent/dst/dir/subdir/file',
+            'parent/src/'
+          ],
+          metadata: [
+            'parent/',
+            'parent/dst/',
+            'parent/dst/dir/',
+            'parent/dst/dir/empty-subdir/',
+            'parent/dst/dir/file',
+            'parent/dst/dir/subdir/',
+            'parent/dst/dir/subdir/file',
+            'parent/src/'
+          ]
+        })
+      })
     })
   })
 })

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -815,6 +815,26 @@ describe('metadata', function() {
     })
   })
 
+  describe('detectSingleSide', () => {
+    it('returns `local` if `remote` side is absent', () => {
+      should(metadata.detectSingleSide({ sides: { local: 1 } })).equal('local')
+    })
+
+    it('returns `remote` if `local` side is absent', () => {
+      should(metadata.detectSingleSide({ sides: { remote: 1 } })).equal(
+        'remote'
+      )
+    })
+
+    it('returns undefined if both sides are absent', () => {
+      should(metadata.detectSingleSide({ sides: {} })).be.undefined()
+    })
+
+    it('returns undefined if `sides` is absent', () => {
+      should(metadata.detectSingleSide({})).be.undefined()
+    })
+  })
+
   describe('buildFile', function() {
     it('creates a document for an existing file', async function() {
       const stats = await fse.stat(

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -24,4 +24,37 @@ describe('move', () => {
         .eql(true)
     })
   })
+
+  describe('convertToDestinationAddition', () => {
+    const side = 'local'
+    let src, dst
+
+    beforeEach(() => {
+      src = builders
+        .metadata()
+        .path('src')
+        .upToDate()
+        .build()
+      dst = builders
+        .metadata(src)
+        .path('destination')
+        .build()
+
+      move(side, src, dst)
+      move.convertToDestinationAddition(side, src, dst)
+    })
+
+    it('deletes the source document', () => {
+      should(src._deleted).be.true()
+    })
+
+    it('marks the destination document as newly added on `side`', () => {
+      should(dst.sides).deepEqual({ target: 1, [side]: 1 })
+    })
+
+    it('removes move hints on both documents', () => {
+      should(src).not.have.property('moveTo')
+      should(dst).not.have.property('moveFrom')
+    })
+  })
 })


### PR DESCRIPTION
If a file is added to a directory on one side while the directory is
moved on the other side, we should not try to apply the move on the
child file but transform it instead so it is interpreted as a file
addition at the new location (i.e. in the directory's new path).
This is allowing us to merge both changes during the initial scan
where the client applies changes coming from both sides before
synchronizing them.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
