### PR TITLE
core/local/atom/initial_diff: Fix dir move + subfile update

### DIFF
--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -278,7 +278,7 @@ function fixPathsAfterParentMove(renamedEvents, event) {
         renamedEvent.path
       )
       if (event.path === oldPathFixed) {
-        event.action = 'ignored'
+        event.action = 'scan'
       } else {
         event.oldPath = oldPathFixed
       }

--- a/test/scenarios/move_dir_and_update_subfile/scenario.js
+++ b/test/scenarios/move_dir_and_update_subfile/scenario.js
@@ -3,9 +3,6 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  disabled: {
-    stopped: 'Broken by a regression on AtomWatcher. To be fixed soon.'
-  },
   init: [
     { ino: 1, path: 'src/' },
     { ino: 2, path: 'src/file', content: 'initial content' }

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -765,7 +765,7 @@ describe('core/local/atom/initial_diff', () => {
       ])
     })
 
-    it('ignores child moves', async function() {
+    it('does not swallow possible changes on move descendants', async function() {
       await builders
         .metadir()
         .path('parent')
@@ -808,7 +808,7 @@ describe('core/local/atom/initial_diff', () => {
         },
         {
           ...fooScan,
-          action: 'ignored',
+          action: 'scan',
           oldPath: path.normalize('parent/foo'),
           [initialDiff.STEP_NAME]: {
             actionConvertedFrom: fooScan.action,


### PR DESCRIPTION
Do not ignore moved descendants to prevent file modification occuring
while client is stopped to be unsynced.

So the `renamed` child gets:

- its checksum computed in the add_checksum step
- converted to `created` in the dispatch step

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
