### PR TITLE
core/local/atom/producer: Log scan ignored events

### DIFF
--- a/core/local/atom/producer.js
+++ b/core/local/atom/producer.js
@@ -126,6 +126,8 @@ module.exports = class Producer {
         if (incomplete) scanEvent.incomplete = incomplete
         if (!isIgnored(scanEvent, this.ignore)) {
           entries.push(scanEvent)
+        } else {
+          log.debug({ event: scanEvent }, 'Ignored via .cozyignore')
         }
       } catch (err) {
         log.error({ err, path: path.join(relPath, entry) })

--- a/test/unit/local/atom/producer.js
+++ b/test/unit/local/atom/producer.js
@@ -29,7 +29,7 @@ onPlatforms(['linux', 'win32'], () => {
     })
 
     describe('scan()', () => {
-      context('when a directory is ignored', () => {
+      context.only('when a directory is ignored', () => {
         const ignoredDir = 'ignored-dir'
         const notIgnoredFile = 'not-ignored-file'
         let ignore


### PR DESCRIPTION
Same as in the filter_ignored step.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
