### PR TITLE
core/local/chokidar: Extract steps

### DIFF
--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -1,0 +1,102 @@
+/* @flow */
+
+const chokidarEvent = require('./event')
+const logger = require('../../utils/logger')
+const metadata = require('../../metadata')
+
+const log = logger({
+  component: 'chokidar/initial_scan'
+})
+
+const NB_OF_DELETABLE_ELEMENT = 3
+
+/*::
+import type { ChokidarEvent } from './event'
+import type LocalEventBuffer from './event_buffer'
+import type Pouch from '../../pouch'
+
+export type InitialScan = {
+  ids: string[],
+  emptyDirRetryCount: number,
+  flushed: boolean,
+  resolve: () => void
+}
+
+export type InitialScanOpts = {
+  buffer: LocalEventBuffer<ChokidarEvent>,
+  initialScan: ?InitialScan,
+  pouch: Pouch
+}
+*/
+
+const detectOfflineUnlinkEvents = async (
+  initialScan /*: InitialScan */,
+  pouch /*: Pouch */
+) /*: Promise<{offlineEvents: Array<ChokidarEvent>, unappliedMoves: string[], emptySyncDir: boolean}> */ => {
+  // Try to detect removed files & folders
+  const events /*: Array<ChokidarEvent> */ = []
+  const docs = await pouch.byRecursivePathAsync('')
+  const inInitialScan = doc =>
+    initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
+
+  // the Syncdir is empty error only occurs if there was some docs beforehand
+  let emptySyncDir = docs.length > NB_OF_DELETABLE_ELEMENT
+  let unappliedMoves = []
+
+  for (const doc of docs) {
+    if (inInitialScan(doc) || doc.trashed || doc.incompatibilities) {
+      emptySyncDir = false
+    } else if (doc.moveFrom) {
+      // unapplied move
+      unappliedMoves.push(metadata.id(doc.moveFrom.path))
+    } else {
+      log.debug({ path: doc.path }, 'pretend unlink or unlinkDir')
+      events.unshift(chokidarEvent.pretendUnlinkFromMetadata(doc))
+    }
+  }
+
+  return { offlineEvents: events, unappliedMoves, emptySyncDir }
+}
+
+const step = async (
+  rawEvents /*: ChokidarEvent[] */,
+  { buffer, initialScan, pouch } /*: InitialScanOpts */
+) /*: Promise<?Array<ChokidarEvent>> */ => {
+  let events = rawEvents.filter(e => e.path !== '') // @TODO handle root dir events
+  if (initialScan != null) {
+    const ids = initialScan.ids
+    events
+      .filter(e => e.type.startsWith('add'))
+      .forEach(e => ids.push(metadata.id(e.path)))
+
+    const {
+      offlineEvents,
+      unappliedMoves,
+      emptySyncDir
+    } = await detectOfflineUnlinkEvents(initialScan, pouch)
+    events = offlineEvents.concat(events)
+
+    events = events.filter(e => {
+      return unappliedMoves.indexOf(metadata.id(e.path)) === -1
+    })
+
+    if (emptySyncDir) {
+      // it is possible this is a temporary faillure (too late mounting)
+      // push back the events and wait until next flush.
+      buffer.unflush(rawEvents)
+      if (--initialScan.emptyDirRetryCount === 0) {
+        throw new Error('Syncdir is empty')
+      }
+      return initialScan.resolve()
+    }
+
+    log.debug({ initialEvents: events })
+  }
+
+  return events
+}
+
+module.exports = {
+  detectOfflineUnlinkEvents,
+  step
+}

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -1,0 +1,112 @@
+/* @flow */
+
+const Promise = require('bluebird')
+const fse = require('fs-extra')
+const _ = require('lodash')
+const path = require('path')
+
+const metadata = require('../../metadata')
+const logger = require('../../utils/logger')
+const { sameDate, fromDate } = require('../../utils/timestamp')
+
+/*::
+import type { ChokidarEvent } from './event'
+import type { InitialScan } from './initial_scan'
+import type { LocalEvent } from './local_event'
+import type { Metadata } from '../../metadata'
+import type Pouch from '../../pouch'
+
+type PrepareEventsOpts = {
+  +checksum: (string) => Promise<string>,
+  initialScan: ?InitialScan,
+  pouch: Pouch,
+  syncPath: string
+}
+*/
+
+const log = logger({
+  component: 'chokidar/prepare_events'
+})
+
+const oldMetadata = async (
+  e /*: ChokidarEvent */,
+  pouch /*: Pouch */
+) /*: Promise<?Metadata> */ => {
+  if (e.old) return e.old
+  try {
+    return await pouch.db.get(metadata.id(e.path))
+  } catch (err) {
+    if (err.status !== 404) log.error({ path: e.path, err })
+  }
+  return null
+}
+
+const step = async (
+  events /*: ChokidarEvent[] */,
+  { checksum, initialScan, pouch, syncPath } /*: PrepareEventsOpts */
+) /*: Promise<LocalEvent[]> */ => {
+  return Promise.map(
+    events,
+    async (e /*: ChokidarEvent */) /*: Promise<?LocalEvent> */ => {
+      const abspath = path.join(syncPath, e.path)
+
+      const e2 /*: Object */ = _.merge(
+        {
+          old: await oldMetadata(e, pouch)
+        },
+        e
+      )
+
+      if (e.type === 'add' || e.type === 'change') {
+        if (
+          initialScan &&
+          e2.old &&
+          e2.path === e2.old.path &&
+          sameDate(fromDate(e2.old.updated_at), fromDate(e2.stats.mtime))
+        ) {
+          log.trace(
+            { path: e.path },
+            'Do not compute checksum : mtime & path are unchanged'
+          )
+          e2.md5sum = e2.old.md5sum
+        } else {
+          try {
+            e2.md5sum = await checksum(e.path)
+            log.trace({ path: e.path, md5sum: e2.md5sum }, 'Checksum complete')
+          } catch (err) {
+            // FIXME: err.code === EISDIR => keep the event? (e.g. rm foo && mkdir foo)
+            // Chokidar reports a change event when a file is replaced by a directory
+            if (err.code.match(/ENOENT/)) {
+              log.debug(
+                { path: e.path, ino: e.stats.ino },
+                'Checksum failed: file does not exist anymore'
+              )
+              e2.wip = true
+            } else {
+              log.error({ path: e.path, err }, 'Checksum failed')
+              return null
+            }
+          }
+        }
+      }
+
+      if (e.type === 'addDir') {
+        if (!(await fse.exists(abspath))) {
+          log.debug(
+            { path: e.path, ino: e.stats.ino },
+            'Dir does not exist anymore'
+          )
+          e2.wip = true
+        }
+      }
+
+      return e2
+    },
+    { concurrency: 50 }
+  ).filter((e /*: ?LocalEvent */) => e != null)
+}
+
+module.exports = {
+  oldMetadata,
+  step
+}

--- a/core/local/chokidar/send_to_prep.js
+++ b/core/local/chokidar/send_to_prep.js
@@ -1,0 +1,186 @@
+/* @flow */
+
+const metadata = require('../../metadata')
+const logger = require('../../utils/logger')
+
+/*::
+import type fse from 'fs-extra'
+
+import type {
+  LocalChange,
+  LocalDirAddition,
+  LocalDirDeletion,
+  LocalDirMove,
+  LocalFileAddition,
+  LocalFileDeletion,
+  LocalFileMove,
+  LocalFileUpdate
+} from './local_change'
+import type {
+  LocalFileAdded,
+  LocalFileUpdated
+} from './local_event'
+import type Pouch from '../../pouch'
+import type Prep from '../../prep'
+
+type SendToPrepOpts = {
+  pouch: Pouch,
+  prep: Prep
+}
+
+*/
+
+const log = logger({
+  component: 'chokidar/send_to_prep'
+})
+
+const SIDE = 'local'
+
+// New file detected
+const onAddFile = (
+  { path: filePath, stats, md5sum } /*: LocalFileAddition */,
+  prep /*: Prep */
+) => {
+  const logError = err => log.error({ err, path: filePath })
+  const doc = metadata.buildFile(filePath, stats, md5sum)
+  log.info({ path: filePath }, 'FileAddition')
+  return prep.addFileAsync(SIDE, doc).catch(logError)
+}
+
+const onMoveFile = async (
+  { path: filePath, stats, md5sum, old, overwrite } /*: LocalFileMove */,
+  prep /*: Prep */
+) => {
+  const logError = err => log.error({ err, path: filePath })
+  const doc = metadata.buildFile(filePath, stats, md5sum, old.remote)
+  if (overwrite) doc.overwrite = overwrite
+  log.info({ path: filePath, oldpath: old.path }, 'FileMove')
+  return prep.moveFileAsync(SIDE, doc, old).catch(logError)
+}
+
+const onMoveFolder = (
+  { path: folderPath, stats, old, overwrite } /*: LocalDirMove */,
+  prep /*: Prep */
+) => {
+  const logError = err => log.error({ err, path: folderPath })
+  const doc = metadata.buildDir(folderPath, stats, old.remote)
+  // $FlowFixMe we set doc.overwrite to true, it will be replaced by metadata in merge
+  if (overwrite) doc.overwrite = overwrite
+  log.info({ path: folderPath, oldpath: old.path }, 'DirMove')
+  return prep.moveFolderAsync(SIDE, doc, old).catch(logError)
+}
+
+// New directory detected
+const onAddDir = (
+  { path: folderPath, stats } /*: LocalDirAddition */,
+  prep /*: Prep */
+) => {
+  const doc = metadata.buildDir(folderPath, stats)
+  log.info({ path: folderPath }, 'DirAddition')
+  return prep
+    .putFolderAsync(SIDE, doc)
+    .catch(err => log.error({ err, path: folderPath }))
+}
+
+// File deletion detected
+//
+// It can be a file moved out. So, we wait a bit to see if a file with the
+// same checksum is added and, if not, we declare this file as deleted.
+const onUnlinkFile = (
+  { path: filePath } /*: LocalFileDeletion */,
+  prep /*: Prep */
+) => {
+  log.info({ path: filePath }, 'FileDeletion')
+  return prep
+    .trashFileAsync(SIDE, { path: filePath })
+    .catch(err => log.error({ err, path: filePath }))
+}
+
+// Folder deletion detected
+//
+// We don't want to delete a folder before files inside it. So we wait a bit
+// after chokidar event to declare the folder as deleted.
+const onUnlinkDir = (
+  { path: folderPath } /*: LocalDirDeletion */,
+  prep /*: Prep */
+) => {
+  log.info({ path: folderPath }, 'DirDeletion')
+  return prep
+    .trashFolderAsync(SIDE, { path: folderPath })
+    .catch(err => log.error({ err, path: folderPath }))
+}
+
+// File update detected
+const onChange = (
+  {
+    path: filePath,
+    stats,
+    md5sum
+  } /*: LocalFileUpdate|LocalFileAdded|LocalFileUpdated */,
+  prep /*: Prep */
+) => {
+  log.info({ path: filePath }, 'FileUpdate')
+  const doc = metadata.buildFile(filePath, stats, md5sum)
+  return prep.updateFileAsync(SIDE, doc)
+}
+
+// @TODO inline this.onXXX in this function
+// @TODO rename LocalChange types to prep.xxxxxx
+const step = async (
+  changes /*: LocalChange[] */,
+  { pouch, prep } /*: SendToPrepOpts */
+) => {
+  const errors /*: Error[] */ = []
+  for (let c of changes) {
+    try {
+      if (c.needRefetch) {
+        // $FlowFixMe
+        c.old = await pouch.db.get(metadata.id(c.old.path))
+      }
+      switch (c.type) {
+        // TODO: Inline old LocalWatcher methods
+        case 'DirDeletion':
+          await onUnlinkDir(c, prep)
+          break
+        case 'FileDeletion':
+          await onUnlinkFile(c, prep)
+          break
+        case 'DirAddition':
+          await onAddDir(c, prep)
+          break
+        case 'FileUpdate':
+          await onChange(c, prep)
+          break
+        case 'FileAddition':
+          await onAddFile(c, prep)
+          break
+        case 'FileMove':
+          await onMoveFile(c, prep)
+          if (c.update) await onChange(c.update, prep)
+          break
+        case 'DirMove':
+          await onMoveFolder(c, prep)
+          break
+        case 'Ignored':
+          break
+        default:
+          throw new Error('wrong changes')
+      }
+    } catch (err) {
+      log.error({ path: c.path, err })
+      errors.push(err)
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Could not apply all changes to Prep:\n- ${errors
+        .map(e => e.stack)
+        .join('\n- ')}`
+    )
+  }
+}
+
+module.exports = {
+  step
+}

--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -4,7 +4,6 @@ const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const chokidar = require('chokidar')
 const fse = require('fs-extra')
-const _ = require('lodash')
 const path = require('path')
 
 const analysis = require('./analysis')
@@ -12,10 +11,10 @@ const checksumer = require('../checksumer')
 const chokidarEvent = require('./event')
 const LocalEventBuffer = require('./event_buffer')
 const initialScan = require('./initial_scan')
+const prepareEvents = require('./prepare_events')
 const metadata = require('../../metadata')
 const syncDir = require('../sync_dir')
 const logger = require('../../utils/logger')
-const { sameDate, fromDate } = require('../../utils/timestamp')
 
 /*::
 import type { Metadata } from '../../metadata'
@@ -185,9 +184,9 @@ module.exports = class LocalWatcher {
     if (!events) return
 
     log.trace('Prepare events...')
-    const preparedEvents /*: LocalEvent[] */ = await this.prepareEvents(
+    const preparedEvents /*: LocalEvent[] */ = await prepareEvents.step(
       events,
-      this.initialScan
+      this
     )
     log.trace('Done with events preparation.')
 
@@ -213,84 +212,6 @@ module.exports = class LocalWatcher {
       this.initialScan.resolve()
       this.initialScan = null
     }
-  }
-
-  async oldMetadata(e /*: ChokidarEvent */) /*: Promise<?Metadata> */ {
-    if (e.old) return e.old
-    try {
-      return await this.pouch.db.get(metadata.id(e.path))
-    } catch (err) {
-      if (err.status !== 404) log.error({ path: e.path, err })
-    }
-    return null
-  }
-
-  async prepareEvents(
-    events /*: ChokidarEvent[] */,
-    initialScan /*: ?InitialScan */
-  ) /*: Promise<LocalEvent[]> */ {
-    return Promise.map(
-      events,
-      async (e /*: ChokidarEvent */) /*: Promise<?LocalEvent> */ => {
-        const abspath = path.join(this.syncPath, e.path)
-
-        const e2 /*: Object */ = _.merge(
-          {
-            old: await this.oldMetadata(e)
-          },
-          e
-        )
-
-        if (e.type === 'add' || e.type === 'change') {
-          if (
-            initialScan &&
-            e2.old &&
-            e2.path === e2.old.path &&
-            sameDate(fromDate(e2.old.updated_at), fromDate(e2.stats.mtime))
-          ) {
-            log.trace(
-              { path: e.path },
-              'Do not compute checksum : mtime & path are unchanged'
-            )
-            e2.md5sum = e2.old.md5sum
-          } else {
-            try {
-              e2.md5sum = await this.checksum(e.path)
-              log.trace(
-                { path: e.path, md5sum: e2.md5sum },
-                'Checksum complete'
-              )
-            } catch (err) {
-              // FIXME: err.code === EISDIR => keep the event? (e.g. rm foo && mkdir foo)
-              // Chokidar reports a change event when a file is replaced by a directory
-              if (err.code.match(/ENOENT/)) {
-                log.debug(
-                  { path: e.path, ino: e.stats.ino },
-                  'Checksum failed: file does not exist anymore'
-                )
-                e2.wip = true
-              } else {
-                log.error({ path: e.path, err }, 'Checksum failed')
-                return null
-              }
-            }
-          }
-        }
-
-        if (e.type === 'addDir') {
-          if (!(await fse.exists(abspath))) {
-            log.debug(
-              { path: e.path, ino: e.stats.ino },
-              'Dir does not exist anymore'
-            )
-            e2.wip = true
-          }
-        }
-
-        return e2
-      },
-      { concurrency: 50 }
-    ).filter((e /*: ?LocalEvent */) => e != null)
   }
 
   // @TODO inline this.onXXX in this function

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -1,0 +1,100 @@
+/* eslint-env mocha */
+
+const should = require('should')
+
+const {
+  detectOfflineUnlinkEvents
+} = require('../../../../core/local/chokidar/initial_scan')
+const metadata = require('../../../../core/metadata')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
+const { platform } = process
+
+describe('core/local/chokidar/initial_scan', () => {
+  let builders
+
+  before('instanciate config', configHelpers.createConfig)
+  before('instanciate pouch', pouchHelpers.createDatabase)
+
+  beforeEach('set up builders', function() {
+    builders = new Builders({ pouch: this.pouch })
+  })
+
+  after('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  describe('.detectOfflineUnlinkEvents()', function() {
+    beforeEach('reset pouchdb', function(done) {
+      this.pouch.resetDatabase(done)
+    })
+
+    it('detects deleted files and folders', async function() {
+      let folder1 = {
+        _id: 'folder1',
+        path: 'folder1',
+        docType: 'folder'
+      }
+      let folder2 = {
+        _id: 'folder2',
+        path: 'folder2',
+        docType: 'folder'
+      }
+      const folder3 = {
+        _id: '.cozy_trash/folder3',
+        path: '.cozy_trash/folder3',
+        trashed: true,
+        docType: 'folder'
+      }
+      let file1 = {
+        _id: 'file1',
+        path: 'file1',
+        docType: 'file'
+      }
+      let file2 = {
+        _id: 'file2',
+        path: 'file2',
+        docType: 'file'
+      }
+      const file3 = {
+        _id: '.cozy_trash/folder3/file3',
+        path: '.cozy_trash/folder3/file3',
+        trashed: true,
+        docType: 'file'
+      }
+      for (let doc of [folder1, folder2, folder3, file1, file2, file3]) {
+        const { rev } = await this.pouch.db.put(doc)
+        doc._rev = rev
+      }
+      const initialScan = { ids: ['folder1', 'file1'].map(metadata.id) }
+
+      const { offlineEvents } = await detectOfflineUnlinkEvents(
+        initialScan,
+        this.pouch
+      )
+
+      should(offlineEvents).deepEqual([
+        { type: 'unlinkDir', path: 'folder2', old: folder2 },
+        { type: 'unlink', path: 'file2', old: file2 }
+      ])
+    })
+
+    if (platform === 'win32' || platform === 'darwin') {
+      it('ignores incompatible docs', async function() {
+        await builders
+          .metafile()
+          .incompatible()
+          .create()
+        const initialScan = { ids: [] }
+
+        const { offlineEvents } = await detectOfflineUnlinkEvents(
+          initialScan,
+          this.pouch
+        )
+        should(offlineEvents).deepEqual([])
+      })
+    }
+  })
+})

--- a/test/unit/local/chokidar/prepare_events.js
+++ b/test/unit/local/chokidar/prepare_events.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+
+const should = require('should')
+
+const prepareEvents = require('../../../../core/local/chokidar/prepare_events')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
+describe('core/local/chokidar_steps/prepare_events', () => {
+  let builders
+
+  before('instanciate config', configHelpers.createConfig)
+  before('instanciate pouch', pouchHelpers.createDatabase)
+
+  beforeEach('set up builders', function() {
+    builders = new Builders({ pouch: this.pouch })
+  })
+
+  after('clean pouch', pouchHelpers.cleanDatabase)
+  after('clean config directory', configHelpers.cleanConfig)
+
+  describe('#oldMetadata()', () => {
+    it('resolves with the metadata whose id matches the event path', async function() {
+      const old = await builders.metadata().create()
+      const resultByEventType = {}
+      for (let type of ['add', 'addDir', 'change', 'unlink', 'unlinkDir']) {
+        resultByEventType[type] = await prepareEvents.oldMetadata(
+          {
+            type,
+            path: old.path
+          },
+          this.pouch
+        )
+      }
+      should(resultByEventType).deepEqual({
+        add: old,
+        addDir: old,
+        change: old,
+        unlink: old,
+        unlinkDir: old
+      })
+    })
+  })
+})

--- a/test/unit/local/chokidar/watcher.js
+++ b/test/unit/local/chokidar/watcher.js
@@ -139,26 +139,6 @@ describe('ChokidarWatcher Tests', function() {
     })
   })
 
-  describe('#oldMetadata()', () => {
-    it('resolves with the metadata whose id matches the event path', async function() {
-      const old = await builders.metadata().create()
-      const resultByEventType = {}
-      for (let type of ['add', 'addDir', 'change', 'unlink', 'unlinkDir']) {
-        resultByEventType[type] = await this.watcher.oldMetadata({
-          type,
-          path: old.path
-        })
-      }
-      should(resultByEventType).deepEqual({
-        add: old,
-        addDir: old,
-        change: old,
-        unlink: old,
-        unlinkDir: old
-      })
-    })
-  })
-
   describe('onAddFile', () => {
     if (process.env.APPVEYOR) {
       it('is unstable on AppVeyor')

--- a/test/unit/local/chokidar/watcher.js
+++ b/test/unit/local/chokidar/watcher.js
@@ -7,7 +7,6 @@ const should = require('should')
 
 const { TMP_DIR_NAME } = require('../../../../core/local/constants')
 const Watcher = require('../../../../core/local/chokidar/watcher')
-const metadata = require('../../../../core/metadata')
 
 const Builders = require('../../../support/builders')
 const configHelpers = require('../../../support/helpers/config')
@@ -447,75 +446,5 @@ describe('ChokidarWatcher Tests', function() {
         }, 1800)
       })
     })
-  })
-
-  describe('detectOfflineUnlinkEvents', function() {
-    beforeEach('reset pouchdb', function(done) {
-      this.pouch.resetDatabase(done)
-    })
-
-    it('detects deleted files and folders', async function() {
-      let folder1 = {
-        _id: 'folder1',
-        path: 'folder1',
-        docType: 'folder'
-      }
-      let folder2 = {
-        _id: 'folder2',
-        path: 'folder2',
-        docType: 'folder'
-      }
-      const folder3 = {
-        _id: '.cozy_trash/folder3',
-        path: '.cozy_trash/folder3',
-        trashed: true,
-        docType: 'folder'
-      }
-      let file1 = {
-        _id: 'file1',
-        path: 'file1',
-        docType: 'file'
-      }
-      let file2 = {
-        _id: 'file2',
-        path: 'file2',
-        docType: 'file'
-      }
-      const file3 = {
-        _id: '.cozy_trash/folder3/file3',
-        path: '.cozy_trash/folder3/file3',
-        trashed: true,
-        docType: 'file'
-      }
-      for (let doc of [folder1, folder2, folder3, file1, file2, file3]) {
-        const { rev } = await this.pouch.db.put(doc)
-        doc._rev = rev
-      }
-      const initialScan = { ids: ['folder1', 'file1'].map(metadata.id) }
-
-      const { offlineEvents } = await this.watcher.detectOfflineUnlinkEvents(
-        initialScan
-      )
-
-      should(offlineEvents).deepEqual([
-        { type: 'unlinkDir', path: 'folder2', old: folder2 },
-        { type: 'unlink', path: 'file2', old: file2 }
-      ])
-    })
-
-    if (platform === 'win32' || platform === 'darwin') {
-      it('ignores incompatible docs', async function() {
-        await builders
-          .metafile()
-          .incompatible()
-          .create()
-        const initialScan = { ids: [] }
-
-        const { offlineEvents } = await this.watcher.detectOfflineUnlinkEvents(
-          initialScan
-        )
-        should(offlineEvents).deepEqual([])
-      })
-    }
   })
 })


### PR DESCRIPTION
- Makes `ChokidarWatcher` smaller
- Makes it easier to understand/document steps
- Better matches the `AtomWatcher` design

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
