### PR TITLE
[WIP] gui/elm/Window/Tray/Settings: Don't change manual sync button label

### DIFF
--- a/gui/elm/Window/Tray/Settings.elm
+++ b/gui/elm/Window/Tray/Settings.elm
@@ -227,19 +227,14 @@ view helpers model =
 
 syncButton : Helpers -> Status -> Html Msg
 syncButton helpers status =
-    case status of
-        UpToDate ->
-            a
-                [ class "btn"
-                , href "#"
-                , onClick Sync
-                ]
-                [ text (helpers.t "Settings Sync") ]
+    a
+        [ class "btn"
+        , href "#"
+        , case status of
+            UpToDate ->
+                onClick Sync
 
-        _ ->
-            a
-                [ class "btn"
-                , href "#"
-                , attribute "disabled" "true"
-                ]
-                [ text (statusToString helpers status) ]
+            _ ->
+                attribute "disabled" "true"
+        ]
+        [ text (helpers.t "Settings Sync") ]


### PR DESCRIPTION
- Sync status is already shown in the status bar
- Using it as the button label can be confusing (e.g. errors)

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
