### PR TITLE
core/path_restrictions: Allow colon (`:`) on macOS

### DIFF
--- a/core/path_restrictions.js
+++ b/core/path_restrictions.js
@@ -129,7 +129,7 @@ const win = pathRestrictions({
 const mac = pathRestrictions({
   pathMaxBytes: 1023, // PATH_MAX without nul
   nameMaxBytes: 255, // NAME_MAX
-  reservedChars: new Set('/:') // macOS API forbids colons for legacy reasons
+  reservedChars: new Set('/')
 })
 
 // See: /usr/include/linux/limits.h

--- a/doc/usage/macos.md
+++ b/doc/usage/macos.md
@@ -12,3 +12,25 @@
 | 10.8 "Mountain Lion" | no | |
 | 10.7 "Lion" | no | |
 | 10.6 "Snow Leopard" | no | |
+
+## Slash (`/`) vs colon (`:`) on macOS
+
+Quoting [this paper][SANCHEZ_USENIX_2000] from Wilfredo Sánchez, senior
+software engineer at Apple :
+
+> Another obvious problem is the different path separators between HFS+
+> (colon, ':') and UFS (slash, '/'). This also means that HFS+ file names may
+> contain the slash character and not colons, while the opposite is true for
+> UFS file names. This was easy to address, though it involves transforming
+> strings back and forth. The HFS+ implementation in the kernel's VFS layer
+> converts colon to slash and vice versa when reading from and writing to the
+> on-disk format. So on disk the separator is a colon, but at the VFS layer
+> (and therefore anything above it and the kernel, such as libc) it's a slash.
+> However, the traditional Mac OS toolkits expect colons, so above the BSD
+> layer, the core Carbon toolkit does yet another translation. The result is
+> that Carbon applications see colons, and everyone else sees slashes. This
+> can create a user-visible schizophrenia in the rare cases of file names
+> containing colon characters, which appear to Carbon applications as slash
+> characters, but to BSD programs and Cocoa applications as colons.
+
+[SANCHEZ_USENIX_2000]: http://www.wsanchez.net/papers/USENIX_2000/

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -12,7 +12,7 @@ const pouchHelpers = require('../support/helpers/pouch')
 const TestHelpers = require('../support/helpers')
 
 describe('Platform incompatibilities', () => {
-  if (process.platform !== 'win32' && process.platform !== 'darwin') {
+  if (process.platform !== 'win32') {
     it.skip(`is not tested on ${process.platform}`, () => {})
     return
   }

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -955,7 +955,7 @@ describe('RemoteWatcher', function() {
     })
 
     onPlatform('darwin', () => {
-      it('detects when a new file is incompatible', async function() {
+      it('does not mistakenly assume a new file is incompatible', async function() {
         const remoteDoc = {
           _id: 'whatever',
           path: '/f:oo/b<a>r',
@@ -968,18 +968,8 @@ describe('RemoteWatcher', function() {
           0,
           []
         )
-        const platform = process.platform
         should(change.type).equal('FileAddition')
-        should((change /*: any */).doc.incompatibilities).deepEqual([
-          {
-            type: 'reservedChars',
-            name: 'f:oo',
-            path: 'f:oo',
-            docType: 'folder',
-            reservedChars: new Set(':'),
-            platform
-          }
-        ])
+        should((change /*: any */).doc.incompatibilities).be.undefined()
       })
     })
 


### PR DESCRIPTION
So it allows slash (`/`) from a macOS user standpoint.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
