### PR TITLE
core/remote/cozy: Expect cozy-client-js FetchErrors

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -2,7 +2,6 @@
 
 const autoBind = require('auto-bind')
 const CozyClient = require('cozy-client-js').Client
-const { FetchError } = require('electron-fetch')
 const _ = require('lodash')
 const path = require('path')
 
@@ -38,6 +37,8 @@ function DirectoryNotFound(path /*: string */, cozyURL /*: string */) {
 }
 
 /*::
+import type FetchError from 'electron-fetch'
+
 type CommonCozyErrorHandlingOptions = {
   events: EventEmitter,
   log: Logger
@@ -45,15 +46,25 @@ type CommonCozyErrorHandlingOptions = {
 
 type CommonCozyErrorHandlingResult =
   | 'offline'
+
+// See definition at https://github.com/cozy/cozy-client-js/blob/v0.13.0/src/fetch.js#L152
+type CozyFetchError = Error & {
+  name: 'FetchError',
+  response: *,
+  url: string,
+  status: number,
+  reason: { message: string } | string,
+  message: string
+}
 */
 
 const COZY_CLIENT_REVOKED_MESSAGE = 'Client has been revoked'
 
 const handleCommonCozyErrors = (
-  err /*: Error */,
+  err /*: FetchError | CozyFetchError | Error */,
   { events, log } /*: CommonCozyErrorHandlingOptions */
 ) /*: CommonCozyErrorHandlingResult */ => {
-  if (err instanceof FetchError) {
+  if (err.name === 'FetchError') {
     if (err.status === 400) {
       log.error({ err })
       throw new Error(COZY_CLIENT_REVOKED_MESSAGE)

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -8,7 +8,6 @@ const path = require('path')
 const sinon = require('sinon')
 const should = require('should')
 const CozyClient = require('cozy-client-js').Client
-const { FetchError } = require('electron-fetch')
 
 const configHelpers = require('../../support/helpers/config')
 const { posixifyPath } = require('../../support/helpers/context_dir')
@@ -153,11 +152,22 @@ describe('RemoteWatcher', function() {
     })
 
     context('on error while fetching changes', () => {
+      /* cozy-client-js defines its own FetchError type which is not exported.
+       * This means we can't use the FetchError class from electron-fetch to
+       * simulate network errors in cozy-client-js calls.
+       */
+      const CozyFetchError = function(message) {
+        this.name = 'FetchError'
+        this.response = {}
+        this.url = faker.internet.url
+        this.reason = message
+        this.message = message
+      }
       const randomMessage = faker.random.words
       let err
 
       beforeEach(function() {
-        err = new FetchError(randomMessage())
+        err = new CozyFetchError(randomMessage())
         this.remoteCozy.changes.rejects(err)
       })
 


### PR DESCRIPTION
Based on #1621 

The `cozy-client-js` lib defines its own `FetchError` objects when
throwing a network error.
This means it is not an instance of the `electron-fetch` defined
`FetchError` type and that calls to `instanceof` won't qualify errors
thrown by calls to `cozy-client-js` methods as `Fetch` errors.

However, we can detect all `Fetch` errors in
`.handleCommonCozyErrors()` by checking if their name is
"FetchError".

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
