### PR TITLE
core/metadata: Dissociate adding and replacing conflict suffixes

### DIFF
--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -27,7 +27,7 @@ const {
   upToDate,
   outOfDateSide,
   createConflictingDoc,
-  conflictRegExp
+  CONFLICT_REGEXP
 } = metadata
 const { Ignore } = require('../../core/ignore')
 const { FILES_DOCTYPE } = require('../../core/remote/constants')
@@ -1004,20 +1004,22 @@ describe('metadata', function() {
         path: 'docname'
       }
       const newDoc = createConflictingDoc(doc)
-      const pathRegExp = conflictRegExp(doc.path)
       should(newDoc.path)
         .be.a.String()
-        .and.match(pathRegExp)
+        .and.startWith(doc.path)
+        .and.match(CONFLICT_REGEXP)
     })
     it('should get the correct _id', () => {
       const doc = {
-        path: 'docname'
+        path: 'docname',
+        _id: metadata.id('docname')
       }
       const newDoc = createConflictingDoc(doc)
-      const pathRegExp = new RegExp(conflictRegExp(doc.path).source, 'i')
+      const idRegExp = new RegExp(CONFLICT_REGEXP.source, 'i')
       should(newDoc._id)
         .be.a.String()
-        .and.match(pathRegExp)
+        .and.startWith(doc._id)
+        .and.match(idRegExp)
     })
     it('should keep the correct extension', () => {
       const ext = '.pdf'
@@ -1042,10 +1044,8 @@ describe('metadata', function() {
           'Lorem ipsum dolor sit amet consectetur adipiscing elit Nam a velit at dolor euismod tincidunt sit amet id ante Cras vehicula lectus purus In lobortis risus lectus vitae rhoncus quam porta nullam'
       }
       const newDoc = createConflictingDoc(doc)
-      const newDocBasename = conflictRegExp('(.*)').exec(
-        path.basename(newDoc.path)
-      )[1]
-      should(newDocBasename.length).equal(180)
+      const conflictStart = path.basename(newDoc.path).search(CONFLICT_REGEXP)
+      should(conflictStart).equal(180)
     })
     it('should handle the renaming of a conflict', () => {
       const ext = `.pdf`
@@ -1054,11 +1054,11 @@ describe('metadata', function() {
         path: `${base}-conflict-1970-01-01T13_37_00.666Z${ext}`
       }
       const secondConflict = createConflictingDoc(doc)
-      const pathRegExp = conflictRegExp(base)
       should(doc.path).not.equal(secondConflict.path)
       should(secondConflict.path)
         .be.a.String()
-        .and.match(pathRegExp)
+        .and.startWith(base)
+        .and.match(CONFLICT_REGEXP)
       should(path.extname(secondConflict.path)).equal(ext)
     })
     it('should not mistake a previous conflict timezone for a file extension', () => {
@@ -1071,7 +1071,8 @@ describe('metadata', function() {
 
       should(secondConflict.path)
         .be.a.String()
-        .and.match(conflictRegExp(base))
+        .and.startWith(base)
+        .and.match(CONFLICT_REGEXP)
         .and.not.containEql(timezone)
     })
     it('should not duplicate its ancestors', () => {

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -1063,7 +1063,8 @@ describe('metadata', function() {
     })
     it('should not mistake a previous conflict timezone for a file extension', () => {
       const base = 'dirname'
-      const firstConflictSuffix = '-conflict-1970-01-01T13_37_00.666Z'
+      const timezone = '666Z'
+      const firstConflictSuffix = `-conflict-1970-01-01T13_37_00.${timezone}`
       const doc = { path: `${base}${firstConflictSuffix}` }
 
       const secondConflict = createConflictingDoc(doc)
@@ -1071,7 +1072,7 @@ describe('metadata', function() {
       should(secondConflict.path)
         .be.a.String()
         .and.match(conflictRegExp(base))
-        .and.not.containEql(firstConflictSuffix)
+        .and.not.containEql(timezone)
     })
     it('should not duplicate its ancestors', () => {
       const doc = { path: 'parent/dir/file.ext' }


### PR DESCRIPTION
The body of `createConflictingDoc()` was getting very complex and
error prone (e.g. keeping the previous conflit's milliseconds part
when a document has no extension).

We have 2 very different situations:
- either the document already has a conflict suffix
- or it does not

In the first case, we want to replace the previous suffix with a new
one while we want to add a conflict suffix in the second case, after
the file's basename but before its extension.
We can then create one function for each case, returning a new version
of the file's path and return a copy of the document with new `path`
and `_id` attributes.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
