### PR TITLE
test/unit: Fix tests broken by unrestricted macOS colon

### DIFF
--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -81,7 +81,7 @@ describe('core/local/chokidar/initial_scan', () => {
       ])
     })
 
-    if (platform === 'win32' || platform === 'darwin') {
+    if (platform === 'win32') {
       it('ignores incompatible docs', async function() {
         await builders
           .metafile()

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -7,7 +7,7 @@ const should = require('should')
 const sinon = require('sinon')
 
 const Builders = require('../support/builders')
-const { onPlatform } = require('../support/helpers/platform')
+const { onPlatform, onPlatforms } = require('../support/helpers/platform')
 
 const metadata = require('../../core/metadata')
 const {
@@ -255,20 +255,11 @@ describe('metadata', function() {
       })
     })
 
-    onPlatform('darwin', () => {
-      it('lists platform incompatibilities for all names in the path', () => {
+    onPlatforms(['darwin', 'linux'], () => {
+      it('does not list Windows incompatibilities', () => {
         const path = 'foo/b:ar/qux'
         const doc = { path, docType: 'folder' }
-        should(detectPlatformIncompatibilities(doc, syncPath)).deepEqual([
-          {
-            type: 'reservedChars',
-            name: 'b:ar',
-            path: 'foo/b:ar',
-            docType: 'folder',
-            reservedChars: new Set(':'),
-            platform
-          }
-        ])
+        should(detectPlatformIncompatibilities(doc, syncPath)).deepEqual([])
       })
     })
   })


### PR DESCRIPTION
Fixes issue in 2731cb3c not detected because electron-mocha was silently
ignoring some `.only()` invocation (forgotten in 2cf9290f, fixed in
32f4564a) despite the `--forbid-only` options, skipping the whole test
suite.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
