### PR TITLE
core/remote/cozy: Introduce CozyClientRevokedError

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -36,6 +36,13 @@ function DirectoryNotFound(path /*: string */, cozyURL /*: string */) {
   this.stack = new Error().stack
 }
 
+const COZY_CLIENT_REVOKED_ERROR = 'CozyClientRevokedError'
+const COZY_CLIENT_REVOKED_MESSAGE = 'Client has been revoked' // Only necessary for the GUI
+function CozyClientRevokedError() {
+  this.name = COZY_CLIENT_REVOKED_ERROR
+  this.message = COZY_CLIENT_REVOKED_MESSAGE
+}
+
 /*::
 import type FetchError from 'electron-fetch'
 
@@ -58,8 +65,6 @@ type CozyFetchError = Error & {
 }
 */
 
-const COZY_CLIENT_REVOKED_MESSAGE = 'Client has been revoked'
-
 const handleCommonCozyErrors = (
   err /*: FetchError | CozyFetchError | Error */,
   { events, log } /*: CommonCozyErrorHandlingOptions */
@@ -67,7 +72,7 @@ const handleCommonCozyErrors = (
   if (err.name === 'FetchError') {
     if (err.status === 400) {
       log.error({ err })
-      throw new Error(COZY_CLIENT_REVOKED_MESSAGE)
+      throw new CozyClientRevokedError()
     } else if (err.status === 402) {
       log.error({ err }, 'User action required')
       throw userActionRequired.includeJSONintoError(err)
@@ -311,9 +316,11 @@ class RemoteCozy {
 
 module.exports = {
   DirectoryNotFound,
+  COZY_CLIENT_REVOKED_ERROR,
   COZY_CLIENT_REVOKED_MESSAGE,
-  RemoteCozy,
-  handleCommonCozyErrors
+  CozyClientRevokedError,
+  handleCommonCozyErrors,
+  RemoteCozy
 }
 
 async function getChangesFeed(

--- a/gui/main.js
+++ b/gui/main.js
@@ -8,6 +8,7 @@ const path = require('path')
 const os = require('os')
 
 const proxy = require('./js/proxy')
+const { COZY_CLIENT_REVOKED_MESSAGE } = require('../core/remote/cozy')
 
 const autoLaunch = require('./js/autolaunch')
 const lastFiles = require('./js/lastfiles')
@@ -81,7 +82,7 @@ let revokedAlertShown = false
 let syncDirUnlinkedShown = false
 
 const sendErrorToMainWindow = msg => {
-  if (msg === 'Client has been revoked') {
+  if (msg === COZY_CLIENT_REVOKED_MESSAGE) {
     if (revokedAlertShown) return
     revokedAlertShown = true // prevent the alert from appearing twice
     const options = {

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -15,6 +15,7 @@ const {
 const {
   DirectoryNotFound,
   RemoteCozy,
+  CozyClientRevokedError,
   handleCommonCozyErrors
 } = require('../../../core/remote/cozy')
 
@@ -57,12 +58,11 @@ describe('core/remote/cozy', () => {
         context('on FetchError status 400', () => {
           const err = new FetchError(randomMessage())
           err.status = 400
-          const expectedMessage = 'Client has been revoked'
 
-          it(`throws an Error with the exact "${expectedMessage}" message to notify the GUI`, () => {
+          it(`throws a CozyClientRevokedError to notify the GUI`, () => {
             should(() => {
               handleCommonCozyErrors(err, { events, log })
-            }).throw()
+            }).throw(new CozyClientRevokedError())
           })
         })
 

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -20,7 +20,7 @@ const { MergeMissingParentError } = require('../../../core/merge')
 const { FILES_DOCTYPE } = require('../../../core/remote/constants')
 const Prep = require('../../../core/prep')
 const {
-  COZY_CLIENT_REVOKED_MESSAGE,
+  CozyClientRevokedError,
   RemoteCozy
 } = require('../../../core/remote/cozy')
 const { RemoteWatcher } = require('../../../core/remote/watcher')
@@ -178,7 +178,7 @@ describe('RemoteWatcher', function() {
 
         it('rejects with a higher-level error', async function() {
           await should(this.watcher.watch()).be.rejectedWith(
-            COZY_CLIENT_REVOKED_MESSAGE
+            new CozyClientRevokedError()
           )
         })
       })


### PR DESCRIPTION
Based on #1650 

We're throwing an error with the message 'Client has been revoked' in
multiple places.
To make sure we're always throwing the same error (i.e. to avoid catch
mistakes) and to DRY up the code, we're extracting this error as its
own type in `RemoteCozy`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
