### PR TITLE
core/remote/watcher: Failing test on Pouch reserved ids error

### DIFF
--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -193,6 +193,30 @@ describe('RemoteWatcher', function() {
         })
       })
     })
+
+    context('on Pouch reserved ids error', () => {
+      const reservedIdsError = {
+        name: 'bad_request',
+        status: 400,
+        message: 'Only reserved document ids may start with underscore.'
+      }
+
+      beforeEach(function() {
+        this.watcher.pullMany.returns([reservedIdsError])
+      })
+
+      it('rejects', async function() {
+        await should(this.watcher.watch()).be.rejected()
+      })
+
+      it('does not reject client revoked error', async function() {
+        try {
+          await this.watcher.watch()
+        } catch (e) {
+          should(e).not.be.an.instanceof(CozyClientRevokedError)
+        }
+      })
+    })
   })
 
   const validMetadata = (remoteDoc /*: RemoteDoc */) /*: Metadata */ => {


### PR DESCRIPTION
Based on #1654 

If we try so save a document whose id starts with an underscore, Pouch
will raise an error with a `status` attribute of value `400`.
This leads us to believe this is an HTTP error coming from the stack
that we interpret as a revoked client error.

This unit test demonstrates the situation.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
