### PR TITLE
core/local/atom/initial_diff: Drop untested code

### DIFF
--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -294,9 +294,7 @@ function fixPathsAfterParentMove(renamedEvents, event) {
         renamedEvent.oldPath,
         renamedEvent.path
       )
-      if (event.oldPath && event.oldPath === pathFixed) {
-        event.action = 'ignored'
-      } else {
+      if (event.oldPath !== pathFixed) {
         event.path = pathFixed
         event._id = id(event.path)
       }


### PR DESCRIPTION
It was introduced in 64f3cb080 but has no corresponding unit test or
scenario.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
