### PR TITLE
test/mocha.opts: Add --color

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+--color
 --slow 150
 --timeout 20000
 --reporter spec


### PR DESCRIPTION
It is not necessarily the default.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
