### PR TITLE
core/local: Re-use untouched files' checksum

### DIFF
--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -177,7 +177,7 @@ async function initialDiff(
           }
         } else if (foundUntouchedFile(event, was)) {
           _.set(event, [STEP_NAME, 'md5sumReusedFrom'], was.path)
-          event.md5sum = was.md5sum
+          event.md5sum = was.local.md5sum
         }
       }
 
@@ -320,20 +320,20 @@ function fixPathsAfterParentMove(renamedEvents, event) {
   }
 }
 
-function eventUpdateTime(event) {
-  const { ctime, mtime } = event.stats
-  return Math.max(ctime.getTime(), mtime.getTime())
+function contentUpdateTime(event) {
+  return event.stats.mtime.getTime()
 }
 
-function docUpdateTime(was) {
-  return new Date(was.updated_at).getTime()
+function docUpdateTime(oldLocal) {
+  return new Date(oldLocal.updated_at).getTime()
 }
 
 function foundUntouchedFile(event, was) /*: boolean %checks */ {
   return (
-    was != null &&
-    was.md5sum != null &&
     event.kind === 'file' &&
-    eventUpdateTime(event) === docUpdateTime(was)
+    was != null &&
+    was.local != null &&
+    was.local.md5sum != null &&
+    contentUpdateTime(event) === docUpdateTime(was.local)
   )
 }

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -30,7 +30,6 @@ const path = require('path')
 
 const metadata = require('../../metadata')
 const logger = require('../../utils/logger')
-const { sameDate, fromDate } = require('../../utils/timestamp')
 
 /*::
 import type { ChokidarEvent } from './event'
@@ -90,14 +89,17 @@ const step = async (
         if (
           initialScan &&
           e2.old &&
-          e2.path === e2.old.path &&
-          sameDate(fromDate(e2.old.updated_at), fromDate(e2.stats.mtime))
+          e2.path.normalize() === e2.old.path.normalize() &&
+          e2.old.local &&
+          e2.old.local.md5sum &&
+          new Date(e2.old.local.updated_at).getTime() ===
+            e2.stats.mtime.getTime()
         ) {
           log.trace(
             { path: e.path },
             'Do not compute checksum : mtime & path are unchanged'
           )
-          e2.md5sum = e2.old.md5sum
+          e2.md5sum = e2.old.local.md5sum
         } else {
           try {
             e2.md5sum = await checksum(e.path)

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -768,7 +768,9 @@ function buildFile(
   if (stats.fileid) {
     doc.fileid = stats.fileid
   }
-  updateLocal(doc)
+  updateLocal(doc, {
+    updated_at: mtime.toISOString()
+  })
   return doc
 }
 
@@ -814,6 +816,13 @@ function shouldIgnore(
   })
 }
 
-function updateLocal(doc /*: Metadata */, newLocal /*: Object */) {
-  doc.local = _.pick(newLocal || doc, LOCAL_ATTRIBUTES)
+function updateLocal(doc /*: Metadata */, newLocal /*: ?Object */ = {}) {
+  // Boolean attributes not set in doc when false will not override an existing
+  // truthy value.
+  // This is the case for `executable` and we need to provide a default falsy
+  // value to override the `newLocal` executable value in all cases.
+  doc.local = _.pick(
+    _.defaults(newLocal, { executable: false }, doc),
+    LOCAL_ATTRIBUTES
+  )
 }

--- a/test/integration/full_loop.js
+++ b/test/integration/full_loop.js
@@ -36,12 +36,13 @@ describe('Full watch/merge/sync/repeat loop', () => {
   })
 
   it('remote -> local add file', async () => {
+    await helpers._local.watcher.start()
+
     await cozy.files.create('some file content', { name: 'file' })
     await helpers.remote.pullChanges()
     await helpers.syncAll()
-    should(await helpers.local.tree()).deepEqual(['file'])
 
-    await helpers._local.watcher.start()
+    should(await helpers.local.tree()).deepEqual(['file'])
 
     const doc = await helpers.pouch.db.get(metadata.id('file'))
     should(doc.ino).be.a.Number()

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -11,6 +11,7 @@ type DispatchedCalls = {
 
 const should = require('should')
 const sinon = require('sinon')
+const _ = require('lodash')
 
 const Builders = require('../../../support/builders')
 const configHelpers = require('../../../support/helpers/config')
@@ -144,7 +145,17 @@ describe('core/local/atom/dispatch.loop()', function() {
       await dispatch.loop(channel, stepOptions).pop()
 
       should(dispatchedCalls(prep)).deepEqual({
-        addFileAsync: [['local', doc]]
+        addFileAsync: [
+          [
+            'local',
+            _.defaultsDeep(
+              {
+                local: { updated_at: updatedAt.toISOString() }
+              },
+              doc
+            )
+          ]
+        ]
       })
     })
   })
@@ -217,7 +228,17 @@ describe('core/local/atom/dispatch.loop()', function() {
       await dispatch.loop(channel, stepOptions).pop()
 
       should(dispatchedCalls(prep)).deepEqual({
-        addFileAsync: [['local', doc]]
+        addFileAsync: [
+          [
+            'local',
+            _.defaultsDeep(
+              {
+                local: { updated_at: updatedAt.toISOString() }
+              },
+              doc
+            )
+          ]
+        ]
       })
     })
   })
@@ -290,7 +311,17 @@ describe('core/local/atom/dispatch.loop()', function() {
       await dispatch.loop(channel, stepOptions).pop()
 
       should(dispatchedCalls(prep)).deepEqual({
-        updateFileAsync: [['local', doc]]
+        updateFileAsync: [
+          [
+            'local',
+            _.defaultsDeep(
+              {
+                local: { updated_at: updatedAt.toISOString() }
+              },
+              doc
+            )
+          ]
+        ]
       })
     })
   })
@@ -378,7 +409,18 @@ describe('core/local/atom/dispatch.loop()', function() {
           await dispatch.loop(channel, stepOptions).pop()
 
           should(dispatchedCalls(prep)).deepEqual({
-            moveFileAsync: [['local', doc, oldDoc]]
+            moveFileAsync: [
+              [
+                'local',
+                _.defaultsDeep(
+                  {
+                    local: { updated_at: updatedAt.toISOString() }
+                  },
+                  doc
+                ),
+                oldDoc
+              ]
+            ]
           })
         })
       })
@@ -489,10 +531,13 @@ describe('core/local/atom/dispatch.loop()', function() {
             moveFileAsync: [
               [
                 'local',
-                {
-                  ...doc,
-                  overwrite: existingDoc
-                },
+                _.defaultsDeep(
+                  {
+                    overwrite: existingDoc,
+                    local: { updated_at: updatedAt.toISOString() }
+                  },
+                  doc
+                ),
                 oldDoc
               ]
             ]
@@ -515,7 +560,15 @@ describe('core/local/atom/dispatch.loop()', function() {
         await dispatch.loop(channel, stepOptions).pop()
 
         should(dispatchedCalls(prep)).deepEqual({
-          addFileAsync: [['local', doc]]
+          addFileAsync: [
+            [
+              'local',
+              _.defaultsDeep(
+                { local: { updated_at: updatedAt.toISOString() } },
+                doc
+              )
+            ]
+          ]
         })
       })
 

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -501,12 +501,6 @@ describe('core/local/atom/initial_diff', () => {
     })
 
     it('does not reuse the checksum of modified files', async function() {
-      const updatedMetadata = await builders
-        .metafile()
-        .path('updatedMetadata')
-        .ino(1)
-        .data('content')
-        .create()
       const updatedContent = await builders
         .metafile()
         .path('updatedContent')
@@ -517,29 +511,19 @@ describe('core/local/atom/initial_diff', () => {
       const state = await initialDiff.initialState({ pouch: this.pouch })
 
       const updateTime = new Date(Date.now() + 1000)
-      const updatedMetadataScan = builders
-        .event()
-        .fromDoc(updatedMetadata)
-        .action('scan')
-        .ctime(updateTime)
-        .build()
       const updatedContentScan = builders
         .event()
         .fromDoc(updatedContent)
         .action('scan')
         .mtime(updateTime)
         .build()
-      inputBatch([updatedMetadataScan, updatedContentScan, initialScanDone])
+      inputBatch([updatedContentScan, initialScanDone])
 
       const events = await initialDiff
         .loop(channel, { pouch: this.pouch, state })
         .pop()
 
-      should(events).deepEqual([
-        updatedMetadataScan,
-        updatedContentScan,
-        initialScanDone
-      ])
+      should(events).deepEqual([updatedContentScan, initialScanDone])
     })
 
     it('ignores events for unapplied moves', async function() {


### PR DESCRIPTION
In order to limit the number of checksum computations during the
initial scan, we try to reuse the existing PouchDB record's local
`md5sum` if the event's update time matches the record's local
`updated_at`.

We compare the event's `mtime` field because we care only about the
file content updates to trigger checksum computations.
Also, we now compare it with the recently added local `updated_at`
which will now contain the latest local `mtime` value instead of
either the remote `updated_at` value or the max between the local
`mtime` and `ctime` that can be stored in the record's main
`updated_at` attribute.
Finally, we re-use the local `md5sum` because the main `md5sum`
attribute can have changed after a remote update was merged but not
applied on the local filesystem.

Since we're changing the way we compute the local `updated_at`, all
existing files' records will be updated during the first launch
including this commit.
This can take a while but all later launches will benefit from it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
