### PR TITLE
travis: Don't run all chokidar flushing scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
         # FIXME: Homebrew 1.7.3 fails to install cask apache-couchdb
         - HOMEBREW_NO_AUTO_UPDATE=1
         - MOCHA_TIMEOUT="240000"
+        - NO_BREAKPOINTS=1
         - NODE_ENV=test
         - NPM_CONFIG_PROGRESS=false
         - COZY_DESKTOP_HEARTBEAT=1000


### PR DESCRIPTION
Could divide the number of scenarios to run by 3 and make macOS CI
faster.

We didn't really change the chokidar watcher recently, so it should be
relatively safe without it. We can still revert this as needed anyway.

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
