### PR TITLE
core: Refactor Side, Reader & Writer

### DIFF
--- a/core/IdConflict.js
+++ b/core/IdConflict.js
@@ -17,7 +17,8 @@
 const _ = require('lodash')
 
 /*::
-import type { Metadata, SideName } from './metadata'
+import type { Metadata } from './metadata'
+import type { SideName } from './side'
 
 type Change = {
   side: SideName,

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -17,7 +17,7 @@ const stater = require('./stater')
 const { isUpToDate } = require('../metadata')
 const { hideOnWindows } = require('../utils/fs')
 const watcher = require('./watcher')
-const { withContentLength } = require('../file_stream_provider')
+const { withContentLength } = require('../reader')
 const syncDir = require('./sync_dir')
 const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
@@ -26,7 +26,7 @@ const sentry = require('../utils/sentry')
 /*::
 import type EventEmitter from 'events'
 import type { Config } from '../config'
-import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider'
+import type { ReadableWithContentLength, Reader } from '../reader'
 import type { Ignore } from '../ignore'
 import type { AtomEventsDispatcher } from './atom/dispatch'
 import type { Metadata } from '../metadata'
@@ -70,7 +70,7 @@ class Local /*:: implements Writer */ {
   syncDirCheckInterval: IntervalID
   tmpPath: string
   watcher: Watcher
-  other: FileStreamProvider
+  other: Reader
   _trash: (Array<string>) => Promise<void>
   */
 

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -32,7 +32,7 @@ import type { AtomEventsDispatcher } from './atom/dispatch'
 import type { Metadata } from '../metadata'
 import type Pouch from '../pouch'
 import type Prep from '../prep'
-import type { Side } from '../side' // eslint-disable-line
+import type { Writer } from '../writer'
 import type { Callback } from '../utils/func'
 import type { Watcher } from './watcher'
 */
@@ -61,7 +61,7 @@ export type LocalOptions = {
  * This allows us to read from the remote Cozy when writing to the local
  * filesystem.
  */
-class Local /*:: implements Side */ {
+class Local /*:: implements Writer */ {
   /*::
   prep: Prep
   pouch: Pouch

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -61,7 +61,7 @@ export type LocalOptions = {
  * This allows us to read from the remote Cozy when writing to the local
  * filesystem.
  */
-class Local /*:: implements Writer */ {
+class Local /*:: implements Reader, Writer */ {
   /*::
   prep: Prep
   pouch: Pouch

--- a/core/merge.js
+++ b/core/merge.js
@@ -18,9 +18,10 @@ const timestamp = require('./utils/timestamp')
 /*::
 import type { IdConflictInfo } from './IdConflict'
 import type Local from './local'
-import type { SideName, Metadata, RemoteRevisionsByID } from './metadata'
+import type { Metadata, RemoteRevisionsByID } from './metadata'
 import type Pouch from './pouch'
 import type { Remote } from './remote'
+import type { SideName } from './side'
 */
 
 const log = logger({

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -54,6 +54,7 @@ import type { PathIssue } from './path_restrictions'
 import type { RemoteDoc } from './remote/document'
 import type { Stats } from './local/stater'
 import type { Ignore } from './ignore'
+import type { SideName } from './side'
 */
 
 const log = logger({
@@ -65,9 +66,6 @@ const { platform } = process
 const CONFLICT_REGEXP = /-conflict-\d{4}(?:-\d{2}){2}T(?:\d{2}_?){3}\.\d{3}Z/
 
 /*::
-export type SideName =
-  | "local"
-  | "remote";
 export type DocType =
   | "file"
   | "folder";

--- a/core/move.js
+++ b/core/move.js
@@ -11,7 +11,8 @@
 const metadata = require('./metadata')
 
 /*::
-import type { SideName, Metadata } from './metadata'
+import type { Metadata } from './metadata'
+import type { SideName } from './side'
 */
 
 module.exports = move

--- a/core/prep.js
+++ b/core/prep.js
@@ -15,7 +15,8 @@ const logger = require('./utils/logger')
 import type { Config } from './config'
 import type { Ignore } from './ignore'
 import type { Merge } from './merge'
-import type { SideName, Metadata, RemoteRevisionsByID } from './metadata'
+import type { Metadata, RemoteRevisionsByID } from './metadata'
+import type { SideName } from './side'
 */
 
 const log = logger({

--- a/core/reader.js
+++ b/core/reader.js
@@ -1,5 +1,9 @@
-/**
- * @module core/file_stream_provider
+/**  Provides a stream.Readable for local or remote file corresponding to the
+ * given metadata.
+ *
+ * See the `Reader` type.
+ *
+ * @module core/reader
  * @flow
  */
 
@@ -27,9 +31,7 @@ function withContentLength(
 }
 
 /*::
-// Provides a stream.Readable for local or remote file corresponding to the
-// given metadata.
-export type FileStreamProvider = {
+export type Reader = {
   createReadStreamAsync: (Metadata) => Promise<ReadableWithContentLength>;
 }
 */

--- a/core/reader.js
+++ b/core/reader.js
@@ -31,8 +31,8 @@ function withContentLength(
 }
 
 /*::
-export type Reader = {
-  createReadStreamAsync: (Metadata) => Promise<ReadableWithContentLength>;
+export interface Reader {
+  createReadStreamAsync (Metadata): Promise<ReadableWithContentLength>;
 }
 */
 

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -12,7 +12,7 @@ const { posix, sep } = path
 const { RemoteCozy } = require('./cozy')
 const { RemoteWarningPoller } = require('./warning_poller')
 const { RemoteWatcher } = require('./watcher')
-const { withContentLength } = require('../file_stream_provider')
+const { withContentLength } = require('../reader')
 const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
 
@@ -23,7 +23,7 @@ import type { Metadata } from '../metadata'
 import type Pouch from '../pouch'
 import type Prep from '../prep'
 import type { RemoteDoc } from './document'
-import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider' // eslint-disable-line
+import type { ReadableWithContentLength, Reader } from '../reader' // eslint-disable-line
 import type { Writer } from '../writer'
 */
 
@@ -53,7 +53,7 @@ export type RemoteOptions = {
  */
 class Remote /*:: implements Writer */ {
   /*::
-  other: FileStreamProvider
+  other: Reader
   pouch: Pouch
   events: EventEmitter
   watcher: RemoteWatcher

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -24,7 +24,7 @@ import type Pouch from '../pouch'
 import type Prep from '../prep'
 import type { RemoteDoc } from './document'
 import type { FileStreamProvider, ReadableWithContentLength } from '../file_stream_provider' // eslint-disable-line
-import type { Side } from '../side' // eslint-disable-line
+import type { Writer } from '../writer'
 */
 
 const log = logger({
@@ -51,7 +51,7 @@ export type RemoteOptions = {
  * This allows us to read from the local filesystem when writing to the remote
  * Cozy.
  */
-class Remote /*:: implements Side */ {
+class Remote /*:: implements Writer */ {
   /*::
   other: FileStreamProvider
   pouch: Pouch

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -51,7 +51,7 @@ export type RemoteOptions = {
  * This allows us to read from the local filesystem when writing to the remote
  * Cozy.
  */
-class Remote /*:: implements Writer */ {
+class Remote /*:: implements Reader, Writer */ {
   /*::
   other: Reader
   pouch: Pouch

--- a/core/side.js
+++ b/core/side.js
@@ -5,12 +5,10 @@
  */
 
 /*::
-import type { SideName } from './metadata'
+export type SideName =
+  | "local"
+  | "remote";
 */
-
-module.exports = {
-  otherSide
-}
 
 function otherSide(side /*: SideName */) /*: SideName */ {
   switch (side) {
@@ -21,4 +19,8 @@ function otherSide(side /*: SideName */) /*: SideName */ {
     default:
       throw new Error(`Invalid side name: ${JSON.stringify(side)}`)
   }
+}
+
+module.exports = {
+  otherSide
 }

--- a/core/side.js
+++ b/core/side.js
@@ -1,25 +1,11 @@
-/** Common interface of Local & Remote sides.
+/** Side helpers.
  *
  * @module core/side
  * @flow
  */
 
 /*::
-import type { SideName, Metadata } from './metadata'
-
-export interface Side {
-  addFileAsync (doc: Metadata): Promise<void>;
-  addFolderAsync (doc: Metadata): Promise<void>;
-  overwriteFileAsync (doc: Metadata, old: ?Metadata): Promise<void>;
-  updateFileMetadataAsync (doc: Metadata, old: Metadata): Promise<void>;
-  updateFolderAsync (doc: Metadata, old: Metadata): Promise<void>;
-  moveFileAsync (doc: Metadata, from: Metadata): Promise<void>;
-  moveFolderAsync (doc: Metadata, from: Metadata): Promise<void>;
-  assignNewRev (doc: Metadata): Promise<void>;
-  trashAsync (doc: Metadata): Promise<void>;
-  deleteFolderAsync (doc: Metadata): Promise<void>;
-  renameConflictingDocAsync (doc: Metadata, newPath: string): Promise<void>;
-}
+import type { SideName } from './metadata'
 */
 
 module.exports = {

--- a/core/sync.js
+++ b/core/sync.js
@@ -79,9 +79,7 @@ class Sync {
     this.remote = remote
     this.ignore = ignore
     this.events = events
-    // $FlowFixMe
     this.local.other = this.remote
-    // $FlowFixMe
     this.remote.other = this.local
 
     autoBind(this)

--- a/core/sync.js
+++ b/core/sync.js
@@ -23,7 +23,7 @@ import type Local from './local'
 import type Pouch from './pouch'
 import type { Remote } from './remote'
 import type { SideName, Metadata } from './metadata'
-import type { Side } from './side' // eslint-disable-line
+import type { Writer } from './writer'
 */
 
 const log = logger({
@@ -275,7 +275,7 @@ class Sync {
 
   async applyDoc(
     doc /*: Metadata */,
-    side /*: Side */,
+    side /*: Writer */,
     sideName /*: SideName */,
     rev /*: number */
   ) /*: Promise<*> */ {
@@ -357,7 +357,6 @@ class Sync {
       if (old) {
         if (doc.docType === 'folder') {
           await side.updateFolderAsync(doc, old)
-          // $FlowFixMe
         } else if (metadata.sameBinary(old, doc)) {
           if (metadata.sameFileIgnoreRev(old, doc)) {
             log.debug({ path: doc.path }, 'Ignoring timestamp-only change')
@@ -372,7 +371,7 @@ class Sync {
     }
   }
 
-  async doAdd(side /*: Side */, doc /*: Metadata */) /*: Promise<void> */ {
+  async doAdd(side /*: Writer */, doc /*: Metadata */) /*: Promise<void> */ {
     if (doc.docType === 'file') {
       await side.addFileAsync(doc)
       this.events.emit('transfer-started', _.clone(doc))
@@ -382,7 +381,7 @@ class Sync {
   }
 
   async doOverwrite(
-    side /*: Side */,
+    side /*: Writer */,
     doc /*: Metadata */
   ) /*: Promise<void> */ {
     if (doc.docType === 'file') {
@@ -395,7 +394,7 @@ class Sync {
   }
 
   async doMove(
-    side /*: Side */,
+    side /*: Writer */,
     doc /*: Metadata */,
     old /*: Metadata */
   ) /*: Promise<void> */ {
@@ -529,7 +528,7 @@ class Sync {
   // preserve the tree in the trash.
   async trashWithParentOrByItself(
     doc /*: Metadata */,
-    side /*: Side */
+    side /*: Writer */
   ) /*: Promise<boolean> */ {
     let parentId = dirname(doc._id)
     if (parentId !== '.') {

--- a/core/sync.js
+++ b/core/sync.js
@@ -22,7 +22,8 @@ import type { Ignore } from './ignore'
 import type Local from './local'
 import type Pouch from './pouch'
 import type { Remote } from './remote'
-import type { SideName, Metadata } from './metadata'
+import type { Metadata } from './metadata'
+import type { SideName } from './side'
 import type { Writer } from './writer'
 */
 

--- a/core/writer.js
+++ b/core/writer.js
@@ -1,0 +1,25 @@
+/** Writes changes to the local FS or the remote Cozy.
+ *
+ * See the `Writer` interface.
+ *
+ * @module core/writer
+ * @flow
+ */
+
+/*::
+import type { SideName, Metadata } from './metadata'
+
+export interface Writer {
+  addFileAsync (doc: Metadata): Promise<void>;
+  addFolderAsync (doc: Metadata): Promise<void>;
+  overwriteFileAsync (doc: Metadata, old: ?Metadata): Promise<void>;
+  updateFileMetadataAsync (doc: Metadata, old: Metadata): Promise<void>;
+  updateFolderAsync (doc: Metadata, old: Metadata): Promise<void>;
+  moveFileAsync (doc: Metadata, from: Metadata): Promise<void>;
+  moveFolderAsync (doc: Metadata, from: Metadata): Promise<void>;
+  assignNewRev (doc: Metadata): Promise<void>;
+  trashAsync (doc: Metadata): Promise<void>;
+  deleteFolderAsync (doc: Metadata): Promise<void>;
+  renameConflictingDocAsync (doc: Metadata, newPath: string): Promise<void>;
+}
+*/

--- a/core/writer.js
+++ b/core/writer.js
@@ -7,7 +7,8 @@
  */
 
 /*::
-import type { SideName, Metadata } from './metadata'
+import type { Metadata } from './metadata'
+import type { SideName } from './side'
 
 export interface Writer {
   addFileAsync (doc: Metadata): Promise<void>;

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 /*::
-import type { SideName } from '../../core/metadata'
+import type { SideName } from '../../core/side'
 
 type FSAddDirAction = {|
   type: 'mkdir',

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -15,10 +15,10 @@ import type {
   Metadata,
   MetadataRemoteInfo,
   MetadataSidesInfo,
-  SideName
 } from '../../../../core/metadata'
 import type Pouch from '../../../../core/pouch'
 import type { RemoteDoc } from '../../../../core/remote/document'
+import type { SideName } from '../../../../core/side'
 */
 
 module.exports = class BaseMetadataBuilder {

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -3,7 +3,7 @@
 const sinon = require('sinon')
 
 /*::
-import type { Side } from '../../../core/side'
+import type { Writer } from '../../../core/writer'
 */
 
 const METHODS = [
@@ -20,7 +20,7 @@ const METHODS = [
   'renameConflictingDocAsync'
 ]
 
-module.exports = function stubSide() /*: Side */ {
+module.exports = function stubSide() /*: Writer */ {
   const double = {}
   for (let method of METHODS) {
     double[method] = sinon.stub().resolves()

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -12,7 +12,7 @@ const sinon = require('sinon')
 const should = require('should')
 const stream = require('stream')
 
-const { withContentLength } = require('../../../core/file_stream_provider')
+const { withContentLength } = require('../../../core/reader')
 const checksumer = require('../../../core/local/checksumer')
 const metadata = require('../../../core/metadata')
 const { ensureValidPath } = metadata


### PR DESCRIPTION
Allows:

- Grouping side-related stuff together
- Breaking cyclic dependencies
- Enforcing interfaces
- Removing a few `$FlowFixMe` & `eslint-disable*` annotations

---

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
