### PR TITLE
Test sync feedback in remote scenarios

### DIFF
--- a/core/local/chokidar/event_buffer.js
+++ b/core/local/chokidar/event_buffer.js
@@ -71,12 +71,12 @@ class EventBuffer /*:: <EventType> */ {
     }
   }
 
-  flush() /*: void */ {
+  async flush() {
     this.clearTimeout()
     if (this.events.length > 0) {
       const flushedEvents = this.events
       this.events = []
-      this.flushed(flushedEvents)
+      return this.flushed(flushedEvents)
     }
   }
 

--- a/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
+++ b/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
@@ -4,7 +4,8 @@
 
 module.exports = ({
   disabled: {
-    stopped: 'Does not work with AtomWatcher yet.'
+    stopped: 'Does not work with AtomWatcher yet.',
+    remote: 'Does not work with AtomWatcher yet.'
   },
   init: [
     { ino: 1, path: 'a/' },

--- a/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
+++ b/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
@@ -4,7 +4,8 @@
 
 module.exports = ({
   disabled: {
-    stopped: 'Does not work with AtomWatcher yet.'
+    stopped: 'Does not work with AtomWatcher yet.',
+    remote: 'Does not work with AtomWatcher yet.'
   },
   init: [
     { ino: 1, path: 'a', content: 'content a' },

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -1,6 +1,8 @@
 /* @flow */
 /* eslint-env mocha */
 
+require('../../../core/globals')
+
 const CozyClient = require('cozy-client-js').Client
 
 const {

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -212,7 +212,7 @@ module.exports.init = async (
         updated_at: lastModifiedDate,
         path: localPath,
         tags: [],
-        sides: { local: 1, remote: 1 }
+        sides: { local: 2, remote: 2 }
       }
       stater.assignInoAndFileId(doc, stats)
 
@@ -229,6 +229,8 @@ module.exports.init = async (
         if (trashed) remoteDocsToTrash.push(remoteDir)
         else {
           debug(`- create dir metadata: ${doc._id}`)
+          const { rev } = await pouch.put(doc)
+          doc._rev = rev
           await pouch.put(doc)
         }
       }
@@ -267,7 +269,7 @@ module.exports.init = async (
         path: localPath,
         size: content.length,
         tags: [],
-        sides: { local: 1, remote: 1 }
+        sides: { local: 2, remote: 2 }
       }
       stater.assignInoAndFileId(doc, stats)
       if (!isOutside) {
@@ -285,6 +287,8 @@ module.exports.init = async (
         if (trashed) remoteDocsToTrash.push(remoteFile)
         else {
           debug(`- create file metadata: ${doc._id}`)
+          const { rev } = await pouch.put(doc)
+          doc._rev = rev
           await pouch.put(doc)
         }
       }


### PR DESCRIPTION
To make sure we don't have bad interactions between the
synchronization of remote changes and the local watcher, we need to
run the local watcher during our remote scenarios.

This involves running the watcher, sending a magic event after we've
run all scenarios actions to signal the end of the test and using real
inodes to make sure the local watcher does not detect and merge inode
changes on init files during its initial scan.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
