### PR TITLE
core/local/atom/dispatch: Compare inodes for moves

### DIFF
--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -143,6 +143,10 @@ actions = {
       event.action = 'created'
       delete event.oldPath
       return actions.createdfile(event, { prep }, 'File moved, assuming added')
+    } else if (was.ino !== event.stats.ino) {
+      _.set(event, [STEP_NAME, 'moveSrcReplacement'], _.clone(was))
+      log.warn({ event }, 'File move source has been replaced in Pouch')
+      return
     }
     log.info({ event }, 'File moved')
 
@@ -169,9 +173,15 @@ actions = {
         { prep },
         'Dir moved, assuming added'
       )
+    } else if (was.ino !== event.stats.ino) {
+      _.set(event, [STEP_NAME, 'moveSrcReplacement'], _.clone(was))
+      log.warn({ event }, 'File move source has been replaced in Pouch')
+      return
     }
     log.info({ event }, 'Dir moved')
+
     const doc = buildDir(event.path, event.stats)
+
     await prep.moveFolderAsync(SIDE, doc, was)
   },
 

--- a/test/scenarios/move_a_to_b_and_create_a/remote/changes.json
+++ b/test/scenarios/move_a_to_b_and_create_a/remote/changes.json
@@ -1,0 +1,36 @@
+[
+  {
+    "_id": "286d994b69698b49049b229f753aef5b",
+    "_rev": "2-f49f82bfe5c2683984723f299a366d57",
+    "class": "text",
+    "created_at": "2019-07-12T15:14:37.849943018Z",
+    "dir_id": "io.cozy.files.root-dir",
+    "executable": false,
+    "md5sum": "lsFcK7KSEZO/KQ34zYXiug==",
+    "mime": "text/plain",
+    "name": "a",
+    "size": "11",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2019-07-12T15:14:37.849943018Z",
+    "path": "/a"
+  },
+  {
+    "_id": "286d994b69698b49049b229f753aeccb",
+    "_rev": "3-a2391e2e0505982add5736cec03f98a6",
+    "class": "files",
+    "created_at": "2019-07-12T15:14:37.46323708Z",
+    "dir_id": "io.cozy.files.root-dir",
+    "executable": false,
+    "md5sum": "Bg5OnjC8ua5nWoAyioemhw==",
+    "mime": "application/octet-stream",
+    "name": "b",
+    "size": "20",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2019-07-12T15:14:37.46323708Z",
+    "path": "/b"
+  }
+]

--- a/test/scenarios/move_a_to_b_and_create_a/scenario.js
+++ b/test/scenarios/move_a_to_b_and_create_a/scenario.js
@@ -1,0 +1,21 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  disabled: {
+    remote: 'Does not work with AtomWatcher yet.'
+  },
+  init: [{ ino: 1, path: 'a', content: 'initial content' }],
+  actions: [
+    { type: 'mv', src: 'a', dst: 'b' },
+    { type: 'create_file', path: 'a', content: 'new content' }
+  ],
+  expected: {
+    tree: ['a', 'b'],
+    contents: {
+      a: 'new content',
+      b: 'initial content'
+    }
+  }
+} /*: Scenario */)

--- a/test/scenarios/move_a_to_b_and_create_a/scenario.js
+++ b/test/scenarios/move_a_to_b_and_create_a/scenario.js
@@ -4,7 +4,7 @@
 
 module.exports = ({
   disabled: {
-    remote: 'Does not work with AtomWatcher yet.'
+    stopped: 'Does not work with AtomWatcher yet.'
   },
   init: [{ ino: 1, path: 'a', content: 'initial content' }],
   actions: [

--- a/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
+++ b/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
@@ -4,8 +4,7 @@
 
 module.exports = ({
   disabled: {
-    stopped: 'Does not work with AtomWatcher yet.',
-    remote: 'Does not work with AtomWatcher yet.'
+    stopped: 'Does not work with AtomWatcher yet.'
   },
   init: [
     { ino: 1, path: 'a/' },

--- a/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
+++ b/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
@@ -4,8 +4,7 @@
 
 module.exports = ({
   disabled: {
-    stopped: 'Does not work with AtomWatcher yet.',
-    remote: 'Does not work with AtomWatcher yet.'
+    stopped: 'Does not work with AtomWatcher yet.'
   },
   init: [
     { ino: 1, path: 'a', content: 'content a' },

--- a/test/scenarios/replace_file_with_file/scenario.js
+++ b/test/scenarios/replace_file_with_file/scenario.js
@@ -3,7 +3,6 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  side: 'local',
   init: [{ ino: 1, path: 'file', content: 'initial content' }],
   actions: [
     { type: 'delete', path: 'file' },


### PR DESCRIPTION
In the AtomWatcher, when an `renamed` event reaches the `dispatch`
step, the Pouch document matching the source path can have changed
 already and not match the old situation anymore.
This is especially true when synchronizing a remote move and a remote
addition at the move source path.

Sending that event to `Merge` would lead to a conflict on the
destination path in our example (i.e. we're using the newly added
document as the move source while it differs from the destination
document).

To mitigate the situation, we can compare the inodes of the
file/directory that triggered the event and the existing document we
found in Pouch corresponding to the event `oldPath` attribute.
If those differ, we discard the event.
We assume here that the filesystem won't change the inode when moving
a file/directory and know that following replacements on the
destination path will be merged after the move.

This includes a new scenario coming from the analysis of a user's log 
files:
> Moving a synchronized file to another location and creating a new file
at the first location on the remote, while the client was stopped,
leads to a conflict on the first location.
> 
> In the user's case, where 2 clients were connected at the same time,
an infinite conflict loop was triggered.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
