### PR TITLE
test/scenarios: Add failing scenario for move+delete child

### DIFF
--- a/test/scenarios/move_and_trash_file_from_inside_move/atom/linux.json
+++ b/test/scenarios/move_and_trash_file_from_inside_move/atom/linux.json
@@ -1,0 +1,17 @@
+[
+  [
+    {
+      "action": "renamed",
+      "kind": "directory",
+      "path": "dst/dir",
+      "oldPath": "src/dir"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "dst/dir/subfile"
+    }
+  ]
+]

--- a/test/scenarios/move_and_trash_file_from_inside_move/local/darwin.json
+++ b/test/scenarios/move_and_trash_file_from_inside_move/local/darwin.json
@@ -1,0 +1,37 @@
+[
+  {
+    "breakpoints": [0, 2, 4]
+  },
+  {
+    "type": "unlinkDir",
+    "path": "src/dir"
+  },
+  {
+    "type": "addDir",
+    "path": "dst/dir",
+    "stats": {
+      "ino": 3,
+      "size": 96,
+      "mtime": "2019-07-29T10:10:41.303Z",
+      "ctime": "2019-07-29T10:10:41.335Z"
+    }
+  },
+  {
+    "type": "unlink",
+    "path": "src/dir/subfile"
+  },
+  {
+    "type": "add",
+    "path": "dst/dir/subfile",
+    "stats": {
+      "ino": 4,
+      "size": 8,
+      "mtime": "2019-07-29T10:10:41.303Z",
+      "ctime": "2019-07-29T10:10:41.303Z"
+    }
+  },
+  {
+    "type": "unlink",
+    "path": "dst/dir/subfile"
+  }
+]

--- a/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
+++ b/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  disabled: {
+    'atom/linux': 'Does not work with AtomWatcher yet.',
+    'local/darwin': 'Does not work with all flush points',
+    stopped: 'Does not work with AtomWatcher yet.'
+  },
+  side: 'local',
+  init: [
+    { ino: 1, path: 'dst/' },
+    { ino: 2, path: 'src/' },
+    { ino: 3, path: 'src/dir/' },
+    { ino: 4, path: 'src/dir/subfile' }
+  ],
+  actions: [
+    { type: 'mv', src: 'src/dir', dst: 'dst/dir' },
+    { type: 'wait', ms: 1500 },
+    { type: 'trash', path: 'dst/dir/subfile' }
+  ],
+  expected: {
+    tree: ['dst/', 'dst/dir/', 'src/'],
+    remoteTrash: ['subfile']
+  }
+} /*: Scenario */)


### PR DESCRIPTION
  Moving a directory and then deleting (or moving outside the synced
  directory) one of its children will result in the child not to be
  trashed.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
