### PR TITLE
gui: Start app minimized in systray

### DIFF
--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -79,7 +79,7 @@ const WindowManager = require('./window_manager')
 module.exports = class TrayWM extends WindowManager {
   constructor(...opts) {
     super(...opts)
-    this.create().then(() => this.hide())
+    this.create()
   }
 
   windowOptions() {

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -125,12 +125,14 @@ module.exports = class WindowManager {
   create() {
     this.log.debug('create')
     const opts = this.windowOptions()
-    opts.show = false
     // https://github.com/AppImage/AppImageKit/wiki/Bundling-Electron-apps
     if (process.platform === 'linux') {
       opts.icon = path.join(__dirname, '../images/icon.png')
     }
-    this.win = new BrowserWindow(opts)
+    this.win = new BrowserWindow({
+      ...opts,
+      show: false
+    })
     this.win.on('unresponsive', () => {
       this.log.warn('Web page becomes unresponsive')
     })
@@ -174,17 +176,18 @@ module.exports = class WindowManager {
       this.win = null
     })
 
-    let resolveCreate = null
-    let promiseReady = new Promise(resolve => {
-      resolveCreate = resolve
+    const windowCreated = new Promise(resolve => {
+      if (opts.show === false) {
+        resolve(this.win)
+      } else {
+        this.win.webContents.on('dom-ready', () => {
+          setTimeout(() => {
+            this.win.show()
+            resolve(this.win)
+          }, ELMSTARTUP)
+        })
+      }
     }).catch(err => log.error(err))
-
-    this.win.webContents.on('dom-ready', () => {
-      setTimeout(() => {
-        this.win.show()
-        resolveCreate(this.win)
-      }, ELMSTARTUP)
-    })
 
     let indexPath = path.resolve(__dirname, '..', 'index.html')
     this.win.loadURL(`file://${indexPath}${this.hash()}`)
@@ -194,6 +197,6 @@ module.exports = class WindowManager {
       this.win.webContents.openDevTools({ mode: 'detach' })
     }
 
-    return promiseReady
+    return windowCreated
   }
 }


### PR DESCRIPTION
  When starting the app, an empty, transparent window is displayed and
  can only be closed by clicking on the systray icon and unfocusing the
  replacing window.

  We actually want no windows to be displayed on start. For some reason,
  waiting for the DOM content to be ready and displayed before hiding
  the window causes its content to be hidden (hence the transparency)
  but not the window itself.
  Since we don't really need to display the window and its content
  before hiding it, we can rely on the `show` window option to
  determine when to display the window and when to return it right after
  its creation.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
