### PR TITLE
core/merge: Treat local-only folder move as addition

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -409,8 +409,9 @@ class Merge {
     newRemoteRevs /*: ?RemoteRevisionsByID */
   ) {
     log.debug({ path: doc.path, oldpath: was.path }, 'moveFolderAsync')
-    if (!was.sides || !was.sides[side]) {
-      // It can happen after a conflict
+    if (!metadata.wasSynced(was)) {
+      metadata.markAsUnsyncable(side, was)
+      await this.pouch.put(was)
       return this.putFolderAsync(side, doc)
     }
 


### PR DESCRIPTION
If a folder is created locally then moved between the merge and the
synchronization of its creation then we should not consider it as a
move but rather as an addition or we will fail at synchronizing it
since it doesn't exist on the remote Cozy yet.

The same is already done for file movements.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
