### PR TITLE
deps: Add direct dependency to node-abi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 dist: trusty
 language: node_js
-node_js: 8
+node_js: 8.16.1
 addons:
   apt:
       sources:

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "lodash": "^4.17.11",
     "micromatch": "^3.1.0",
     "mime": "^1.3.4",
+    "node-abi": "^2.11.0",
     "opn": "5.0.0",
     "pouchdb": "^7.0.0",
     "pouchdb-find": "^7.0.0",
@@ -153,6 +154,7 @@
     "@gyselroth/windows-fsstat": "^0.0.7"
   },
   "resolutions": {
-    "levelup": "4.0.2"
+    "levelup": "4.0.2",
+    "node-abi": "2.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,24 +5047,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.1.2.tgz#4da6caceb6685fcd31e7dd1994ef6bb7d0a9c0b2"
-  integrity sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==
-  dependencies:
-    semver "^5.4.1"
-
-node-abi@^2.2.0:
+node-abi@2.11.0, node-abi@^2.1.1, node-abi@^2.11.0, node-abi@^2.2.0, node-abi@^2.7.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.11.0.tgz#b7dce18815057544a049be5ae75cd1fdc2e9ea59"
   integrity sha512-kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==
-  dependencies:
-    semver "^5.4.1"
-
-node-abi@^2.7.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.8.0.tgz#bd2e88dbe6a6871e6dd08553e0605779325737ec"
-  integrity sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==
   dependencies:
     semver "^5.4.1"
 


### PR DESCRIPTION
`node-abi` is used to find the node ABI (sequential build number?)
which is in turn used to find pre-built packages of native
dependencies like atom/watcher.

`atom/watcher` depends on `prebuild-install@5.2.4` which depends on
`node-abi@^2.7.0`.
`node-abi@2.7.0` adds the ABI for Electron v4.0.4 but not the latest v4
version.
So we'll need to upgrade Electron further and thus require a
greater version of `node-abi`.
But Yarn won't upgrade the package to its latest version even when
manually upgrading it. Which means we need to set it as a direct
dependency.

We'll also force all dependencies requiring `node-abi@^2.x.x` to use
`node-abi@2.11.0` via a resolution.
