### PR TITLE
gui/proxy: Add request options for HTTP and HTTPS

### DIFF
--- a/gui/js/proxy.js
+++ b/gui/js/proxy.js
@@ -116,23 +116,25 @@ const setup = (app, config, session, userAgent, doneSetup) => {
   http.Agent.globalAgent = http.globalAgent = https.globalAgent = new ElectronProxyAgent(
     session.defaultSession
   )
-  const originalHttpRequest = http.request
-  http.request = function(options, cb) {
-    options.agent = options.agent || http.globalAgent
-    options.headers = options.headers || {}
-    if (options.hostname) options.headers.host = options.hostname
-    options.headers['User-Agent'] = userAgent
-    return originalHttpRequest.call(http, options, cb)
-  }
-  const originalHttpsRequest = https.request
-  https.request = function(options, cb) {
+  const parseRequestOptions = options => {
     if (typeof options === 'string') {
       options = new url.URL(options)
     } else {
       options = Object.assign({}, options)
     }
-    options.agent = options.agent || https.globalAgent
-    return originalHttpsRequest.call(https, options, cb)
+    options.agent = options.agent || http.globalAgent
+    options.headers = options.headers || {}
+    if (options.hostname) options.headers.host = options.hostname
+    options.headers['User-Agent'] = userAgent
+    return options
+  }
+  const originalHttpRequest = http.request
+  http.request = function(options, cb) {
+    return originalHttpRequest.call(http, parseRequestOptions(options), cb)
+  }
+  const originalHttpsRequest = https.request
+  https.request = function(options, cb) {
+    return originalHttpsRequest.call(https, parseRequestOptions(options), cb)
   }
 
   const callback = () => {


### PR DESCRIPTION
We were setting the `host` and `User-Agent` request headers for HTTP
requests but not for HTTPS requests.
On the other side, we were handling string options for HTTPS requests
but not for HTTP requests.

We're now applying the same changes to the options for both HTTP and
HTTPS requests.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
