### PR TITLE
core/local/chokidar/analysis: Stabilize updates sort order

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -449,6 +449,18 @@ const finalSorter = (a /*: LocalChange */, b /*: LocalChange */) => {
     return -1
   if (localChange.lower(localChange.addPath(b), localChange.addPath(a)))
     return 1
+  if (localChange.lower(localChange.updatePath(a), localChange.addPath(b)))
+    return -1
+  if (localChange.lower(localChange.addPath(b), localChange.updatePath(a)))
+    return 1
+  if (localChange.lower(localChange.addPath(a), localChange.updatePath(b)))
+    return -1
+  if (localChange.lower(localChange.updatePath(b), localChange.addPath(a)))
+    return 1
+  if (localChange.lower(localChange.updatePath(a), localChange.updatePath(b)))
+    return -1
+  if (localChange.lower(localChange.updatePath(b), localChange.updatePath(a)))
+    return 1
 
   // if there isnt 2 add paths, sort by del path
   if (localChange.lower(localChange.delPath(b), localChange.delPath(a)))

--- a/core/local/chokidar/local_change.js
+++ b/core/local/chokidar/local_change.js
@@ -39,6 +39,7 @@ module.exports = {
   isChildUpdate,
   addPath,
   delPath,
+  updatePath,
   childOf,
   lower,
   isChildDelete,

--- a/test/unit/local/chokidar/analysis.js
+++ b/test/unit/local/chokidar/analysis.js
@@ -961,15 +961,6 @@ describe('core/local/chokidar/analysis', function() {
       should(analysis(events, pendingChanges)).deepEqual([
         {
           sideName,
-          type: 'FileUpdate',
-          path: 'other-file',
-          stats: otherFileStats,
-          ino: otherFileStats.ino,
-          md5sum: 'yolo',
-          old: otherFileMetadata
-        },
-        {
-          sideName,
           type: 'DirMove',
           path: 'dst',
           stats: dirStats,
@@ -984,6 +975,15 @@ describe('core/local/chokidar/analysis', function() {
           stats: otherDirStats,
           ino: otherDirStats.ino,
           old: otherDirMetadata
+        },
+        {
+          sideName,
+          type: 'FileUpdate',
+          path: 'other-file',
+          stats: otherFileStats,
+          ino: otherFileStats.ino,
+          md5sum: 'yolo',
+          old: otherFileMetadata
         }
       ])
     })

--- a/test/unit/local/chokidar/analysis.js
+++ b/test/unit/local/chokidar/analysis.js
@@ -864,7 +864,7 @@ describe('core/local/chokidar/analysis', function() {
 
       const oldDirPath = 'root/src/dir'
       const oldFilePath = 'root/src/dir/file.rtf'
-      const newDirPath = 'root/dir/file.rtf'
+      const newDirPath = 'root/dir'
       const newFilePath = 'root/dir/file.rtf'
 
       const dirMetadata /*: Metadata */ = builders


### PR DESCRIPTION
The relative sort order of moves and file additions depends solely
on their paths.
But, the sorter does not handle file updates as file additions like
the remote watcher does.
This means that the relative order of moves and file updates is not
stable and leads to randomly failing tests.
We can use the same algorithm for sorting local file updates and moves
as the remote watcher does and sort them by "add" path only.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
