### PR TITLE
test/integration/id_conflict: Fix normalization tests

### DIFF
--- a/test/integration/id_conflict.js
+++ b/test/integration/id_conflict.js
@@ -420,24 +420,23 @@ describe('Identity conflict', () => {
         await helpers.local.syncDir.rename(nfcDir, nfdDir)
         await helpers.local.syncDir.rename(nfcFile, nfdFile)
 
-        await helpers.local.scan()
-        should(await helpers.trees('local', 'metadata', 'remote')).deepEqual({
+        const nfdLocalOnly = {
           local: [`${nfdDir}/`, nfdFile],
-          metadata: [`${nfdDir}/`, nfdFile],
+          metadata: [`${nfcDir}/`, nfcFile],
           remote: [`${nfcDir}/`, nfcFile]
-        })
-        await helpers.syncAll()
-        const nfdEverywhere = {
-          local: [`${nfdDir}/`, nfdFile],
-          metadata: [`${nfdDir}/`, nfdFile],
-          remote: [`${nfdDir}/`, nfdFile]
         }
+
+        await helpers.local.scan()
         should(await helpers.trees('local', 'metadata', 'remote')).deepEqual(
-          nfdEverywhere
+          nfdLocalOnly
+        )
+        await helpers.syncAll()
+        should(await helpers.trees('local', 'metadata', 'remote')).deepEqual(
+          nfdLocalOnly
         )
         await helpers.remote.pullChanges()
         should(await helpers.trees('local', 'metadata', 'remote')).deepEqual(
-          nfdEverywhere
+          nfdLocalOnly
         )
       })
     })


### PR DESCRIPTION
The expected behavior for NFC -> NFD renaming has changed in v3.15.1
but has not been reflected in the integration tests.
This should have failed but has not.

Those reflect the new expected behavior (i.e. local HFS+ renamings
are not propagated to the Cozy on macOS).
