### PR TITLE
test/scenarios: Don't use stats from captures

### DIFF
--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -23,6 +23,7 @@ const log = logger({
 
 /*::
 import type Channel from './channel'
+import type { AtomEvent } from './event'
 */
 
 module.exports = {
@@ -50,7 +51,7 @@ function loop(
       try {
         if (event.action !== 'initial-scan-done') {
           event._id = id(event.path)
-          if (['created', 'modified', 'renamed'].includes(event.action)) {
+          if (needsStats(event)) {
             log.debug({ path: event.path, action: event.action }, 'stat')
             event.stats = await stater.stat(
               path.join(opts.syncPath, event.path)
@@ -76,4 +77,11 @@ function loop(
     }
     return batch
   })
+}
+
+function needsStats(event /*: AtomEvent */) /*: boolean %checks */ {
+  return (
+    ['created', 'modified', 'renamed', 'scan'].includes(event.action) &&
+    !event.stats
+  )
 }

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/atom/linux.json
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/atom/linux.json
@@ -31,81 +31,7 @@
     {
       "action": "scan",
       "path": "JOHN/exact-same-subdir",
-      "stats": {
-        "dev": 64771,
-        "mode": 16893,
-        "nlink": 2,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19797470,
-        "size": 4096,
-        "blocks": 8,
-        "atimeMs": 1550661698826.9436,
-        "mtimeMs": 1550661698828.9436,
-        "ctimeMs": 1550661698828.9436,
-        "birthtimeMs": 1550661698828.9436,
-        "atime": "2019-02-20T11:21:38.827Z",
-        "mtime": "2019-02-20T11:21:38.829Z",
-        "ctime": "2019-02-20T11:21:38.829Z",
-        "birthtime": "2019-02-20T11:21:38.829Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
-      "action": "scan",
-      "path": "JOHN/exact-same-subdir/a.txt",
-      "stats": {
-        "dev": 64771,
-        "mode": 33204,
-        "nlink": 1,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19797471,
-        "size": 8,
-        "blocks": 8,
-        "atimeMs": 1550661698828.9436,
-        "mtimeMs": 1550661698829.9436,
-        "ctimeMs": 1550661698829.9436,
-        "birthtimeMs": 1550661698829.9436,
-        "atime": "2019-02-20T11:21:38.829Z",
-        "mtime": "2019-02-20T11:21:38.830Z",
-        "ctime": "2019-02-20T11:21:38.830Z",
-        "birthtime": "2019-02-20T11:21:38.830Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
-      "action": "scan",
-      "path": "JOHN/exact-same-subdir/a.txt",
-      "stats": {
-        "dev": 64771,
-        "mode": 33204,
-        "nlink": 1,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19797471,
-        "size": 8,
-        "blocks": 8,
-        "atimeMs": 1550661698828.9436,
-        "mtimeMs": 1550661698829.9436,
-        "ctimeMs": 1550661698829.9436,
-        "birthtimeMs": 1550661698829.9436,
-        "atime": "2019-02-20T11:21:38.829Z",
-        "mtime": "2019-02-20T11:21:38.830Z",
-        "ctime": "2019-02-20T11:21:38.830Z",
-        "birthtime": "2019-02-20T11:21:38.830Z"
-      },
-      "kind": "unknown"
+      "kind": "directory"
     }
   ],
   [
@@ -124,9 +50,33 @@
   ],
   [
     {
+      "action": "scan",
+      "path": "JOHN/exact-same-subdir/a.txt",
+      "kind": "file"
+    },
+    {
+      "action": "scan",
+      "path": "JOHN/exact-same-subdir/b.txt",
+      "kind": "file"
+    }
+  ],
+  [
+    {
       "action": "created",
       "kind": "directory",
       "path": "JOHN/other-subdir-JOHN-1"
+    }
+  ],
+  [
+    {
+      "action": "scan",
+      "path": "JOHN/exact-same-subdir/a.txt",
+      "kind": "file"
+    },
+    {
+      "action": "scan",
+      "path": "JOHN/exact-same-subdir/b.txt",
+      "kind": "file"
     }
   ],
   [
@@ -159,87 +109,6 @@
   ],
   [
     {
-      "action": "scan",
-      "path": "john/exact-same-subdir",
-      "stats": {
-        "dev": 64771,
-        "mode": 16893,
-        "nlink": 2,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19798495,
-        "size": 4096,
-        "blocks": 8,
-        "atimeMs": 1550661698846.9436,
-        "mtimeMs": 1550661698848.9436,
-        "ctimeMs": 1550661698848.9436,
-        "birthtimeMs": 1550661698848.9436,
-        "atime": "2019-02-20T11:21:38.847Z",
-        "mtime": "2019-02-20T11:21:38.849Z",
-        "ctime": "2019-02-20T11:21:38.849Z",
-        "birthtime": "2019-02-20T11:21:38.849Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
-      "action": "scan",
-      "path": "john/exact-same-subdir/a.txt",
-      "stats": {
-        "dev": 64771,
-        "mode": 33204,
-        "nlink": 1,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19798496,
-        "size": 8,
-        "blocks": 8,
-        "atimeMs": 1550661698848.9436,
-        "mtimeMs": 1550661698849.9436,
-        "ctimeMs": 1550661698849.9436,
-        "birthtimeMs": 1550661698849.9436,
-        "atime": "2019-02-20T11:21:38.849Z",
-        "mtime": "2019-02-20T11:21:38.850Z",
-        "ctime": "2019-02-20T11:21:38.850Z",
-        "birthtime": "2019-02-20T11:21:38.850Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
-      "action": "scan",
-      "path": "john/exact-same-subdir/a.txt",
-      "stats": {
-        "dev": 64771,
-        "mode": 33204,
-        "nlink": 1,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19798496,
-        "size": 8,
-        "blocks": 8,
-        "atimeMs": 1550661698848.9436,
-        "mtimeMs": 1550661698849.9436,
-        "ctimeMs": 1550661698849.9436,
-        "birthtimeMs": 1550661698849.9436,
-        "atime": "2019-02-20T11:21:38.849Z",
-        "mtime": "2019-02-20T11:21:38.850Z",
-        "ctime": "2019-02-20T11:21:38.850Z",
-        "birthtime": "2019-02-20T11:21:38.850Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
       "action": "created",
       "kind": "file",
       "path": "john/exact-same-subdir/b.txt"
@@ -252,11 +121,48 @@
       "path": "john/exact-same-subdir/b.txt"
     }
   ],
+  [],
   [
     {
       "action": "created",
       "kind": "directory",
       "path": "john/other-subdir-john-2"
+    }
+  ],
+  [
+    {
+      "action": "scan",
+      "path": "john/exact-same-subdir",
+      "kind": "directory"
+    },
+    {
+      "action": "scan",
+      "path": "john/other-subdir-john-2",
+      "kind": "directory"
+    }
+  ],
+  [
+    {
+      "action": "scan",
+      "path": "john/exact-same-subdir/a.txt",
+      "kind": "file"
+    },
+    {
+      "action": "scan",
+      "path": "john/exact-same-subdir/b.txt",
+      "kind": "file"
+    }
+  ],
+  [
+    {
+      "action": "scan",
+      "path": "john/exact-same-subdir/a.txt",
+      "kind": "file"
+    },
+    {
+      "action": "scan",
+      "path": "john/exact-same-subdir/b.txt",
+      "kind": "file"
     }
   ]
 ]

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/win_mac/atom/win32.json
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/win_mac/atom/win32.json
@@ -10,16 +10,6 @@
     {
       "action": "scan",
       "path": "JOHN\\exact-same-subdir",
-      "stats": {
-        "fileid": "0x000A00000000D065",
-        "ino": 2814749767159909,
-        "size": 0,
-        "atime": "2019-02-21T09:40:59.000Z",
-        "mtime": "2019-02-21T09:40:59.000Z",
-        "ctime": "2019-02-21T09:40:59.000Z",
-        "directory": true,
-        "symbolicLink": false
-      },
       "kind": "directory"
     }
   ],
@@ -41,16 +31,6 @@
     {
       "action": "scan",
       "path": "JOHN\\exact-same-subdir\\a.txt",
-      "stats": {
-        "fileid": "0x000A00000000D066",
-        "ino": 2814749767159910,
-        "size": 0,
-        "atime": "2019-02-21T09:40:59.000Z",
-        "mtime": "2019-02-21T09:40:59.000Z",
-        "ctime": "2019-02-21T09:40:59.000Z",
-        "directory": false,
-        "symbolicLink": false
-      },
       "kind": "file"
     }
   ],
@@ -65,16 +45,6 @@
     {
       "action": "scan",
       "path": "JOHN\\exact-same-subdir\\a.txt",
-      "stats": {
-        "fileid": "0x000A00000000D066",
-        "ino": 2814749767159910,
-        "size": 8,
-        "atime": "2019-02-21T09:40:59.000Z",
-        "mtime": "2019-02-21T09:40:59.000Z",
-        "ctime": "2019-02-21T09:40:59.000Z",
-        "directory": false,
-        "symbolicLink": false
-      },
       "kind": "file"
     }
   ],

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/atom/linux.json
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/atom/linux.json
@@ -31,81 +31,7 @@
     {
       "action": "scan",
       "path": "FOO/subdir",
-      "stats": {
-        "dev": 64771,
-        "mode": 16893,
-        "nlink": 2,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19797470,
-        "size": 4096,
-        "blocks": 8,
-        "atimeMs": 1550661704972.9673,
-        "mtimeMs": 1550661704974.9673,
-        "ctimeMs": 1550661704974.9673,
-        "birthtimeMs": 1550661704974.9673,
-        "atime": "2019-02-20T11:21:44.973Z",
-        "mtime": "2019-02-20T11:21:44.975Z",
-        "ctime": "2019-02-20T11:21:44.975Z",
-        "birthtime": "2019-02-20T11:21:44.975Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
-      "action": "scan",
-      "path": "FOO/subdir/file",
-      "stats": {
-        "dev": 64771,
-        "mode": 33204,
-        "nlink": 1,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19797471,
-        "size": 8,
-        "blocks": 8,
-        "atimeMs": 1550661704974.9673,
-        "mtimeMs": 1550661704975.9673,
-        "ctimeMs": 1550661704975.9673,
-        "birthtimeMs": 1550661704975.9673,
-        "atime": "2019-02-20T11:21:44.975Z",
-        "mtime": "2019-02-20T11:21:44.976Z",
-        "ctime": "2019-02-20T11:21:44.976Z",
-        "birthtime": "2019-02-20T11:21:44.976Z"
-      },
-      "kind": "unknown"
-    }
-  ],
-  [
-    {
-      "action": "scan",
-      "path": "FOO/subdir/file",
-      "stats": {
-        "dev": 64771,
-        "mode": 33204,
-        "nlink": 1,
-        "uid": 1000,
-        "gid": 1000,
-        "rdev": 0,
-        "blksize": 4096,
-        "ino": 19797471,
-        "size": 8,
-        "blocks": 8,
-        "atimeMs": 1550661704974.9673,
-        "mtimeMs": 1550661704975.9673,
-        "ctimeMs": 1550661704975.9673,
-        "birthtimeMs": 1550661704975.9673,
-        "atime": "2019-02-20T11:21:44.975Z",
-        "mtime": "2019-02-20T11:21:44.976Z",
-        "ctime": "2019-02-20T11:21:44.976Z",
-        "birthtime": "2019-02-20T11:21:44.976Z"
-      },
-      "kind": "unknown"
+      "kind": "directory"
     }
   ],
   [
@@ -113,13 +39,25 @@
       "action": "created",
       "kind": "file",
       "path": "foo"
-    }
-  ],
-  [
+    },
     {
       "action": "modified",
       "kind": "file",
       "path": "foo"
+    }
+  ],
+  [
+    {
+      "action": "scan",
+      "path": "FOO/subdir/file",
+      "kind": "file"
+    }
+  ],
+  [
+    {
+      "action": "scan",
+      "path": "FOO/subdir/file",
+      "kind": "file"
     }
   ]
 ]

--- a/test/scenarios/create_dirs/atom/win32.json
+++ b/test/scenarios/create_dirs/atom/win32.json
@@ -17,16 +17,6 @@
     {
       "action": "scan",
       "path": "foo\\bar",
-      "stats": {
-        "fileid": "0x000F00000000D068",
-        "ino": 4222124650713192,
-        "size": 0,
-        "atime": "2019-02-21T09:41:06.000Z",
-        "mtime": "2019-02-21T09:41:06.000Z",
-        "ctime": "2019-02-21T09:41:06.000Z",
-        "directory": true,
-        "symbolicLink": false
-      },
       "kind": "directory"
     }
   ]

--- a/test/scenarios/move_dir_from_the_outside/atom/win32.json
+++ b/test/scenarios/move_dir_from_the_outside/atom/win32.json
@@ -10,31 +10,11 @@
     {
       "action": "scan",
       "path": "dst\\dir\\empty-subdir",
-      "stats": {
-        "fileid": "0x000900000000D0B0",
-        "ino": 3,
-        "size": 0,
-        "atime": "2019-02-21T09:41:34.000Z",
-        "mtime": "2019-02-21T09:41:34.000Z",
-        "ctime": "2019-02-21T09:41:34.000Z",
-        "directory": true,
-        "symbolicLink": false
-      },
       "kind": "directory"
     },
     {
       "action": "scan",
       "path": "dst\\dir\\subdir",
-      "stats": {
-        "fileid": "0x000900000000D0B2",
-        "ino": 4,
-        "size": 0,
-        "atime": "2019-02-21T09:41:34.000Z",
-        "mtime": "2019-02-21T09:41:34.000Z",
-        "ctime": "2019-02-21T09:41:34.000Z",
-        "directory": true,
-        "symbolicLink": false
-      },
       "kind": "directory"
     }
   ],
@@ -42,16 +22,6 @@
     {
       "action": "scan",
       "path": "dst\\dir\\subdir\\file",
-      "stats": {
-        "fileid": "0x001700000000E7C9",
-        "ino": 5,
-        "size": 8,
-        "atime": "2019-02-21T09:41:34.000Z",
-        "mtime": "2019-02-21T09:41:34.000Z",
-        "ctime": "2019-02-21T09:41:34.000Z",
-        "directory": false,
-        "symbolicLink": false
-      },
       "kind": "file"
     }
   ]


### PR DESCRIPTION
  When captures contain stats, the Sync will detect changes on inodes
  since files and folders are recreated for each test run but captures
  are not and thus their stats will differ.

  We need to modify the `addInfos` step so `scan` events too get stats
  if they're missing.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
