### PR TITLE
core/config: Stop doing copy on write

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -76,12 +76,7 @@ class Config {
 
   _moveTmpConfig() {
     if (fs.copyFileSync && fs.constants.COPYFILE_FICLONE) {
-      // Node v8.5.0+ can use a copy-on-write reflink
-      fs.copyFileSync(
-        this.tmpConfigPath,
-        this.configPath,
-        fs.constants.COPYFILE_FICLONE
-      )
+      fs.copyFileSync(this.tmpConfigPath, this.configPath)
     } else {
       // Fallback for old node versions
       fse.copySync(this.tmpConfigPath, this.configPath)


### PR DESCRIPTION
  When persisting the config, we use a temporary file to avoid losing
  data if writing the config file fails.
  When we introduced this mechanism, we decided to use copy on write but
  this seems to lead to errors on macOS and is not really necessery
  after all.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
