### PR TITLE
deps: Add direct dependency to babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "async": "^2.6.2",
     "auto-bind": "^2.0.0",
     "auto-launch": "^5.0.3",
+    "babel-polyfill": "^6.26.0",
     "bluebird": "^3.5.4",
     "btoa": "^1.1.2",
     "bunyan": "^2.0.2",


### PR DESCRIPTION
Our `cozy-client-js` dependency has a peer dependency to
`babel-polyfill` which was not satisfied and would result in errors in
production builds.
