### PR TITLE
core/local/chokidar: Fix wrong fsevents event type

### DIFF
--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -147,6 +147,12 @@ class LocalWatcher {
           const isInitialScan = this.initialScan && !this.initialScan.flushed
           log.chokidar.debug({ path, stats, isInitialScan }, eventType)
           const newEvent = chokidarEvent.build(eventType, path, stats)
+          if (newEvent.type !== eventType) {
+            log.info(
+              { eventType, event: newEvent },
+              'fixed wrong fsevents event type'
+            )
+          }
           this.buffer.push(newEvent)
           this.events.emit('buffering-start')
         })


### PR DESCRIPTION
Sometimes `fsevents` can fire an `add` or `addDir` event when it
should fire its directory or file counterpart respectively.
Since we have access to the file/directory stats we can fix the event
type when building a `ChokidarEvent` to handle the change correctly.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
