### PR TITLE
core/app: Don't specify protocol when sending logs

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -217,7 +217,6 @@ class App {
       const req = https.request(
         {
           method: 'PUT',
-          protocol: 'https:',
           hostname: 'desktop-upload.cozycloud.cc',
           path: `/${incident}/${name}`,
           headers: {


### PR DESCRIPTION
The new `https` module's `request` builder does not need the protocol
to be specified.
In fact, it doesn't expect any `protocol` and specifying one throws an
error and logs are not sent to us.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
