### PR TITLE
doc/usage/linux: Update desktop integration how-to

### DIFF
--- a/doc/usage/linux.md
+++ b/doc/usage/linux.md
@@ -35,11 +35,10 @@ The current AppImage needs a relatively recent version of `GLIBCXX >= 3.4.21`.
 | **Archlinux (Cinnamon)**                  | **yes**   | 3.4.24    | WORK                  |
 | **Archlinux (KDE PLASMA)**                | **yes**   | 3.4.24    | WORK                  |
 | **Archlinux (Deepin)**                    | **yes**   | 3.4.24    | WORK                  |
-| Debian 7 (Wheezy)                         | no        | 3.4.17    |                       |
-| Debian 8 (Jessie)                         | no        | 3.4.20    |                       |
-| **Debian 9 (Stretch)**                    | ?         | 3.4.22    | **should work**       |
-| **Fedora 28**                             | **yes**   | 3.4.25    | with TopIcons         |
-| **Fedora 27**                             | **yes**   | 3.4.24    | with TopIcons-Plus    |
+| Debian 9 (Stretch)                        | ?         | 3.4.22    | **should work**       |
+| **Debian 10 (Buster)**                    | yes       | 3.14.0    | with TopIcons-Plus    |
+| Fedora 30                                 | **yes**   | 3.4.24    | with TopIcons-Plus    |
+| **Fedora 31**                             | **yes**   | 3.4.27    | with TopIcons-Plus    |
 | Linux Mint 17.1 LTS (Rebecca)             | no        |           |                       |
 | Linux Mint 17.3                           | no        | 3.4.19    |                       |
 | **Linux Mint 18.3 (Sylvia)**              | **yes**   | 3.4.2     |                       |
@@ -61,9 +60,15 @@ The current AppImage needs a relatively recent version of `GLIBCXX >= 3.4.21`.
   (and include the output in your request)
 - Install the app, run it and make sure it actually works
 
-**If your distribution is not supported,** follow [the manual build guide][Build]
+> **If your distribution is not supported**
+> follow [the manual build guide][Build] and jump to the second part of the
+> [Install](#Install) section.
 
 ## Install
+
+> **Note for Archlinux Users**
+>
+> You can install `cozy-desktop` from the [community] repo.
 
 1. Download the `*.AppImage` file for your architecture from the
    [latest release][Latest].
@@ -71,51 +76,90 @@ The current AppImage needs a relatively recent version of `GLIBCXX >= 3.4.21`.
    it from there. You can for example create a macOS-like `Applications` folder
    and move it there. Advanced users may prefer to move it to some special
    folder (`~/.local/bin/`, `~/bin/`, `/opt/`...).
-3. Make the file executable. In GNOME 3, right-click on the file, select the
-   *Properties* menu entry, go to the *Permissions* tab and enable the
-   *Execution* checkbox. Or in a terminal:
-   `cd /dir/where/you/put/the/file && chmod +x *.AppImage`
-4. Run the application for the first time by double-clicking it. It will add
-   itself to your existing application shortcuts.
-5. Optionally install the *appimaged* daemon (it can be downloaded from the
-   [AppImageKit releases][AppImageKitReleases] or installed from your
-   distribution).
 
-**Note for GNOME Users** : From 3.26 onwards, GNOME removed the systray which is the only interface for *Cozy Drive*. It should be replaced in the future by `libcloudprovider`, which we will implement when it spreads. In the meantime, you need to install an extension such as [TopIcons][TopIcons]
+### Integration with the system
 
-**Note for Archlinux Users** : You can also install `cozy-desktop` from the [community] repo.
+By default, the application will only be launchable by double-clicking the
+AppImage file you downloaded. If you want it to be available in your
+applications menu, you can install the *appimaged* daemon, available from its
+[github repository][appimaged]'s releases or via
+your distribution package manager.
+If you install it from the repository, you might need to run the following
+commands in a terminal to make sure it is run when starting your user session:
+```bash
+$ systemctl --user add-wants default.target appimaged
+$ systemctl --user start appimaged
+# restart your user session now
+```
 
-**Note for i3wm Users** : You can set `"gui": {"visibleOnBlur": true}` in your `~/.cozy-desktop/config.json` so the popover doesn't hide when focusing another
-window.
+After that, **any** AppImage file found in one of those folders will be
+automatically made executable and available in your applications menu:
+- `$HOME/Downloads` (or its localized equivalent, as determined by
+  `G_USER_DIRECTORY_DOWNLOAD` in glib)
+- `$HOME/.local/bin`
+- `$HOME/bin`
+- `$HOME/Applications`
+- `/Applications`
+- `[any mounted partition]/Applications`
+- `/opt`
+- `/usr/local/bin`
 
 ## Running
+
+If you have decided not to integrate AppImages with your system, you'll need to
+make the file executable. In GNOME 3, right-click on the file, select the
+*Properties* menu entry, go to the *Permissions* tab and enable the *Execution*
+checkbox. Or in a terminal:
+```bash
+cd /dir/where/you/put/the/file && chmod +x *.AppImage`
+```
 
 On first run, the application should have configured itself to run automatically
 on system start.
 
-You should also see the *Cozy Drive* application with other ones in GNOME Shell
-or in your applications menu (in the *utility* category).
-
 ## Where are the application files?
 
-Almost everything is in the `*.AppImage` file. On first run, the following
-additional files are created:
+Almost everything is in the `*.AppImage` file however, if you have installed
+`appimaged`, the following additional files are created:
 
-- Launcher file in `~/.local/share/applications/appimagekit-CozyDrive.desktop`
-- Icons in `~/.local/share/icons/hicolor/*/apps/appimagekit-CozyDrive.png`
+- Launcher file in `~/.local/share/applications/appimagekit_<unique identifier>-Cozy_Drive.desktop`
+- Icons in `~/.local/share/icons/hicolor/*/apps/appimagekit<same unique identifier>-cozydrive.png`
 
 Everything else works the same as Windows or macOS: your synchronized files are
 in `~/Cozy Drive/` or the folder you choose on first run, and the hidden
 `~/.cozy-desktop/` folder contains the application configuration, metadata and
 logs.
 
+## Displaying the app window
+
+To show the application preferences and the recently synchronized files list, you
+can either launch the app again (i.e. it will simply open the app's window as
+only one instance can run at a time) or click on the systray icon.
+If `libappindicator` is installed on your system, left-clicks won't have any
+effects so you need to do a right-click on the icon then select the
+*Show Application* menu entry.
+
+> **Note for GNOME Users**
+>
+> From 3.26 onwards, GNOME removed the systray which is the only interface for
+> *Cozy Drive*. It should be replaced in the future by `libcloudprovider`, which
+> we will implement when it spreads. In the meantime, you need to install an
+> extension such as [TopIcons][TopIcons] or [TopIcons Plus][TopIconsPlus].
+
+> **Note for i3wm Users**
+>
+> You can set `"gui": {"visibleOnBlur": true}` in your
+> `~/.cozy-desktop/config.json` so the popover doesn't hide when focusing
+> another window.
+
 ## Uninstall
 
 Manually remove the files listed above.
 
 [AppImage]: https://appimage.org/
-[AppImageKitReleases]: https://github.com/AppImage/AppImageKit/releases
+[appimaged]: https://github.com/AppImage/appimaged
 [Build]: ./build.md
 [Edit]: https://github.com/cozy-labs/cozy-desktop/edit/master/doc/usage/linux.md
 [Latest]: https://github.com/cozy-labs/cozy-desktop/releases/latest
-[TopIcons]: https://extensions.gnome.org/extension/1031/topicons/
+[TopIcons]: https://extensions.gnome.org/extension/495/topicons/
+[TopIconsPlus]: https://extensions.gnome.org/extension/1031/topicons/


### PR DESCRIPTION
  From now on, the Cozy Desktop AppImages won't include any code to
  integrate the app with the user's desktop (see
  https://www.electron.build/configuration/appimage).

  For integrating the app with a linux desktop the user now needs to
  install the previously optional `appimaged` daemon and move the
  AppImage file in specific locations.

  The documentation now reflects those changes and some changes to the
  supported distributions: some old unsupported distributions were
  removed from the list and the newest Fedora and Debian (thanks
  @Picus13) were added.
