### PR TITLE
gui/tray: Add context menu on Windows

### DIFF
--- a/gui/js/tray.js
+++ b/gui/js/tray.js
@@ -41,7 +41,7 @@ module.exports.init = (app, listener) => {
   tray.on('double-click', clicked)
   tray.setToolTip('loading')
 
-  if (!isMac && !isWindows) {
+  if (!isMac) {
     // When click events are not triggered, we need to display a context menu so
     // users can open the app's window.
     const cm = Menu.buildFromTemplate([


### PR DESCRIPTION
  The systray icon context menu used to be displayed on Windows and
  Linux.
  As part of a refactoring of the tray logic, the context menu was
  removed from Windows by mistake.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
