### PR TITLE
Load docs in bulk in initial scans and migrations

### DIFF
--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -87,7 +87,7 @@ async function initialState(
   // which files/folders have been deleted, as it is stable even if the
   // file/folder has been moved or renamed
   const byInode /*: Map<number|string, Metadata> */ = new Map()
-  const docs /*: Metadata[] */ = await opts.pouch.byRecursivePathAsync('')
+  const docs /*: Metadata[] */ = await opts.pouch.allDocs()
   for (const doc of docs) {
     if (doc.ino != null) {
       // Process only files/dirs that were created locally or synchronized

--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -39,7 +39,7 @@ const detectOfflineUnlinkEvents = async (
 ) /*: Promise<{offlineEvents: Array<ChokidarEvent>, unappliedMoves: string[], emptySyncDir: boolean}> */ => {
   // Try to detect removed files & folders
   const events /*: Array<ChokidarEvent> */ = []
-  const docs = await pouch.byRecursivePathAsync('')
+  const docs = await pouch.allDocs()
   const inInitialScan = doc =>
     initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
 

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -152,6 +152,13 @@ class Pouch {
 
   /* Mini ODM */
 
+  async allDocs() /*: Promise<void> */ {
+    const results = await this.db.allDocs({ include_docs: true })
+    return Array.from(results.rows)
+      .filter(row => !row.key.startsWith('_'))
+      .map(row => row.doc)
+  }
+
   put(doc /*: Metadata */) /*: Promise<void> */ {
     metadata.invariants(doc)
     const { local, remote } = doc.sides

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -121,7 +121,7 @@ async function migrate(
 
     let result /*: MigrationResult */
     try {
-      const docs = await pouch.byRecursivePathAsync('')
+      const docs = await pouch.allDocs()
       const affectedDocs = migration.affectedDocs(docs)
       const migratedDocs = migration.run(affectedDocs)
 


### PR DESCRIPTION
  When loading all documents in migrations or the initial scan of either
  local watchers, we end up using a low-level db iterator which seems to
  fail at parsing documents when they're too deeply nested (i.e. lots of
  `moveFrom` inside `moveFrom`, probably resulting from conflict loops).

  PouchDB uses a fallback mechanism when parsing JSON documents fails
  and uses the vuvuzela library instead (see
  https://github.com/nolanlawson/vuvuzela) which does not suffer from
  deeply nested documents parsing errors.

  By using the PouchDB's `allDocs()` method to get all the saved
  documents, we hope not to use the low-level iterator that's failing
  us.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
