### PR TITLE
gui: Improve state computation

### DIFF
--- a/core/local/atom/fire_local_start_event.js
+++ b/core/local/atom/fire_local_start_event.js
@@ -1,0 +1,36 @@
+/** This step fires a `local-start` event for every batch of FS events so we
+ * keep the app's activity status up-to-date.
+ *
+ * `local-end` events will be fired by the dispatch step.
+ *
+ * @module core/local/atom/fire_local_start_event
+ * @flow
+ */
+
+// eslint-disable-next-line no-unused-vars
+const STEP_NAME = 'fireLocatStartEvent'
+
+/*::
+import type Channel from './channel'
+import type EventEmitter from 'events'
+*/
+
+module.exports = {
+  loop
+}
+
+/** Fire a local-start event for every batch of events
+ *
+ * Arbitrarily assume event kind is file by default.
+ *
+ * Return a new Channel where new events with stats will be pushed.
+ */
+function loop(
+  channel /*: Channel */,
+  opts /*: { events: EventEmitter } */
+) /*: Channel */ {
+  return channel.asyncMap(async events => {
+    opts.events.emit('local-start')
+    return events
+  })
+}

--- a/core/local/atom/producer.js
+++ b/core/local/atom/producer.js
@@ -17,6 +17,7 @@ const logger = require('../../utils/logger')
 /*::
 import type { Ignore } from '../../ignore'
 import type { AtomEvent } from './event'
+import type EventEmitter from 'events'
 
 export type Scanner = (string) => Promise<void>
 */
@@ -60,12 +61,16 @@ class Producer {
   channel: Channel
   syncPath: string
   ignore: Ignore
+  events: EventEmitter
   watcher: *
   */
-  constructor(opts /*: { syncPath: string, ignore: Ignore } */) {
+  constructor(
+    opts /*: { syncPath: string, ignore: Ignore, events: EventEmitter } */
+  ) {
     this.channel = new Channel()
     this.syncPath = opts.syncPath
     this.ignore = opts.ignore
+    this.events = opts.events
     this.watcher = null
     autoBind(this)
   }
@@ -90,6 +95,7 @@ class Producer {
    * the recursive option.
    */
   async start() {
+    this.events.emit('buffering-start')
     this.watcher = await watcher.watchPath(
       this.syncPath,
       { recursive: true },
@@ -108,6 +114,7 @@ class Producer {
     // been emited.
     await Promise.delay(1000)
     this.channel.push([INITIAL_SCAN_DONE])
+    this.events.emit('buffering-end')
   }
 
   async scan(

--- a/core/sync.js
+++ b/core/sync.js
@@ -143,13 +143,13 @@ class Sync {
     let seq = await this.pouch.getLocalSeqAsync()
     log.trace({ seq }, 'Waiting for changes since seq')
     if (waitForNewChanges) await this.waitForNewChanges(seq)
-    this.events.emit('sync-start')
     const release = await this.pouch.lock(this)
+    this.events.emit('sync-start')
     try {
       await this.syncBatch()
     } finally {
-      release()
       this.events.emit('sync-end')
+      release()
     }
     log.debug('No more metadata changes for now')
   }

--- a/gui/js/tray.js
+++ b/gui/js/tray.js
@@ -103,15 +103,15 @@ if (newReleaseAvailable) {
 tray.setContextMenu(menu)
 */
 
-var setState = (module.exports.setState = (state, filename) => {
+var setState = (module.exports.setState = (state, data) => {
   let statusLabel = ''
   let icon = 'idle'
   if (state === 'error') {
     icon = 'error'
-    statusLabel = filename
-  } else if (filename) {
+    statusLabel = data
+  } else if (state === 'syncing' && data && data.filename) {
     icon = 'sync'
-    statusLabel = `${translate('Tray Syncing')} ‟${filename}“`
+    statusLabel = `${translate('Tray Syncing')} ‟${data.filename}“`
   } else if (state === 'up-to-date' || state === 'online') {
     icon = 'idle'
     statusLabel = translate('Tray Your cozy is up to date')

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -33,7 +33,12 @@ function dispatchedCalls(obj /*: Stub */) /*: DispatchedCalls */ {
 
     for (const call of calls) {
       if (!dispatchedCalls[method]) dispatchedCalls[method] = []
-      dispatchedCalls[method].push(call.args)
+      if (
+        method !== 'emit' ||
+        !['local-start', 'local-end', 'sync-target'].includes(call.args[0])
+      ) {
+        dispatchedCalls[method].push(call.args)
+      }
     }
   }
 

--- a/test/unit/local/atom/producer.js
+++ b/test/unit/local/atom/producer.js
@@ -10,6 +10,7 @@ const path = require('path')
 const Producer = require('../../../../core/local/atom/producer')
 const { Ignore } = require('../../../../core/ignore')
 const stater = require('../../../../core/local/stater')
+const EventEmitter = require('events')
 
 const { ContextDir } = require('../../../support/helpers/context_dir')
 const { onPlatforms } = require('../../../support/helpers/platform')
@@ -19,13 +20,15 @@ onPlatforms(['linux', 'win32'], () => {
     let syncDir
     let syncPath
     let ignore
+    let events
     let producer
 
     beforeEach(() => {
       syncPath = fs.mkdtempSync(path.join(os.tmpdir(), 'Cozy Drive.test-'))
       syncDir = new ContextDir(syncPath)
       ignore = new Ignore([])
-      producer = new Producer({ syncPath, ignore })
+      events = new EventEmitter()
+      producer = new Producer({ syncPath, ignore, events })
     })
 
     describe('scan()', () => {
@@ -36,7 +39,7 @@ onPlatforms(['linux', 'win32'], () => {
 
         beforeEach(async () => {
           ignore = new Ignore([ignoredDir])
-          producer = new Producer({ syncPath, ignore })
+          producer = new Producer({ syncPath, ignore, events })
 
           await syncDir.makeTree([
             `${ignoredDir}/`,


### PR DESCRIPTION
I found out that when files are uploaded to the remote Cozy, the app's
icon is not showing the activity spinner.
I fear that combined with the fact that files show up in Drive Web as
soon as we start uploading it, users might think that the file is
fully synchronized before we've actually completely uploaded it.

From there I decided to refactor the state computation and the steps
we go through with the Atom Watcher since it does not buffer events
like we do in the Chokidar Watcher and thus the sync state computation
built for the Chokidar Watcher was not working very well with it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
