### PR TITLE
core/local/atom/incomplete_fixer: Keep renamed for existing docs

### DIFF
--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -5,11 +5,13 @@ const Promise = require('bluebird')
 const fse = require('fs-extra')
 const _ = require('lodash')
 const path = require('path')
+const rimraf = require('rimraf')
 
 const checksumer = require('../../../core/local/checksumer')
 const { TMP_DIR_NAME } = require('../../../core/local/constants')
 
 Promise.promisifyAll(checksumer)
+const rimrafAsync = Promise.promisify(rimraf)
 
 function getPath(target /*: string | {path: string} */) /*: string */ {
   return typeof target === 'string' ? target : target.path
@@ -28,6 +30,12 @@ class ContextDir {
   constructor(root /*: string */) {
     this.root = root
     autoBind(this)
+  }
+
+  async clean() {
+    for (const pattern of ['*', '.*']) {
+      await rimrafAsync(path.join(this.root, pattern))
+    }
   }
 
   abspath(target /*: string | {path: string} */) /*: string */ {


### PR DESCRIPTION
When analysing the logs of users who experienced local conflict loops,
I saw that the loop started if the conflict happens on a document with
an inode that can be found on another document.
From what I've seen, the other document is the source of a move while
the document on which we detect a conflict is the destination.
This means that we did not detect and process this move as such but as
the creation of the destination only.

I've been able to reproduce at least one of the situations in which
this can happen by downloading a file directly within the local
Cozy Drive folder using Chromium. This browser uses a temporary file
with the `crdownload` extension that is renamed into the desired name
when the download is complete.
We're missing that specific renaming for large files because we end up
with a lot of incomplete events for the temporary file which are
completed by the Atom Watcher's incomplete fixer, thus generating a
`created` or `modified` event for the temporary file (which does exist
anymore) and no `renamed` event from the temporary file to the final
one. We have this behavior because the incomplete fixer was intended
at completing events before they're dispatched and documents are
created. In our situation, it seems that we have so many events that
the awaitWriteFinish step stops gathering them and the first `created`
events gets to the dispatch step before we finish processing all of
them.
Since this renaming also generates a `created` event for the final
file path, we end up creating a new document for it, with the same
inode as the temporary file.

We avoid this situation by checking whether there is a document with
the incomplete event's id in Pouch or not and keeping the `renamed`
event in case there is one, even completely dropping the incomplete
event in case it is a `created` event (the document already exists so
no need to spend time processing this).

This might not be the solution to all local conflict loops but this
should improve the situation (Chrome is the most popular browser after
all) and we can work on other situations later.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
