### PR TITLE
dist: Add back arch in x64 linux AppImage name

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,6 +20,13 @@ asarUnpack:
 - gui/scripts/**
 directories:
   buildResources: gui/assets
+mac:
+  hardenedRuntime: true
+  entitlements: './build/entitlements.mac.inherit.plist'
+  category: public.app-category.productivity
+  target:
+  - dmg
+  - zip
 dmg:
   contents:
     - x: 110
@@ -31,13 +38,6 @@ dmg:
 win:
   target:
   - nsis
-mac:
-  hardenedRuntime: true
-  entitlements: './build/entitlements.mac.inherit.plist'
-  category: public.app-category.productivity
-  target:
-  - dmg
-  - zip
 linux:
   target:
   - AppImage
@@ -50,3 +50,5 @@ linux:
     anytime with the mobile application and share them with the world or just your
     friends and colleagues. You can host your own Cozy Cloud, and or use the hosting
     services. Your freedom to chose is why you can trust us.
+appImage:
+  artifactName: 'Cozy-Drive-${version}-${arch}.${ext}'


### PR DESCRIPTION
  With the recent versions of `electron-builder`, the generated AppImage
  file for x64 archictectures does not have `x86_64` in its name like it
  used to.
  We need this part in the file name for the nuts server to find it when
  users want to download the app from our website.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
