### PR TITLE
dist: Copy regedit files into app resources folder

### DIFF
--- a/core/utils/win_registry.js
+++ b/core/utils/win_registry.js
@@ -18,6 +18,7 @@
  */
 
 const regedit = require('regedit')
+regedit.setExternalVBSLocation('resources/regedit/vbs')
 
 // Key used prior to v3.16.0
 const OLD_UNINSTALL_KEY =

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -52,3 +52,8 @@ linux:
     services. Your freedom to chose is why you can trust us.
 appImage:
   artifactName: 'Cozy-Drive-${version}-${arch}.${ext}'
+extraResources:
+  - from: 'node_modules/regedit/vbs'
+    to: 'regedit/vbs'
+    filter:
+      - '**/*'


### PR DESCRIPTION
  Files within the app's asar archive are not accessible at runtime
  while the `regedit` module uses `.vbs` files to execute the Windows
  registry modifications so we need to copy those to the `resources`
  folder and tell `regedit` where to find them for our registry
  modifications to work.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
