### PR TITLE
gui/autolaunch: Use app name for entry on Linux

### DIFF
--- a/gui/js/autolaunch.js
+++ b/gui/js/autolaunch.js
@@ -5,8 +5,9 @@
 
 const AutoLaunch = require('auto-launch')
 
+const APP_NAME = 'Cozy-Desktop'
 const opts = {
-  name: 'Cozy-Desktop',
+  name: APP_NAME,
   isHidden: true
 }
 
@@ -15,6 +16,27 @@ if (process.env.APPIMAGE) {
 }
 
 const autoLauncher = new AutoLaunch(opts)
+
+if (process.env.APPIMAGE) {
+  // Fix issue with `auto-launch` that uses the path instead of the app name
+  // when defining the autolaunch entry leading to autolaunch to stop working
+  // after an app update.
+  // See https://github.com/Teamwork/node-auto-launch/issues/92
+
+  // Check if there is an autolaunch entry with the app's path.
+  const pathAutoLaunchEnabled = autoLauncher.isEnabled()
+  // Remove it to avoid having multiple entries.
+  if (pathAutoLaunchEnabled) {
+    autoLauncher.disable()
+  }
+  // Make sure the autolaunch entry will use the app's name.
+  autoLauncher.opts.appName = APP_NAME
+  // Create an autolaunch entry with the app's name if there was an entry with
+  // the app's path.
+  if (pathAutoLaunchEnabled) {
+    autoLauncher.enable()
+  }
+}
 
 module.exports.isEnabled = () => autoLauncher.isEnabled()
 


### PR DESCRIPTION
  On Linux, the auto-launch entry is a `.desktop` file containing the
  app's name and path and some arguments like the `--hidden` flag.
  It is generated within `$HOME/.config/autostart/` and is supposed to
  be named after the given `name` option but a bug in `auto-launch`
  changes that `.desktop` file name into the executable name.

  Since our executable name contains the app's version, every time a
  user updates the app, the auto-launch `.desktop` file name does not
  match anymore and the autolaunch is disabled.

  We can however force the `appName` option right after initializing a
  new `auto-launch` object and have the library create a `.desktop` file
  that will match any version of the application.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
