### PR TITLE
dist: Disable sandbox on kernels not supporting it

### DIFF
--- a/build/afterPackHook.js
+++ b/build/afterPackHook.js
@@ -1,0 +1,36 @@
+const path = require('path')
+const fs = require('fs')
+const util = require('util')
+
+const renameAsync = util.promisify(fs.rename)
+const unlinkAsync = util.promisify(fs.unlink)
+
+module.exports = async function(context) {
+  // Replace the app launcher on linux only.
+  if (process.platform !== 'linux') {
+    return
+  }
+  // eslint-disable-next-line no-console
+  console.log('afterPack hook triggered', context)
+
+  const executableName = context.packager.executableName
+  const sourceExecutable = path.join(context.appOutDir, executableName)
+  const targetExecutable = path.join(context.appOutDir, `${executableName}-bin`)
+  const launcherScript = path.join(
+    context.appOutDir,
+    'resources',
+    'launcher-script.sh'
+  )
+  const chromeSandbox = path.join(context.appOutDir, 'chrome-sandbox')
+
+  return Promise.all([
+    // rename cozydrive to cozydrive-bin
+    renameAsync(sourceExecutable, targetExecutable),
+
+    // rename launcher script to cozydrive
+    renameAsync(launcherScript, sourceExecutable),
+
+    // remove the chrome-sandbox file since we explicitly disable it
+    unlinkAsync(chromeSandbox)
+  ])
+}

--- a/build/launcher-script.sh
+++ b/build/launcher-script.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+
+UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+exec "$SCRIPT_DIR/cozydrive-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,6 +15,7 @@ files:
 - gui/scripts/**
 - package.json
 forceCodeSigning: true
+afterPack: './build/afterPackHook.js'
 afterSign: './build/afterSignHook.js'
 asarUnpack:
 - gui/scripts/**
@@ -53,6 +54,8 @@ linux:
 appImage:
   artifactName: 'Cozy-Drive-${version}-${arch}.${ext}'
 extraResources:
+  - from: 'build/launcher-script.sh'
+    to: 'launcher-script.sh'
   - from: 'node_modules/regedit/vbs'
     to: 'regedit/vbs'
     filter:


### PR DESCRIPTION
Electron packages a Chromium executable within each app to render the
application's graphical content and starting with Electron v5, the
Chromium sandbox is activated by default.
On Linux, recent versions of Chromium use a kernel feature to run this
sandbox: unprivileged user namespaces with clone. This feature is
unfortunately disabled by default on Debian issued kernels as they
consider it is not ready for production and increases the attack
surface of the operating system (see
https://lwn.net/Articles/673597/).

Chromium has another option to run sandboxes: using a root owned
binary with the SUID bit to access the privileged user namespaces.
This is a separate binary which is shipped with Electron applications.

Our problem is that the SUID binary is packaged within our AppImage
and is therefore not owned by root so it doesn't have acces to the
user namespaces operations.
Our only way is then to disable the Chromium sandbox via the
`--no-sandbox` flag.

This commit adds a bash launcher setting the flag only when the kernel
does not support unprivileged user namespaces so users of upstream
kernels can benefit of the sandbox while users of Debian issued
kernels can use the application even with decreased security (this is
very limited since we only load web pages from cozy.io during the
onboarding and then load only local html files).

This solution was built upon https://github.com/electron-userland/electron-builder/issues/4278.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
