### PR TITLE
core/merge: Migrating fileid on Windows does not raise Invarian…

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -552,10 +552,14 @@ function markSide(
 }
 
 function incSides(doc /*: Metadata */) /*: void */ {
-  doc.sides = {
-    target: target(doc) + 1,
-    local: side(doc, 'local') + 1,
-    remote: side(doc, 'remote') + 1
+  const prevTarget = target(doc)
+  const local = side(doc, 'local')
+  const remote = side(doc, 'remote')
+
+  if (prevTarget) {
+    doc.sides.target = prevTarget + 1
+    if (local) doc.sides.local = local + 1
+    if (remote) doc.sides.remote = remote + 1
   }
 }
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -792,15 +792,14 @@ describe('metadata', function() {
       return doc
     }
 
-    it('increments both sides by 1 in-place', () => {
-      should(docAfterIncSides({})).deepEqual({
-        sides: { target: 1, local: 1, remote: 1 }
-      })
+    it('increments existing sides by 1 in-place', () => {
+      should(docAfterIncSides({})).deepEqual({})
+      should(docAfterIncSides({ sides: {} })).deepEqual({ sides: {} })
       should(docAfterIncSides({ sides: { target: 1, local: 1 } })).deepEqual({
-        sides: { target: 2, local: 2, remote: 1 }
+        sides: { target: 2, local: 2 }
       })
       should(docAfterIncSides({ sides: { target: 1, remote: 1 } })).deepEqual({
-        sides: { target: 2, local: 1, remote: 2 }
+        sides: { target: 2, remote: 2 }
       })
       should(
         docAfterIncSides({ sides: { target: 2, local: 2, remote: 2 } })


### PR DESCRIPTION
When migrating documents missing a `fileid` on Windows, we increase both sides to keep the same out-of-date side and not prevent the synchronization of merged changes while still marking the document has been updated.
We were increasing the sides even if they were not present in the original document, leading to the invariant error `Metadata has sides.remote but no remote` error being raised when the document had never been synchronized before the migration.
This prevents changes on that document from being merged and synchronized with the remote Cozy.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
