### PR TITLE
core/local/atom/add_infos: Try to guess deleted event kind

### DIFF
--- a/test/unit/local/atom/add_infos.js
+++ b/test/unit/local/atom/add_infos.js
@@ -2,12 +2,32 @@
 /* @flow */
 
 const should = require('should')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+
 const metadata = require('../../../../core/metadata')
 const addInfos = require('../../../../core/local/atom/add_infos')
 const Channel = require('../../../../core/local/atom/channel')
 
 describe('core/local/atom/add_infos.loop()', () => {
-  it('should returns an enhanced batch with infos', async () => {
+  let builders
+  let opts
+
+  before('instanciate config', configHelpers.createConfig)
+  beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+  beforeEach('instanciate builders', async function() {
+    builders = new Builders({ pouch: this.pouch })
+  })
+  beforeEach('create step opts', async function() {
+    opts = {
+      syncPath: '',
+      pouch: this.pouch
+    }
+  })
+
+  it('returns an enhanced batch with infos', async () => {
     const batch = [
       {
         action: 'scan',
@@ -17,16 +37,14 @@ describe('core/local/atom/add_infos.loop()', () => {
     ]
     const channel = new Channel()
     channel.push(batch)
-    const enhancedChannel = addInfos.loop(channel, {
-      syncPath: ''
-    })
+    const enhancedChannel = addInfos.loop(channel, opts)
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch)
       .be.an.Array()
       .and.have.length(batch.length)
   })
 
-  it('should add specific infos for specific events', async () => {
+  it('adds specific infos for specific events', async () => {
     const batch = [
       {
         action: 'deleted',
@@ -61,9 +79,7 @@ describe('core/local/atom/add_infos.loop()', () => {
     ]
     const channel = new Channel()
     channel.push(batch)
-    const enhancedChannel = addInfos.loop(channel, {
-      syncPath: ''
-    })
+    const enhancedChannel = addInfos.loop(channel, opts)
     const [
       deletedEvent,
       ignoredEvent,
@@ -85,6 +101,93 @@ describe('core/local/atom/add_infos.loop()', () => {
       should(event._id).eql(metadata.id(event.path))
       should(event.kind).eql('directory')
       should.exist(event.stats)
+    })
+  })
+
+  context('when deleted event kind is unknown', () => {
+    context('and document exists in Pouch', () => {
+      beforeEach('populate Pouch with documents', async function() {
+        await builders
+          .metafile()
+          .path('file')
+          .create()
+        await builders
+          .metadir()
+          .path('dir')
+          .create()
+      })
+
+      it('looks up existing document doctype from Pouch', async () => {
+        const batch = [
+          {
+            action: 'deleted',
+            kind: 'unknown',
+            path: 'file'
+          },
+          {
+            action: 'deleted',
+            kind: 'unknown',
+            path: 'dir'
+          }
+        ]
+        const channel = new Channel()
+        channel.push(batch)
+        const enhancedChannel = addInfos.loop(channel, opts)
+
+        should(await enhancedChannel.pop()).deepEqual([
+          {
+            action: 'deleted',
+            kind: 'file',
+            path: 'file',
+            _id: metadata.id('file'),
+            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' }
+          },
+          {
+            action: 'deleted',
+            kind: 'directory',
+            path: 'dir',
+            _id: metadata.id('dir'),
+            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' }
+          }
+        ])
+      })
+    })
+
+    context('and document was never saved in Pouch', () => {
+      it('forces kind to file for unknown documents', async () => {
+        const batch = [
+          {
+            action: 'deleted',
+            kind: 'unknown',
+            path: __filename
+          },
+          {
+            action: 'deleted',
+            kind: 'unknown',
+            path: __dirname
+          }
+        ]
+        const channel = new Channel()
+        channel.push(batch)
+        const enhancedChannel = addInfos.loop(channel, opts)
+
+        should(await enhancedChannel.pop()).deepEqual([
+          {
+            action: 'deleted',
+            kind: 'file',
+            path: __filename,
+            _id: metadata.id(__filename),
+            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' }
+          },
+          {
+            action: 'deleted',
+            kind: 'file',
+            path: __dirname,
+            _id: metadata.id(__dirname),
+            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' }
+          }
+        ])
+      })
     })
   })
 })


### PR DESCRIPTION
Sometimes, AtomWatcher won't know the kind of a deleted document and
will trigger a `deleted` event with an `unknown` type.
In those situations, we decided to always force the kind to `file`.

However, if the deleted document is actually a directory, the deletion
won't happen because we'll get an `Mismatch on doctype for doTrash`
error during merge.

It seems more reasonable today to try and fetch the document with the
event's `_id` from Pouch and use its doctype to set the event's kind.
If we don't have any document in Pouch with the event's `_id`, we can
resort back to forcing the kind to `file`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
