### PR TITLE
core/remote/warning_poller: Fix binding in setTimeout

### DIFF
--- a/core/remote/warning_poller.js
+++ b/core/remote/warning_poller.js
@@ -101,7 +101,9 @@ class RemoteWarningPoller {
   scheduleNext(ticks /*: Ticks */) {
     clearTimeout(this.timeout)
     this.ticks = ticks
-    this.timeout = setTimeout(this.poll, ticks.next)
+    this.timeout = setTimeout(() => {
+      this.poll()
+    }, ticks.next)
     log.debug({ ticks }, `Next polling in ${ticks.next} milliseconds`)
   }
 


### PR DESCRIPTION
The warnings poller uses a system of timeouts with defined delays
called ticks to check if any action is required from the user.
The main function `poll()` is called via `setTimeout` but wasn't bound
to the instance so the instance's ticks where not defined anymore when
trying to figure out the next tick.

This prevents the poller from polling after the first attempt and is
easily fixed by wrapping the call to `poll()` with an arrow function.
