### PR TITLE
doc: Update supported macOS versions

### DIFF
--- a/doc/usage/macos.md
+++ b/doc/usage/macos.md
@@ -4,11 +4,13 @@
 
 | macOS version | supported | comment |
 | --- | --- | --- |
-| 10.13 "High Sierra" | yes | actively tested |
-| 10.12 "Sierra" | yes | actively tested |
+| 10.15 "Catalina" | yes | actively tested |
+| 10.14 "Mojave" | yes | should work |
+| 10.13 "High Sierra" | | should work |
+| 10.12 "Sierra" | | should work |
 | 10.11 "El Capitan" | | should work |
 | 10.10 "Yosemite" | | should work |
-| 10.9 "Mavericks" | | should work |
+| 10.9 "Mavericks" | no | |
 | 10.8 "Mountain Lion" | no | |
 | 10.7 "Lion" | no | |
 | 10.6 "Snow Leopard" | no | |


### PR DESCRIPTION
It has been reported to us that the application does not work on
macOS 10.9 Mavericks anymore. Since we don't have any device to test
this, Apple does not officially support this version anymore and the
Chrome documentation states that only macOS 10.10+ is supported, we've
decided to show we don't support this version at all and that we don't
expect Cozy Desktop to work on it anymore.

We also take the opportunity to add the last 2 versions of macOS and
state that we only actively support those 2 while only the latest
version is actively tested since we have a device to test it.
