### PR TITLE
launcher: Don't bail out on bash errors

### DIFF
--- a/build/launcher-script.sh
+++ b/build/launcher-script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -ex
+
+# Uncomment for debugging purposes:
+# set -eux
 
 UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
To determine whether unprivileged user namespaces are enabled in the
user's kernel or not, we check the content of a file that will
probably be missing in most kernels where unprivileged user namespaces
have not been disabled by default.
This will trigger an error that we send to `/dev/null` but the `-e`
option of the launcher script forces the script to stop anyway.

Now that the script has been implemented and tested, we can remove
this option as well as the `-x` option which prints out every single
command.
