### PR TITLE
core/utils/sentry: Send report for every error

### DIFF
--- a/core/utils/sentry.js
+++ b/core/utils/sentry.js
@@ -115,8 +115,8 @@ const handleBunyanMessage = msg => {
 
   if (!isSentryConfigured) return
 
-  // for now only logs marked explicitly for sentry get sent
-  if (msg.sentry || (msg.err && msg.err.sentry)) {
+  // Send messages explicitly marked for sentry and all errors
+  if (msg.sentry || msg.err) {
     const extra = _.omit(msg, [
       'err',
       'tags',


### PR DESCRIPTION
Until now, only errors marked with the `sentry: true` property were
sent to Sentry so their number would be limited.
However, some issues our users face are hard to analyze and understand
even when we can get our hands on user logs since those are usually
too recent compared to the time the original issue happened.

By sending a report for every error, we can hope we'll be alerted
sooner of potential issues or at least go back to older reports when a
user comes to us with some issue.

This should also give us a more global overview of issues users run
into and how many are affected.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
