### PR TITLE
core/pouch: Pick correct previous revision

### DIFF
--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -406,10 +406,11 @@ class Pouch {
       if (err) {
         return callback(err)
       } else {
-        let { ids } = infos[0].ok._revisions
-        let { start } = infos[0].ok._revisions
-        let revId = ids[start - revDiff]
-        let rev = `${revDiff}-${revId}`
+        const { ids } = infos[0].ok._revisions
+        const { start } = infos[0].ok._revisions
+        const shortRev = start - revDiff
+        const revId = ids[revDiff]
+        const rev = `${shortRev}-${revId}`
         return this.db.get(id, { rev }, function(err, doc) {
           if (err) {
             log.debug(infos[0].doc)

--- a/test/unit/pouch.js
+++ b/test/unit/pouch.js
@@ -603,17 +603,33 @@ if (doc.docType === 'folder') {
   describe('Helpers', function() {
     describe('getPreviousRev', () =>
       it('retrieves previous document informations', async function() {
-        let id = metadata.id(path.join('my-folder', 'folder-1'))
-        let doc = await this.pouch.db.get(id)
-        doc.tags = ['yipee']
-        const updated = await this.pouch.db.put(doc)
+        const id = metadata.id(path.join('my-folder', 'folder-1'))
+        const doc = await this.pouch.db.get(id)
+
+        // Update 1
+        const tags = ['yipee']
+        const updated = await this.pouch.db.put({
+          ...doc,
+          tags
+        })
+        // Update 2
         await this.pouch.db.remove(id, updated.rev)
-        doc = await this.pouch.getPreviousRevAsync(id, 1)
-        doc._id.should.equal(id)
-        doc.tags.should.not.equal(['yipee'])
-        doc = await this.pouch.getPreviousRevAsync(id, 2)
-        doc._id.should.equal(id)
-        doc.tags.join(',').should.equal('yipee')
+
+        // Get doc as it was 2 revisions ago
+        should(await this.pouch.getPreviousRevAsync(id, 2)).have.properties({
+          _id: id,
+          tags: doc.tags
+        })
+        // Get doc as it was 1 revision ago
+        should(await this.pouch.getPreviousRevAsync(id, 1)).have.properties({
+          _id: id,
+          tags
+        })
+        // Get doc as it is now
+        should(await this.pouch.getPreviousRevAsync(id, 0)).have.properties({
+          _id: id,
+          _deleted: true
+        })
       }))
   })
 


### PR DESCRIPTION
We changed the arguments of `Pouch#getPreviousRev()` to get passed a
revision diff count so we could introduce the `sides.target` on
documents.
This count is meant to select the count'th previous revision of the
specified document. To do so, we fetch all revision ids of the
document (i.e. the hash part of each revision) and use the count to
pick the id at the right index. We thought those were ordered by
ascending short revision order while they're actually ordered by
descending short revision order (i.e. the latest revision id is the
first of array).

This means that we were not selecting the right revision in Sync when
trying to get the latest known remote revision to propagate a file
update to the Cozy. This would cause conflict errors and prevent the
propagation.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
