### PR TITLE
gui/js/updater.window: Reset skipped on update check

### DIFF
--- a/gui/js/updater.window.js
+++ b/gui/js/updater.window.js
@@ -52,9 +52,8 @@ module.exports = class UpdaterWM extends WindowManager {
     autoUpdater.on('update-available', info => {
       this.clearTimeoutIfAny()
       log.info({ update: info, skipped: this.skipped }, 'Update available')
-      // Make sure UI don't show up in front of onboarding after timeout
+      // Make sure UI doesn't show up after timeout
       if (!this.skipped) {
-        this.skipped = true
         const shouldUpdate =
           dialog.showMessageBox({
             icon: path.resolve(__dirname, '..', 'images', 'icon.png'),
@@ -66,11 +65,12 @@ module.exports = class UpdaterWM extends WindowManager {
             type: 'question',
             buttons: ['Update', 'Cancel'].map(translate)
           }) === 0
+
         if (shouldUpdate) {
           autoUpdater.downloadUpdate()
           this.show()
         } else {
-          this.skipped = false
+          this.skipUpdate('refused update')
         }
       }
     })
@@ -123,6 +123,7 @@ module.exports = class UpdaterWM extends WindowManager {
   }
 
   checkForUpdates() {
+    this.skipped = false
     this.timeout = setTimeout(() => {
       this.skipUpdate(`check is taking more than ${UPDATE_CHECK_TIMEOUT} ms`)
     }, UPDATE_CHECK_TIMEOUT)
@@ -130,7 +131,7 @@ module.exports = class UpdaterWM extends WindowManager {
   }
 
   skipUpdate(reason) {
-    log.info(`Not updating: ${reason}`)
+    log.info({ sentry: true }, `Not updating: ${reason}`)
     this.skipped = true
 
     // Disable handler & warn on future calls

--- a/test/unit/gui/updater.window.js
+++ b/test/unit/gui/updater.window.js
@@ -1,0 +1,14 @@
+const should = require('should')
+
+const UpdaterWM = require('../../../gui/js/updater.window')
+
+describe('updater.window', () => {
+  describe('checkForUpdates', () => {
+    it('resets the skipped property', () => {
+      const updater = new UpdaterWM()
+      updater.skipped = true
+      updater.checkForUpdates()
+      should(updater.skipped).be.false()
+    })
+  })
+})


### PR DESCRIPTION
When we reach the update check timeout, we mark the update as skipped.
This is done so we won't offer to update while we've just started the
initial scan and risk stopping it.
However, this means that the next time we check for an update (i.e.
about 24 hours later), we will skip the update if it is available.

To avoid skipping later updates, we can make sure that
`checkForUpdates()` resets the `skipped` property so any available
update won't be skipped by default.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
