### PR TITLE
core/app: Update client version when updating app

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -36,6 +36,19 @@ import type { Config } from './config'
 import type stream from 'stream'
 import type { Callback } from './utils/func'
 import type { SyncMode } from './sync'
+
+export type ClientInfo = {
+  appVersion: string,
+  configPath: string,
+  configVersion: ?string,
+  cozyUrl: string,
+  deviceName: ?string,
+  osType: string,
+  osRelease: string,
+  osArch: string,
+  permissions: string[],
+  syncPath: string
+}
 */
 
 const log = logger({
@@ -329,7 +342,7 @@ class App {
     this.instanciate()
   }
 
-  clientInfo() {
+  clientInfo() /*: ClientInfo */ {
     const config = this.config || {}
 
     return {

--- a/core/config.js
+++ b/core/config.js
@@ -144,11 +144,11 @@ class Config {
   }
 
   get version() /*: ?string */ {
-    return _.get(this.fileConfig, 'creds.client.softwareVersion')
+    return _.get(this.fileConfig, 'creds.client.softwareVersion', '')
   }
 
-  get permissions() /*: * */ {
-    const scope = _.get(this.fileConfig, 'creds.token.scope')
+  get permissions() /*: string[] */ {
+    const scope = _.get(this.fileConfig, 'creds.token.scope', '')
     return scope ? scope.split(' ') : []
   }
 

--- a/core/config.js
+++ b/core/config.js
@@ -132,7 +132,7 @@ class Config {
 
   // Return the name of the registered client
   get deviceName() /*: ?string */ {
-    return _.get(this, 'config.creds.client.clientName', '')
+    return _.get(this.fileConfig, 'creds.client.clientName', '')
   }
 
   // Return config related to the OAuth client
@@ -144,11 +144,11 @@ class Config {
   }
 
   get version() /*: ?string */ {
-    return _.get(this, 'config.creds.client.softwareVersion')
+    return _.get(this.fileConfig, 'creds.client.softwareVersion')
   }
 
   get permissions() /*: * */ {
-    const scope = _.get(this, 'config.creds.token.scope')
+    const scope = _.get(this.fileConfig, 'creds.token.scope')
     return scope ? scope.split(' ') : []
   }
 

--- a/core/config.js
+++ b/core/config.js
@@ -147,6 +147,11 @@ class Config {
     return _.get(this.fileConfig, 'creds.client.softwareVersion', '')
   }
 
+  set version(newVersion /*: string */) /*: * */ {
+    _.set(this.fileConfig, 'creds.client.softwareVersion', newVersion)
+    this.persist()
+  }
+
   get permissions() /*: string[] */ {
     const scope = _.get(this.fileConfig, 'creds.token.scope', '')
     return scope ? scope.split(' ') : []

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -127,6 +127,10 @@ class RemoteCozy {
     return this.client.auth.unregisterClient()
   }
 
+  update() /*: Promise<void> */ {
+    return this.client.auth.updateClient()
+  }
+
   diskUsage() /* Promise<*> */ {
     return this.client.settings.diskUsage()
   }

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -91,6 +91,10 @@ class Remote /*:: implements Reader, Writer */ {
     return this.remoteCozy.unregister()
   }
 
+  update() {
+    return this.remoteCozy.update()
+  }
+
   /** Create a readable stream for the given doc */
   async createReadStreamAsync(
     doc /*: Metadata */

--- a/core/utils/sentry.js
+++ b/core/utils/sentry.js
@@ -7,7 +7,6 @@
 const Sentry = require('@sentry/electron')
 const bunyan = require('bunyan')
 const url = require('url')
-const os = require('os')
 
 const logger = require('./logger')
 const log = logger({
@@ -56,10 +55,7 @@ const bunyanErrObjectToError = data => {
 let isSentryConfigured = false
 
 /*::
-type ClientInfo = {
-  appVersion: string,
-  cozyUrl: string
-}
+import type { ClientInfo } from '../app'
 */
 
 function setup(clientInfos /*: ClientInfo */) {
@@ -76,7 +72,7 @@ function setup(clientInfos /*: ClientInfo */) {
       scope.setUser({ username: instance })
       scope.setTag('domain', domain)
       scope.setTag('instance', instance)
-      scope.setTag('server_name', os.hostname())
+      scope.setTag('server_name', clientInfos.deviceName)
     })
     logger.defaultLogger.addStream({
       type: 'raw',

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -174,15 +174,18 @@ describe('App', function() {
 
       const info = app.clientInfo()
 
-      should(info.appVersion).equal(version)
-      should(info.configPath).startWith(basePath)
-      should.not.exist(info.configVersion)
-      should.not.exist(info.cozyUrl)
-      should(info.deviceName).equal('')
-      should.exist(info.osRelease)
-      should.exist(info.osType)
-      should(info.permissions).deepEqual([])
-      should.not.exist(info.syncPath)
+      should(info).deepEqual({
+        appVersion: version,
+        configPath: path.join(basePath, '.cozy-desktop', 'config.json'),
+        configVersion: '',
+        cozyUrl: undefined,
+        deviceName: '',
+        osRelease: os.release(),
+        osType: os.type(),
+        osArch: os.arch(),
+        permissions: [],
+        syncPath: undefined
+      })
     })
 
     it('works when app is configured', function() {


### PR DESCRIPTION
The OAuth client stored on the Cozy contains the app's version. This
is used in io.cozy.files cozyMetadata to tell which version of which
app uploaded or updated documents for example.
This could also be useful to know which versions of the app are
installed.

However, the Desktop client would not update its OAuth client after
installing a new version. This means that the version used in metadata
and available in the OAuth client is the version that was installed
when connecting the client to the Cozy.

Updating the app's version in the OAuth client is a first step towards
being able to block some versions of the Desktop client from
connecting to the Cozy by allowing us to delete OAuth clients for old
versions and force a re-connection (with an app update).

We also take this opportunity to fix the device name display in the `Preferences` tab and to use it as Sentry's `server_name` tag's value so we have the same reference for clients across the board (and have a stable `server_name` independent from the user's network configuration).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
