### PR TITLE
core: Update last sync date when Cozy is up-to-date

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -135,6 +135,10 @@ class RemoteCozy {
     return this.client.settings.diskUsage()
   }
 
+  updateLastSync() /*: Promise<void> */ {
+    return this.client.settings.updateLastSync()
+  }
+
   createFile(
     data /*: Readable */,
     options /*: {name: string,

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -95,6 +95,10 @@ class Remote /*:: implements Reader, Writer */ {
     return this.remoteCozy.update()
   }
 
+  updateLastSync() {
+    return this.remoteCozy.updateLastSync()
+  }
+
   /** Create a readable stream for the given doc */
   async createReadStreamAsync(
     doc /*: Metadata */

--- a/gui/main.js
+++ b/gui/main.js
@@ -242,11 +242,18 @@ const updateState = (newState, data) => {
     tray.setState('syncing', data)
     trayWindow.send('transfer', data)
   } else if (newState === 'sync-status') {
-    syncStatusTimeout = setTimeout(() => {
-      tray.setState(
-        data && data.label === 'uptodate' ? 'up-to-date' : 'syncing'
-      )
+    syncStatusTimeout = setTimeout(async () => {
+      const upToDate = data && data.label === 'uptodate'
+      tray.setState(upToDate ? 'up-to-date' : 'syncing')
       trayWindow.send('sync-status', data)
+      if (upToDate) {
+        try {
+          await desktop.remote.updateLastSync()
+          log.debug('last sync updated')
+        } catch (err) {
+          log.warn({ err }, 'could not update last sync date')
+        }
+      }
     }, SYNC_STATUS_DELAY)
   }
 


### PR DESCRIPTION
The connected devices list in the Settings of the Cozy includes the
date of the last successful synchronization for each client.
The Desktop client was not updating it thus leaving it blank for all
devices.

We're now updating this date whenever the Cozy is up-to-date from the
Desktop's point of view.
This means that either there were no changes to synchronize or all
changes, either from the Cozy or the computer, were propagated to
the other side.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
