### PR TITLE
core/remote/watcher: Retry failed changes merge

### DIFF
--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -61,7 +61,7 @@ describe('core/remote/cozy', () => {
 
           it(`throws a CozyClientRevokedError to notify the GUI`, () => {
             should(() => {
-              handleCommonCozyErrors(err, { events, log })
+              handleCommonCozyErrors({ err }, { events, log })
             }).throw(new CozyClientRevokedError())
           })
         })
@@ -76,7 +76,7 @@ describe('core/remote/cozy', () => {
 
           it('throws an error decorated with JSON parsed from the original message', () => {
             should(() => {
-              handleCommonCozyErrors(err, { events, log })
+              handleCommonCozyErrors({ err }, { events, log })
             }).throw({ status, message })
           })
         })
@@ -87,7 +87,7 @@ describe('core/remote/cozy', () => {
 
           it('throws a permissions error', () => {
             should(() => {
-              handleCommonCozyErrors(err, { events, log })
+              handleCommonCozyErrors({ err }, { events, log })
             }).throw(/permissions/)
           })
         })
@@ -96,12 +96,14 @@ describe('core/remote/cozy', () => {
           const err = new FetchError(randomMessage())
 
           it('emits "offline" to notify the GUI', () => {
-            handleCommonCozyErrors(err, { events, log })
+            handleCommonCozyErrors({ err }, { events, log })
             should(events.emit).have.been.calledWith('offline')
           })
 
           it('returns "offline" to allow custom behavior', () => {
-            should(handleCommonCozyErrors(err, { events, log })).eql('offline')
+            should(handleCommonCozyErrors({ err }, { events, log })).eql(
+              'offline'
+            )
           })
         })
 
@@ -110,7 +112,7 @@ describe('core/remote/cozy', () => {
 
           it('throws the error', () => {
             should(() => {
-              handleCommonCozyErrors(err, { events, log })
+              handleCommonCozyErrors({ err }, { events, log })
             }).throw(err)
           })
         })


### PR DESCRIPTION
  We can fail to merge some changes for various reasons that are not
  definitive.
  For example, we could encounter very brief network issues or the
  remote changes can be in an order that prevents some of them to be
  merged (i.e. we have merged the creation of their parent folder yet).

  The order issue should not happen in theory since we order the changes
  prior to merging them but we know that in some cases, we fail to
  correctly order all changes, especially when there's a lot of them
  (like during the first synchronisation on a new device).

  We decided to implement a similar retry process than the one done
  during the propagation of merged changes by pushing to the end of the
  list changes which we've failed to merge.
  We hope that later changes will make it possible to merge the earlier
  ones (e.g. we finally get to the parent folder creation change which
  will let us merge its descendants).
  This process should also help with short network issues.

  We stop retrying to merge changes once we've been through the entire
  changes list without merging any changes. In this situation, we know
  the order of changes is not the problem and the network outage might
  longer than expected (e.g. no network at all) and retrying again and
  again would be pointless.

  Once we're done with all our retries, we gather the latest encountered
  errors and pass them along to the watcher.
  For now, we don't change the way we handle them: if there were any
  errors, the remote sequence isn't updated. The next time we fetch the
  remote changes, all merged changes will still be included but the
  watcher will detect they're up-to-date and won't try to merge them
  again.
  The errors are then handled one by one, network errors forcing the
  client into offline mode and the first not network related being
  thrown and stopping the synchronization with a status message and
  notification.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
