### PR TITLE
core/utils/sentry: Format errors to help grouping

### DIFF
--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -27,7 +27,7 @@ const defaultLogger = bunyan.createLogger({
   name: 'Cozy Desktop',
   level: 'trace',
   serializers: {
-    err: bunyan.stdSerializers.err
+    err: errSerializer
   },
   streams: [
     {
@@ -69,6 +69,22 @@ if (process.env.TESTDEBUG) {
       }
     }
   })
+}
+
+function errSerializer(err) {
+  const obj = bunyan.stdSerializers.err(err)
+  const { type, reason, address, dest, info, path, port, syscall } = err
+
+  if (type) obj.type = type
+  if (reason) obj.reason = reason
+  if (address) obj.address = err.address
+  if (dest) obj.dest = err.dest
+  if (info) obj.info = info
+  if (path) obj.path = path
+  if (port) obj.port = port
+  if (syscall) obj.syscall = syscall
+
+  return obj
 }
 
 function logger(options) {

--- a/test/unit/utils/sentry.js
+++ b/test/unit/utils/sentry.js
@@ -1,8 +1,32 @@
 /* eslint-env mocha */
 
-require('should')
+const should = require('should')
+const fs = require('fs')
 
 const sentry = require('../../../core/utils/sentry')
+const { FetchError } = require('electron-fetch')
+
+// This class is a copy of the `cozy-client-js` package's `FetchError` as it is
+// not exported and could therefore not be imported.
+class CozyClientFetchError extends Error {
+  constructor(res, reason) {
+    super()
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    }
+    this.name = 'FetchError'
+    this.response = res
+    this.url = res.url
+    this.status = res.status
+    this.reason = reason
+
+    Object.defineProperty(this, 'message', {
+      message:
+        reason.message ||
+        (typeof reason === 'string' ? reason : JSON.stringify(reason))
+    })
+  }
+}
 
 describe('Sentry', function() {
   describe('toSentryContext', function() {
@@ -25,6 +49,104 @@ describe('Sentry', function() {
         domain: 'mycozy-example.com',
         instance: 'mycozy-example.com',
         environment: 'selfhost'
+      })
+    })
+  })
+
+  describe('format', function() {
+    it('formats Node system errors', () => {
+      try {
+        fs.readFileSync(`${__filename}.missing-file`)
+      } catch (err) {
+        const result = sentry.format(err)
+        should(result).be.an.instanceof(Error)
+        should(result).have.properties({
+          type: 'Error',
+          message: 'ENOENT'
+        })
+        return
+      }
+      should.fail()
+    })
+
+    it('formats system FetchError', () => {
+      const err = new FetchError('reason', 'system', { code: 'ECONNREFUSED' })
+
+      const result = sentry.format(err)
+      should(result).be.an.instanceof(Error)
+      should(result).have.properties({
+        type: 'FetchError',
+        message: 'ECONNREFUSED'
+      })
+    })
+
+    it('formats electron-feth FetchError', () => {
+      const err = new FetchError(
+        `network timeout at: https://localhost`,
+        'request-timeout'
+      )
+
+      const result = sentry.format(err)
+      should(result).be.an.instanceof(Error)
+      should(result).have.properties({
+        type: 'FetchError',
+        message: 'request-timeout'
+      })
+    })
+
+    it('formats electron-fetch proxy FetchError', () => {
+      const err = new FetchError(
+        `login event received from myproxy.local but no credentials provided`,
+        'proxy',
+        { code: 'PROXY_AUTH_FAILED' }
+      )
+
+      const result = sentry.format(err)
+      should(result).be.an.instanceof(Error)
+      should(result).have.properties({
+        type: 'FetchError',
+        message: 'PROXY_AUTH_FAILED'
+      })
+    })
+
+    it('formats cozy-client-js FetchError with JSON body', async () => {
+      const response = new Response(
+        JSON.stringify({
+          errors: [
+            {
+              status: 412,
+              title: 'Precondition Failed',
+              detail: 'Invalid hash',
+              source: { parameter: 'Content-MD5' }
+            }
+          ]
+        }),
+        { status: 412 }
+      )
+      const reason = await response.json()
+      const err = new CozyClientFetchError(response, reason)
+
+      const result = sentry.format(err)
+      should(result).be.an.instanceof(Error)
+      should(result).have.properties({
+        type: 'FetchError',
+        message: 'Invalid hash'
+      })
+    })
+
+    it('formats cozy-client-js FetchError with text body', async () => {
+      const response = new Response('Not Found', {
+        status: 404,
+        statusText: 'Not Found'
+      })
+      const reason = await response.text()
+      const err = new CozyClientFetchError(response, reason)
+
+      const result = sentry.format(err)
+      should(result).be.an.instanceof(Error)
+      should(result).have.properties({
+        type: 'FetchError',
+        message: 'Not Found'
       })
     })
   })


### PR DESCRIPTION
A lot of errors that are sent to Sentry don't have the required
fingerprinting attributes for Sentry to group them together and their
messages differ slightly with file paths, request domains or other
dynamic elements in system calls or network requests.

This generates a lot of noise in our Sentry dashboard, especially for
network requests as those events happen quite often and are not
grouped together at the moment.

To have Sentry group those events, we make sure that every exception
reported will have the appropriate `type` and `message` so they get
grouped together while still retaining the important dynamic parts in
other fields which will get attached to each individual event.

This requires some changes in the bunyan error serializer since the
standard serializer removes a lot of interesting fields from errors
and this would prevent us from doing some pattern matching on them
to format those errors for Sentry.

We start from an object as the standard serializer would return and
add back a few specific attributes that we'll use later in Sentry
errors formatting.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
