### PR TITLE
core/local/index: Catch streaming read errors

### DIFF
--- a/test/support/builders/stream.js
+++ b/test/support/builders/stream.js
@@ -5,10 +5,12 @@ const stream = require('stream')
 module.exports = class StreamBuilder {
   /*::
   data: string
+  err: ?Error
   */
 
   constructor() {
     this.data = ''
+    this.err = null
   }
 
   push(data /*: string */) /*: StreamBuilder */ {
@@ -16,12 +18,22 @@ module.exports = class StreamBuilder {
     return this
   }
 
+  error(err /*: Error */) /* StreamBuilder */ {
+    this.err = err
+    return this
+  }
+
   build() /*: stream.Readable */ {
-    const result = new stream.Readable()
-
-    result.push(this.data)
-    result.push(null)
-
-    return result
+    const builder = this
+    return new stream.Readable({
+      read: function() {
+        if (builder.err) {
+          this.emit('error', builder.err)
+        } else {
+          this.push(builder.data)
+          this.push(null)
+        }
+      }
+    })
   }
 }


### PR DESCRIPTION
When downloading a file from the remote Cozy, we create a reading
stream from the distant file that we pipe into a writing stream to the
local destination.

We already handle writing errors on the writing stream but we don't
handle reading errors on the reading stream.
This means that the most common errors during downloads (i.e. network
errors) are not caught and will break the synchronization process
without ever noticing the user.
The synchronization would only get back to normal after restarting the
application.

By catching those errors, we let the synchronization process continue,
retrying up to 2 times when catching network errors and notifying the
user of an incomplete synchronization if we couldn't successfully
download the file.

With this change, we want to be able to simulate streaming errors to 
test our resilience to download errors and especially network errors 
while reading the distant file content.
To do so, we override the `read()` method of the built Readable so
that it will emit the given error if it exists instead of pushing the
stream data when read.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
