### PR TITLE
deps: Force Node version to 10.0.0+

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ environment:
       - BUILD_JOB: "scenarios_build"
 
 install:
-  - ps: Install-Product node 8.16.0 x64
+  - ps: Install-Product node 10.13.0 x64
   - cmd: appveyor-retry yarn install:all
   - cmd: appveyor-retry yarn bootstrap:remote
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 dist: trusty
 language: node_js
-node_js: 8.16.1
+node_js: 10.13.0
 osx_image: xcode11
 addons:
   apt:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/cozy-labs/cozy-desktop.git"
   },
   "engines": {
-    "node": ">=8.9.3"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "Electron",


### PR DESCRIPTION
We want to be able to use the `stream.pipeline` method which is
available only starting with Node v10.0.0.
If we don't force the Node engine's version to at least 10.0.0,
`eslint` will complain when using this method.