### PR TITLE
Release v3.17.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.17.0-beta.2 - 2019-12-13
+
+Improvements for all users:
+
+- We found out that errors while downloading a file from the remote Cozy (mostly
+  network errors which are quite common) were not handled at all. The result was
+  that the synchronization was stopped without notice (not even an error message
+  in the status bar) and would only work again after restarting the application.
+  We now catch them so the synchronization won't get completely blocked, we'll
+  wait for an internet connection to come back in the event of network errors
+  and we'll try downloading the file up to 3 times before giving up.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.17.0-beta.1 - 2019-12-10
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.17.0-beta.1",
+  "version": "3.17.0-beta.2",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- We found out that errors while downloading a file from the remote Cozy (mostly
  network errors which are quite common) were not handled at all. The result was
  that the synchronization was stopped without notice (not even an error message
  in the status bar) and would only work again after restarting the application.
  We now catch them so the synchronization won't get completely blocked, we'll
  wait for an internet connection to come back in the event of network errors
  and we'll try downloading the file up to 3 times before giving up.
