### PR TITLE
core/remote/change: New changes sorting algorithm

### DIFF
--- a/test/unit/remote/change.js
+++ b/test/unit/remote/change.js
@@ -120,7 +120,7 @@ describe('sorter()', () => {
       ])
     })
 
-    it('sorts child move of replaced and child move of replacing by created path', () => {
+    it('sorts child move of replaced and child move of replacing by deleted path', () => {
       const moveReplacing = {
         type: 'DescendantChange',
         doc: { path: path.normalize('dirA/dir/subdir') },
@@ -133,12 +133,12 @@ describe('sorter()', () => {
       }
 
       should(remoteChange.sort([moveReplacing, moveReplaced])).deepEqual([
-        moveReplacing,
-        moveReplaced
+        moveReplaced,
+        moveReplacing
       ])
       should(remoteChange.sort([moveReplaced, moveReplacing])).deepEqual([
-        moveReplacing,
-        moveReplaced
+        moveReplaced,
+        moveReplacing
       ])
     })
   })
@@ -227,16 +227,6 @@ describe('sorter()', () => {
         was: { path: path.normalize('parent/src/dir') }
       },
       {
-        doc: { path: path.normalize('parent/dst/dir/empty-subdir') },
-        type: 'DescendantChange',
-        was: { path: path.normalize('parent/src/dir/empty-subdir') }
-      },
-      {
-        doc: { path: path.normalize('parent/dst/dir/subdir') },
-        type: 'DescendantChange',
-        was: { path: path.normalize('parent/src/dir/subdir') }
-      },
-      {
         doc: { path: path.normalize('parent/dst/dir/subdir/filerenamed') },
         type: 'FileMove',
         was: { path: path.normalize('parent/dst/dir/subdir/file') }
@@ -245,10 +235,20 @@ describe('sorter()', () => {
         doc: { path: path.normalize('parent/dst/dir/subdir/filerenamed2') },
         type: 'FileMove',
         was: { path: path.normalize('parent/dst/dir/subdir/file2') }
+      },
+      {
+        doc: { path: path.normalize('parent/dst/dir/empty-subdir') },
+        type: 'DescendantChange',
+        was: { path: path.normalize('parent/src/dir/empty-subdir') }
+      },
+      {
+        doc: { path: path.normalize('parent/dst/dir/subdir') },
+        type: 'DescendantChange',
+        was: { path: path.normalize('parent/src/dir/subdir') }
       }
     ]
 
-    it('sorts parents before children', () => {
+    it('sorts moves before descendant moves', () => {
       const order1 = [
         {
           doc: { path: path.normalize('parent/dst/dir/subdir/filerenamed2') },

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -534,7 +534,7 @@ describe('RemoteWatcher', function() {
 
       describe('when moved source is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('detects the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', function() {
             const remoteDocs = [srcFileMoved, dstFileTrashed]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
@@ -553,19 +553,19 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('detects the move before the trashing', function() {
+          it('sorts the move before the trashing', function() {
             const remoteDocs = [srcFileMoved, dstFileTrashed]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
-                type: 'FileMove',
-                doc: { path: 'dst/file' },
-                was: { path: 'src/file' }
-              },
-              {
                 type: 'FileTrashing',
                 doc: { path: '.cozy_trash/FILE' },
                 was: { path: 'dst/FILE' }
+              },
+              {
+                type: 'FileMove',
+                doc: { path: 'dst/file' },
+                was: { path: 'src/file' }
               }
             ])
           })
@@ -574,7 +574,7 @@ describe('RemoteWatcher', function() {
 
       describe('when trashed destination is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('detects the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', function() {
             const remoteDocs = [dstFileTrashed, srcFileMoved]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
@@ -593,19 +593,19 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('detects the move before the trashing', function() {
+          it('sorts the move before the trashing', function() {
             const remoteDocs = [dstFileTrashed, srcFileMoved]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
-                type: 'FileMove',
-                doc: { path: 'dst/file' },
-                was: { path: 'src/file' }
-              },
-              {
                 type: 'FileTrashing',
                 doc: { path: '.cozy_trash/FILE' },
                 was: { path: 'dst/FILE' }
+              },
+              {
+                type: 'FileMove',
+                doc: { path: 'dst/file' },
+                was: { path: 'src/file' }
               }
             ])
           })
@@ -748,7 +748,7 @@ describe('RemoteWatcher', function() {
 
       describe('when moved source is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('detects the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', function() {
             const remoteDocs = [srcMoved, dstTrashed]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
@@ -767,19 +767,19 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('is detects the move before the trashing', function() {
+          it('sorts the trashing before the move ', function() {
             const remoteDocs = [srcMoved, dstTrashed]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
-                type: 'DirMove',
-                doc: { path: 'dst/dir' },
-                was: { path: 'src/dir' }
-              },
-              {
                 type: 'DirTrashing',
                 doc: { path: '.cozy_trash/DIR' },
                 was: { path: 'dst/DIR' }
+              },
+              {
+                type: 'DirMove',
+                doc: { path: 'dst/dir' },
+                was: { path: 'src/dir' }
               }
             ])
           })
@@ -788,7 +788,7 @@ describe('RemoteWatcher', function() {
 
       describe('when trashed destination is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('detects the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', function() {
             const remoteDocs = [dstTrashed, srcMoved]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
@@ -807,19 +807,19 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('detects the move before the trashing ', function() {
+          it('sorts the trashing before the move', function() {
             const remoteDocs = [dstTrashed, srcMoved]
             const changes = this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
-                type: 'DirMove',
-                doc: { path: 'dst/dir' },
-                was: { path: 'src/dir' }
-              },
-              {
                 type: 'DirTrashing',
                 doc: { path: '.cozy_trash/DIR' },
                 was: { path: 'dst/DIR' }
+              },
+              {
+                type: 'DirMove',
+                doc: { path: 'dst/dir' },
+                was: { path: 'src/dir' }
               }
             ])
           })


### PR DESCRIPTION
We've recently added a retry mechanism to the remote watcher so that
we'll try again to merge changes that could not be merged the first
time (or any subsequent time until we stop retrying).
We did so mostly to mitigate some sorting issues where we end up with
changes for documents before the creation change of their parent
folder.

However, there are other cases where the order of changes matters and
the wrong order will create issues that cannot be mitigated by the
retry mechanism.
For example, if a file is replaced by another one, we'll have 2
changes that need to be applied in this very order to avoid conflicts:
- a `FileTrashing` change for the previous version
- a `FileAddition` change with the new version

Since we've tried countless times to improve the sorting algorithm bit
by bit and we're still facing issues, we've decided to try another
approach and come up with a new algorithm.
This time, we'll try only to respect a few rules to order our changes
instead of trying to have the perfect order. We'll count on the retry
mechanism to finally merge those changes that could be in the wrong
order without creating issues.

Here are the rules we'll try to respect:
- Priorities will be as follow:
  1. Deletion & Trashing
  2. Moves
  3. Descendant Moves
  4. Restore & Additions
  5. Everything else
- Moved documents will come before replacing documents
- Ancestors will come before their descendants as much as possible

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
