### PR TITLE
core: Create proper custom error objects

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -24,9 +24,16 @@ type FileConfig = Object
 
 const INVALID_CONFIG_ERROR = 'InvalidConfigError'
 const INVALID_CONFIG_MESSAGE = 'Invalid client configuration'
-function InvalidConfigError() {
-  this.name = INVALID_CONFIG_ERROR
-  this.message = INVALID_CONFIG_MESSAGE
+class InvalidConfigError extends Error {
+  constructor() {
+    super(INVALID_CONFIG_MESSAGE)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidConfigError)
+    }
+
+    this.name = INVALID_CONFIG_ERROR
+  }
 }
 
 // Config can keep some configuration parameters in a JSON file,

--- a/core/pouch/error.js
+++ b/core/pouch/error.js
@@ -24,10 +24,14 @@ class PouchError extends Error {
       message
     } /*:{ name: string, status: number, message: string } */
   ) {
-    super()
+    super(message)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PouchError)
+    }
+
     this.name = name
     this.status = status
-    this.message = message
   }
 
   toString() {

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -82,6 +82,11 @@ class MigrationFailedError extends Error {
 
   constructor(migration /*: Migration */, errors /*: PouchError[] */) {
     super(migration.description)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MigrationFailedError)
+    }
+
     this.name = MIGRATION_RESULT_FAILED
     this.errors = errors
     this.sentry = true

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -33,17 +33,37 @@ const log = logger({
   component: 'RemoteCozy'
 })
 
-function DirectoryNotFound(path /*: string */, cozyURL /*: string */) {
-  this.name = 'DirectoryNotFound'
-  this.message = `Directory ${path} was not found on Cozy ${cozyURL}`
-  this.stack = new Error().stack
+class DirectoryNotFound extends Error {
+  /*::
+  path: string
+  cozyURL: string
+  */
+
+  constructor(path /*: string */, cozyURL /*: string */) {
+    super(`Directory ${path} was not found on Cozy ${cozyURL}`)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DirectoryNotFound)
+    }
+
+    this.name = 'DirectoryNotFound'
+    this.path = path
+    this.cozyURL = cozyURL
+  }
 }
 
 const COZY_CLIENT_REVOKED_ERROR = 'CozyClientRevokedError'
 const COZY_CLIENT_REVOKED_MESSAGE = 'Client has been revoked' // Only necessary for the GUI
-function CozyClientRevokedError() {
-  this.name = COZY_CLIENT_REVOKED_ERROR
-  this.message = COZY_CLIENT_REVOKED_MESSAGE
+class CozyClientRevokedError extends Error {
+  constructor() {
+    super(COZY_CLIENT_REVOKED_MESSAGE)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CozyClientRevokedError)
+    }
+
+    this.name = COZY_CLIENT_REVOKED_ERROR
+  }
 }
 
 /*::

--- a/core/utils/win_registry.js
+++ b/core/utils/win_registry.js
@@ -15,6 +15,8 @@
  *  We introduce here a registry cleanup during the app startup phase so
  *  that our users won't have to manually edit their registry to remove
  *  the old subkey.
+ *
+ * @flow
  */
 
 const regedit = require('regedit')
@@ -26,10 +28,25 @@ const OLD_UNINSTALL_KEY =
 
 const REGEDIT_INEXISTANT_PATH_ERROR_CODE = 2
 const REGEDIT_ERROR = 'RegeditError'
-function RegeditError(code, msg) {
-  this.name = REGEDIT_ERROR
-  this.code = code
-  this.message = msg
+class RegeditError extends Error {
+  /*::
+  code: number
+  */
+
+  constructor(code /*: number */, msg /*: string */) {
+    super(msg)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, RegeditError)
+    }
+
+    this.name = REGEDIT_ERROR
+    this.code = code
+  }
+
+  toString() {
+    return `(${this.code}) ${this.name}: ${this.message}`
+  }
 }
 
 async function removeOldUninstallKey() {


### PR DESCRIPTION
Some of our custom errors are created via simple functions which do
not properly inherit from the Error prototype.
This means that when those errors are caught and sent to Sentry,
Sentry finds them to be "Non-Error exception captured with keys:
message, name" instead of the custom error type we expect.

To help better triage those errors, we can use the `class` construct
to properly extend `Error` and have the expected error reports.

Besides, we use the V8 `Error.captureStackTrace` function to keep a
proper stack trace for our custom errors.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
