### PR TITLE
gui/elm: Disable manual sync after first click

### DIFF
--- a/gui/elm/Window/Tray.elm
+++ b/gui/elm/Window/Tray.elm
@@ -230,10 +230,7 @@ viewTabsWithContent helpers model =
                 Html.map DashboardMsg (Dashboard.view helpers model.dashboard)
 
             SettingsPage ->
-                let
-                    settingsModel = model.settings
-                in
-                    Html.map SettingsMsg (Settings.view helpers { settingsModel | status = model.status } )
+                Html.map SettingsMsg (Settings.view helpers model.status model.settings)
         ]
 
 

--- a/gui/elm/Window/Tray.elm
+++ b/gui/elm/Window/Tray.elm
@@ -106,7 +106,11 @@ update msg model =
             ( { model | settings = settings }, Cmd.map SettingsMsg cmd )
 
         Updated ->
-            ( { model | status = UpToDate }, Cmd.none )
+            let
+                ( settings, _ ) =
+                    Settings.update Settings.EndManualSync model.settings
+            in
+            ( { model | status = UpToDate, settings = settings }, Cmd.none )
 
         StartSyncing n ->
             ( { model | status = Syncing n }, Cmd.none )

--- a/gui/elm/Window/Tray/Settings.elm
+++ b/gui/elm/Window/Tray/Settings.elm
@@ -33,7 +33,6 @@ type alias Model =
     , disk : DiskSpace
     , busyUnlinking : Bool
     , busyQuitting : Bool
-    , status : Status
     }
 
 
@@ -50,7 +49,6 @@ init version =
         }
     , busyUnlinking = False
     , busyQuitting = False
-    , status = Starting
     }
 
 
@@ -151,8 +149,8 @@ versionLine helpers model =
             span [ class "version-uptodate" ] [ text model.version ]
 
 
-view : Helpers -> Model -> Html Msg
-view helpers model =
+view : Helpers -> Status -> Model -> Html Msg
+view helpers status model =
     section [ class "two-panes__content two-panes__content--settings" ]
         [ h2 [] [ text (helpers.t "Account Cozy disk space") ]
         , diskQuotaLine helpers model
@@ -174,7 +172,7 @@ view helpers model =
             , text (helpers.t "Settings Startup")
             ]
         , h2 [] [ text (helpers.t "Settings Synchronize manually") ]
-        , syncButton helpers model.status
+        , syncButton helpers status
         , h2 [] [ text (helpers.t "Account About") ]
         , p []
             [ strong [] [ text (helpers.t "Account Account" ++ " ") ]


### PR DESCRIPTION
When clicking on the manual synchronization button in the Settings
pane, we send a message to the main thread to restart in the Sync
flow.
However, until we receive the first status update back from the
synchronization process, the button stays enabled and we can
mistakenly request more manual synchronizations (e.g. by
double/triple/... clicking the button).

This can potentially lead to mistakes during the triggered initial
scan and should be avoided.
We introduce a new field in the Settings model that keeps track of
manual synchronizations. It gets updated when we click the button and
when we receive an up-to-date status back from the synchronization
process.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
