### PR TITLE
core: Mark local versions of Notes as read-only

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -14,6 +14,7 @@ const stream = require('stream')
 const bluebird = require('bluebird')
 
 const { TMP_DIR_NAME } = require('./constants')
+const { NOTE_MIME_TYPE } = require('../remote/constants')
 const stater = require('./stater')
 const { isUpToDate } = require('../metadata')
 const { hideOnWindows } = require('../utils/fs')
@@ -162,8 +163,12 @@ class Local /*:: implements Reader, Writer */ {
     let filePath = path.resolve(this.syncPath, doc.path)
 
     if (doc.docType === 'file') {
-      // TODO: Honor existing read/write permissions
-      await fse.chmod(filePath, doc.executable ? 0o755 : 0o644)
+      if (doc.mime === NOTE_MIME_TYPE) {
+        await fse.chmod(filePath, 0o444)
+      } else {
+        // TODO: Honor existing read/write permissions
+        await fse.chmod(filePath, doc.executable ? 0o755 : 0o644)
+      }
     }
 
     if (doc.updated_at) {

--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -16,5 +16,8 @@ module.exports = {
   ROOT_DIR_ID: 'io.cozy.files.root-dir',
   TRASH_DIR_ID: 'io.cozy.files.trash-dir',
 
-  TRASH_DIR_NAME: '.cozy_trash'
+  TRASH_DIR_NAME: '.cozy_trash',
+
+  // Special MIME types
+  NOTE_MIME_TYPE: 'text/vnd.cozy.note+markdown'
 }

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -75,6 +75,19 @@ describe('Local', function() {
   })
 
   describe('updateMetadataAsync', () => {
+    it('makes Cozy Notes read-only', async function() {
+      const doc = {
+        docType: 'file',
+        mime: 'text/vnd.cozy.note+markdown',
+        path: 'my-note.cozy-note'
+      }
+      await syncDir.ensureFileMode(doc.path, 0o777)
+
+      await this.local.updateMetadataAsync(doc)
+
+      should(await syncDir.octalMode(doc)).equal('444')
+    })
+
     it('chmod -x for a non-executable file', async function() {
       const doc = {
         docType: 'file',


### PR DESCRIPTION
Since the introduction of the Cozy Notes application, we've started
synchronizing their markdown version on users' desktops.

The problem is, those version are not meant to be modified as they're
just a markdown export of the actual Note and modifications made on
those files with any application other than Cozy Notes won't be
reflected on the Note stored in the Cozy.

To avoid situations where users modify those files and lose content or
just don't find it on their Cozy, we've decided to use file system
permissions to show those files should not be modified.
Users can still change the permissions but we find this is a good
warning while we add the capacity to open Notes from the file system
(i.e. we'll launch the Cozy Notes application for that).

Warning: This behavior is based on the premise that Cozy Notes
related files will have the `text/vnd.cozy.note+markdown` MIME type.
This is not the case yet!
But we're relying on the idea that users will run a version of the
Desktop app with this behavior before documents are migrated on their
Cozy to have the correct MIME type. Cozy Desktop will detect the
change and apply the new permissions on the local file system.
Any other change on Notes will also trigger a permissions change.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
