### PR TITLE
core/sync: Create conflict copy on 409 errors

### DIFF
--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -4,6 +4,7 @@
 const path = require('path')
 const should = require('should')
 
+const metadata = require('../../core/metadata')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
@@ -36,61 +37,200 @@ describe('Add', () => {
   })
 
   describe('file', () => {
-    it('local')
+    const createDoc = async (side, filename) => {
+      if (side === 'remote') {
+        await cozy.files.create('foo', {
+          name: filename,
+          dirID: parent._id
+        })
+      } else {
+        await helpers.local.syncDir.outputFile(
+          path.join(parent.attributes.path.slice(1), filename),
+          'foo'
+        )
+      }
+    }
+    const syncSideAddition = async side => {
+      if (side === 'remote') {
+        await helpers.pullAndSyncAll()
+      } else {
+        await helpers.flushLocalAndSyncAll()
+      }
+    }
 
-    it('remote', async () => {
-      await cozy.files.create('foo', { name: 'file', dirID: parent._id })
-      await helpers.remote.pullChanges()
+    describe('on local file system', () => {
+      it('creates the file on the remote Cozy', async () => {
+        await createDoc('local', 'file')
+        await helpers.local.scan()
 
-      should(helpers.putDocs('path', '_deleted', 'trashed', 'sides')).deepEqual(
-        [
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
+          {
+            path: path.normalize('parent/file'),
+            sides: { target: 1, local: 1 }
+          }
+        ])
+
+        await helpers.syncAll()
+
+        // $FlowFixMe
+        should(await helpers.remote.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/file'
+        ])
+      })
+
+      context('if file already exists on the remote Cozy', () => {
+        it('renames the remote file as conflict', async () => {
+          await createDoc('remote', 'file.txt')
+          await createDoc('local', 'file.txt')
+
+          await syncSideAddition('local')
+          should(await helpers.trees()).deepEqual({
+            local: ['parent/', 'parent/file.txt'],
+            remote: ['parent/', 'parent/file-conflict-...', 'parent/file.txt']
+          })
+
+          await helpers.pullAndSyncAll()
+          should(await helpers.trees()).deepEqual({
+            local: ['parent/', 'parent/file-conflict-...', 'parent/file.txt'],
+            remote: ['parent/', 'parent/file-conflict-...', 'parent/file.txt']
+          })
+        })
+      })
+    })
+
+    describe('on remote Cozy', () => {
+      it('creates the file on the local file system', async () => {
+        await createDoc('remote', 'file')
+        await helpers.remote.pullChanges()
+
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
           {
             path: path.normalize('parent/file'),
             sides: { target: 1, remote: 1 }
           }
-        ]
-      )
+        ])
 
-      await helpers.syncAll()
+        await helpers.syncAll()
 
-      should(await helpers.local.tree()).deepEqual(['parent/', 'parent/file'])
+        should(await helpers.local.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/file'
+        ])
+      })
     })
   })
 
   describe('dir', () => {
-    it('local')
+    const createDoc = async (side, name, parent) => {
+      if (side === 'remote') {
+        return await cozy.files.createDirectory({ name, dirID: parent._id })
+      } else {
+        const dirPath = path.join(parent.attributes.path.slice(1), name)
+        await helpers.local.syncDir.ensureDir(dirPath)
+        return {
+          _id: metadata.id(dirPath),
+          attributes: { path: `/${dirPath}` },
+          _rev: '1'
+        }
+      }
+    }
+    const syncSideAddition = async side => {
+      if (side === 'remote') {
+        await helpers.pullAndSyncAll()
+      } else {
+        await helpers.flushLocalAndSyncAll()
+      }
+    }
 
-    it('remote', async () => {
-      const dir = await cozy.files.createDirectory({
-        name: 'dir',
-        dirID: parent._id
+    describe('on local file system', () => {
+      it('creates the directory and its content on the remote Cozy', async () => {
+        const dir = await createDoc('local', 'dir', parent)
+        const subdir = await createDoc('local', 'subdir', dir)
+        await createDoc('local', 'empty-subdir', dir)
+        await helpers.local.syncDir.outputFile(
+          path.join(subdir.attributes.path, 'file'),
+          'foo'
+        )
+        await helpers.local.scan()
+
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
+          { path: 'parent/dir', sides: { target: 1, local: 1 } },
+          { path: 'parent/dir/empty-subdir', sides: { target: 1, local: 1 } },
+          { path: 'parent/dir/subdir', sides: { target: 1, local: 1 } },
+          { path: 'parent/dir/subdir/file', sides: { target: 1, local: 1 } }
+        ])
+
+        await helpers.syncAll()
+
+        should(await helpers.remote.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/dir/',
+          'parent/dir/empty-subdir/',
+          'parent/dir/subdir/',
+          'parent/dir/subdir/file'
+        ])
       })
-      const subdir = await cozy.files.createDirectory({
-        name: 'subdir',
-        dirID: dir._id
+
+      context('if directory already exists on the remote Cozy', () => {
+        it('links the two directories', async () => {
+          const remoteDir = await createDoc('remote', 'dir', parent)
+          await createDoc('local', 'dir', parent)
+
+          await syncSideAddition('local')
+          should(await helpers.trees()).deepEqual({
+            local: ['parent/', 'parent/dir/'],
+            remote: ['parent/', 'parent/dir/']
+          })
+          should(helpers.putDocs('path', 'remote', 'sides')).deepEqual([
+            {
+              path: 'parent/dir',
+              remote: undefined,
+              sides: { target: 1, local: 1 }
+            },
+            {
+              path: 'parent/dir',
+              remote: { _id: remoteDir._id, _rev: remoteDir._rev },
+              sides: { target: 2, local: 2, remote: 2 }
+            }
+          ])
+        })
       })
-      await cozy.files.createDirectory({ name: 'empty-subdir', dirID: dir._id })
-      await cozy.files.create('foo', { name: 'file', dirID: subdir._id })
-      await helpers.remote.pullChanges()
+    })
 
-      /* FIXME: Nondeterministic
-      should(helpers.putDocs('path', '_deleted', 'trashed', 'sides')).deepEqual([
-        {path: 'parent/dir', sides: {remote: 1}},
-        {path: 'parent/dir/empty-subdir', sides: {remote: 1}},
-        {path: 'parent/dir/subdir', sides: {remote: 1}},
-        {path: 'parent/dir/subdir/file', sides: {remote: 1}}
-      ])
-      */
+    describe('on remote Cozy', () => {
+      it('creates the directory and its content on the local file system', async () => {
+        const dir = await createDoc('remote', 'dir', parent)
+        const subdir = await createDoc('remote', 'subdir', dir)
+        await createDoc('remote', 'empty-subdir', dir)
+        await cozy.files.create('foo', { name: 'file', dirID: subdir._id })
+        await helpers.remote.pullChanges()
 
-      await helpers.syncAll()
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
+          { path: 'parent/dir', sides: { target: 1, remote: 1 } },
+          { path: 'parent/dir/empty-subdir', sides: { target: 1, remote: 1 } },
+          { path: 'parent/dir/subdir', sides: { target: 1, remote: 1 } },
+          { path: 'parent/dir/subdir/file', sides: { target: 1, remote: 1 } }
+        ])
 
-      should(await helpers.local.tree()).deepEqual([
-        'parent/',
-        'parent/dir/',
-        'parent/dir/empty-subdir/',
-        'parent/dir/subdir/',
-        'parent/dir/subdir/file'
-      ])
+        await helpers.syncAll()
+
+        should(await helpers.local.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/dir/',
+          'parent/dir/empty-subdir/',
+          'parent/dir/subdir/',
+          'parent/dir/subdir/file'
+        ])
+      })
     })
   })
 })


### PR DESCRIPTION
When the stacks responds to a Sync request with a 409 status error, it
means the change we're trying to push is conflicting with an existing
document.
This can only happen when we try to push a new file as updates with
the wrong revision number will result in 412 status errors and
conflicts on directories are resolved by linking the two together.

In this situation, to avoid losing data by overriding any of the
documents (i.e. the existing one and the one we're trying to push)
we'll rename the existing remote document with a conflict suffix and
mark our local change with an increased error counter so it can be
retried later (and work this time as the existing document has been
renamed).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
