### PR TITLE
core/sync: Don't setup Pouch during manual sync

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -18,6 +18,7 @@ require('./globals')
 const pkg = require('../package.json')
 const config = require('./config')
 const { Pouch } = require('./pouch')
+const { migrations } = require('./pouch/migrations')
 const Ignore = require('./ignore')
 const { Merge } = require('./merge')
 const Prep = require('./prep')
@@ -333,7 +334,7 @@ class App {
     return this.sync.stop()
   }
 
-  setup() {
+  async setup() {
     const clientInfo = this.clientInfo()
     log.info(clientInfo, 'user config')
 
@@ -357,6 +358,9 @@ class App {
     }
 
     this.instanciate()
+
+    await this.pouch.addAllViewsAsync()
+    await this.pouch.runMigrations(migrations)
 
     if (wasUpdated && this.remote) {
       try {

--- a/core/sync.js
+++ b/core/sync.js
@@ -13,7 +13,6 @@ const metadata = require('./metadata')
 const { handleCommonCozyErrors } = require('./remote/cozy')
 const { HEARTBEAT } = require('./remote/watcher')
 const { otherSide } = require('./side')
-const { migrations } = require('./pouch/migrations')
 const logger = require('./utils/logger')
 const measureTime = require('./utils/perfs')
 
@@ -97,8 +96,6 @@ class Sync {
   // - full for the full synchronization of the both sides
   async start(mode /*: SyncMode */) /*: Promise<*> */ {
     this.stopped = false
-    await this.pouch.addAllViewsAsync()
-    await this.pouch.runMigrations(migrations)
 
     let sidePromises = []
     if (mode !== 'pull') {

--- a/gui/main.js
+++ b/gui/main.js
@@ -311,7 +311,7 @@ const sendDiskUsage = () => {
   }
 }
 
-const startSync = force => {
+const startSync = async force => {
   trayWindow.send(
     'synchronization',
     desktop.config.cozyUrl,
@@ -374,7 +374,7 @@ const startSync = force => {
     desktop.events.on('delete-file', removeFile)
 
     try {
-      desktop.setup()
+      await desktop.setup()
     } catch (err) {
       log.fatal({ err, sentry: true }, 'Could not setup app')
       if (err instanceof config.InvalidConfigError) {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -7,7 +7,6 @@ const should = require('should')
 const { Ignore } = require('../../core/ignore')
 const metadata = require('../../core/metadata')
 const { otherSide } = require('../../core/side')
-const migrations = require('../../core/pouch/migrations')
 const Sync = require('../../core/sync')
 
 const stubSide = require('../support/doubles/side')
@@ -89,20 +88,6 @@ describe('Sync', function() {
       this.local.start.calledOnce.should.be.true()
       this.remote.start.called.should.be.false()
       this.sync.sync.calledOnce.should.be.false()
-    })
-
-    it('runs all available Pouch migrations', async function() {
-      sinon.spy(this.pouch, 'runMigrations')
-
-      await should(this.sync.start('full')).be.rejectedWith({
-        message: 'stopped'
-      })
-
-      should(
-        this.pouch.runMigrations.withArgs(migrations.migrations)
-      ).have.been.calledOnce()
-
-      this.pouch.runMigrations.restore()
     })
   })
 


### PR DESCRIPTION
The PouchDB views and migrations are setup during the start of the
Sync module. This seemed appropriate as this would make sure the DB
was ready before launching the watchers.

However, we've since reused the `Sync#start()` method to run manual
synchronizations. This means that views are created and migrations run
every time users click the manual synchronization button.
Even if these should not have any effects after the first run, it
seems risky and unnecessary to run them at this point.

It seems reasonable to do these actions during the application setup
which will happen before the synchronization is started.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
