### PR TITLE
core/sync: Properly stop synchronizations

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -321,17 +321,12 @@ class App {
   // Start the synchronization
   startSync(mode /*: SyncMode */) {
     this.config.saveMode(mode)
-    log.info('Run first synchronisation...')
     return this.sync.start(mode)
   }
 
   // Stop the synchronisation
   stopSync() {
-    if (!this.sync) {
-      // $FlowFixMe
-      return Promise.resolve()
-    }
-    return this.sync.stop()
+    return this.sync && this.sync.stop()
   }
 
   async setup() {

--- a/core/sync.js
+++ b/core/sync.js
@@ -162,7 +162,14 @@ class Sync {
       if (runningResolve) {
         runningResolve()
       }
+      log.info('Sync stopped')
     }
+  }
+
+  // Manually force a full synchronization
+  async forceSync() {
+    await this.stop()
+    await this.start('full')
   }
 
   // Stop the synchronization
@@ -171,9 +178,11 @@ class Sync {
     log.info('Stopping Sync...')
     this.stopRequested = true
     this.events.emit('stopRequested')
-    await this.running
-    this.stopRequested = false
-    log.info('Sync stopped')
+    const stopped = this.running || Promise.resolve()
+    stopped.then(() => {
+      this.stopRequested = false
+    })
+    return stopped
   }
 
   // TODO: remove waitForNewChanges to .start while(true)

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -180,9 +180,14 @@ module.exports = class TrayWM extends WindowManager {
       'open-file': (event, path) => this.openPath(path),
       'unlink-cozy': this.onUnlink,
       'manual-start-sync': () =>
-        this.desktop.stopSync().then(() => {
-          this.desktop.startSync('full')
-        })
+        this.desktop
+          .stopSync()
+          .then(() => {
+            this.desktop.startSync('full')
+          })
+          .catch(err => {
+            if (err) log.error({ err }, 'Could not run manual sync')
+          })
     }
   }
 

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -176,18 +176,16 @@ module.exports = class TrayWM extends WindowManager {
       'go-to-cozy': () => shell.openExternal(this.desktop.config.cozyUrl),
       'go-to-folder': () => shell.openItem(this.desktop.config.syncPath),
       'auto-launcher': (event, enabled) => autoLaunch.setEnabled(enabled),
-      'close-app': () => this.desktop.stopSync().then(() => this.app.quit()),
+      'close-app': () => {
+        this.desktop.stopSync()
+        this.app.quit()
+      },
       'open-file': (event, path) => this.openPath(path),
       'unlink-cozy': this.onUnlink,
       'manual-start-sync': () =>
-        this.desktop
-          .stopSync()
-          .then(() => {
-            this.desktop.startSync('full')
-          })
-          .catch(err => {
-            if (err) log.error({ err }, 'Could not run manual sync')
-          })
+        this.desktop.sync.forceSync().catch(err => {
+          if (err) log.error({ err }, 'Could not run manual sync')
+        })
     }
   }
 

--- a/gui/main.js
+++ b/gui/main.js
@@ -397,32 +397,29 @@ const startSync = async force => {
       })
     }
 
-    desktop
-      .startSync(desktop.config.fileConfig.mode)
-      .then(() => sendErrorToMainWindow('stopped'))
-      .catch(err => {
-        if (err.status === 402) {
-          // Only show notification popup on the first check (the GUI will
-          // include a warning anyway).
-          if (!userActionRequired) UserActionRequiredDialog.show(err)
+    desktop.startSync(desktop.config.fileConfig.mode).catch(err => {
+      if (err.status === 402) {
+        // Only show notification popup on the first check (the GUI will
+        // include a warning anyway).
+        if (!userActionRequired) UserActionRequiredDialog.show(err)
 
-          userActionRequired = pick(err, [
-            'title',
-            'code',
-            'detail',
-            'links',
-            'message'
-          ])
-          trayWindow.send('user-action-required', userActionRequired)
-          desktop.remote.warningsPoller.switchMode('medium')
-          return
-        } else if (err instanceof migrations.MigrationFailedError) {
-          updateState('error', err.name)
-        } else {
-          updateState('error', err.message)
-        }
-        sendDiskUsage()
-      })
+        userActionRequired = pick(err, [
+          'title',
+          'code',
+          'detail',
+          'links',
+          'message'
+        ])
+        trayWindow.send('user-action-required', userActionRequired)
+        desktop.remote.warningsPoller.switchMode('medium')
+        return
+      } else if (err instanceof migrations.MigrationFailedError) {
+        updateState('error', err.name)
+      } else {
+        updateState('error', err.message)
+      }
+      sendDiskUsage()
+    })
     sendDiskUsage()
   }
   autoLaunch.isEnabled().then(enabled => {

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -256,7 +256,6 @@ describe('Update file', () => {
           was
         )
       )
-      helpers._sync.stopped = false
       await helpers.syncAll()
       const doc = await pouch.byRemoteIdMaybeAsync(file._id)
       should(doc.errors).be.undefined()

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -66,7 +66,6 @@ class TestHelpers {
     this._local = merge.local = local
     this._remote = merge.remote = remote
     this._sync = sync
-    this._sync.stopped = false
     this._sync.diskUsage = this._remote.diskUsage
     this.pouch = pouch
     this.local = localHelpers

--- a/test/unit/regressions/850.js
+++ b/test/unit/regressions/850.js
@@ -3,7 +3,7 @@
 const fse = require('fs-extra')
 const path = require('path')
 const sinon = require('sinon')
-// import should from 'should'
+const EventEmitter = require('events')
 
 // import { TMP_DIR_NAME } from '../../../core/local/constants'
 const ChokidarEvent = require('../../../core/local/chokidar/event')
@@ -35,7 +35,7 @@ describe('issue 850', function() {
       }),
       stop: sinon.stub().resolves()
     }
-    this.events = { emit: () => {} }
+    this.events = new EventEmitter()
     this.ignore = new Ignore([])
     this.sync = new Sync(
       this.pouch,


### PR DESCRIPTION
The way the synchronization is stopped at the moment does not properly
end infinite loops that take care of waiting for changes either local
or remote.
This is an issue especially when requesting a manual synchronization
as it works by stopping the current synchronization and starting a new
one. If the former is not completely stopped, we can end up with
multiple loops working on changes making for unpredictable behavior.

We also suspect that this may cause errors when trying to disconnect
the client from the Cozy with a process still using the PouchDB logs
file while trying to remove it.

We now use a promise that resolves when we call the `Sync#stop()`
method and we race it again synchronization promises so we can know
when to break out of the loops.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
