### PR TITLE
core/sync: Remove unused synchronization modes

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -319,9 +319,8 @@ class App {
   }
 
   // Start the synchronization
-  startSync(mode /*: SyncMode */) {
-    this.config.saveMode(mode)
-    return this.sync.start(mode)
+  startSync() {
+    return this.sync.start()
   }
 
   // Stop the synchronisation

--- a/core/config.js
+++ b/core/config.js
@@ -18,7 +18,6 @@ const log = logger({
 
 /*::
 export type WatcherType = 'atom' | 'chokidar'
-export type SyncMode = 'full' | 'pull' | 'push'
 type FileConfig = Object
 */
 
@@ -172,22 +171,6 @@ class Config {
 
   get watcherType() /*: WatcherType */ {
     return watcherType(this.fileConfig)
-  }
-
-  // Set the pull, push or full mode for this device
-  // It will throw an exception if the mode is not compatible with the last
-  // mode used!
-  saveMode(mode /*: SyncMode */) {
-    const old = this.fileConfig.mode
-    if (old === mode) {
-      return true
-    } else if (old) {
-      throw new Error(
-        `Once you set mode to "${old}", you cannot switch to "${mode}"`
-      )
-    }
-    this.fileConfig.mode = mode
-    this.persist()
   }
 
   // Implement the Storage interface for cozy-client-js oauth

--- a/gui/main.js
+++ b/gui/main.js
@@ -397,7 +397,7 @@ const startSync = async force => {
       })
     }
 
-    desktop.startSync(desktop.config.fileConfig.mode).catch(err => {
+    desktop.startSync().catch(err => {
       if (err.status === 402) {
         // Only show notification popup on the first check (the GUI will
         // include a warning anyway).

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -218,19 +218,6 @@ describe('core/config', function() {
         should(this.config.watcherType).equal(config.watcherType())
       })
     })
-
-    describe('saveMode', function() {
-      it('sets the pull or push mode', function() {
-        this.config.saveMode('push')
-        should(this.config.fileConfig.mode).equal('push')
-      })
-
-      it('throws an error for incompatible mode', function() {
-        this.config.saveMode('push')
-        should.throws(() => this.config.saveMode('pull'), /you cannot switch/)
-        should.throws(() => this.config.saveMode('full'), /you cannot switch/)
-      })
-    })
   })
 
   describe('.watcherType()', () => {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -55,26 +55,8 @@ describe('Sync', function() {
       this.sync.sync = sinon.stub().rejects(new Error('stopped'))
     })
 
-    it('starts the metadata replication of remote in read only', async function() {
-      await should(this.sync.start('pull')).be.rejectedWith({
-        message: 'stopped'
-      })
-      this.local.start.called.should.be.false()
-      this.remote.start.calledOnce.should.be.true()
-      this.sync.sync.calledOnce.should.be.true()
-    })
-
-    it('starts the metadata replication of local in write only', async function() {
-      await should(this.sync.start('push')).be.rejectedWith({
-        message: 'stopped'
-      })
-      this.local.start.calledOnce.should.be.true()
-      this.remote.start.called.should.be.false()
-      this.sync.sync.calledOnce.should.be.true()
-    })
-
-    it('starts the metadata replication of both in full', async function() {
-      await should(this.sync.start('full')).be.rejectedWith({
+    it('starts the metadata replication of both sides', async function() {
+      await should(this.sync.start()).be.rejectedWith({
         message: 'stopped'
       })
       this.local.start.calledOnce.should.be.true()
@@ -84,7 +66,7 @@ describe('Sync', function() {
 
     it('does not start sync if metadata replication fails', async function() {
       this.local.start = sinon.stub().rejects(new Error('failed'))
-      await should(this.sync.start('full')).be.rejectedWith({
+      await should(this.sync.start()).be.rejectedWith({
         message: 'failed'
       })
       this.local.start.calledOnce.should.be.true()


### PR DESCRIPTION
We used to give users the ability to choose whether they wanted to:
- synchronize their Cozy with their computer (i.e. `full` mode)
- backup their computer to their Cozy (i.e. `push` mode)
- backup their Cozy to their computer (i.e. `pull` mode)

We have removed this ability a long time ago and it's time to remove
these modes from the code since we don't expect to use them again
soon.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
