### PR TITLE
core/merge: Don't override unsynced file updates

### DIFF
--- a/core/local/chokidar/local_change.js
+++ b/core/local/chokidar/local_change.js
@@ -664,7 +664,7 @@ function includeChangeEventIntoFileMove(
   const moveChange /*: ?LocalFileMove */ = maybeMoveFile(sameInodeChange)
   if (!moveChange) return
   log.debug({ path: e.path }, 'FileMove + change')
-  moveChange.md5sum = moveChange.old.md5sum || moveChange.md5sum
+  moveChange.md5sum = e.md5sum
   moveChange.update = _.defaults(
     {
       // In almost all cases, change event has the destination path.

--- a/core/local/chokidar/send_to_prep.js
+++ b/core/local/chokidar/send_to_prep.js
@@ -161,7 +161,6 @@ const step = async (
           break
         case 'FileMove':
           await onMoveFile(c, prep)
-          if (c.update) await onChange(c.update, prep)
           break
         case 'DirMove':
           await onMoveFolder(c, prep)

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -10,6 +10,7 @@ const fse = require('fs-extra')
 const path = require('path')
 const trash = require('trash')
 const stream = require('stream')
+const _ = require('lodash')
 
 const bluebird = require('bluebird')
 
@@ -443,6 +444,17 @@ class Local /*:: implements Reader, Writer */ {
     }
     log.warn({ path: doc.path }, 'Folder is not empty!')
     await this.trashAsync(doc)
+  }
+
+  async createBackupCopyAsync(doc /*: Metadata */) /*: Promise<Metadata> */ {
+    const backupPath = `${doc.path}.bck`
+    await fse.copy(
+      path.join(this.syncPath, doc.path),
+      path.join(this.syncPath, backupPath)
+    )
+    const copy = _.cloneDeep(doc)
+    copy.path = backupPath
+    return copy
   }
 
   /** Rename a file/folder to resolve a conflict */

--- a/core/sync.js
+++ b/core/sync.js
@@ -426,6 +426,10 @@ class Sync {
             await side.updateFileMetadataAsync(doc, old)
           }
         } else {
+          if (sideName === 'local' && !doc.overwrite) {
+            const copy = await this.local.createBackupCopyAsync(doc)
+            await this.local.trashAsync(copy)
+          }
           await side.overwriteFileAsync(doc, old)
           this.events.emit('transfer-started', _.clone(doc))
         }

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -3,6 +3,8 @@
 
 const should = require('should')
 
+const metadata = require('../../core/metadata')
+
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
@@ -64,6 +66,41 @@ describe('Sync gets interrupted, initialScan occurs', () => {
     should(await helpers.trees()).deepEqual({
       remote: expected,
       local: expected
+    })
+  })
+
+  describe('remote file update', () => {
+    it('does not override the remote file with the local version', async function() {
+      const path = 'file'
+      const _id = metadata.id(path)
+
+      await helpers.local.syncDir.outputFile(path, 'original content')
+      await helpers.flushLocalAndSyncAll()
+
+      const doc = await this.pouch.byIdMaybeAsync(_id)
+      await cozy.files.updateById(doc.remote._id, 'remote content', {
+        contentType: 'text/plain'
+      })
+      await helpers.remote.pullChanges() // Merge
+
+      // but not sync (client restart)
+
+      await helpers.local.scan()
+      await helpers.syncAll()
+
+      await helpers.remote.pullChanges()
+      await helpers.syncAll()
+
+      // A conflict version is created
+      should(await helpers.trees()).deepEqual({
+        remote: ['file'],
+        local: ['/Trash/file.bck', 'file']
+      })
+
+      // Contents are kept untouched
+      const resp = await helpers.remote.cozy.files.downloadById(doc.remote._id)
+      should(await resp.text()).eql('remote content')
+      should(await helpers.local.readFile('file')).eql('remote content')
     })
   })
 })

--- a/test/unit/local/chokidar/analysis.js
+++ b/test/unit/local/chokidar/analysis.js
@@ -376,7 +376,7 @@ onPlatform('darwin', () => {
               sideName,
               type: 'FileMove',
               path: 'dst',
-              md5sum: old.md5sum,
+              md5sum: 'yata',
               ino: 1,
               stats,
               old,


### PR DESCRIPTION
When starting Cozy Desktop, we gather and merge local changes then
remote changes and last we try to synchronize them.
This can create issues when the same document was modified both
locally and remotely.

So, to avoid loosing data, we decided to rename the document with a
conflict suffix on the side that would overwrite the existing
document. In the case of a startup sync, this would be the remote
side.

However, if the application was stopped right after a remote update
was merged and before it was propagated to the local file system, when
starting it up again, we'll wrongly detect a local update (i.e. the
local version does not reflect the remote version and its Pouch
representation). In this case, the conflict resolution would happen on
the local file system, thus generating a local `renamed` event that
would lead to the remote version being overwritten with the local
version on top of being renamed with a conflict suffix.

We could decide this is fine now that we have versions management on
the remote Cozy but users don't seem to think about looking at those
and believe their changes are gone.
Besides, the change would be propagated to other Cozies in case the
file was shared and this can be even harder to understand for the
owners of those Cozies.

So we decided to overwrite the local version with the unsynced remote
version. Since, the local version could have really been updated,
we'll create a backup copy of the local file (i.e. with the `.bck`
file extension) and trash it for safe keeping in case that version was
the one the user wanted to keep.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
