### PR TITLE
tools: Associate `.cozy-note` files with Desktop

### DIFF
--- a/build/launcher-script.sh
+++ b/build/launcher-script.sh
@@ -3,6 +3,49 @@
 # Uncomment for debugging purposes:
 # set -eux
 
+APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+RESOURCES_DIR="$APP_DIR/resources"
+DESKTOP_DATABASE_DIR="$HOME/.local/share/applications"
+MIME_DATABASE_DIR="$HOME/.local/share/mime"
+CUSTOM_MIME_DIR="$MIME_DATABASE_DIR/packages"
+COZY_NOTE_MIME_TYPE_DECLARATION_FILENAME="vnd.cozy.note+markdown.xml"
+
+function isCozyNoteMimeTypeDeclared() {
+    # does our MIME type declaration file exist in the MIME database folder?
+    [[ -f "$CUSTOM_MIME_DIR/$COZY_NOTE_MIME_TYPE_DECLARATION_FILENAME" ]] && return
+
+    false
+}
+
+function declareCozyNoteMimeType() {
+    # make sure the `packages` folder exists
+    mkdir -p "$CUSTOM_MIME_DIR"
+    # copy our MIME type declaration file
+    cp "$RESOURCES_DIR/$COZY_NOTE_MIME_TYPE_DECLARATION_FILENAME" "$CUSTOM_MIME_DIR/$COZY_NOTE_MIME_TYPE_DECLARATION_FILENAME"
+    # rebuild the local MIME database to make sure our new type is known
+    update-mime-database $MIME_DATABASE_DIR
+}
+
+# For Desktop to be declared as the default application to open Cozy Notes on
+# linux, we need to declare the custom MIME type via an xml file in the system
+# or local MIME database folder.
+# We chose the local database at `~/.local/share/mime` since it doesn't require
+# root priviledges.
+#
+# To avoid overwriting modifications made by the user to the type once declared,
+# we don't overwrite the file if it exists.
+if ! isCozyNoteMimeTypeDeclared; then
+    declareCozyNoteMimeType
+fi
+
 UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-exec "$SCRIPT_DIR/cozydrive-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"
+
+# The Chromium app included in recent electron releases use a new kernel feature
+# to manage sandboxes and those electron releases also forcibly enable the usage
+# of sandboxes.
+# However, this feature called "unprivileged user namespaces" is considered a
+# security risk by Debian and so the feature is disabled on Debian and all other
+# distributions using its custom kernel.
+# This prevents the app from starting and so the only way for our users to use
+# Cozy Desktop is for us to manually disable the Chromium sandbox at runtime.
+exec "$APP_DIR/cozydrive-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"

--- a/build/vnd.cozy.note+markdown.xml
+++ b/build/vnd.cozy.note+markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/vnd.cozy.note+markdown">
+    <glob pattern="*.cozy-note"/>
+    <comment>Cozy Note markdown export</comment>
+    <icon name="x-office-document" />
+  </mime-type>
+</mime-info>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,6 +21,12 @@ asarUnpack:
 - gui/scripts/**
 directories:
   buildResources: gui/assets
+fileAssociations:
+  ext: cozy-note
+  name: Cozy Note
+  description: Cozy Note markdown export
+  mimeType: 'text/vnd.cozy.note+markdown'
+  role: Viewer
 mac:
   hardenedRuntime: true
   entitlements: './build/entitlements.mac.inherit.plist'
@@ -60,3 +66,5 @@ extraResources:
     to: 'regedit/vbs'
     filter:
       - '**/*'
+  - from: 'build/vnd.cozy.note+markdown.xml'
+    to: 'vnd.cozy.note+markdown.xml'


### PR DESCRIPTION
Create a file association on the user's computer via the
`electron-builder` configuration.
This will create the `text/vnd.cozy.note+markdown` MIME type on macOS
and Windows and will set Cozy Desktop as the default application to
open files with the `cozy-note` extension.

On Linux, since we don't install the application but hand an
executable, we need to create the MIME type by hand by putting a
declaration file in the local MIME types database.
The association will only work if a `desktop` file with the right MIME
type association points to the Desktop app. This is done automatically
if using `appimaged`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
