### PR TITLE
core/local/chokidar: Reuse non-NFC path on HFS+

### DIFF
--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/changes.json
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/changes.json
@@ -1,0 +1,19 @@
+[
+  {
+    "_id": "2491b75e6a47270ab274a59ae6005fbb",
+    "_rev": "2-bf665d6083038af512836d52f0a605c7",
+    "class": "text",
+    "created_at": "2020-01-29T16:48:57.951229059Z",
+    "dir_id": "2491b75e6a47270ab274a59ae6005ded",
+    "executable": false,
+    "md5sum": "ihJ0JyvnormYrQkI6TUGyg==",
+    "mime": "text/plain",
+    "name": "AccuséRéception.pdf",
+    "size": "14",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2020-01-29T16:48:57.951229059Z",
+    "path": "/Impôts Gérard/AccuséRéception.pdf"
+  }
+]

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/scenario.js
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/scenario.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+/*:: import type { Scenario } from '../..' */
+
+//const save = 'Partages reçus/'
+const nfdDir = 'Impo\u0302ts Ge\u0301rard/'
+const nfcFile = 'Accus\u00E9R\u00E9ception.pdf'
+
+module.exports = ({
+  side: 'remote',
+  init: [{ path: nfdDir, ino: 1 }],
+  actions: [
+    {
+      type: 'create_file',
+      path: `${nfdDir}${nfcFile}`,
+      content: 'remote content'
+    }
+  ],
+  expected: {
+    localTree: [nfdDir, `${nfdDir}${nfcFile}`],
+    remoteTrash: []
+  }
+} /*: Scenario */)

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/remote/changes.json
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/remote/changes.json
@@ -1,0 +1,19 @@
+[
+  {
+    "_id": "2491b75e6a47270ab274a59ae6005335",
+    "_rev": "2-5d1ab2c2ca77d0a3ffb62a8364e318ad",
+    "class": "text",
+    "created_at": "2020-01-29T16:48:43.338589143Z",
+    "dir_id": "2491b75e6a47270ab274a59ae60046fe",
+    "executable": false,
+    "md5sum": "ihJ0JyvnormYrQkI6TUGyg==",
+    "mime": "text/plain",
+    "name": "AccuséRéception.pdf",
+    "size": "14",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2020-01-29T16:48:43.338589143Z",
+    "path": "/Impôts Gérard/AccuséRéception.pdf"
+  }
+]

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/scenario.js
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/scenario.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+/*:: import type { Scenario } from '../..' */
+
+//const save = 'Partages reçus/'
+const nfdDir = 'Impo\u0302ts Ge\u0301rard/'
+const nfdFile = 'Accuse\u0301Re\u0301ception.pdf'
+
+module.exports = ({
+  side: 'remote',
+  init: [{ path: nfdDir, ino: 1 }],
+  actions: [
+    {
+      type: 'create_file',
+      path: `${nfdDir}${nfdFile}`,
+      content: 'remote content'
+    }
+  ],
+  expected: {
+    tree: [nfdDir, `${nfdDir}${nfdFile}`],
+    remoteTrash: []
+  }
+} /*: Scenario */)


### PR DESCRIPTION
When synchronizing a remotely added document with a path containing
utf-8 characters on an HFS+ file system, we have to take care of the
re-normalization done by the file system itself (i.e. it renames the
document with `NFD` normalized path.
To avoid treating those renames as normal movements (invalid since
they give the same PouchDB document id via the `NFD` normalization
done to get the id of documents on macOS), we check if an existing
document with the same equivalent path exists in PouchDB and if so, we
normalize our document path with `NFC` to make sure it won't trigger a
rename action if it is strictly equal to the existing path.

However, this only works if the entire existing PouchDB document's
path is normalized with `NFC`.
We have encountered cases where the remote document path had its name
normalized with `NFC` (e.g. created on the Cozy by a connector) while
its ancestors were normalized with `NFD` (e.g. created locally and
thus synchronized with this norm).

We propose to re-use the existing document's ancestors part so don't
change its normalization and only apply the `NFC` normalization to the
name of the document.

The whole point of those re-normalizations are to avoid detecting
false renamings when it's only the HFS+ normalization process that
kicks in.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
