### PR TITLE
gui/notes: Fix public notes route path

### DIFF
--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -74,7 +74,7 @@ const computeNoteURL = async (
   if (sharecode) searchParams.push(['sharecode', sharecode])
   if (public_name) searchParams.push(['username', public_name])
 
-  const pathname = sharecode ? '/public' : ''
+  const pathname = sharecode ? '/public/' : ''
 
   return generateWebLink({
     cozyUrl: `${protocol}://${instance}`,

--- a/test/unit/gui/notes/index.js
+++ b/test/unit/gui/notes/index.js
@@ -207,7 +207,7 @@ describe('gui/notes/index', () => {
       })
 
       it('points to the public notes view', async function() {
-        should(await computeNoteURL(myNoteId, client)).containEql('public')
+        should(await computeNoteURL(myNoteId, client)).containEql('public/')
       })
 
       it('includes the appropriate share code', async function() {


### PR DESCRIPTION
The Cozy Notes web application is only routing to the public view of a
note if the path ends with a `/`.
Otherwise the assets won't be loaded and the note won't be displayed.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
