### PR TITLE
Fix collision between file move and update

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -494,6 +494,10 @@ class Merge {
       let dst = _.cloneDeep(doc)
       dst._id = makeDestinationID(doc)
       dst.path = doc.path.replace(was.path, folder.path)
+      // If the source needs to be overwritten, we'll take care of it during
+      // Sync while it does not say anything about the existence of a document
+      // at the destination.
+      if (dst.overwrite) delete dst.overwrite
 
       const singleSide = metadata.detectSingleSide(src)
       if (singleSide) {

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -69,6 +69,26 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 1,
+    targetSchemaVersion: 2,
+    description: 'Removing overwrite attribute of synced documents',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(
+        doc =>
+          doc.overwrite &&
+          doc.sides &&
+          doc.sides.target === doc.sides.local &&
+          doc.sides.target === doc.sides.remote
+      )
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        if (doc.overwrite) delete doc.overwrite
+        return doc
+      })
+    }
   }
 ]
 

--- a/core/sync.js
+++ b/core/sync.js
@@ -394,7 +394,10 @@ class Sync {
         await this.doMove(side, doc, from)
       }
       delete doc.moveFrom // the move succeeded, delete moveFrom before attempting overwrite
-      if (!metadata.sameBinary(from, doc)) {
+      if (
+        !metadata.sameBinary(from, doc) ||
+        (from.overwrite && !metadata.sameBinary(from.overwrite, doc))
+      ) {
         await side.overwriteFileAsync(doc, doc) // move & update
       }
     } else if (doc._deleted) {

--- a/core/sync.js
+++ b/core/sync.js
@@ -319,7 +319,11 @@ class Sync {
         }
       } else {
         await this.applyDoc(doc, side, sideName, rev)
+        // Clean up documents so that we don't mistakenly take action based on
+        // previous changes and keep our Pouch documents as small as possible
+        // and especially avoid deep nesting levels.
         delete doc.moveFrom
+        delete doc.overwrite
       }
 
       log.trace({ path, seq }, `Applied change on ${sideName} side`)


### PR DESCRIPTION
Cozy Desktop v3.18.0 introduced a mechanism to avoid losing remote updates on files when they were merged but not applied on the local file system.
This mechanism uses the `overwrite` attribute which was previously only used for movements which should overwrite the destination. A loophole in our new algorithm created issues when mixing file updates and movements.

Our solution to this problem is to remove the `overwrite` attribute after we've successfully synced the associated change or when we're creating child moves since the destination might not exist already (and this part will be handled via the `overwrite` attribute on the parent being moved).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
