### PR TITLE
core/app: Always return a Promise from `stopSync`

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -324,8 +324,12 @@ class App {
   }
 
   // Stop the synchronisation
-  stopSync() {
-    return this.sync && this.sync.stop()
+  stopSync() /*: Promise<void> */ {
+    if (this.sync) {
+      return this.sync.stop()
+    } else {
+      return Promise.resolve()
+    }
   }
 
   async setup() {

--- a/core/sync.js
+++ b/core/sync.js
@@ -165,7 +165,7 @@ class Sync {
   }
 
   // Stop the synchronization
-  async stop() {
+  async stop() /*: Promise<void> */ {
     if (this.started) await this.started
     log.info('Stopping Sync...')
     this.stopRequested = true

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -167,6 +167,32 @@ describe('App', function() {
     }
   })
 
+  describe('stopSync', () => {
+    let app
+    beforeEach('create app', function() {
+      configHelpers.createConfig.call(this)
+      configHelpers.registerClient.call(this)
+      this.config.persist() // the config helper does not persist it
+      app = new App(this.basePath)
+    })
+
+    context('when we have an instanciated Sync', () => {
+      beforeEach('instanciate app', function() {
+        app.instanciate()
+      })
+
+      it('returns a Promise', () => {
+        should(app.stopSync()).be.a.Promise()
+      })
+    })
+
+    context('when we do not have an instanciated Sync', () => {
+      it('returns a Promise', () => {
+        should(app.stopSync()).be.a.Promise()
+      })
+    })
+  })
+
   describe('clientInfo', () => {
     it('works when app is not configured', () => {
       const basePath = fse.mkdtempSync(path.join(os.tmpdir(), 'base-dir-'))


### PR DESCRIPTION
We don't always use async/await calls for `App.stopSync()` and thus
its return value is not automatically converted into a resolved
Promise.
This prevents the auto-update process from restarting the application
after the update was applied since we've moved the App setup after the
update process.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
