### PR TITLE
core/local/atom/watcher: Catch producer errors

### DIFF
--- a/core/local/atom/producer.js
+++ b/core/local/atom/producer.js
@@ -126,6 +126,7 @@ class Producer {
   ) {
     const entries = []
     const fullPath = path.join(this.syncPath, relPath)
+
     for (const entry of await readdir(fullPath)) {
       try {
         const absPath = path.join(this.syncPath, relPath, entry)
@@ -152,7 +153,11 @@ class Producer {
 
     for (const entry of entries) {
       if (entry.stats && stater.isDirectory(entry.stats)) {
-        await this.scan(entry.path)
+        try {
+          await this.scan(entry.path)
+        } catch (err) {
+          log.error({ err, path: entry.path }, 'could not scan dir')
+        }
       }
     }
   }

--- a/core/local/atom/watcher.js
+++ b/core/local/atom/watcher.js
@@ -146,10 +146,12 @@ class AtomWatcher {
       this._runningReject = reject
     })
     await stepsInitialState(this.state, this)
-    this.producer.start()
-    const scanDone = new Promise(resolve => {
+    let rejectScan
+    const scanDone = new Promise((resolve, reject) => {
+      rejectScan = reject
       this.events.on('initial-scan-done', resolve)
     })
+    this.producer.start().catch(err => rejectScan(err))
     return scanDone
   }
 

--- a/test/unit/local/atom/producer.js
+++ b/test/unit/local/atom/producer.js
@@ -31,6 +31,22 @@ onPlatforms(['linux', 'win32'], () => {
       producer = new Producer({ syncPath, ignore, events })
     })
 
+    describe('start()', () => {
+      context('on readdir error on dir', () => {
+        beforeEach(
+          'create content with missing read permission',
+          async function() {
+            await syncDir.makeTree(['dirA/fileA', 'dirB/fileB', 'dirC/fileC'])
+            await syncDir.chmod('dirB', 0o220)
+          }
+        )
+
+        it('should not reject', async function() {
+          await should(producer.start()).be.fulfilled()
+        })
+      })
+    })
+
     describe('scan()', () => {
       context('when a directory is ignored', () => {
         const ignoredDir = 'ignored-dir'

--- a/test/unit/local/atom/watcher.js
+++ b/test/unit/local/atom/watcher.js
@@ -2,25 +2,56 @@
 /* @flow */
 
 const should = require('should')
+const sinon = require('sinon')
 
-const AtomWatcher = require('../../../../core/local/atom/watcher')
+const {
+  AtomWatcher,
+  stepsInitialState
+} = require('../../../../core/local/atom/watcher')
 const initialDiff = require('../../../../core/local/atom/initial_diff')
 
 const configHelpers = require('../../../support/helpers/config')
 const pouchHelpers = require('../../../support/helpers/pouch')
+const TestHelpers = require('../../../support/helpers/index')
+const { onPlatforms } = require('../../../support/helpers/platform')
 
-describe('core/local/atom/watcher', () => {
-  before('instanciate config', configHelpers.createConfig)
-  before('instanciate pouch', pouchHelpers.createDatabase)
-  after('clean pouch', pouchHelpers.cleanDatabase)
-  after('clean config directory', configHelpers.cleanConfig)
+onPlatforms(['linux', 'win32'], () => {
+  describe('core/local/atom/watcher', () => {
+    before('instanciate config', configHelpers.createConfig)
+    before('register client', configHelpers.registerClient)
+    before('instanciate pouch', pouchHelpers.createDatabase)
+    after('clean pouch', pouchHelpers.cleanDatabase)
+    after('clean config directory', configHelpers.cleanConfig)
 
-  describe('.stepsInitialState()', () => {
-    it('includes initial diff state key', async function() {
-      const state = {}
-      const initialState = await AtomWatcher.stepsInitialState(state, this)
-      should(state).have.property(initialDiff.STEP_NAME)
-      should(initialState).have.property(initialDiff.STEP_NAME)
+    describe('.stepsInitialState()', () => {
+      it('includes initial diff state key', async function() {
+        const state = {}
+        const initialState = await stepsInitialState(state, this)
+        should(state).have.property(initialDiff.STEP_NAME)
+        should(initialState).have.property(initialDiff.STEP_NAME)
+      })
+    })
+
+    describe('start', () => {
+      let helpers
+      beforeEach('init helpers', async function() {
+        helpers = TestHelpers.init(this)
+      })
+
+      context('when producer.start() rejects', () => {
+        it('should reject with the same error', async function() {
+          const watcher = new AtomWatcher({
+            ...helpers,
+            ignore: helpers._sync.ignore,
+            syncPath: this.config.syncPath
+          })
+
+          const error = new Error('producer start error')
+          sinon.stub(watcher.producer, 'start').rejects(error)
+
+          await should(watcher.start()).be.rejectedWith(error)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
We would not catch errors coming from the producer during the `start` phase.
This is an issue since we use Promises and those errors will stop the initial scan while we're not aware of it.
Besides, an error coming from one path should not stop the producer and prevent it from analyzing the rest of the synchronized folder.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
