### PR TITLE
gui/notes: Use `fetchURL` from the cozy-client note model

### DIFF
--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -4,7 +4,7 @@
  */
 
 const path = require('path')
-const { default: CozyClient, generateWebLink } = require('cozy-client')
+const { default: CozyClient, models } = require('cozy-client')
 
 const metadata = require('../../core/metadata')
 const {
@@ -59,33 +59,6 @@ const remoteDoc = async (
   }
 }
 
-const computeNoteURL = async (
-  noteId /*: string */,
-  client /*: CozyClient */
-) /*: Promise<string> */ => {
-  const {
-    data: { note_id, subdomain, protocol, instance, sharecode, public_name }
-  } = await client
-    .getStackClient()
-    .collection('io.cozy.notes')
-    .fetchURL({ _id: noteId })
-
-  const searchParams = [['id', note_id]]
-  if (sharecode) searchParams.push(['sharecode', sharecode])
-  if (public_name) searchParams.push(['username', public_name])
-
-  const pathname = sharecode ? '/public/' : ''
-
-  return generateWebLink({
-    cozyUrl: `${protocol}://${instance}`,
-    searchParams,
-    pathname,
-    hash: `/n/${note_id}`,
-    slug: 'notes',
-    subDomainType: subdomain
-  })
-}
-
 const getCozyClient = async (desktop /*: App */) /*: CozyClient */ => {
   await desktop.remote.remoteCozy.client.authorize()
   return await CozyClient.fromOldOAuthClient(desktop.remote.remoteCozy.client)
@@ -106,7 +79,7 @@ const openNote = async (
       })
     }
 
-    const noteURL = await computeNoteURL(note.remote._id, client)
+    const noteURL = await models.note.fetchURL(client, { id: note.remote._id })
     log.info({ noteURL }, 'computed url')
     shell.openExternal(noteURL)
   } catch (err) {
@@ -129,4 +102,4 @@ const openNote = async (
   }
 }
 
-module.exports = { localDoc, remoteDoc, computeNoteURL, openNote }
+module.exports = { localDoc, remoteDoc, openNote }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "btoa": "^1.1.2",
     "bunyan": "^2.0.2",
     "chokidar": "^3.2.2",
-    "cozy-client": "^10.7.0",
+    "cozy-client": "^11.2.1",
     "cozy-client-js": "0.15.0",
     "deep-diff": "^1.0.2",
     "dtrace-provider": "^0.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,19 +1362,19 @@ cozy-client-js@0.15.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-10.7.0.tgz#0cc76491f79caba7dfaee87ab19908d0e1f315f2"
-  integrity sha512-U7z9zQeGO4Tft1PhS+d+zJtl/ZmZPyxC3bmDsSazR1B2kfJhMf/WsI3Exp2yYu2KeKmQ9FUYhVxdAnhtwK+ppg==
+cozy-client@^11.2.1:
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-11.2.1.tgz#0e261df94499cc93561fa2f305028ae6c99c8f12"
+  integrity sha512-JqMiDF8UPZ3ZP3LRl1s1x2EkKXcw8NCSnPSUGUo3jmqop3gvs0JHYeixakVeWVQpZzb90BFfUbEmZvtSb9gXyA==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^10.7.0"
+    cozy-stack-client "^11.2.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
-    opn "^6.0.0"
+    open "^7.0.2"
     prop-types "^15.6.2"
     react-redux "^5.0.7"
     redux "^3.7.2"
@@ -1398,10 +1398,10 @@ cozy-logger@^1.6.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-10.7.0.tgz#2f9a886af423abe9111d6c1524104c29d2ed517f"
-  integrity sha512-O2z9sFwDhcbn/rZJr0f2BL3CAc2L37QMzmIlQXY/70x/SqkSd+zyFhgwfYImqlwYsByf6Mo6qwtpwv5goRj9Ig==
+cozy-stack-client@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-11.2.0.tgz#78506c47e86063dbfc3d214f2833a8b693286344"
+  integrity sha512-782/jXltjoUs0qoukJjW8KFZWGMODH0hIzdyYZQQu2v3G16pfM4qjudoVekHYDPXu+5um3qLCqYrbHR0+sfOfQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -3660,6 +3660,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-electron-renderer@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz#a469d056f975697c58c98c6023eb0aa79af895a2"
@@ -3849,6 +3854,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 is-yarn-global@^0.3.0:
   version "0.3.0"
@@ -5200,6 +5210,14 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.2.tgz#fb3681f11f157f2361d2392307548ca1792960e8"
+  integrity sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opencollective-postinstall@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -5209,13 +5227,6 @@ opn@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.0.0.tgz#f8870d7cd969b218030cb6ce5a1285e795931df3"
   integrity sha1-+IcNfNlpshgDDLbOWhKF55WTHfM=
-  dependencies:
-    is-wsl "^1.1.0"
-
-opn@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
-  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
   dependencies:
     is-wsl "^1.1.0"
 


### PR DESCRIPTION
The `computeUrl` method has been copied into `cozy-client` and can
thus be replaced by a call to the new `fetchURL` method.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
