### PR TITLE
gui/main: Change reconnection button label

### DIFF
--- a/gui/locales/de.json
+++ b/gui/locales/de.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "Sie haben das Passwort nicht ausgefüllt:",
   "Password Your password for the cozy address:": "Ihr Passwort für die Cozy Adresse:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Log out",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "Eine neue Version ist verfügbar",

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Log out",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "A new release is available",

--- a/gui/locales/eo.json
+++ b/gui/locales/eo.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Log out",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "A new release is available",

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "¡Usted no ha escrito la contraseña!",
   "Password Your password for the cozy address:": "Su contraseña para la direccion cozy:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "En caso de que no pueda, contáctenos en contact@cozycloud.cc",
-  "Revoked Log out": "Desconexión",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "La sincronización con su Cozy no está disponible, quizás usted ha suspendido este computador.",
   "Revoked Try again later": "Vuelva a ensayar más tarde",
   "Settings A new release is available": "Una nueva versión está disponible",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "Vous n’avez pas rempli le mot de passe !",
   "Password Your password for the cozy address:": "Le mot de passe pour cette adresse Cozy :",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Dans le cas contraire, contactez nous sur contact@cozycloud.cc",
-  "Revoked Log out": "Se déconnecter",
+  "Revoked Reconnect": "Reconnecter",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "La synchronisation avec votre Cozy est impossible, peut-être avez-vous révoqué cet ordinateur ?",
   "Revoked Try again later": "Réessayer plus tard",
   "Settings A new release is available": "Une nouvelle version est disponible",

--- a/gui/locales/it_IT.json
+++ b/gui/locales/it_IT.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "Non hai inserito la password!",
   "Password Your password for the cozy address:": "La tua password per l'indirizzo cozy:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Esci",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "E' disponibile una nuova versione",

--- a/gui/locales/ja.json
+++ b/gui/locales/ja.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "パスワードが入力されていません!",
   "Password Your password for the cozy address:": "cozy アドレスのパスワード:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "行っていない場合は contact@cozycloud.cc にご連絡ください",
-  "Revoked Log out": "ログアウト",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "お使いの Cozy との同期が利用できません。このコンピュータを無効にしましたか?",
   "Revoked Try again later": "後でもう一度やり直してください",
   "Settings A new release is available": "新しいリリースが利用可能です",

--- a/gui/locales/nl.json
+++ b/gui/locales/nl.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "Je hebt geen wachtwoord ingevoerd!",
   "Password Your password for the cozy address:": "Je wachtwoord voor het Cozy-adres:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Als dat niet het geval is, neem dan contact met ons op via contact@cozycloud.cc",
-  "Revoked Log out": "Uitloggen",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Cozy-synchronisatie is niet beschikbaar. Heb je de machtiging voor deze computer ingetrokken?",
   "Revoked Try again later": "Probeer het later opnieuw",
   "Settings A new release is available": "Er is een nieuwe versie beschikbaar",

--- a/gui/locales/nl_NL.json
+++ b/gui/locales/nl_NL.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "Je hebt geen wachtwoord ingevoerd!",
   "Password Your password for the cozy address:": "Je wachtwoord voor het Cozy-adres:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Als dat niet zo is, neem dan contact met ons op via contact@cozycloud.cc",
-  "Revoked Log out": "Uitloggen",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronisatie is niet beschikbaar. Heb je de machtiging voor deze computer ingetrokken?",
   "Revoked Try again later": "Probeer het later opnieuw",
   "Settings A new release is available": "Er is een nieuwe versie beschikbaar",

--- a/gui/locales/pl.json
+++ b/gui/locales/pl.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "Nie wpisałeś hasła?",
   "Password Your password for the cozy address:": "Twoje hasło do adresu Cozy:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Log out",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "Dostępna jest nowsza wersja",

--- a/gui/locales/sq.json
+++ b/gui/locales/sq.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Log out",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "A new release is available",

--- a/gui/locales/zh_CN.json
+++ b/gui/locales/zh_CN.json
@@ -138,7 +138,7 @@
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
-  "Revoked Log out": "Log out",
+  "Revoked Reconnect": "Reconnect",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronization with your Cozy is unavailable, maybe you revoked this computer?",
   "Revoked Try again later": "Try again later",
   "Settings A new release is available": "有新版本",

--- a/gui/main.js
+++ b/gui/main.js
@@ -222,7 +222,7 @@ const sendErrorToMainWindow = msg => {
         "Revoked In case you didn't, contact us at contact@cozycloud.cc"
       ),
       buttons: [
-        translate('Revoked Log out'),
+        translate('Revoked Reconnect'),
         translate('Revoked Try again later')
       ],
       defaultId: 1


### PR DESCRIPTION
When we detect the OAuth client has been revoked, we offer the user to
fully disconnect Cozy Desktop from her Cozy and we restart the
application.
Doing so, the user is presented with the on-boarding process again.

To better reflect this behavior, we changed the button label to
"Reconnect". We believe users that disconnect their Cozy mostly do so
to reinitialize their app or by mistake.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
