### PR TITLE
core/local/atom: Default event kind to file

### DIFF
--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -11,9 +11,9 @@
 const _ = require('lodash')
 const path = require('path')
 
-const { id } = require('../../metadata')
-const stater = require('../stater')
+const { id, kind } = require('../../metadata')
 const logger = require('../../utils/logger')
+const stater = require('../stater')
 
 const STEP_NAME = 'addInfos'
 
@@ -27,9 +27,6 @@ import type { Metadata } from '../../metadata'
 import type Channel from './channel'
 import type { AtomEvent } from './event'
 */
-
-const kind = (doc /*: Metadata */) =>
-  doc.docType === 'folder' ? 'directory' : doc.docType
 
 module.exports = {
   STEP_NAME,

--- a/core/local/atom/fire_local_start_event.js
+++ b/core/local/atom/fire_local_start_event.js
@@ -21,9 +21,8 @@ module.exports = {
 
 /** Fire a local-start event for every batch of events
  *
- * Arbitrarily assume event kind is file by default.
- *
- * Return a new Channel where new events with stats will be pushed.
+ * Return a new Channel where all events will be pushed after we've emitted a
+ * `local-start` event for each of them.
  */
 function loop(
   channel /*: Channel */,

--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -12,9 +12,9 @@
 const _ = require('lodash')
 const path = require('path')
 
-const { id } = require('../../metadata')
-const Channel = require('./channel')
+const { id, kind } = require('../../metadata')
 const logger = require('../../utils/logger')
+const Channel = require('./channel')
 
 /*::
 import type { Pouch } from '../../pouch'
@@ -332,8 +332,4 @@ function foundUntouchedFile(event, was) /*: boolean %checks */ {
     event.kind === 'file' &&
     eventUpdateTime(event) === docUpdateTime(was)
   )
-}
-
-function kind(doc /*: Metadata */) /*: EventKind */ {
-  return doc.docType === 'folder' ? 'directory' : doc.docType
 }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -57,6 +57,7 @@ import type { RemoteDoc } from './remote/document'
 import type { Stats } from './local/stater'
 import type { Ignore } from './ignore'
 import type { SideName } from './side'
+import type { EventKind } from './local/atom/event'
 */
 
 const log = logger({
@@ -146,6 +147,7 @@ module.exports = {
   assignPlatformIncompatibilities,
   fromRemoteDoc,
   isFile,
+  kind,
   id,
   invalidPath,
   invariants,
@@ -224,6 +226,14 @@ function fromRemoteDoc(remoteDoc /*: RemoteDoc */) /*: Metadata */ {
 
 function isFile(doc /*: Metadata */) /*: bool */ {
   return doc.docType === 'file'
+}
+
+function kind(doc /*: Metadata */) /*: EventKind */ {
+  return doc.docType == null
+    ? 'file'
+    : doc.docType === 'folder'
+    ? 'directory'
+    : doc.docType
 }
 
 // Build an _id from the path for a case sensitive file system (Linux, BSD)


### PR DESCRIPTION
In some situations, the stats returned by the file system for a given
path don't contain a type (i.e. file, directory, symbolic link…).
This means that we won't know what kind of action to apply on
documents generated by events for this path.

We decided a while ago to default the event kind for such paths to
`file` in the hope we could reduce the amount of situations where the
kind is unknown or wrong.

However, some users already have Pouch documents without doctypes so
we have to use a default value when inferring the event kind from it
(i.e. during the initial diff when we created `deleted` events for
documents we couldn't match with a file or directory on the file
system).
We'll use the same default type of `file`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
