### PR TITLE
test: Include trash expectations in all scenarios

### DIFF
--- a/test/scenarios/add_delete_dir_and_file/scenario.js
+++ b/test/scenarios/add_delete_dir_and_file/scenario.js
@@ -12,6 +12,6 @@ module.exports = ({
   ],
   expected: {
     tree: [],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/add_file/scenario.js
+++ b/test/scenarios/add_file/scenario.js
@@ -6,6 +6,6 @@ module.exports = ({
   actions: [{ type: 'create_file', path: 'file' }],
   expected: {
     tree: ['file'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/add_trash_dir/scenario.js
+++ b/test/scenarios/add_trash_dir/scenario.js
@@ -10,6 +10,6 @@ module.exports = ({
   ],
   expected: {
     tree: [],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/add_trash_file/scenario.js
+++ b/test/scenarios/add_trash_file/scenario.js
@@ -10,6 +10,6 @@ module.exports = ({
   ],
   expected: {
     tree: [],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/scenario.js
@@ -18,6 +18,6 @@ module.exports = ({
       'john/exact-same-subdir/b.txt',
       'john/other-subdir-john-2/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/win_mac/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/win_mac/scenario.js
@@ -19,6 +19,6 @@ module.exports = ({
       'john-conflict.../exact-same-subdir/b.txt',
       'john-conflict.../other-subdir-john-2/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/scenario.js
@@ -13,6 +13,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['FOO/', 'FOO/subdir/', 'FOO/subdir/file', 'foo'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/win_mac/scenario.js
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/win_mac/scenario.js
@@ -21,6 +21,6 @@ module.exports = ({
       // foo-conflict-.../ will be synced on next polling
     ],
     remoteTree: ['FOO/', 'FOO/subdir/', 'FOO/subdir/file', 'foo-conflict-...'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/change_file/scenario.js
+++ b/test/scenarios/change_file/scenario.js
@@ -7,7 +7,7 @@ module.exports = ({
   actions: [{ type: 'update_file', path: 'file', content: 'updated content' }],
   expected: {
     tree: ['file'],
-    remoteTrash: [],
+    trash: [],
     contents: {
       file: 'updated content'
     }

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/scenario.js
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/scenario.js
@@ -17,7 +17,7 @@ module.exports = ({
     }
   ],
   expected: {
-    localTree: [nfdDir, `${nfdDir}${nfcFile}`],
-    remoteTrash: []
+    tree: [nfdDir, `${nfdDir}${nfcFile}`],
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/scenario.js
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/scenario.js
@@ -18,6 +18,6 @@ module.exports = ({
   ],
   expected: {
     tree: [nfdDir, `${nfdDir}${nfdFile}`],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/create_dir_into_moved_one/scenario.js
+++ b/test/scenarios/create_dir_into_moved_one/scenario.js
@@ -14,6 +14,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/dir1/', 'dst/dir1/dir2/', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/create_dir_with_utf8_character/scenario.js
+++ b/test/scenarios/create_dir_with_utf8_character/scenario.js
@@ -10,6 +10,6 @@ module.exports = ({
   actions: [],
   expected: {
     tree: ['Partages reçus/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/create_dirs/scenario.js
+++ b/test/scenarios/create_dirs/scenario.js
@@ -6,6 +6,6 @@ module.exports = ({
   actions: [{ type: 'mkdir', path: 'foo' }, { type: 'mkdir', path: 'foo/bar' }],
   expected: {
     tree: ['foo/', 'foo/bar/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/delete_dir_permanently/scenario.js
+++ b/test/scenarios/delete_dir_permanently/scenario.js
@@ -16,7 +16,7 @@ module.exports = ({
   actions: [{ type: 'delete', path: 'parent/dir' }],
   expected: {
     tree: ['parent/', 'parent/other_dir/'],
-    remoteTrash: [
+    trash: [
       'file'
       // TODO: Trash with ancestor dir:
       // 'dir/',

--- a/test/scenarios/delete_file_permanently/scenario.js
+++ b/test/scenarios/delete_file_permanently/scenario.js
@@ -8,6 +8,6 @@ module.exports = ({
   actions: [{ type: 'delete', path: 'foo' }],
   expected: {
     tree: [],
-    remoteTrash: ['foo']
+    trash: ['foo']
   }
 } /*: Scenario */)

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -76,6 +76,23 @@ type ScenarioTestName =
 type ScenarioCompletelyDisabled = Explanation
 type ScenarioTestsDisabled = {[ScenarioTestName]: Explanation}
 
+type ScenarioTreeExpectation =
+  | {
+    localTree: Array<string>,
+    remoteTree: Array<string>,
+    }
+  | { tree: Array<string>, }
+type ScenarioTrashExpectation =
+  | {
+    localTrash: Array<string>,
+    remoteTrash: Array<string>,
+    }
+  | { trash: Array<string>, }
+type ScenarioExpectations =
+  & ScenarioTreeExpectation
+  & ScenarioTrashExpectation
+  & { contents?: { [string]: string } }
+
 export type Scenario = {|
   platforms?: Array<'win32'|'darwin'|'linux'>,
   side?: SideName,
@@ -85,12 +102,6 @@ export type Scenario = {|
     ino: number, path: string, content?: string
   |}>,
   actions: Array<FSAction>,
-  expected: {|
-    localTree?: Array<string>,
-    remoteTree?: Array<string>,
-    tree?: Array<string>,
-    remoteTrash?: Array<string>,
-    contents?: { [string]: string }
-  |}
+  expected: ScenarioExpectations,
 |}
 */

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -80,6 +80,7 @@ export type Scenario = {|
   platforms?: Array<'win32'|'darwin'|'linux'>,
   side?: SideName,
   disabled?: ScenarioCompletelyDisabled | ScenarioTestsDisabled,
+  useCaptures?: boolean,
   init?: Array<{|
     ino: number, path: string, content?: string
   |}>,

--- a/test/scenarios/manage_moves_with_ignored_src_or_dst/scenario.js
+++ b/test/scenarios/manage_moves_with_ignored_src_or_dst/scenario.js
@@ -14,6 +14,6 @@ module.exports = ({
   expected: {
     localTree: ['file1', 'file2.tmp'],
     remoteTree: ['file1'],
-    remoteTrash: ['file2']
+    trash: ['file2']
   }
 } /*: Scenario */)

--- a/test/scenarios/move_a_to_b_and_create_a/scenario.js
+++ b/test/scenarios/move_a_to_b_and_create_a/scenario.js
@@ -13,6 +13,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['a', 'b'],
+    trash: [],
     contents: {
       a: 'new content',
       b: 'initial content'

--- a/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
+++ b/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/scenario.js
@@ -18,6 +18,7 @@ module.exports = ({
     { type: 'mv', src: 'b', dst: 'a' }
   ],
   expected: {
-    tree: ['a/', 'a/file-b', 'c/', 'c/file-a']
+    tree: ['a/', 'a/file-b', 'c/', 'c/file-a'],
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_and_trash_dir/scenario.js
+++ b/test/scenarios/move_and_trash_dir/scenario.js
@@ -3,6 +3,8 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  disabled: 'requires handling moveFrom + trashed', // FIXME
+  useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },
@@ -12,14 +14,11 @@ module.exports = ({
   actions: [
     { type: 'mv', src: 'src/subdir', dst: 'dst/subdir' },
     { type: 'wait', ms: 1500 },
-    { type: 'trash', path: 'dst/subdir' }
+    { type: 'trash', path: 'dst/subdir' },
+    { type: 'wait', ms: 1500 }
   ],
   expected: {
-    tree: ['dst/', 'src/']
-    // FIXME: file should be trashed with its parent
-    // remoteTrash: [
-    //   'subdir/',
-    //   'subdir/file'
-    // ]
+    tree: ['dst/', 'src/'],
+    trash: ['file']
   }
 } /*: Scenario */)

--- a/test/scenarios/move_and_trash_file/scenario.js
+++ b/test/scenarios/move_and_trash_file/scenario.js
@@ -3,6 +3,8 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  disabled: 'requires handling moveFrom + trashed', // FIXME
+  useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },
@@ -11,10 +13,11 @@ module.exports = ({
   actions: [
     { type: 'mv', src: 'src/file', dst: 'dst/file' },
     { type: 'wait', ms: 1500 },
-    { type: 'trash', path: 'dst/file' }
+    { type: 'trash', path: 'dst/file' },
+    { type: 'wait', ms: 1500 }
   ],
   expected: {
     tree: ['dst/', 'src/'],
-    remoteTrash: ['file']
+    trash: ['file']
   }
 } /*: Scenario */)

--- a/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
+++ b/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
@@ -22,6 +22,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/dir/', 'src/'],
-    remoteTrash: ['subfile']
+    trash: ['subfile']
   }
 } /*: Scenario */)

--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -15,6 +15,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],
+    trash: [],
     contents: {
       'dst/file': 'updated content'
     }

--- a/test/scenarios/move_dir_a_to_b_to_c_to_b/scenario.js
+++ b/test/scenarios/move_dir_a_to_b_to_c_to_b/scenario.js
@@ -13,6 +13,7 @@ module.exports = ({
     { type: 'wait', ms: 1500 }
   ],
   expected: {
-    tree: ['src/', 'src/B/']
+    tree: ['src/', 'src/B/'],
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_and_replace_subfile/scenario.js
+++ b/test/scenarios/move_dir_and_replace_subfile/scenario.js
@@ -22,7 +22,7 @@ module.exports = ({
   expected: {
     tree: ['dst/', 'dst/file'],
     // FIXME: old file will end up in the trash with chokidar, not with atom.
-    // remoteTrash: [],
+    trash: [],
     contents: {
       'dst/file': 'new content'
     }

--- a/test/scenarios/move_dir_and_update_subfile/scenario.js
+++ b/test/scenarios/move_dir_and_update_subfile/scenario.js
@@ -14,7 +14,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/file'],
-    remoteTrash: [],
+    trash: [],
     contents: {
       'dst/file': 'updated content'
     }

--- a/test/scenarios/move_dir_from_the_outside/scenario.js
+++ b/test/scenarios/move_dir_from_the_outside/scenario.js
@@ -19,6 +19,6 @@ module.exports = ({
       'dst/dir/subdir/',
       'dst/dir/subdir/file'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_into_created_one/scenario.js
+++ b/test/scenarios/move_dir_into_created_one/scenario.js
@@ -10,6 +10,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dir2/', 'dir2/dir1/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_parent_and_child/scenario.js
+++ b/test/scenarios/move_dir_parent_and_child/scenario.js
@@ -29,6 +29,6 @@ module.exports = ({
       'parent/dst/dir2/subdir/',
       'parent/dst/dir2/subdir/file2'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_reversed_events/scenario.js
+++ b/test/scenarios/move_dir_reversed_events/scenario.js
@@ -11,6 +11,6 @@ module.exports = ({
   actions: [{ type: 'mv', src: 'src/dir', dst: 'dst/dir' }],
   expected: {
     tree: ['dst/', 'dst/dir/', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_successive_same_level/scenario.js
+++ b/test/scenarios/move_dir_successive_same_level/scenario.js
@@ -29,6 +29,6 @@ module.exports = ({
       'parent/dst2/dir/subdir/file',
       'parent/src/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_successive_with_delay/scenario.js
+++ b/test/scenarios/move_dir_successive_with_delay/scenario.js
@@ -29,6 +29,6 @@ module.exports = ({
       'parent/dst2/dir/subdir/file',
       'parent/src/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_dir_with_content/scenario.js
+++ b/test/scenarios/move_dir_with_content/scenario.js
@@ -23,6 +23,6 @@ module.exports = ({
       'parent/dst/dir/subdir/file',
       'parent/src/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_file/scenario.js
+++ b/test/scenarios/move_file/scenario.js
@@ -11,6 +11,6 @@ module.exports = ({
   actions: [{ type: 'mv', src: 'src/file', dst: 'dst/file' }],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_file_a_to_b_to_c_to_b/local/darwin.json
+++ b/test/scenarios/move_file_a_to_b_to_c_to_b/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0, 2, 4]
+  },
+  {
     "type": "unlink",
     "path": "src/A"
   },

--- a/test/scenarios/move_file_a_to_b_to_c_to_b/scenario.js
+++ b/test/scenarios/move_file_a_to_b_to_c_to_b/scenario.js
@@ -3,6 +3,7 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  useCaptures: false,
   init: [{ ino: 1, path: 'src/' }, { ino: 2, path: 'src/A' }],
   actions: [
     { type: 'mv', src: 'src/A', dst: 'src/B' },
@@ -14,6 +15,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['src/', 'src/B'],
+    trash: [],
     contents: {
       'src/B': 'foo'
     }

--- a/test/scenarios/move_file_reversed_events/scenario.js
+++ b/test/scenarios/move_file_reversed_events/scenario.js
@@ -11,6 +11,6 @@ module.exports = ({
   actions: [{ type: 'mv', src: 'src/file', dst: 'dst/file' }],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_file_successive/scenario.js
+++ b/test/scenarios/move_file_successive/scenario.js
@@ -16,6 +16,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst1/', 'dst2/', 'dst2/file', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_file_successive_2/scenario.js
+++ b/test/scenarios/move_file_successive_2/scenario.js
@@ -16,6 +16,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst1/', 'dst2/', 'dst2/file', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
+++ b/test/scenarios/move_files_a_to_c_and_b_to_a/scenario.js
@@ -21,6 +21,6 @@ module.exports = ({
       a: 'content b',
       c: 'content a'
     },
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_from_inside_move/scenario.js
+++ b/test/scenarios/move_from_inside_move/scenario.js
@@ -28,6 +28,6 @@ module.exports = ({
       'parent/dst2/subdir/file',
       'parent/src/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
+++ b/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
@@ -36,7 +36,7 @@ module.exports = ({
       'dst/dir/subdir/subsub/',
       'src/'
     ],
-    remoteTrash: ['file', 'file (__cozy__: ...)'],
+    trash: ['file', 'file (__cozy__: ...)'],
     contents: {
       'dst/dir/file': 'overwriter',
       'dst/dir/subdir/file': 'sub-overwriter'

--- a/test/scenarios/move_overwriting_dir/trashed_first/scenario.js
+++ b/test/scenarios/move_overwriting_dir/trashed_first/scenario.js
@@ -36,7 +36,7 @@ module.exports = ({
     // When the overwrite happens while the client is turned off, we won't detect
     // the files' deletion before the folder's movement so we won't trash them
     // by themselves and will thus be trashed as part of the folder hierarchy.
-    remoteTrash: process.env.STOPPED_CLIENT
+    trash: process.env.STOPPED_CLIENT
       ? [
           'dir/',
           'dir/file',

--- a/test/scenarios/move_overwriting_file/not_trashed/scenario.js
+++ b/test/scenarios/move_overwriting_file/not_trashed/scenario.js
@@ -13,7 +13,7 @@ module.exports = ({
   actions: [{ type: 'mv', src: 'src/file', dst: 'dst/file' }],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],
-    remoteTrash: ['file'],
+    trash: ['file'],
     contents: {
       'dst/file': 'src-content'
     }

--- a/test/scenarios/move_overwriting_file/trashed_first/scenario.js
+++ b/test/scenarios/move_overwriting_file/trashed_first/scenario.js
@@ -12,7 +12,7 @@ module.exports = ({
   actions: [{ type: 'mv', force: true, src: 'src/file', dst: 'dst/file' }],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],
-    remoteTrash: ['file'],
+    trash: ['file'],
     contents: {
       'dst/file': 'src-content'
     }

--- a/test/scenarios/move_two_dirs/scenario.js
+++ b/test/scenarios/move_two_dirs/scenario.js
@@ -16,6 +16,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/dir1/', 'dst/dir2/', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_two_dirs_same_prefix/scenario.js
+++ b/test/scenarios/move_two_dirs_same_prefix/scenario.js
@@ -16,6 +16,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/dir1/', 'dst/dir12/', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/move_two_files/scenario.js
+++ b/test/scenarios/move_two_files/scenario.js
@@ -16,6 +16,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'dst/file1', 'dst/file2', 'src/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/ods_update_through_osl_tmp_file/scenario.js
+++ b/test/scenarios/ods_update_through_osl_tmp_file/scenario.js
@@ -13,7 +13,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['file.ods'],
-    remoteTrash: [],
+    trash: [],
     contents: {
       'file.ods': 'updated content #1'
     }

--- a/test/scenarios/rename_identical/scenario.js
+++ b/test/scenarios/rename_identical/scenario.js
@@ -34,6 +34,6 @@ module.exports = ({
       'dir-nfc-to-nfd-e\u0301/',
       'file-nfc-to-nfd-e\u0301'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/rename_identical_local_loopback/scenario.js
+++ b/test/scenarios/rename_identical_local_loopback/scenario.js
@@ -12,6 +12,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['DIR_CASE/', 'FILE.CASE'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/rename_subdir_after_parent/scenario.js
+++ b/test/scenarios/rename_subdir_after_parent/scenario.js
@@ -22,6 +22,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['parent-2/', 'parent-2/subdir-2/', 'parent-2/subdir-2/subsubdir-2/'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/replace_dir_with_file/scenario.js
+++ b/test/scenarios/replace_dir_with_file/scenario.js
@@ -11,6 +11,6 @@ module.exports = ({
   ],
   expected: {
     tree: ['foo'],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/replace_file_with_dir/scenario.js
+++ b/test/scenarios/replace_file_with_dir/scenario.js
@@ -8,6 +8,6 @@ module.exports = ({
   actions: [{ type: 'delete', path: 'foo' }, { type: 'mkdir', path: 'foo' }],
   expected: {
     tree: ['foo/'],
-    remoteTrash: ['foo']
+    trash: ['foo']
   }
 } /*: Scenario */)

--- a/test/scenarios/replace_file_with_file/scenario.js
+++ b/test/scenarios/replace_file_with_file/scenario.js
@@ -10,7 +10,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['file'],
-    remoteTrash: [],
+    trash: [],
     contents: {
       file: 'new content'
     }

--- a/test/scenarios/restore/scenario.js
+++ b/test/scenarios/restore/scenario.js
@@ -30,6 +30,6 @@ module.exports = ({
       'parent/file',
       'parent/other_dir/'
     ],
-    remoteTrash: []
+    trash: []
   }
 } /*: Scenario */)

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -27,22 +27,22 @@ const { platform } = process
 
 const stoppedEnvVar = 'STOPPED_CLIENT'
 
+const logger = require('../../core/utils/logger')
+const log = new logger({ component: 'TEST' })
+
 describe('Test scenarios', function() {
   let helpers
 
-  before(configHelpers.createConfig)
-  before(configHelpers.registerClient)
+  beforeEach(configHelpers.createConfig)
+  beforeEach(configHelpers.registerClient)
   beforeEach(pouchHelpers.createDatabase)
   beforeEach(cozyHelpers.deleteAll)
-  beforeEach('set up synced dir', async function() {
-    await fse.emptyDir(this.syncPath)
-  })
   beforeEach('set up outside dir', async function() {
     await fse.emptyDir(path.resolve(path.join(this.syncPath, '..', 'outside')))
   })
 
   afterEach(pouchHelpers.cleanDatabase)
-  after(configHelpers.cleanConfig)
+  afterEach(configHelpers.cleanConfig)
 
   beforeEach(async function() {
     helpers = TestHelpers.init(this)

--- a/test/scenarios/trash_dir_with_content/scenario.js
+++ b/test/scenarios/trash_dir_with_content/scenario.js
@@ -19,13 +19,7 @@ module.exports = ({
   actions: [{ type: 'trash', path: 'parent/dir' }],
   expected: {
     tree: ['parent/', 'parent/other_dir/'],
-    remoteTrash: [
-      'file'
-      // TODO: Trash with ancestor dir:
-      // 'dir/',
-      // 'dir/empty-subdir/',
-      // 'dir/subdir/',
-      // 'dir/subdir/file'
-    ]
+    localTrash: ['dir/', 'dir/empty-subdir/', 'dir/subdir/', 'dir/subdir/file'],
+    remoteTrash: ['file']
   }
 } /*: Scenario */)

--- a/test/scenarios/update_file/scenario.js
+++ b/test/scenarios/update_file/scenario.js
@@ -7,7 +7,7 @@ module.exports = ({
   actions: [{ type: 'update_file', path: 'file', content: 'new content' }],
   expected: {
     tree: ['file'],
-    remoteTrash: [],
+    trash: [],
     contents: {
       file: 'new content'
     }

--- a/test/scenarios/update_through_unignored_tmp_file/scenario.js
+++ b/test/scenarios/update_through_unignored_tmp_file/scenario.js
@@ -14,7 +14,7 @@ module.exports = ({
   ],
   expected: {
     tree: ['file.ods'],
-    remoteTrash: [],
+    trash: [],
     contents: {
       'file.ods': 'updated content #2'
     }

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -174,6 +174,7 @@ class LocalTestHelpers {
   async simulateAtomStart() {
     const watcher = this._ensureAtomWatcher()
     await atomWatcher.stepsInitialState(watcher.state, watcher)
+    await watcher.producer.scan('.')
     watcher.producer.channel.push([INITIAL_SCAN_DONE])
   }
 

--- a/test/support/helpers/local.js
+++ b/test/support/helpers/local.js
@@ -83,12 +83,16 @@ class LocalTestHelpers {
     this.side._trash = this.trashFunc
   }
 
+  async trash() {
+    return await this.trashDir.tree()
+  }
+
   async tree(
     opts /*: {ellipsize: boolean} */ = { ellipsize: true }
   ) /*: Promise<string[]> */ {
     let trashContents
     try {
-      trashContents = await this.trashDir.tree()
+      trashContents = await this.trash()
     } catch (err) {
       if (err.code !== 'ENOENT') throw err
       throw new Error(

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -135,6 +135,7 @@ class RemoteTestHelpers {
     return _.chain(await this.tree())
       .map(p => _.nth(p.match(TRASH_REGEXP), 1))
       .compact()
+      .map(p => p.replace(/\(__cozy__: \d+\)/, '(__cozy__: ...)'))
       .value()
   }
 

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -44,6 +44,9 @@ const scenarioByPath = (module.exports.scenarioByPath = scenarioPath => {
     }
   }
 
+  scenario.useCaptures =
+    scenario.useCaptures != null ? scenario.useCaptures : true
+
   return scenario
 })
 


### PR DESCRIPTION
Test scenarios can already have expectations for the content of the
remote trash but this is not enforced in all scenarios and the content
of the local trash is not checked.

It would be good to check we're using the local trash appropriately
and since we're about to change the way documents are marked for
deletion and actually deleted, it would be best to make sure the
behavior does not change.

For now, we're just documenting the current behavior and we should
spend some time making sure it is actually the one we want for each
test.
Since we should also enforce expectations on the content of each file
(and maybe some metadata), we can do it all at once later.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
