### PR TITLE
atom/initial_diff: Delete missing children before parents

### DIFF
--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -88,6 +88,10 @@ async function initialState(
   // file/folder has been moved or renamed
   const byInode /*: Map<number|string, Metadata> */ = new Map()
   const docs /*: Metadata[] */ = await opts.pouch.allDocs()
+  // Make sure all paths are sorted in reverse path order so that missing
+  // children will be deleted before missing parents and folders that would not
+  // have any content are not trashed but completely deleted
+  docs.sort((a, b) => (a.path < b.path ? 1 : a.path > b.path ? -1 : 0))
   for (const doc of docs) {
     if (doc.ino != null) {
       // Process only files/dirs that were created locally or synchronized

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -400,18 +400,6 @@ describe('core/local/atom/initial_diff', () => {
 
       should(events).deepEqual([
         {
-          _id: bar._id,
-          action: 'deleted',
-          initialDiff: {
-            notFound: _.defaults(
-              { kind: kind(bar) },
-              _.pick(bar, ['path', 'md5sum', 'updated_at'])
-            )
-          },
-          kind: 'file',
-          path: bar.path
-        },
-        {
           _id: foo._id,
           action: 'deleted',
           initialDiff: {
@@ -422,6 +410,18 @@ describe('core/local/atom/initial_diff', () => {
           },
           kind: 'directory',
           path: foo.path
+        },
+        {
+          _id: bar._id,
+          action: 'deleted',
+          initialDiff: {
+            notFound: _.defaults(
+              { kind: kind(bar) },
+              _.pick(bar, ['path', 'md5sum', 'updated_at'])
+            )
+          },
+          kind: 'file',
+          path: bar.path
         },
         initialScanDone
       ])


### PR DESCRIPTION
When propagating the deletion of a folder to the remote Cozy, we
trash it and then, if it's empty, completely remove it from the trash.
The idea behind this is to keep the hierarchy leading to deleted files
in the trash (this is not true all the time so we should probably
revise this at some point).
This means that if a folder is not empty because we're trying to
propagate its deletion before propagating the deletion of its
empty children folders, we'll end up with a bunch empty folders in the
trash.

This behavior can be seen easily when deleting a folder while the
client is stopped because we'll fire `deleted` events in the path
order so the parent folder will be deleted before its children (their
paths are longer and start with their parent's path).

To get a reproducible behavior in tests (and actual usage) we can fire
`deleted` events in the reverse path order during the initial scan so
child deletions will be propagated first and the folders will always
be empty when we propagate their deletion.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
