### PR TITLE
atom/win_detect_move: Fix moves detection

### DIFF
--- a/core/utils/sorted_set.js
+++ b/core/utils/sorted_set.js
@@ -27,13 +27,20 @@ class SortedSet /* ::<A> */ {
     this._values = []
   }
 
+  get size() {
+    return this._set.size
+  }
+
   has(value /*: A */) {
     return this._set.has(value)
   }
 
   add(value /*: A */) {
+    const prevSize = this.size
     this._set.add(value)
-    this._values.push(value)
+    if (this.size > prevSize) {
+      this._values.push(value)
+    }
     return this
   }
 


### PR DESCRIPTION
In some situations like the overwriting move of a directory, the
`deleted` event for the movement source will be fired after the
`created` event for the destination so we need to be able to match a
`deleted` event with a previously received `created` event.

We also need to keep track of pending events across batches in case
both events aren't fired in the same batch.

With this change, all `created` events on Windows will be withheld for
1 second so we can potentially match it with a `deleted` event that
would come later.
Maybe we could improve this by withholding only `created` events with
a known inode or fileid (i.e. we'd look for a document in PouchDB with
the event's inode or fileid).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
