### PR TITLE
travis: Fix matrix jobs exclusion format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,23 +55,23 @@ branches:
 jobs:
     fast_finish: true
     exclude:
-        - os: linux
+        - if: os = linux
           env: JOB=unit COZY_DESKTOP_FS=APFS
-        - os: linux
+        - if: os = linux
           env: JOB=scenarios COZY_DESKTOP_FS=APFS
-        - os: linux
+        - if: os = linux
           env: JOB=stopped_scenarios COZY_DESKTOP_FS=APFS
-        - os: linux
+        - if: os = linux
           env: JOB=dist COZY_DESKTOP_FS=APFS
-        - os: linux
+        - if: os = linux
           env: JOB=scenarios COZY_DESKTOP_FS=HFS+
-        - os: osx
+        - if: os = osx
           env: JOB=unit CC=gcc-8 CXX=g++-8
-        - os: osx
+        - if: os = osx
           env: JOB=scenarios CC=gcc-8 CXX=g++-8
-        - os: osx
+        - if: os = osx
           env: JOB=stopped_scenarios CC=gcc-8 CXX=g++-8
-        - os: osx
+        - if: os = osx
           env: JOB=dist CC=gcc-8 CXX=g++-8
 script: travis_wait ./dev/ci/script.sh
 


### PR DESCRIPTION
Travis has changed their jobs exclusion format so all env variable
combinations were executed, even the ones which make no sense like
macOS specific variables on linux jobs.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
