### PR TITLE
atom/win_detect_move: Fix lint issue

### DIFF
--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -55,8 +55,7 @@ type WinDetectMoveOptions = {
 module.exports = {
   forget,
   initialState,
-  loop,
-  previousPaths
+  loop
 }
 
 const areParentChildPaths = (p /*: string */, c /*: string */) /*: boolean */ =>


### PR DESCRIPTION
Stop exporting private `previousPaths` method so that arguments types
are not required by the linter.
