### PR TITLE
core/merge: Mark documents for deletion

### DIFF
--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -69,6 +69,8 @@ function loop(
             if (event.kind !== 'directory' && event.kind !== 'file') {
               _.set(event, [STEP_NAME, 'kindConvertedFrom'], event.kind)
 
+              // Even if the doc is deleted, we probably have a better chance to
+              // get the right kind by using its own.
               const doc =
                 event._id && (await opts.pouch.byIdMaybeAsync(event._id))
               event.kind = doc ? kind(doc) : 'file'

--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -146,6 +146,7 @@ actions = {
 
   renamedfile: async (event, { pouch, prep }) => {
     const was = await pouch.byIdMaybeAsync(id(event.oldPath))
+    // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       // A renamed event where the source does not exist can be seen as just an
       // add. It can happen on Linux when a file is added when the client is
@@ -172,6 +173,7 @@ actions = {
 
   renameddirectory: async (event, { pouch, prep }) => {
     const was = await pouch.byIdMaybeAsync(id(event.oldPath))
+    // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       // A renamed event where the source does not exist can be seen as just an
       // add. It can happen on Linux when a dir is added when the client is
@@ -202,7 +204,7 @@ actions = {
 
   deletedfile: async (event, { pouch, prep }) => {
     const was = await pouch.byIdMaybeAsync(event._id)
-    if (!was) {
+    if (!was || was.deleted) {
       log.debug({ event }, 'Assuming file already removed')
       // The file was already marked as deleted in pouchdb
       // => we can ignore safely this event
@@ -214,7 +216,7 @@ actions = {
 
   deleteddirectory: async (event, { pouch, prep }) => {
     const was = await pouch.byIdMaybeAsync(event._id)
-    if (!was) {
+    if (!was || was.deleted) {
       log.debug({ event }, 'Assuming dir already removed')
       // The dir was already marked as deleted in pouchdb
       // => we can ignore safely this event

--- a/core/local/atom/incomplete_fixer.js
+++ b/core/local/atom/incomplete_fixer.js
@@ -248,6 +248,7 @@ function step(
           )
           if (
             incompleteForExistingDoc &&
+            !incompleteForExistingDoc.deleted &&
             (item.event.action === 'created' || item.event.action === 'scan')
           ) {
             // Simply drop the incomplete event since we already have a document at this
@@ -255,6 +256,7 @@ function step(
             keepEvent(event, { incompletes, batch })
           } else if (
             incompleteForExistingDoc &&
+            !incompleteForExistingDoc.deleted &&
             item.event.action === 'modified'
           ) {
             // Keep the completed modified event to make sure we don't miss any

--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -87,7 +87,9 @@ async function initialState(
   // which files/folders have been deleted, as it is stable even if the
   // file/folder has been moved or renamed
   const byInode /*: Map<number|string, Metadata> */ = new Map()
-  const docs /*: Metadata[] */ = await opts.pouch.allDocs()
+  const docs /*: Metadata[] */ = (await opts.pouch.allDocs()).filter(
+    doc => !doc.deleted
+  )
   // Make sure all paths are sorted in reverse path order so that missing
   // children will be deleted before missing parents and folders that would not
   // have any content are not trashed but completely deleted

--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -104,13 +104,13 @@ function previousPaths(deletedPath, unmergedRenamedEvents) {
 
 async function findDeletedInoById(id, pouch) {
   const doc = await pouch.byIdMaybeAsync(id)
-  return doc && { deletedIno: doc.fileid || doc.ino }
+  return doc && !doc.deleted && { deletedIno: doc.fileid || doc.ino }
 }
 
 async function findDeletedInoRecentlyRenamed(previousPaths, pouch) {
   for (const [index, previousPath] of previousPaths.entries()) {
     const doc = await pouch.byIdMaybeAsync(id(previousPath))
-    if (doc) {
+    if (doc && !doc.deleted) {
       return {
         deletedIno: doc.fileid || doc.ino,
         oldPaths: previousPaths.slice(index)

--- a/core/local/atom/win_identical_renaming.js
+++ b/core/local/atom/win_identical_renaming.js
@@ -91,7 +91,7 @@ const fixIdenticalRenamed = async (event, { byIdMaybeAsync }) => {
   if (event.path === event.oldPath) {
     const doc = event._id && (await byIdMaybeAsync(event._id))
 
-    if (doc && doc.path !== event.oldPath) {
+    if (doc && !doc.deleted && doc.path !== event.oldPath) {
       _.set(event, [STEP_NAME, 'oldPathBeforeFix'], event.oldPath)
       event.oldPath = doc.path
     }

--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -39,7 +39,7 @@ const detectOfflineUnlinkEvents = async (
 ) /*: Promise<{offlineEvents: Array<ChokidarEvent>, unappliedMoves: string[], emptySyncDir: boolean}> */ => {
   // Try to detect removed files & folders
   const events /*: Array<ChokidarEvent> */ = []
-  const docs = await pouch.allDocs()
+  const docs = (await pouch.allDocs()).filter(doc => !doc.deleted)
   const inInitialScan = doc =>
     initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
 

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -61,7 +61,8 @@ const oldMetadata = async (
   pouch /*: Pouch */
 ) /*: Promise<?Metadata> */ => {
   if (e.old) return e.old
-  return await pouch.byIdMaybeAsync(metadata.id(e.path))
+  const old = await pouch.byIdMaybeAsync(metadata.id(e.path))
+  if (old && !old.deleted) return old
 }
 
 /**

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -95,6 +95,7 @@ export type MetadataSidesInfo = {
 // The files/dirs metadata, as stored in PouchDB
 export type Metadata = {
   _deleted?: true,
+  deleted?: true,
   _id: string,
   _rev?: string,
   md5sum?: string,
@@ -407,7 +408,11 @@ function isAtLeastUpToDate(sideName /*: SideName */, doc /*: Metadata */) {
 
 function markAsUnsyncable(side /*: SideName */, doc /*: Metadata */) {
   doc._deleted = true
-  markSide(side, doc, doc)
+  if (wasSynced(doc)) {
+    markAsUpToDate(doc)
+  } else {
+    markSide(side, doc, doc)
+  }
 }
 
 function markAsNew(doc /*: Metadata */) {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -153,7 +153,7 @@ class Remote /*:: implements Reader, Writer */ {
     } catch (err) {
       if (err.code === 'ENOENT') {
         log.warn({ path }, 'Local file does not exist anymore.')
-        doc._deleted = true // XXX: This prevents the doc to be saved with new revs
+        doc.deleted = true // XXX: This prevents the doc to be saved with new revs
         return doc
       }
       throw err
@@ -193,7 +193,7 @@ class Remote /*:: implements Reader, Writer */ {
     } catch (err) {
       if (err.code === 'ENOENT') {
         log.warn({ path }, 'Local file does not exist anymore.')
-        doc._deleted = true // XXX: This prevents the doc to be saved with new revs
+        doc.deleted = true // XXX: This prevents the doc to be saved with new revs
         return doc
       }
       throw err

--- a/core/sync.js
+++ b/core/sync.js
@@ -49,6 +49,25 @@ export type SyncMode =
   | "full";
 */
 
+const isMarkedForDeletion = (doc /*: Metadata */) => {
+  // During a transition period, we'll need to consider both documents with the
+  // deletion marker and documents which were deleted but not yet synced before
+  // the application was updated and are thus completely _deleted from PouchDB.
+  return doc.deleted || doc._deleted
+}
+
+// This method lets us completely erase a document from PouchDB after the
+// propagation of a deleted doc while removing all attributes that could get
+// picked up by the Sync the next time the document shows up in the changesfeed
+// (erasing documents generates changes) and thus result in an attempt to take
+// action.
+const eraseDocument = async (
+  { _id, _rev } /*: Metadata */,
+  { pouch } /*: { pouch: Pouch } */
+) => {
+  await pouch.db.put({ _id, _rev, _deleted: true })
+}
+
 // Sync listens to PouchDB about the metadata changes, and calls local and
 // remote sides to apply the changes on the filesystem and remote CouchDB
 // respectively.
@@ -307,6 +326,9 @@ class Sync {
 
     if (metadata.shouldIgnore(doc, this.ignore)) {
       return this.pouch.setLocalSeqAsync(change.seq)
+    } else if (!metadata.wasSynced(doc) && isMarkedForDeletion(doc)) {
+      await eraseDocument(doc, this)
+      return this.pouch.setLocalSeqAsync(change.seq)
     }
 
     // FIXME: Acquire lock for as many changes as possible to prevent next huge
@@ -327,17 +349,21 @@ class Sync {
         }
       } else {
         await this.applyDoc(doc, side, sideName, rev)
-        // Clean up documents so that we don't mistakenly take action based on
-        // previous changes and keep our Pouch documents as small as possible
-        // and especially avoid deep nesting levels.
-        delete doc.moveFrom
-        delete doc.overwrite
       }
 
-      log.trace({ path, seq }, `Applied change on ${sideName} side`)
       await this.pouch.setLocalSeqAsync(change.seq)
-      if (!change.doc._deleted) {
-        await this.updateRevs(change.doc, sideName)
+      log.trace({ path, seq }, `Applied change on ${sideName} side`)
+
+      // Clean up documents so that we don't mistakenly take action based on
+      // previous changes and keep our Pouch documents as small as possible
+      // and especially avoid deep nesting levels.
+      if (doc.deleted) {
+        await eraseDocument(doc, this)
+      } else {
+        delete doc.moveFrom
+        delete doc.overwrite
+        // We also update the sides in case the document is not erased
+        await this.updateRevs(doc, sideName)
       }
     } catch (err) {
       await this.handleApplyError(change, sideName, err)
@@ -381,7 +407,7 @@ class Sync {
       }
     } else if (doc.docType !== 'file' && doc.docType !== 'folder') {
       throw new Error(`Unknown docType: ${doc.docType}`)
-    } else if (doc._deleted && rev === 0) {
+    } else if (isMarkedForDeletion(doc) && rev === 0) {
       // do nothing
     } else if (doc.moveTo != null) {
       log.debug(
@@ -413,7 +439,7 @@ class Sync {
       ) {
         await side.overwriteFileAsync(doc, doc) // move & update
       }
-    } else if (doc._deleted) {
+    } else if (isMarkedForDeletion(doc)) {
       log.debug({ path: doc.path }, `Applying ${doc.docType} deletion`)
       if (doc.docType === 'file') await side.trashAsync(doc)
       else await side.deleteFolderAsync(doc)

--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -33,7 +33,7 @@ const localDoc = async (
 ) /*: Promise<Metadata> */ => {
   const relPath = path.relative(config.syncPath, filePath)
   const doc = await pouch.byIdMaybeAsync(metadata.id(relPath))
-  if (!doc) {
+  if (!doc || doc.deleted) {
     throw new CozyDocumentMissingError({
       cozyURL: config.cozyUrl,
       doc: { name: path.basename(relPath) }

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -199,8 +199,8 @@ describe('Move', () => {
         )
 
         should(
-          helpers.putDocs('path', '_deleted', 'trashed', 'moveFrom')
-        ).deepEqual([{ path: path.normalize('src/file'), _deleted: true }])
+          helpers.putDocs('path', 'deleted', 'trashed', 'moveFrom')
+        ).deepEqual([{ path: path.normalize('src/file'), deleted: true }])
 
         await helpers.syncAll()
 
@@ -245,11 +245,11 @@ describe('Move', () => {
           )
 
           should(
-            helpers.putDocs('path', '_deleted', 'trashed', 'moveFrom')
+            helpers.putDocs('path', 'deleted', 'trashed', 'moveFrom')
           ).deepEqual([
             {
               path: intermediaryPath,
-              _deleted: true
+              deleted: true
             }
           ])
 
@@ -663,21 +663,21 @@ describe('Move', () => {
         await prep.moveFolderAsync('local', doc, oldFolder)
 
         should(
-          helpers.putDocs('path', '_deleted', 'trashed', 'childMove')
+          helpers.putDocs('path', 'deleted', 'trashed', 'childMove')
         ).deepEqual([
           {
             path: path.normalize('parent/src/dir/subdir/file'),
-            _deleted: true
+            deleted: true
           },
           {
             path: path.normalize('parent/src/dir/subdir'),
-            _deleted: true
+            deleted: true
           },
           {
             path: path.normalize('parent/src/dir/empty-subdir'),
-            _deleted: true
+            deleted: true
           },
-          { path: path.normalize('parent/src/dir'), _deleted: true }
+          { path: path.normalize('parent/src/dir'), deleted: true }
         ])
 
         await helpers.syncAll()
@@ -718,21 +718,21 @@ describe('Move', () => {
           await prep.moveFolderAsync('local', doc, oldFolder)
 
           should(
-            helpers.putDocs('path', '_deleted', 'trashed', 'childMove')
+            helpers.putDocs('path', 'deleted', 'trashed', 'childMove')
           ).deepEqual([
             {
               path: path.normalize('parent/dst/dir/subdir/file'),
-              _deleted: true
+              deleted: true
             },
             {
               path: path.normalize('parent/dst/dir/subdir'),
-              _deleted: true
+              deleted: true
             },
             {
               path: path.normalize('parent/dst/dir/empty-subdir'),
-              _deleted: true
+              deleted: true
             },
-            { path: path.normalize('parent/dst/dir'), _deleted: true }
+            { path: path.normalize('parent/dst/dir'), deleted: true }
           ])
 
           await helpers.syncAll()

--- a/test/integration/permanent_deletion.js
+++ b/test/integration/permanent_deletion.js
@@ -38,8 +38,8 @@ describe('Permanent deletion remote', () => {
     await cozy.files.destroyById(file._id)
     await helpers.remote.pullChanges()
 
-    should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-      { path: 'file', _deleted: true }
+    should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+      { path: 'file', deleted: true }
     ])
 
     await helpers.syncAll()

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -49,8 +49,8 @@ describe('Trash', () => {
       it('trashes the file on the remote Cozy', async () => {
         await prep.trashFileAsync('local', { path: 'parent/file' })
 
-        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-          { path: path.normalize('parent/file'), _deleted: true }
+        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+          { path: path.normalize('parent/file'), deleted: true }
         ])
         await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
 
@@ -65,9 +65,6 @@ describe('Trash', () => {
 
       context('before the file was moved on the remote Cozy', () => {
         it('does not trash the file on the remote Cozy and re-downloads it', async () => {
-          // TODO: Works only because the deletion could not be synced since the
-          // Cozy refuses it after the moved changed the remote rev.
-          // Could use the deletion marker.
           await helpers.local.syncDir.remove('parent/file')
           await helpers.local.scan()
           await cozy.files.updateAttributesById(file._id, {
@@ -113,8 +110,8 @@ describe('Trash', () => {
 
         await helpers.remote.pullChanges()
 
-        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-          { path: path.normalize('parent/file'), _deleted: true }
+        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+          { path: path.normalize('parent/file'), deleted: true }
         ])
         await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
 
@@ -224,11 +221,11 @@ describe('Trash', () => {
           path: path.normalize('parent/dir')
         })
 
-        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
+        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
           // XXX: Why isn't file deleted? (it works anyway)
-          { path: path.normalize('parent/dir/subdir'), _deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), _deleted: true },
-          { path: path.normalize('parent/dir'), _deleted: true }
+          { path: path.normalize('parent/dir/subdir'), deleted: true },
+          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
+          { path: path.normalize('parent/dir'), deleted: true }
         ])
 
         await helpers.syncAll()
@@ -249,11 +246,12 @@ describe('Trash', () => {
         await cozy.files.trashById(dir._id)
 
         await helpers.remote.pullChanges()
-        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-          { path: path.normalize('parent/dir/subdir'), _deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), _deleted: true },
-          { path: path.normalize('parent/dir'), _deleted: true },
-          { path: path.normalize('parent/dir/subdir/file'), _deleted: true }
+        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+          // XXX: Why isn't file deleted? (it works anyway)
+          { path: path.normalize('parent/dir/subdir'), deleted: true },
+          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
+          { path: path.normalize('parent/dir'), deleted: true },
+          { path: path.normalize('parent/dir/subdir/file'), deleted: true }
         ])
 
         await helpers.syncAll()

--- a/test/scenarios/move_overwriting_dir/not_trashed/atom/linux.json
+++ b/test/scenarios/move_overwriting_dir/not_trashed/atom/linux.json
@@ -1,6 +1,13 @@
 [
   [
     {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src/dir/deletedFile"
+    }
+  ],
+  [
+    {
       "action": "renamed",
       "kind": "file",
       "path": "dst/dir/file",

--- a/test/scenarios/move_overwriting_dir/not_trashed/local/darwin.json
+++ b/test/scenarios/move_overwriting_dir/not_trashed/local/darwin.json
@@ -18,11 +18,15 @@
     "type": "addDir",
     "path": "dst/dir/subdir/subsub",
     "stats": {
-      "ino": 15,
+      "ino": 17,
       "size": 64,
-      "mtime": "2020-03-03T16:48:15.478Z",
-      "ctime": "2020-03-03T16:48:15.507Z"
+      "mtime": "2020-04-20T15:50:33.832Z",
+      "ctime": "2020-04-20T15:50:33.887Z"
     }
+  },
+  {
+    "type": "unlink",
+    "path": "src/dir/deletedFile"
   },
   {
     "type": "unlink",
@@ -42,42 +46,42 @@
   },
   {
     "type": "change",
-    "path": "dst/dir/file",
-    "stats": {
-      "ino": 11,
-      "size": 8,
-      "mtime": "2020-03-03T16:48:15.474Z",
-      "ctime": "2020-03-03T16:48:15.500Z"
-    }
-  },
-  {
-    "type": "change",
     "path": "dst/dir/subdir/file",
     "stats": {
-      "ino": 12,
+      "ino": 14,
       "size": 8,
-      "mtime": "2020-03-03T16:48:15.475Z",
-      "ctime": "2020-03-03T16:48:15.504Z"
+      "mtime": "2020-04-20T15:50:33.827Z",
+      "ctime": "2020-04-20T15:50:33.882Z"
     }
   },
   {
     "type": "add",
     "path": "dst/dir/file2",
     "stats": {
-      "ino": 14,
+      "ino": 16,
       "size": 8,
-      "mtime": "2020-03-03T16:48:15.477Z",
-      "ctime": "2020-03-03T16:48:15.503Z"
+      "mtime": "2020-04-20T15:50:33.831Z",
+      "ctime": "2020-04-20T15:50:33.878Z"
+    }
+  },
+  {
+    "type": "change",
+    "path": "dst/dir/file",
+    "stats": {
+      "ino": 13,
+      "size": 8,
+      "mtime": "2020-04-20T15:50:33.826Z",
+      "ctime": "2020-04-20T15:50:33.868Z"
     }
   },
   {
     "type": "add",
     "path": "dst/dir/subdir/file6",
     "stats": {
-      "ino": 13,
+      "ino": 15,
       "size": 8,
-      "mtime": "2020-03-03T16:48:15.476Z",
-      "ctime": "2020-03-03T16:48:15.506Z"
+      "mtime": "2020-04-20T15:50:33.829Z",
+      "ctime": "2020-04-20T15:50:33.884Z"
     }
   }
 ]

--- a/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
+++ b/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
@@ -4,28 +4,36 @@
 
 module.exports = ({
   side: 'local',
+  useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'dst/dir/' },
     { ino: 3, path: 'dst/dir/subdir/' },
-    { ino: 4, path: 'dst/dir/file', content: 'overwritten' },
-    { ino: 5, path: 'dst/dir/file3', content: 'not-overwritten' },
-    { ino: 6, path: 'dst/dir/subdir/file', content: 'sub-overwritten' },
-    { ino: 7, path: 'dst/dir/subdir/file5', content: 'sub-not-overwritten' },
-    { ino: 8, path: 'src/' },
-    { ino: 9, path: 'src/dir/' },
-    { ino: 10, path: 'src/dir/subdir/' },
-    { ino: 11, path: 'src/dir/file', content: 'overwriter' },
-    { ino: 12, path: 'src/dir/subdir/file', content: 'sub-overwriter' },
-    { ino: 13, path: 'src/dir/subdir/file6', content: 'sub-other' },
-    { ino: 14, path: 'src/dir/file2', content: 'other' },
-    { ino: 15, path: 'src/dir/subdir/subsub/' }
+    { ino: 4, path: 'dst/dir/deletedFile', content: 'should be kept' },
+    { ino: 5, path: 'dst/dir/file', content: 'overwritten' },
+    { ino: 6, path: 'dst/dir/file3', content: 'not-overwritten' },
+    { ino: 7, path: 'dst/dir/subdir/file', content: 'sub-overwritten' },
+    { ino: 8, path: 'dst/dir/subdir/file5', content: 'sub-not-overwritten' },
+    { ino: 9, path: 'src/' },
+    { ino: 10, path: 'src/dir/' },
+    { ino: 11, path: 'src/dir/subdir/' },
+    { ino: 12, path: 'src/dir/deletedFile', content: 'should be deleted' },
+    { ino: 13, path: 'src/dir/file', content: 'overwriter' },
+    { ino: 14, path: 'src/dir/subdir/file', content: 'sub-overwriter' },
+    { ino: 15, path: 'src/dir/subdir/file6', content: 'sub-other' },
+    { ino: 16, path: 'src/dir/file2', content: 'other' },
+    { ino: 17, path: 'src/dir/subdir/subsub/' }
   ],
-  actions: [{ type: 'mv', merge: true, src: 'src/dir', dst: 'dst/dir' }],
+  actions: [
+    { type: 'delete', path: 'src/dir/deletedFile' },
+    { type: 'mv', merge: true, src: 'src/dir', dst: 'dst/dir' },
+    { type: 'wait', ms: 1500 }
+  ],
   expected: {
     tree: [
       'dst/',
       'dst/dir/',
+      'dst/dir/deletedFile',
       'dst/dir/file',
       'dst/dir/file2',
       'dst/dir/file3',
@@ -36,8 +44,9 @@ module.exports = ({
       'dst/dir/subdir/subsub/',
       'src/'
     ],
-    trash: ['file', 'file (__cozy__: ...)'],
+    trash: ['deletedFile', 'file', 'file (__cozy__: ...)'],
     contents: {
+      'dst/dir/deletedFile': 'should be kept',
       'dst/dir/file': 'overwriter',
       'dst/dir/subdir/file': 'sub-overwriter'
     }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -2598,7 +2598,7 @@ describe('Merge', function() {
           _.defaults(
             {
               sides: increasedSides(doc.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(doc, ['_rev'])
           )
@@ -2630,7 +2630,7 @@ describe('Merge', function() {
           _.defaults(
             {
               sides: increasedSides(doc.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(doc, ['moveFrom', '_rev'])
           )
@@ -2657,7 +2657,7 @@ describe('Merge', function() {
           _.defaults(
             {
               sides: increasedSides(doc.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(doc, ['_rev'])
           )
@@ -2698,28 +2698,28 @@ describe('Merge', function() {
           _.defaults(
             {
               sides: increasedSides(subsubsubfile.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(subsubsubfile, ['_rev'])
           ),
           _.defaults(
             {
               sides: increasedSides(subsubdir.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(subsubdir, ['_rev'])
           ),
           _.defaults(
             {
               sides: increasedSides(subdir.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(subdir, ['_rev'])
           ),
           _.defaults(
             {
               sides: increasedSides(doc.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(doc, ['_rev'])
           )
@@ -2753,7 +2753,7 @@ describe('Merge', function() {
           _.defaults(
             {
               sides: increasedSides(doc.sides, this.side, 1),
-              _deleted: true
+              deleted: true
             },
             _.omit(doc, ['moveFrom', '_rev'])
           )
@@ -2788,7 +2788,7 @@ describe('Merge', function() {
             _.defaults(
               {
                 sides: increasedSides(was.sides, this.side, 1),
-                _deleted: true
+                deleted: true
               },
               _.omit(was, ['_rev'])
             )
@@ -2871,7 +2871,7 @@ describe('Merge', function() {
             _.defaults(
               {
                 sides: increasedSides(was.sides, this.side, 1),
-                _deleted: true
+                deleted: true
               },
               _.omit(was, ['_rev'])
             )

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -249,7 +249,7 @@ describe('remote.Remote', function() {
       await this.remote.addFileAsync(doc)
       should.exist(doc.remote._id)
       should.exist(doc.remote._rev)
-      should.exist(doc._deleted)
+      should.exist(doc.deleted)
     })
   })
 
@@ -400,7 +400,7 @@ describe('remote.Remote', function() {
         await this.remote.overwriteFileAsync(doc)
         should.exist(doc.remote._id)
         should.exist(doc.remote._rev)
-        should.exist(doc._deleted)
+        should.exist(doc.deleted)
       })
     })
   }

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -147,6 +147,25 @@ describe('Sync', function() {
       this.sync.applyDoc.called.should.be.false()
     })
 
+    it('does nothing for an up-to-date _deleted document', async function() {
+      let change = {
+        seq: 122,
+        doc: {
+          _id: 'foo',
+          docType: 'folder',
+          _deleted: true,
+          sides: {
+            target: 2,
+            local: 2,
+            remote: 2
+          }
+        }
+      }
+      this.sync.applyDoc = sinon.spy()
+      await this.sync.apply(change)
+      this.sync.applyDoc.called.should.be.false()
+    })
+
     it('trashes a locally deleted file or folder', async function() {
       const change = {
         seq: 145,
@@ -456,7 +475,7 @@ describe('Sync', function() {
       let doc = {
         _id: 'foo/baz',
         _rev: '4-1234567890',
-        _deleted: true,
+        deleted: true,
         docType: 'file',
         sides: {
           target: 2,
@@ -472,7 +491,7 @@ describe('Sync', function() {
       let doc = {
         _id: 'tmp/fooz',
         _rev: '2-1234567890',
-        _deleted: true,
+        deleted: true,
         docType: 'file',
         sides: {
           target: 2,
@@ -517,7 +536,7 @@ describe('Sync', function() {
       let was = {
         _id: 'foobar/bar',
         _rev: '3-9876543210',
-        _deleted: true,
+        deleted: true,
         moveTo: 'foobar/baz',
         docType: 'folder',
         tags: ['qux'],
@@ -549,7 +568,7 @@ describe('Sync', function() {
       let doc = {
         _id: 'foobar/baz',
         _rev: '4-1234567890',
-        _deleted: true,
+        deleted: true,
         docType: 'folder',
         sides: {
           target: 2,
@@ -565,7 +584,7 @@ describe('Sync', function() {
       let doc = {
         _id: 'tmp/foobaz',
         _rev: '2-1234567890',
-        _deleted: true,
+        deleted: true,
         docType: 'folder',
         sides: {
           target: 2,
@@ -795,7 +814,7 @@ describe('Sync', function() {
       should.not.exist(rev)
     })
 
-    it('returns an empty array if a local only doc is deleted', function() {
+    it('returns an empty array if a local only doc is erased', function() {
       let doc = {
         _id: 'selectSide/5',
         _rev: '5-0123456789',
@@ -812,7 +831,7 @@ describe('Sync', function() {
       should.not.exist(rev)
     })
 
-    it('returns an empty array if a remote only doc is deleted', function() {
+    it('returns an empty array if a remote only doc is erased', function() {
       let doc = {
         _id: 'selectSide/5',
         _rev: '5-0123456789',


### PR DESCRIPTION
Until now, when we detected the deletion of a document either on the
local file system or the remote Cozy, we would merge it by deleting
it from the PouchDB database.
Then, The Sync module would detect that change via the PouchDB changes
feed and propagate it.

However, deleted documents in PouchDB cannot be queried by `get()`.
Also, when multiple modifications are made to the same document (i.e.
saved with the same `_id` attribute), the changes feed will return
only the latest version of the document.

Those 2 "restrictions" make merging some changes harder. For example:
- the remote addition of files or folders into a locally deleted
  folder (i.e. the parent folder can't be queried so it's "missing")
- the deletion and creation of a file at the same path/_id (i.e. we
  lose the _rev of the deleted document and can't propagate it as an
  update)

The solution we found to this problem is to mark documents for
deletion during the Merge step so they can still be queried until the
deletion has been propagated. This way we can decide to cancel the
deletion or take any other appropriate action to merge other changes
that could not be merged (or merged in a way that would result in an
incorrect or impossible propagation).

This commit introduces the `deleted` marker and does not make use of
it to solve our problems yet. Its goal is to achieve feature parity.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
