### PR TITLE
sync: Propagate move with incompatibilites to Cozy

### DIFF
--- a/core/sync.js
+++ b/core/sync.js
@@ -394,7 +394,7 @@ class Sync {
         `Applying ${doc.docType} change with moveFrom`
       )
 
-      if (from.incompatibilities) {
+      if (from.incompatibilities && sideName === 'local') {
         await this.doAdd(side, doc)
       } else if (from.childMove) {
         await side.assignNewRev(doc)


### PR DESCRIPTION
If a document with incompatibilities is moved locally (i.e. via one of
its ancestors) we should propagate the movement to the remote Cozy and
not transform it into an addition because the document exists on the
Cozy and not on the local file system (we'd end up with an error
because the file could not be read and the Cozy would reject the
addition anyway).

We'll still transform the remote movements of documents with platform
incompatibilities into additions since the document does not exist on
the local filesystem and therefore could not be moved.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
