### PR TITLE
core/sync: Emit `delete-file` event after trash

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -420,7 +420,6 @@ class Local /*:: implements Reader, Writer */ {
 
   async trashAsync(doc /*: Metadata */) /*: Promise<void> */ {
     log.info({ path: doc.path }, 'Moving to the OS trash...')
-    this.events.emit('delete-file', doc)
     const fullpath = path.join(this.syncPath, doc.path)
     try {
       await this._trash([fullpath])
@@ -444,7 +443,6 @@ class Local /*:: implements Reader, Writer */ {
     try {
       log.info({ path: doc.path }, 'Deleting empty folder...')
       await fse.rmdir(fullpath)
-      this.events.emit('delete-file', doc)
       return
     } catch (err) {
       if (err.code === 'ENOENT') {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -329,6 +329,7 @@ class Remote /*:: implements Reader, Writer */ {
   async trashAsync(doc /*: Metadata */) /*: Promise<void> */ {
     const { path } = doc
     log.info({ path }, 'Moving to the trash...')
+
     let newRemoteDoc /*: RemoteDoc */
     try {
       newRemoteDoc = await this.remoteCozy.trashById(doc.remote._id, {

--- a/core/sync.js
+++ b/core/sync.js
@@ -366,6 +366,7 @@ class Sync {
             `Trashing ${sideName} ${doc.docType} since new remote one is incompatible`
           )
           await side.trashAsync(was)
+          this.events.emit('delete-file', _.clone(was))
         } else {
           log.debug(
             { path: doc.path, incompatibilities: doc.incompatibilities },
@@ -416,6 +417,7 @@ class Sync {
       log.debug({ path: doc.path }, `Applying ${doc.docType} deletion`)
       if (doc.docType === 'file') await side.trashAsync(doc)
       else await side.deleteFolderAsync(doc)
+      this.events.emit('delete-file', _.clone(doc))
     } else if (rev === 0) {
       log.debug({ path: doc.path }, `Applying ${doc.docType} addition`)
       await this.doAdd(side, doc)
@@ -485,8 +487,8 @@ class Sync {
         await side.trashAsync(old)
       } else {
         await side.moveFileAsync(doc, old)
-        this.events.emit('transfer-move', _.clone(doc), _.clone(old))
       }
+      this.events.emit('transfer-move', _.clone(doc), _.clone(old))
     } else {
       if (doc.overwrite)
         await this.trashWithParentOrByItself(doc.overwrite, side)
@@ -647,6 +649,7 @@ class Sync {
 
     log.info(`${doc.path}: should be trashed by itself`)
     await side.trashAsync(doc)
+    this.events.emit('delete-file', _.clone(doc))
     return true
   }
 }

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -735,7 +735,6 @@ describe('Local', function() {
       await this.local.deleteFolderAsync(doc)
 
       should(await fse.pathExists(fullPath(doc))).be.false()
-      should(this.events.emit.args).deepEqual([['delete-file', doc]])
     })
 
     it('trashes a non-empty folder (ENOTEMPTY)', async function() {


### PR DESCRIPTION
The local side emits `delete-file` events for each file or folder that
was trashed so that we can update the Recent files list in the main
app window but the remote side would not.

Besides, the responsibility for emitting those events rested with the
local and remote sides while other sync events are rightfully emitted
by the Sync itself so this event is now emitted by the Sync as well
whenever necessary.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
