### PR TITLE
scenarios: Test meaningful breakpoints on macOS

### DIFF
--- a/test/scenarios/move_and_update_file/local/darwin.json
+++ b/test/scenarios/move_and_update_file/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0, 2]
+  },
+  {
     "type": "unlink",
     "path": "src/file"
   },


### PR DESCRIPTION
On macOS, since file system events are buffered and can be flushed
pretty much at any time we run our scenarios for different flushing
points (or breakpoints) in the captures.

However, some breakpoints would clearly not not give us the expected
behavior and should be completely different tests altogether so we can
select the ones that should give us the tested behavior.

We just selected some breakpoints for the
`test/scenarios/move_and_update_file` scenario.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
