### PR TITLE
core/merge: Simplify conditional blocks

### DIFF
--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -1206,7 +1206,7 @@ describe('Merge', function() {
                 {
                   _id: dstId,
                   path: dstPath,
-                  sides: { target: 1, [this.side]: 1 },
+                  sides: increasedSides(was.sides, this.side, 1),
                   moveFrom: movedSrc
                 },
                 doc


### PR DESCRIPTION
Each action is quite complex with a lot of different behaviors
depending on several conditions.
Those conditional blocks were intertwined and it was hard to determine
what behavior was to be expected in different situations.

This is an attempt at simplifying those blocks with early returns and
a bit of duplication to keep related statements close to each other.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
