### PR TITLE
core/pouch: Log doc's path with bulkDocs errors

### DIFF
--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -190,7 +190,8 @@ class Pouch {
     for (let [idx, result] of results.entries()) {
       if (result.error) {
         const err = new PouchError(result)
-        log.error({ doc: docs[idx] }, err)
+        const doc = docs[idx]
+        log.error({ path: doc.path, doc }, err)
         throw err
       }
     }


### PR DESCRIPTION
To help debug those errors and find them using our `jq`'s path filter,
we need to log the `path` attribute of the document we couldn't save.