### PR TITLE
build: Unpack native extensions

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,6 +22,7 @@ afterPack: './build/afterPackHook.js'
 afterSign: './build/afterSignHook.js'
 asarUnpack:
 - gui/scripts/**
+- '*.node' # see https://www.electronjs.org/docs/tutorial/application-packaging#adding-unpacked-files-to-asar-archives
 directories:
   buildResources: gui/assets
 fileAssociations:


### PR DESCRIPTION
As stipulated in the Electron documentation about application
packaging, files are packaged by default into an `asar` archive to
speed up some require calls and prevent path name length issues on
Windows.
However, some Node API calls do not work with packed files and need to
unpack them first. This is the case for native extensions (i.e.
`.node` files) and this operation can trigger antiviruses, thus
throwing exceptions (see https://www.electronjs.org/docs/tutorial/application-packaging#adding-unpacked-files-to-asar-archives).

We believe some of our users can be experiencing those issues and as a
workaround, we propose to not pack (or unpack in Electron terms) the
native extensions when building the application.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
