### PR TITLE
gui/main: Instanciate sync only once

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -126,7 +126,6 @@ const startApp = async () => {
       onboardingWindow.jumpToSyncPath()
     }
   } else {
-    await setupDesktop()
     startSync()
   }
 }


### PR DESCRIPTION
The `main` module is responsible for instantiating the synchronization
process and thus all its sub-modules (i.e. watchers and sync mainly)
once the proxy and config and set.

With the different states in which the app can be started (i.e. not
connected to a Cozy, waiting for an update, already connected, opening
a note…), we have different paths leading to an instantiation.
However, we should not ever instantiate the app more than once or we
could see multiple instances of the local watcher running and maybe
different processes accessing the PouchDB database file.

Unfortunately, we were instantiating the sync twice in case the client
was already connected to a Cozy and running in normal, synchronization
mode.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
