### PR TITLE
.cozyignore: Ignore all Microsoft Office tmp files

### DIFF
--- a/core/config/.cozyignore
+++ b/core/config/.cozyignore
@@ -29,7 +29,7 @@
 .Trash-*
 
 # Microsoft Office
-~$*.{doc,xls,ppt}*
+~$*
 
 # OSX
 .DS_Store

--- a/test/unit/ignore.js
+++ b/test/unit/ignore.js
@@ -305,6 +305,12 @@ describe('Ignore', function() {
           isFolder: false
         })
         .should.be.true()
+      ignore
+        .isIgnored({
+          relativePath: metadata.id('~$whatever.ods'),
+          isFolder: false
+        })
+        .should.be.true()
     })
 
     it('ignores hidden folder $Recycle.bin', () => {


### PR DESCRIPTION
We want to make sure all temporary files created by a Microsoft Office
software are ignored to avoid synchronizing them and later detect a
movement instead of a file update when the edited file is saved.

We were ignoring temporary files for `.doc*`, `.xls*` and `.ppt*`
documents only (i.e. and not the open document types).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
