### PR TITLE
core/remote: Fix typo in newClient condition

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -154,7 +154,7 @@ class RemoteCozy {
   }
 
   async newClient() /*: Promise<CozyClient>  */ {
-    if (this.client.oauth) {
+    if (this.client._oauth) {
       return await CozyClient.fromOldOAuthClient(this.client)
     } else {
       return await CozyClient.fromOldClient(this.client)


### PR DESCRIPTION
We have 2 different methods in `cozy-client` to build a new
`CozyClient` object from an old one created by `cozy-client-js`.
We call one or the other if the old client was either an OAuth client
or a Token based client.
To make the difference between both, we can check if the `_oauth`
attribute is set to `true`.

Unfortunately, we were checking the value of `oauth` so we were always
calling the function for Token based clients.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
