### PR TITLE
gui: Shrink new updater design

### DIFF
--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -188,7 +188,7 @@
   "Updater Error EPERM": "Une erreur de permission empêche le téléchargement de la mise à jour.",
   "Updater Error Other": "Une erreur inconnue empêche la mise à jour. Veuillez contacter le support.",
   "Updater Error": "Erreur de mise à jour",
-  "Updater Please wait": "Merci de patienter jusqu'à la fin du téléchargement.",
+  "Updater Please wait": "Merci de patienter pendant le téléchargement.",
   "Updater It may take a while": "Cela peut prendre quelques minutes, selon la vitesse de votre connexion.",
   "UserActionRequiredDialog Title": "Action requise pour continuer à utiliser votre Cozy",
   "Warning Ok": "Ok",

--- a/gui/styles/_updater.styl
+++ b/gui/styles/_updater.styl
@@ -24,13 +24,12 @@
   .progress-spinner
     @extend $icon-spinner-blue
     display: inline-block
-    width: 8em
-    height: 8em
+    width: 4em
+    height: 4em
     translate: 0 50%
 
   p
     box-sizing border-box
-    font-size: 1.5em
 
   h1 .logo
     margin: 0


### PR DESCRIPTION
The updater window is a lot smaller than anticipated when doing the
redesign and not everything would fit into the window, especially in
French.
So the spinner has been shrinked down to give more room for the text 
and the French text for "please wait" is smaller so it can fit in 
one line.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
