### PR TITLE
core/merge: Don't trash file moved on other side

### DIFF
--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -50,7 +50,7 @@ const detectOfflineUnlinkEvents = async (
   for (const doc of docs) {
     if (inInitialScan(doc) || doc.trashed || doc.incompatibilities) {
       emptySyncDir = false
-    } else if (doc.moveFrom) {
+    } else if (doc.moveFrom && inInitialScan(doc.moveFrom)) {
       // unapplied move
       unappliedMoves.push(metadata.id(doc.moveFrom.path))
     } else {

--- a/core/merge.js
+++ b/core/merge.js
@@ -754,6 +754,16 @@ class Merge {
       // We don't want Sync to pick up this move hint and try to synchronize a
       // move so we delete it.
       delete file.moveFrom
+
+      if (side === 'remote') {
+        // The file was moved locally and we don't want to delete it as we think
+        // users delete "paths" but the file was completely destroyed on the
+        // Cozy and cannot be restored from the trash so we dissociate our
+        // record from its previous remote version to force its re-upload.
+        delete file.remote
+        delete file.sides.remote
+        return this.pouch.put(file)
+      }
     }
     if (file.sides && file.sides[side]) {
       metadata.markSide(side, file, file)

--- a/core/prep.js
+++ b/core/prep.js
@@ -226,6 +226,10 @@ class Prep {
   ) {
     log.debug({ path: doc && doc.path, oldpath: was.path }, 'trashFileAsync')
     metadata.ensureValidPath(was)
+    const trashed = {
+      path: was.path,
+      _id: metadata.id(was.path)
+    }
 
     if (!doc) {
       doc = clone(was)
@@ -233,13 +237,12 @@ class Prep {
     }
 
     metadata.ensureValidPath(doc)
-
     doc.trashed = true
     doc.docType = 'file'
     metadata.assignId(doc)
-    metadata.assignId(was)
+
     // TODO metadata.shouldIgnore
-    return this.merge.trashFileAsync(side, was, doc)
+    return this.merge.trashFileAsync(side, trashed, doc)
   }
 
   // TODO add comments + tests
@@ -250,6 +253,10 @@ class Prep {
   ) {
     log.debug({ path: doc && doc.path, oldpath: was.path }, 'trashFolderAsync')
     metadata.ensureValidPath(was)
+    const trashed = {
+      path: was.path,
+      _id: metadata.id(was.path)
+    }
 
     if (!doc) {
       doc = clone(was)
@@ -257,13 +264,12 @@ class Prep {
     }
 
     metadata.ensureValidPath(doc)
-
     doc.trashed = true
     doc.docType = 'folder'
     metadata.assignId(doc)
-    metadata.assignId(was)
+
     // TODO metadata.shouldIgnore
-    return this.merge.trashFolderAsync(side, was, doc)
+    return this.merge.trashFolderAsync(side, trashed, doc)
   }
 
   // Expectations:

--- a/core/sync.js
+++ b/core/sync.js
@@ -437,7 +437,7 @@ class Sync {
         if (doc.docType === 'folder') {
           await side.updateFolderAsync(doc, old)
         } else if (metadata.sameBinary(old, doc)) {
-          if (metadata.sameFileIgnoreRev(old, doc)) {
+          if (metadata.sameFile(old, doc)) {
             log.debug({ path: doc.path }, 'Ignoring timestamp-only change')
           } else {
             await side.updateFileMetadataAsync(doc, old)

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -45,36 +45,40 @@ describe('Trash', () => {
       helpers.spyPouch()
     })
 
-    it('local', async () => {
-      await prep.trashFileAsync('local', { path: 'parent/file' })
+    context('on the local filesystem', () => {
+      it('trashes the file on the remote Cozy', async () => {
+        await prep.trashFileAsync('local', { path: 'parent/file' })
 
-      should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        { path: path.normalize('parent/file'), _deleted: true }
-      ])
-      await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
+        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
+          { path: path.normalize('parent/file'), _deleted: true }
+        ])
+        await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
 
-      await helpers.syncAll()
+        await helpers.syncAll()
 
-      should(await helpers.remote.tree()).deepEqual([
-        '.cozy_trash/',
-        '.cozy_trash/file',
-        'parent/'
-      ])
+        should(await helpers.remote.tree()).deepEqual([
+          '.cozy_trash/',
+          '.cozy_trash/file',
+          'parent/'
+        ])
+      })
     })
 
-    it('remote', async () => {
-      await cozy.files.trashById(file._id)
+    context('on the remote Cozy', () => {
+      it('trashes the file on the local filesystem', async () => {
+        await cozy.files.trashById(file._id)
 
-      await helpers.remote.pullChanges()
+        await helpers.remote.pullChanges()
 
-      should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        { path: path.normalize('parent/file'), _deleted: true }
-      ])
-      await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
+        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
+          { path: path.normalize('parent/file'), _deleted: true }
+        ])
+        await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
 
-      await helpers.syncAll()
+        await helpers.syncAll()
 
-      should(await helpers.local.tree()).deepEqual(['/Trash/file', 'parent/'])
+        should(await helpers.local.tree()).deepEqual(['/Trash/file', 'parent/'])
+      })
     })
   })
 
@@ -97,50 +101,53 @@ describe('Trash', () => {
       helpers.spyPouch()
     })
 
-    it('local', async () => {
-      await prep.trashFolderAsync('local', {
-        path: path.normalize('parent/dir')
+    context('on the local filesystem', () => {
+      it('trashes the directory on the remote Cozy', async () => {
+        await prep.trashFolderAsync('local', {
+          path: path.normalize('parent/dir')
+        })
+
+        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
+          // XXX: Why isn't file deleted? (it works anyway)
+          { path: path.normalize('parent/dir/subdir'), _deleted: true },
+          { path: path.normalize('parent/dir/empty-subdir'), _deleted: true },
+          { path: path.normalize('parent/dir'), _deleted: true }
+        ])
+
+        await helpers.syncAll()
+
+        should(await helpers.remote.tree()).deepEqual([
+          '.cozy_trash/',
+          '.cozy_trash/dir/',
+          '.cozy_trash/dir/empty-subdir/',
+          '.cozy_trash/dir/subdir/',
+          '.cozy_trash/dir/subdir/file',
+          'parent/'
+        ])
       })
-
-      should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        // XXX: Why isn't file deleted? (it works anyway)
-        { path: path.normalize('parent/dir/subdir'), _deleted: true },
-        { path: path.normalize('parent/dir/empty-subdir'), _deleted: true },
-        { path: path.normalize('parent/dir'), _deleted: true }
-      ])
-
-      await helpers.syncAll()
-
-      should(await helpers.remote.tree()).deepEqual([
-        '.cozy_trash/',
-        '.cozy_trash/dir/',
-        '.cozy_trash/dir/empty-subdir/',
-        '.cozy_trash/dir/subdir/',
-        '.cozy_trash/dir/subdir/file',
-        'parent/'
-      ])
     })
 
-    it('remote', async () => {
-      // FIXME: should pass a remote doc, or trash from Cozy
-      await prep.trashFolderAsync('remote', { path: 'parent/dir' })
+    context('on the remote Cozy', () => {
+      it('trashes the directory on the local filesystem', async () => {
+        await cozy.files.trashById(dir._id)
 
-      should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        // XXX: Why isn't file deleted? (it works anyway)
-        { path: path.normalize('parent/dir/subdir'), _deleted: true },
-        { path: path.normalize('parent/dir/empty-subdir'), _deleted: true },
-        { path: path.normalize('parent/dir'), _deleted: true }
-      ])
+        await helpers.remote.pullChanges()
+        should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
+          { path: path.normalize('parent/dir/subdir'), _deleted: true },
+          { path: path.normalize('parent/dir/empty-subdir'), _deleted: true },
+          { path: path.normalize('parent/dir'), _deleted: true },
+          { path: path.normalize('parent/dir/subdir/file'), _deleted: true }
+        ])
 
-      await helpers.syncAll()
-
-      should(await helpers.local.tree()).deepEqual([
-        '/Trash/dir/',
-        '/Trash/dir/empty-subdir/',
-        '/Trash/dir/subdir/',
-        '/Trash/dir/subdir/file',
-        'parent/'
-      ])
+        await helpers.syncAll()
+        should(await helpers.local.tree()).deepEqual([
+          '/Trash/dir/',
+          '/Trash/dir/empty-subdir/',
+          '/Trash/dir/subdir/',
+          '/Trash/dir/subdir/file',
+          'parent/'
+        ])
+      })
     })
   })
 })

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -159,6 +159,44 @@ describe('Trash', () => {
         })
       })
     })
+
+    context('destroyed on the remote Cozy', () => {
+      context('before the file was moved on the local filesystem', () => {
+        it('does not trash the file on the local filesystem and re-uploads it', async () => {
+          await cozy.files.destroyById(file._id)
+          await helpers.remote.pullChanges()
+          await helpers.local.syncDir.move(
+            path.normalize('parent/file'),
+            'file'
+          )
+          await helpers.local.scan()
+          await helpers.syncAll()
+
+          should(await helpers.trees()).deepEqual({
+            local: ['file', 'parent/'],
+            remote: ['file', 'parent/']
+          })
+        })
+      })
+
+      context('after the file was moved on the local filesystem', () => {
+        it('does not trash the file on the local filesystem and re-uploads it', async () => {
+          await helpers.local.syncDir.move(
+            path.normalize('parent/file'),
+            'file'
+          )
+          await helpers.local.scan()
+          await cozy.files.destroyById(file._id)
+          await helpers.remote.pullChanges()
+          await helpers.syncAll()
+
+          should(await helpers.trees()).deepEqual({
+            local: ['file', 'parent/'],
+            remote: ['file', 'parent/']
+          })
+        })
+      })
+    })
   })
 
   describe('directory', () => {

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -50,6 +50,15 @@ onPlatform('darwin', () => {
           trashed: true,
           docType: 'folder'
         }
+        const folder4 = {
+          _id: 'folder4',
+          path: 'folder4',
+          docType: 'folder',
+          moveFrom: {
+            _id: 'folder1/folder4',
+            path: 'folder1/folder4'
+          }
+        }
         let file1 = {
           _id: 'file1',
           path: 'file1',
@@ -66,7 +75,25 @@ onPlatform('darwin', () => {
           trashed: true,
           docType: 'file'
         }
-        for (let doc of [folder1, folder2, folder3, file1, file2, file3]) {
+        const file4 = {
+          _id: 'file4',
+          path: 'file4',
+          docType: 'file',
+          moveFrom: {
+            _id: 'folder1/file4',
+            path: 'folder1/file4'
+          }
+        }
+        for (let doc of [
+          folder1,
+          folder2,
+          folder3,
+          folder4,
+          file1,
+          file2,
+          file3,
+          file4
+        ]) {
           const { rev } = await this.pouch.db.put(doc)
           doc._rev = rev
         }
@@ -78,7 +105,9 @@ onPlatform('darwin', () => {
         )
 
         should(offlineEvents).deepEqual([
+          { type: 'unlinkDir', path: 'folder4', old: folder4 },
           { type: 'unlinkDir', path: 'folder2', old: folder2 },
+          { type: 'unlink', path: 'file4', old: file4 },
           { type: 'unlink', path: 'file2', old: file2 }
         ])
       })

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -2763,20 +2763,24 @@ describe('Merge', function() {
     })
   })
 
-  describe('doTrash', () => {
+  describe('trashFileAsync', () => {
     context('when metadata are found in Pouch', () => {
       it('deletes it with trashed property and up-to-date sides info', async function() {
         const was = await builders
-          .metadata()
+          .metafile()
           .upToDate()
           .create()
         const doc = builders
-          .metadata(was)
+          .metafile(was)
           .trashed()
           .build()
 
         const sideEffects = await mergeSideEffects(this, () =>
-          this.merge.doTrash(this.side, _.cloneDeep(was), _.cloneDeep(doc))
+          this.merge.trashFileAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
         )
 
         should(sideEffects).deepEqual({
@@ -2796,14 +2800,18 @@ describe('Merge', function() {
 
     context('when metadata are not found in Pouch', () => {
       it('does nothing', async function() {
-        const was = builders.metadata().build()
+        const was = builders.metafile().build()
         const doc = builders
-          .metadata(was)
+          .metafile(was)
           .trashed()
           .build()
 
         const sideEffects = await mergeSideEffects(this, () =>
-          this.merge.doTrash(this.side, _.cloneDeep(was), _.cloneDeep(doc))
+          this.merge.trashFileAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
         )
 
         should(sideEffects).deepEqual({
@@ -2823,7 +2831,94 @@ describe('Merge', function() {
           .build()
 
         const sideEffects = await mergeSideEffects(this, () =>
-          this.merge.doTrash(this.side, _.cloneDeep(was), _.cloneDeep(doc))
+          this.merge.trashFileAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
+        )
+
+        should(sideEffects).deepEqual({
+          savedDocs: [],
+          resolvedConflicts: []
+        })
+      })
+    })
+  })
+
+  describe('trashFolderAsync', () => {
+    context('when metadata are found in Pouch', () => {
+      it('deletes it with trashed property and up-to-date sides info', async function() {
+        const was = await builders
+          .metadir()
+          .upToDate()
+          .create()
+        const doc = builders
+          .metadir(was)
+          .trashed()
+          .build()
+
+        const sideEffects = await mergeSideEffects(this, () =>
+          this.merge.trashFolderAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
+        )
+
+        should(sideEffects).deepEqual({
+          savedDocs: [
+            _.defaults(
+              {
+                sides: increasedSides(was.sides, this.side, 1),
+                _deleted: true
+              },
+              _.omit(was, ['_rev'])
+            )
+          ],
+          resolvedConflicts: []
+        })
+      })
+    })
+
+    context('when metadata are not found in Pouch', () => {
+      it('does nothing', async function() {
+        const was = builders.metadir().build()
+        const doc = builders
+          .metadir(was)
+          .trashed()
+          .build()
+
+        const sideEffects = await mergeSideEffects(this, () =>
+          this.merge.trashFolderAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
+        )
+
+        should(sideEffects).deepEqual({
+          savedDocs: [],
+          resolvedConflicts: []
+        })
+      })
+    })
+
+    context('when docType does not match', () => {
+      it('does nothing', async function() {
+        const was = await builders.metadir().create()
+        const doc = builders
+          .metafile()
+          .path(was.path)
+          .trashed()
+          .build()
+
+        const sideEffects = await mergeSideEffects(this, () =>
+          this.merge.trashFolderAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
         )
 
         should(sideEffects).deepEqual({


### PR DESCRIPTION
We believe users expect the path of their documents to be their
identifier and thus that deleting a file on one side while it was
moved on the other should not result in the file being deleted since
its path has changed.

To meet those expectations, we undo the trashing/deletion of files
when we detect they have been moved on the other side.

We note that when we merge the local deletion of a file before we
merge its remote movement, we cannot undo the merged trashing since
the PouchDB record has been erased.
However, the local deletion is not propagated to the remote Cozy
thanks to the movement updating the remote revision of the document
and thus implying a rejected trashing.
This situation can be stabilized once we'll have deletion markers
since we'll be able to fetch the deleted record when merging the
movement.

We're now preventing the deletion of files moved on the other side but
if the file was completely erased on the Cozy (i.e. removed from the
trash as well), we can't restore it and need to re-upload it.

Besides, it's managed through another method,
`Merge.deleteFileAsync()` and needs its own behavior changes.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
