### PR TITLE
core/merge: Deleting ignored doc removes move hint

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -725,6 +725,11 @@ class Merge {
     log.debug({ path: doc.path }, 'deleteFileAsync')
     const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
     if (!file) return null
+    if (file.moveFrom) {
+      // We don't want Sync to pick up this move hint and try to synchronize a
+      // move so we delete it.
+      delete file.moveFrom
+    }
     if (file.sides && file.sides[side]) {
       metadata.markSide(side, file, file)
       file._deleted = true
@@ -747,6 +752,11 @@ class Merge {
     log.debug({ path: doc.path }, 'deleteFolderAsync')
     const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
     if (!folder) return null
+    if (folder.moveFrom) {
+      // We don't want Sync to pick up this move hint and try to synchronize a
+      // move so we delete it.
+      delete folder.moveFrom
+    }
     if (folder.sides && folder.sides[side]) {
       return this.deleteFolderRecursivelyAsync(side, folder)
     } else {

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -2606,6 +2606,38 @@ describe('Merge', function() {
         resolvedConflicts: []
       })
     })
+
+    it('removes move hints', async function() {
+      const old = await builders
+        .metafile()
+        .path('FILE')
+        .data('content')
+        .sides({ [this.side]: 1 })
+        .create()
+      const doc = await builders
+        .metafile(old)
+        .moveFrom(old)
+        .path('MOVED')
+        .sides({ [this.side]: 2 })
+        .create()
+
+      const sideEffects = await mergeSideEffects(this, () =>
+        this.merge.deleteFileAsync(this.side, _.cloneDeep(doc))
+      )
+
+      should(sideEffects).deepEqual({
+        savedDocs: [
+          _.defaults(
+            {
+              sides: increasedSides(doc.sides, this.side, 1),
+              _deleted: true
+            },
+            _.omit(doc, ['moveFrom', '_rev'])
+          )
+        ],
+        resolvedConflicts: []
+      })
+    })
   })
 
   describe('deleteFolder', function() {
@@ -2690,6 +2722,40 @@ describe('Merge', function() {
               _deleted: true
             },
             _.omit(doc, ['_rev'])
+          )
+        ],
+        resolvedConflicts: []
+      })
+    })
+
+    it('removes move hints', async function() {
+      // TODO: make sure we remove the move hints on children. This will be part
+      // of a larger refactoring to make sure folders are trashed with their
+      // hierarchy.
+      const old = await builders
+        .metadir()
+        .path('FOLDER')
+        .sides({ [this.side]: 1 })
+        .create()
+      const doc = await builders
+        .metadir(old)
+        .moveFrom(old)
+        .path('MOVED')
+        .sides({ [this.side]: 1 })
+        .create()
+
+      const sideEffects = await mergeSideEffects(this, () =>
+        this.merge.deleteFolderAsync(this.side, _.cloneDeep(doc))
+      )
+
+      should(sideEffects).deepEqual({
+        savedDocs: [
+          _.defaults(
+            {
+              sides: increasedSides(doc.sides, this.side, 1),
+              _deleted: true
+            },
+            _.omit(doc, ['moveFrom', '_rev'])
           )
         ],
         resolvedConflicts: []


### PR DESCRIPTION
When a document is moved to an ignored path on the local filesystem,
we want to trash it on the remote Cozy and stop synchronizing changes
made on either side.

However, when the document is moved to a non ignored location before
being moved to the ignored path without a synchronization between the
2, the Sync picks up the move hint of the first move and propagates it
to the remote Cozy instead of the deletion.

We can make sure this does not happen by removing any move hint (i.e.
the `moveFrom` attribute) on its PouchDB record when we decide to
delete a document.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
