### PR TITLE
core/remote: Treat restore changes as additions

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -37,6 +37,7 @@ import type { Config } from './config'
 import type stream from 'stream'
 import type { Callback } from './utils/func'
 import type { SyncMode } from './sync'
+import type { Metadata } from './metadata'
 
 export type ClientInfo = {
   appVersion: string,
@@ -265,7 +266,7 @@ class App {
       level: 3
     })
     const logs = fse.createReadStream(LOG_FILE)
-    const pouchdbTree = await this.pouch.treeAsync()
+    const pouchdbTree /*: Metadata[] */ = await this.pouch.treeAsync()
 
     const logsSent = Promise.all([
       this.uploadFileToSupport(incidentID, 'logs.gz', logs.pipe(zipper)),

--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -71,8 +71,9 @@ function loop(
 
               // Even if the doc is deleted, we probably have a better chance to
               // get the right kind by using its own.
-              const doc =
-                event._id && (await opts.pouch.byIdMaybeAsync(event._id))
+              const doc /*: ?Metadata */ = event._id
+                ? await opts.pouch.byIdMaybeAsync(event._id)
+                : null
               event.kind = doc ? kind(doc) : 'file'
             }
           }

--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -30,6 +30,7 @@ import type { WinDetectMoveState } from './win_detect_move'
 import type EventEmitter from 'events'
 import type Prep from '../../prep'
 import type { Pouch } from '../../pouch'
+import type { Metadata } from '../../metadata'
 
 export type AtomEventsDispatcher = (AtomBatch) => Promise<AtomBatch>
 
@@ -145,7 +146,7 @@ actions = {
   },
 
   renamedfile: async (event, { pouch, prep }) => {
-    const was = await pouch.byIdMaybeAsync(id(event.oldPath))
+    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(id(event.oldPath))
     // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       // A renamed event where the source does not exist can be seen as just an
@@ -172,7 +173,7 @@ actions = {
   },
 
   renameddirectory: async (event, { pouch, prep }) => {
-    const was = await pouch.byIdMaybeAsync(id(event.oldPath))
+    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(id(event.oldPath))
     // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       // A renamed event where the source does not exist can be seen as just an
@@ -203,7 +204,7 @@ actions = {
   },
 
   deletedfile: async (event, { pouch, prep }) => {
-    const was = await pouch.byIdMaybeAsync(event._id)
+    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(event._id)
     if (!was || was.deleted) {
       log.debug({ event }, 'Assuming file already removed')
       // The file was already marked as deleted in pouchdb
@@ -215,7 +216,7 @@ actions = {
   },
 
   deleteddirectory: async (event, { pouch, prep }) => {
-    const was = await pouch.byIdMaybeAsync(event._id)
+    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(event._id)
     if (!was || was.deleted) {
       log.debug({ event }, 'Assuming dir already removed')
       // The dir was already marked as deleted in pouchdb

--- a/core/local/atom/incomplete_fixer.js
+++ b/core/local/atom/incomplete_fixer.js
@@ -37,6 +37,7 @@ import type Channel from './channel'
 import type { AtomEvent, AtomBatch } from './event'
 import type { Checksumer } from '../checksumer'
 import type { Pouch } from '../../pouch'
+import type { Metadata } from '../../metadata'
 
 type IncompleteItem = {
   event: AtomEvent,
@@ -243,7 +244,7 @@ function step(
           // (e.g. a temporary document now renamed), we'll want to make sure the old
           // document is removed to avoid having 2 documents with the same inode.
           // We can do this by keeping the completing renamed event.
-          const incompleteForExistingDoc = await opts.pouch.byIdMaybeAsync(
+          const incompleteForExistingDoc /*: ?Metadata */ = await opts.pouch.byIdMaybeAsync(
             metadata.id(item.event.path)
           )
           if (

--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -70,7 +70,7 @@ function loop(
   opts /*: { pouch: Pouch, state: InitialDiffState } */
 ) /*: Channel */ {
   const out = new Channel()
-  initialDiff(channel, out, opts.pouch, opts.state).catch(err => {
+  initialDiff(channel, out, opts.state).catch(err => {
     log.error({ err })
   })
   return out
@@ -87,9 +87,8 @@ async function initialState(
   // which files/folders have been deleted, as it is stable even if the
   // file/folder has been moved or renamed
   const byInode /*: Map<number|string, Metadata> */ = new Map()
-  const docs /*: Metadata[] */ = (await opts.pouch.allDocs()).filter(
-    doc => !doc.deleted
-  )
+  const docs = (await opts.pouch.allDocs() /*: Metadata[] */)
+    .filter(doc => !doc.deleted)
   // Make sure all paths are sorted in reverse path order so that missing
   // children will be deleted before missing parents and folders that would not
   // have any content are not trashed but completely deleted
@@ -124,7 +123,6 @@ function clearState(state /*: InitialDiffState */) {
 async function initialDiff(
   channel /*: Channel */,
   out /*: Channel */,
-  pouch /*: Pouch */,
   state /*: InitialDiffState */
 ) /*: Promise<void> */ {
   // eslint-disable-next-line no-constant-condition

--- a/core/local/atom/win_identical_renaming.js
+++ b/core/local/atom/win_identical_renaming.js
@@ -89,7 +89,9 @@ const indexDeletedEvent = (event, state) => {
 /** Possibly fix oldPath when event is identical renamed. */
 const fixIdenticalRenamed = async (event, { byIdMaybeAsync }) => {
   if (event.path === event.oldPath) {
-    const doc = event._id && (await byIdMaybeAsync(event._id))
+    const doc /*: ?Metadata */ = event._id
+      ? await byIdMaybeAsync(event._id)
+      : null
 
     if (doc && !doc.deleted && doc.path !== event.oldPath) {
       _.set(event, [STEP_NAME, 'oldPathBeforeFix'], event.oldPath)

--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -18,6 +18,7 @@ const NB_OF_DELETABLE_ELEMENT = 3
 import type { ChokidarEvent } from './event'
 import type LocalEventBuffer from './event_buffer'
 import type { Pouch } from '../../pouch'
+import type { Metadata } from '../../metadata'
 
 export type InitialScan = {
   ids: string[],
@@ -39,7 +40,8 @@ const detectOfflineUnlinkEvents = async (
 ) /*: Promise<{offlineEvents: Array<ChokidarEvent>, unappliedMoves: string[], emptySyncDir: boolean}> */ => {
   // Try to detect removed files & folders
   const events /*: Array<ChokidarEvent> */ = []
-  const docs = (await pouch.allDocs()).filter(doc => !doc.deleted)
+  const docs = (await pouch.allDocs() /*: Metadata[] */)
+    .filter(doc => !doc.deleted)
   const inInitialScan = doc =>
     initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
 

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -61,7 +61,7 @@ const oldMetadata = async (
   pouch /*: Pouch */
 ) /*: Promise<?Metadata> */ => {
   if (e.old) return e.old
-  const old = await pouch.byIdMaybeAsync(metadata.id(e.path))
+  const old /*: ?Metadata */ = await pouch.byIdMaybeAsync(metadata.id(e.path))
   if (old && !old.deleted) return old
 }
 

--- a/core/local/chokidar/send_to_prep.js
+++ b/core/local/chokidar/send_to_prep.js
@@ -138,8 +138,7 @@ const step = async (
   const errors /*: Error[] */ = []
   for (let c of changes) {
     try {
-      if (c.needRefetch) {
-        // $FlowFixMe
+      if (c.type !== 'Ignored' && c.needRefetch && c.old) {
         c.old = await pouch.db.get(metadata.id(c.old.path))
       }
       switch (c.type) {

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -198,14 +198,14 @@ class Local /*:: implements Reader, Writer */ {
 
   /** Check if a file corresponding to given checksum already exists */
   fileExistsLocally(checksum /*: string */, callback /*: Callback */) {
-    this.pouch.byChecksum(checksum, (err, docs) => {
+    this.pouch.byChecksum(checksum, (err, docs /*: Metadata[] */) => {
       if (err) {
         callback(err)
       } else if (docs == null || docs.length === 0) {
         callback(null, false)
       } else {
         let paths = Array.from(docs)
-          .filter(doc => isUpToDate('local', doc))
+          .filter((doc /*: Metadata */) => isUpToDate('local', doc))
           .map(doc => path.resolve(this.syncPath, doc.path))
         async.detect(
           paths,

--- a/core/merge.js
+++ b/core/merge.js
@@ -603,39 +603,6 @@ class Merge {
     return this.pouch.bulkDocs(bulk)
   }
 
-  async restoreFileAsync(
-    side /*: SideName */,
-    was /*: Metadata */,
-    doc /*: Metadata */
-  ) /*: Promise<*> */ {
-    log.debug({ path: doc.path, oldpath: was.path }, 'restoreFileAsync')
-    const { path } = doc
-    // TODO we can probably do something smarter for conflicts and avoiding to
-    // transfer again the file
-    try {
-      await this.deleteFileAsync(side, was)
-    } catch (err) {
-      log.warn({ path, err })
-    }
-    return this.updateFileAsync(side, doc)
-  }
-
-  async restoreFolderAsync(
-    side /*: SideName */,
-    was /*: Metadata */,
-    doc /*: Metadata */
-  ) /*: Promise<*> */ {
-    log.debug({ path: doc.path, oldpath: was.path }, 'restoreFolderAsync')
-    const { path } = doc
-    // TODO we can probably do something smarter for conflicts
-    try {
-      await this.deleteFolderAsync(side, was)
-    } catch (err) {
-      log.warn({ path, err })
-    }
-    return this.putFolderAsync(side, doc)
-  }
-
   async doTrash(
     side /*: SideName */,
     was /*: Metadata */,

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -146,7 +146,7 @@ async function migrate(
 
     let result /*: MigrationResult */
     try {
-      const docs = await pouch.allDocs()
+      const docs /*: Metadata[] */ = await pouch.allDocs()
       const affectedDocs = migration.affectedDocs(docs)
       const migratedDocs = migration.run(affectedDocs)
 

--- a/core/prep.js
+++ b/core/prep.js
@@ -182,43 +182,6 @@ class Prep {
   }
 
   // TODO add comments + tests
-  async restoreFileAsync(
-    side /*: SideName */,
-    was /*: Metadata */,
-    doc /*: Metadata */
-  ) {
-    log.debug({ path: doc.path, oldpath: was.path }, 'restoreFileAsync')
-    metadata.ensureValidPath(doc)
-    metadata.ensureValidPath(was)
-    metadata.ensureValidChecksum(doc)
-
-    delete doc.trashed
-    doc.docType = 'file'
-    metadata.assignId(doc)
-    metadata.assignId(was)
-    // TODO metadata.shouldIgnore
-    return this.merge.restoreFileAsync(side, was, doc)
-  }
-
-  // TODO add comments + tests
-  async restoreFolderAsync(
-    side /*: SideName */,
-    was /*: Metadata */,
-    doc /*: Metadata */
-  ) {
-    log.debug({ path: doc.path, oldpath: was.path }, 'restoreFolderAsync')
-    metadata.ensureValidPath(doc)
-    metadata.ensureValidPath(was)
-
-    delete doc.trashed
-    doc.docType = 'folder'
-    metadata.assignId(doc)
-    metadata.assignId(was)
-    // TODO metadata.shouldIgnore
-    return this.merge.restoreFolderAsync(side, was, doc)
-  }
-
-  // TODO add comments + tests
   async trashFileAsync(
     side /*: SideName */,
     was /*: {path: string} */,

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -131,7 +131,6 @@ module.exports = {
   added,
   trashed,
   deleted,
-  restored,
   upToDate,
   updated,
   isChildSource,
@@ -200,27 +199,6 @@ function deleted(
       sideName,
       type: 'DirDeletion',
       doc
-    }
-  }
-}
-
-function restored(
-  doc /*: Metadata */,
-  was /*: Metadata */
-) /*: RemoteFileRestoration | RemoteDirRestoration */ {
-  if (metadata.isFile(doc)) {
-    return {
-      sideName,
-      type: 'FileRestoration',
-      doc,
-      was
-    }
-  } else {
-    return {
-      sideName,
-      type: 'DirRestoration',
-      doc,
-      was
     }
   }
 }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -151,7 +151,7 @@ class RemoteWatcher {
     docs /*: Array<RemoteDoc|RemoteDeletion> */
   ) /*: Promise<Array<{ change: RemoteChange, err: Error }>> */ {
     const remoteIds = docs.reduce((ids, doc) => ids.add(doc._id), new Set())
-    const olds = await this.pouch.allByRemoteIds(remoteIds)
+    const olds /*: Metadata[] */ = await this.pouch.allByRemoteIds(remoteIds)
 
     const changes = this.analyse(docs, olds)
 

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -338,11 +338,9 @@ class RemoteWatcher {
       }
       return remoteChange.trashed(doc, was)
     }
-    if (!was) {
+
+    if (!was || was.trashed) {
       return remoteChange.added(doc)
-    }
-    if (!inRemoteTrash(remoteDoc) && was.trashed) {
-      return remoteChange.restored(doc, was)
     }
     if (was._id === doc._id && was.path === doc.path) {
       if (
@@ -422,14 +420,6 @@ class RemoteWatcher {
         case 'DirAddition':
           log.info({ path }, 'folder was added remotely')
           await this.prep.putFolderAsync(sideName, change.doc)
-          break
-        case 'FileRestoration':
-          log.info({ path }, 'file was restored remotely')
-          await this.prep.restoreFileAsync(sideName, change.doc, change.was)
-          break
-        case 'DirRestoration':
-          log.info({ path }, 'folder was restored remotely')
-          await this.prep.restoreFolderAsync(sideName, change.doc, change.was)
           break
         case 'FileUpdate':
           log.info({ path }, 'file was updated remotely')

--- a/core/sync.js
+++ b/core/sync.js
@@ -451,10 +451,10 @@ class Sync {
       log.debug({ path: doc.path }, `Applying else for ${doc.docType} change`)
       let old
       try {
-        old = await this.pouch.getPreviousRevAsync(
+        old = (await this.pouch.getPreviousRevAsync(
           doc._id,
           doc.sides.target - rev
-        )
+        ) /*: ?Metadata */)
       } catch (err) {
         await this.doOverwrite(side, doc)
       }
@@ -622,7 +622,7 @@ class Sync {
       // a thumbnail before apply has finished. In that case, we try to
       // reconciliate the documents.
       if (err && err.status === 409) {
-        const unsynced = await this.pouch.db.get(doc._id)
+        const unsynced /*: Metadata */ = await this.pouch.db.get(doc._id)
         const other = otherSide(side)
         await this.pouch.put({
           ...unsynced,
@@ -647,7 +647,7 @@ class Sync {
   ) /*: Promise<boolean> */ {
     let parentId = dirname(doc._id)
     if (parentId !== '.') {
-      let parent = await this.pouch.db.get(parentId)
+      let parent /*: Metadata */ = await this.pouch.db.get(parentId)
 
       if (!parent.trashed) {
         await Promise.delay(TRASHING_DELAY)

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -93,14 +93,16 @@ type ScenarioExpectations =
   & ScenarioTrashExpectation
   & { contents?: { [string]: string } }
 
+export type ScenarioInit = Array<{|
+  ino: number, path: string, content?: string, trashed?: boolean
+|}>
+
 export type Scenario = {|
   platforms?: Array<'win32'|'darwin'|'linux'>,
   side?: SideName,
   disabled?: ScenarioCompletelyDisabled | ScenarioTestsDisabled,
   useCaptures?: boolean,
-  init?: Array<{|
-    ino: number, path: string, content?: string
-  |}>,
+  init?: ScenarioInit,
   actions: Array<FSAction>,
   expected: ScenarioExpectations,
 |}

--- a/test/scenarios/restore/scenario.js
+++ b/test/scenarios/restore/scenario.js
@@ -4,22 +4,20 @@
 
 module.exports = ({
   side: 'remote',
-  disabled:
-    "Not sure why we don't handle this case yet. At least because of init trashed property.",
   init: [
     { ino: 1, path: 'parent/' },
-    // FIXME: For some reason, this line had `trashed: true`.
-    // But `trashed` is not part of the `Scenario` type.
-    // Keeping it commented so we remember about it when working to make this
-    // scenario pass and figure about what to do about it.
-    { ino: 2, path: 'parent/dir/' /*, trashed: true */ }, // eslint-disable-line
-    { ino: 3, path: 'parent/dir/empty-subdir/' },
-    { ino: 4, path: 'parent/dir/subdir/' },
-    { ino: 5, path: 'parent/dir/subdir/file' },
+    { ino: 2, path: 'parent/dir/', trashed: true },
+    { ino: 3, path: 'parent/dir/empty-subdir/', trashed: true },
+    { ino: 4, path: 'parent/dir/subdir/', trashed: true },
+    { ino: 5, path: 'parent/dir/subdir/file', trashed: true },
     { ino: 6, path: 'parent/file' },
     { ino: 7, path: 'parent/other_dir/' }
   ],
-  actions: [{ type: 'restore', pathInTrash: 'dir' }],
+  actions: [
+    { type: 'restore', pathInTrash: 'dir' },
+    { type: 'trash', path: 'parent/file' },
+    { type: 'restore', pathInTrash: 'file' }
+  ],
   expected: {
     tree: [
       'parent/',

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -357,7 +357,15 @@ module.exports.init = async (
     } // for (... of scenario.init)
   }
   for (let remoteDoc of remoteDocsToTrash) {
-    await cozy.files.trashById(remoteDoc._id)
+    debug(
+      `- trashing remote ${remoteDoc.attributes.type}: ${remoteDoc.attributes.path}`
+    )
+    try {
+      await cozy.files.trashById(remoteDoc._id)
+    } catch (err) {
+      if (err.status === 400) continue
+      throw err
+    }
   }
 }
 

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -1,6 +1,7 @@
 /** Test scenario helpers
  *
  * @module test/support/helpers/scenarios
+ * @flow weak
  */
 
 const Promise = require('bluebird')
@@ -15,8 +16,14 @@ const metadata = require('../../../core/metadata')
 
 const { cozy } = require('./cozy')
 
-// eslint-disable-next-line no-console
-const debug = process.env.TESTDEBUG ? console.log : () => {}
+/*::
+import type { ScenarioInit } from '../../scenarios'
+import type { Metadata } from '../../../core/metadata'
+*/
+
+const debug = (...args) =>
+  // eslint-disable-next-line no-console
+  process.env.TESTDEBUG ? console.log(...args) : () => {}
 
 const scenariosDir = path.resolve(__dirname, '../../scenarios')
 
@@ -208,7 +215,7 @@ const merge = async (srcPath, dstPath) => {
 }
 
 module.exports.init = async (
-  scenario,
+  scenario /*: { init: ScenarioInit } */,
   pouch,
   abspath,
   relpathFix,
@@ -216,122 +223,139 @@ module.exports.init = async (
 ) => {
   debug('[init]')
   const remoteDocsToTrash = []
-  for (let { path: relpath, ino: fakeIno, trashed, content } of scenario.init) {
-    debug(relpath)
-    const isOutside = relpath.startsWith('../outside')
-    let remoteParent
-    if (!isOutside) {
-      const remoteParentPath = path.posix.join('/', path.posix.dirname(relpath))
-      debug(`- retrieve remote parent: ${remoteParentPath}`)
-      remoteParent = await cozy.files.statByPath(remoteParentPath)
-    }
-    const remoteName = path.posix.basename(relpath)
-    const remotePath = path.posix.join(
-      _.get(remoteParent, 'attributes.path', ''),
-      remoteName
-    )
-    const localPath = relpathFix(_.trimEnd(relpath, '/'))
-    const lastModifiedDate = new Date('2011-04-11T10:20:30Z')
-    if (relpath.endsWith('/')) {
-      if (!trashed) {
-        debug(`- create local dir: ${localPath}`)
-        await fse.ensureDir(abspath(localPath))
-      }
-
-      const stats = await getInoAndFileId({
-        path: abspath(localPath),
-        fakeIno,
-        trashed,
-        useRealInodes
-      })
-      const doc = {
-        _id: metadata.id(localPath),
-        docType: 'folder',
-        updated_at: lastModifiedDate,
-        path: localPath,
-        tags: [],
-        sides: { target: 2, local: 2, remote: 2 }
-      }
-      stater.assignInoAndFileId(doc, stats)
-
+  if (scenario.init) {
+    for (let {
+      path: relpath,
+      ino: fakeIno,
+      trashed,
+      content
+    } of scenario.init) {
+      debug(relpath)
+      const isOutside = relpath.startsWith('../outside')
+      let remoteParent
       if (!isOutside) {
-        debug(
-          `- create${trashed ? ' and trash' : ''} remote dir: ${remotePath}`
+        const remoteParentPath = path.posix.join(
+          '/',
+          path.posix.dirname(relpath)
         )
-        const remoteDir = await cozy.files.createDirectory({
-          name: remoteName,
-          dirID: remoteParent._id,
-          lastModifiedDate
-        })
-        doc.remote = _.pick(remoteDir, ['_id', '_rev'])
-        if (trashed) remoteDocsToTrash.push(remoteDir)
-        else {
-          debug(`- create dir metadata: ${doc._id}`)
-          const { rev } = await pouch.put(doc)
-          doc._rev = rev
-          await pouch.put(doc)
-        }
+        debug(`- retrieve remote parent: ${remoteParentPath}`)
+        remoteParent = await cozy.files.statByPath(remoteParentPath)
       }
-    } else {
-      let md5sum
-      if (!content) {
-        content = 'foo'
-        md5sum = 'rL0Y20zC+Fzt72VPzMSk2A=='
+      const remoteName = path.posix.basename(relpath)
+      const remotePath = path.posix.join(
+        _.get(remoteParent, 'attributes.path', ''),
+        remoteName
+      )
+      const localPath = relpathFix(_.trimEnd(relpath, '/'))
+      const lastModifiedDate = new Date('2011-04-11T10:20:30Z')
+      if (relpath.endsWith('/')) {
+        if (!trashed) {
+          debug(`- create local dir: ${localPath}`)
+          await fse.ensureDir(abspath(localPath))
+        }
+
+        const stats = await getInoAndFileId({
+          path: abspath(localPath),
+          fakeIno,
+          trashed,
+          useRealInodes
+        })
+        const doc /*: Metadata */ = {
+          _id: metadata.id(localPath),
+          docType: 'folder',
+          updated_at: lastModifiedDate.toISOString(),
+          path: localPath,
+          tags: [],
+          remote: { _id: 'xxx', _rev: 'xxx' },
+          sides: { target: 2, local: 2, remote: 2 }
+        }
+        stater.assignInoAndFileId(doc, stats)
+
+        if (!isOutside && remoteParent) {
+          debug(
+            `- create${trashed ? ' and trash' : ''} remote dir: ${remotePath}`
+          )
+          const remoteDir = await cozy.files.createDirectory({
+            name: remoteName,
+            dirID: remoteParent._id,
+            lastModifiedDate
+          })
+          doc.remote = _.pick(remoteDir, ['_id', '_rev'])
+          if (trashed) remoteDocsToTrash.push(remoteDir)
+          else {
+            debug(`- create dir metadata: ${doc._id}`)
+            const { rev } = await pouch.put(doc)
+            doc._rev = rev
+            await pouch.put(doc)
+          }
+        } else {
+          delete doc.remote
+          delete doc.sides.remote
+        }
       } else {
-        md5sum = crypto
-          .createHash('md5')
-          .update(content)
-          .digest()
-          .toString('base64')
-      }
-
-      if (!trashed) {
-        debug(`- create local file: ${localPath}`)
-        await fse.outputFile(abspath(localPath), content)
-      }
-
-      const stats = await getInoAndFileId({
-        path: abspath(localPath),
-        fakeIno,
-        trashed,
-        useRealInodes
-      })
-      const doc = {
-        _id: metadata.id(localPath),
-        md5sum,
-        class: 'text',
-        docType: 'file',
-        executable: false,
-        updated_at: lastModifiedDate,
-        mime: 'text/plain',
-        path: localPath,
-        size: content.length,
-        tags: [],
-        sides: { target: 2, local: 2, remote: 2 }
-      }
-      stater.assignInoAndFileId(doc, stats)
-      if (!isOutside) {
-        debug(
-          `- create${trashed ? ' and trash' : ''} remote file: ${remotePath}`
-        )
-        const remoteFile = await cozy.files.create(content, {
-          name: remoteName,
-          dirID: remoteParent._id,
-          checksum: md5sum,
-          contentType: 'text/plain',
-          lastModifiedDate
-        })
-        doc.remote = _.pick(remoteFile, ['_id', '_rev'])
-        if (trashed) remoteDocsToTrash.push(remoteFile)
-        else {
-          debug(`- create file metadata: ${doc._id}`)
-          const { rev } = await pouch.put(doc)
-          doc._rev = rev
-          await pouch.put(doc)
+        let md5sum
+        if (!content) {
+          content = 'foo'
+          md5sum = 'rL0Y20zC+Fzt72VPzMSk2A=='
+        } else {
+          md5sum = crypto
+            .createHash('md5')
+            .update(content)
+            .digest()
+            .toString('base64')
         }
-      }
-    } // if relpath ...
-  } // for (... of scenario.init)
+
+        if (!trashed) {
+          debug(`- create local file: ${localPath}`)
+          await fse.outputFile(abspath(localPath), content)
+        }
+
+        const stats = await getInoAndFileId({
+          path: abspath(localPath),
+          fakeIno,
+          trashed,
+          useRealInodes
+        })
+        const doc /*: Metadata */ = {
+          _id: metadata.id(localPath),
+          md5sum,
+          class: 'text',
+          docType: 'file',
+          updated_at: lastModifiedDate.toISOString(),
+          mime: 'text/plain',
+          path: localPath,
+          size: content.length,
+          tags: [],
+          remote: { _id: 'xxx', _rev: 'xxx' },
+          sides: { target: 2, local: 2, remote: 2 }
+        }
+        stater.assignInoAndFileId(doc, stats)
+        if (!isOutside && remoteParent) {
+          debug(
+            `- create${trashed ? ' and trash' : ''} remote file: ${remotePath}`
+          )
+          const remoteFile = await cozy.files.create(content, {
+            name: remoteName,
+            dirID: remoteParent._id,
+            checksum: md5sum,
+            contentType: 'text/plain',
+            lastModifiedDate
+          })
+          doc.remote = _.pick(remoteFile, ['_id', '_rev'])
+          if (trashed) remoteDocsToTrash.push(remoteFile)
+          else {
+            debug(`- create file metadata: ${doc._id}`)
+            const { rev } = await pouch.put(doc)
+            doc._rev = rev
+            await pouch.put(doc)
+          }
+        } else {
+          delete doc.remote
+          delete doc.sides.remote
+        }
+      } // if relpath ...
+    } // for (... of scenario.init)
+  }
   for (let remoteDoc of remoteDocsToTrash) {
     await cozy.files.trashById(remoteDoc._id)
   }


### PR DESCRIPTION
We were processing the restoration of files and folders from the
remote trash separately from the addition of files and folders while
we can actually treat them the same way since, from the Desktop
client's point of view, they're the same.

This removes some unnecessary code and should help us simplify how we
handle trashing elements by using one `trashed` attributes regardless
of whether the deletion happened on the local filesystem or the remote
Cozy.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
