### PR TITLE
core: Refactor sync modules lifecycle management

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -74,11 +74,7 @@ class Remote /*:: implements Reader, Writer */ {
   }
 
   start() {
-    const { started, running } = this.watcher.start()
-    return {
-      started: started.then(() => this.warningsPoller.start()),
-      running
-    }
+    return this.watcher.start().then(() => this.warningsPoller.start())
   }
 
   stop() {

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -43,7 +43,7 @@ class RemoteWatcher {
   remoteCozy: RemoteCozy
   events: EventEmitter
   runningResolve: ?() => void
-  runningReject: ?() => void
+  running: Promise
   */
 
   constructor(
@@ -56,26 +56,21 @@ class RemoteWatcher {
     this.prep = prep
     this.remoteCozy = remoteCozy
     this.events = events
+    this.running = new Promise(() => {})
 
     autoBind(this)
   }
 
-  start() {
-    const started /*: Promise<void> */ = this.watch()
-    const running /*: Promise<void> */ = started.then(() =>
-      Promise.race([
-        // run until either stop is called or watchLoop reject
-        new Promise(resolve => {
-          this.runningResolve = resolve
-        }),
-        this.watchLoop()
-      ])
-    )
+  async start() {
+    await this.watch()
 
-    return {
-      started: started,
-      running: running
-    }
+    this.running = Promise.race([
+      // run until either stop is called or watchLoop reject
+      new Promise(resolve => {
+        this.runningResolve = resolve
+      }),
+      this.watchLoop()
+    ])
   }
 
   stop() {

--- a/core/sync.js
+++ b/core/sync.js
@@ -131,14 +131,12 @@ class Sync {
 
       try {
         await this.local.start()
-        const localRunning = this.local.watcher.running
-        const {
-          running: remoteRunning,
-          started: remoteStarted
-        } = this.remote.start()
-        await remoteStarted
+        await this.remote.start()
 
-        Promise.all([localRunning, remoteRunning]).catch(err => {
+        Promise.all([
+          this.local.watcher.running,
+          this.remote.watcher.running
+        ]).catch(err => {
           throw err
         })
       } catch (err) {

--- a/core/sync.js
+++ b/core/sync.js
@@ -15,6 +15,7 @@ const { HEARTBEAT } = require('./remote/watcher')
 const { otherSide } = require('./side')
 const logger = require('./utils/logger')
 const measureTime = require('./utils/perfs')
+const { LifeCycle } = require('./utils/lifecycle')
 
 /*::
 import type EventEmitter from 'events'
@@ -80,9 +81,7 @@ class Sync {
   pouch: Pouch
   remote: Remote
   moveTo: ?string
-  stopRequested: Promise
-  started: ?Promise<boolean>
-  running: ?Promise
+  lifecycle: LifeCycle
 
   diskUsage: () => Promise<*>
   */
@@ -103,7 +102,7 @@ class Sync {
     this.events = events
     this.local.other = this.remote
     this.remote.other = this.local
-    this.stopRequested = false
+    this.lifecycle = new LifeCycle(log)
 
     autoBind(this)
   }
@@ -112,69 +111,49 @@ class Sync {
   // First, start metadata synchronization in pouch, with the watchers
   // Then, when a stable state is reached, start applying changes from pouch
   async start() /*: Promise<void> */ {
-    if (this.started && (await this.started)) return
-
-    let runningResolve, runningReject
-    this.running = new Promise((resolve, reject) => {
-      runningResolve = resolve
-      runningReject = reject
-    })
-
-    this.started = new Promise(async (resolve, reject) => {
-      if (this.stopRequested) {
-        reject()
-        runningReject()
-        return
-      }
-
-      log.info('Starting Sync...')
-
-      try {
-        await this.local.start()
-        await this.remote.start()
-
-        Promise.all([
-          this.local.watcher.running,
-          this.remote.watcher.running
-        ]).catch(err => {
-          throw err
-        })
-      } catch (err) {
-        log.error({ err }, 'Could not start watchers')
-        this.local.stop()
-        this.remote.stop()
-        reject(err)
-        runningReject(err)
-      }
-      resolve(true)
-    })
-
-    await this.started
-
-    log.info('Sync started')
+    if (this.lifecycle.willStop()) {
+      await this.lifecycle.stopped()
+    } else {
+      return
+    }
 
     try {
-      // eslint-disable-next-line no-constant-condition
-      while (!this.stopRequested) {
+      this.lifecycle.begin('start')
+    } catch (err) {
+      return
+    }
+    try {
+      await this.local.start()
+      await this.remote.start()
+    } catch (err) {
+      this.error(err)
+      this.lifecycle.end('start')
+      await this.stop()
+      return
+    }
+    this.lifecycle.end('start')
+
+    Promise.all([
+      this.local.watcher.running,
+      this.remote.watcher.running
+    ]).catch(err => {
+      this.error(err)
+      this.stop()
+      return
+    })
+
+    try {
+      while (!this.lifecycle.willStop()) {
         await this.sync()
       }
     } catch (err) {
-      log.error({ err }, 'Sync error')
-      throw err
-    } finally {
-      if (this.changes) {
-        this.changes.cancel()
-        this.changes = null
-      }
-
-      await Promise.all([this.local.stop(), this.remote.stop()])
-
-      this.started = null
-      if (runningResolve) {
-        runningResolve()
-      }
-      log.info('Sync stopped')
+      this.error(err)
+      await this.stop()
     }
+  }
+
+  async started() {
+    await this.lifecycle.started()
   }
 
   // Manually force a full synchronization
@@ -185,21 +164,33 @@ class Sync {
 
   // Stop the synchronization
   async stop() /*: Promise<void> */ {
-    try {
-      if (this.started) await this.started
-    } catch (err) {
-      log.error({ err }, 'started errored out during Sync stop')
+    if (this.lifecycle.willStart()) {
+      await this.lifecycle.started()
+    } else {
+      return
     }
-    log.info('Stopping Sync...')
-    this.stopRequested = true
-    this.events.emit('stopRequested')
-    const stopped = this.running || Promise.resolve()
+
     try {
-      await stopped
-      this.stopRequested = false
+      this.lifecycle.begin('stop')
     } catch (err) {
-      log.error({ err }, 'running errored out during Sync stop')
+      return
     }
+    if (this.changes) {
+      this.changes.cancel()
+      this.changes = null
+    }
+
+    await Promise.all([this.local.stop(), this.remote.stop()])
+    this.lifecycle.end('stop')
+  }
+
+  async stopped() {
+    await this.lifecycle.stopped()
+  }
+
+  error(err /*: Error */) {
+    log.error({ err }, 'sync error')
+    this.events.emit('sync-error', err)
   }
 
   // TODO: remove waitForNewChanges to .start while(true)
@@ -224,7 +215,7 @@ class Sync {
   async syncBatch() {
     let seq = null
     // eslint-disable-next-line no-constant-condition
-    while (!this.stopRequested) {
+    while (!this.lifecycle.willStop()) {
       seq = await this.pouch.getLocalSeqAsync()
       // TODO: Prevent infinite loop
       const change = await this.getNextChange(seq)
@@ -234,7 +225,7 @@ class Sync {
         await this.apply(change)
         // XXX: apply should call setLocalSeqAsync
       } catch (err) {
-        if (!this.stopRequested) throw err
+        if (!this.lifecycle.willStop()) throw err
       }
     }
   }
@@ -258,29 +249,23 @@ class Sync {
     const opts = await this.baseChangeOptions(seq)
     opts.live = true
     return new Promise((resolve, reject) => {
-      const resolver = data => {
-        this.events.off('stopRequested', resolver)
-        resolve(data)
-      }
-      const rejecter = err => {
-        this.events.off('stopRequested', resolver)
-        reject(err)
-      }
-      this.events.on('stopRequested', resolver)
+      this.lifecycle.once('will-stop', resolve)
       this.changes = this.pouch.db
         .changes(opts)
-        .on('change', c => {
+        .on('change', data => {
+          this.lifecycle.off('will-stop', resolve)
           if (this.changes) {
             this.changes.cancel()
             this.changes = null
-            resolver(c)
+            resolve(data)
           }
         })
         .on('error', err => {
+          this.lifecycle.off('will-stop', resolve)
           if (this.changes) {
-            // FIXME: pas de cancel ici ??
+            this.changes.cancel()
             this.changes = null
-            rejecter(err)
+            reject(err)
           }
         })
     })
@@ -291,22 +276,21 @@ class Sync {
     const opts = await this.baseChangeOptions(seq)
     opts.include_docs = true
     const p = new Promise((resolve, reject) => {
-      const resolver = data => {
-        this.events.off('stopRequested', resolver)
-        resolve(data)
-      }
-      const rejecter = err => {
-        this.events.off('stopRequested', resolver)
-        reject(err)
-      }
-      this.events.on('stopRequested', resolver)
-      this.pouch.db
+      this.lifecycle.once('will-stop', resolve)
+      this.changes = this.pouch.db
         .changes(opts)
-        .on('change', info => resolver(info))
-        .on('error', err => rejecter(err))
-        .on('complete', info => {
-          if (info.results == null || info.results.length === 0) {
-            resolver(null)
+        .on('change', data => {
+          this.lifecycle.off('will-stop', resolve)
+          resolve(data)
+        })
+        .on('error', err => {
+          this.lifecycle.off('will-stop', resolve)
+          reject(err)
+        })
+        .on('complete', data => {
+          this.lifecycle.off('will-stop', resolve)
+          if (data.results == null || data.results.length === 0) {
+            resolve(null)
           }
         })
     })

--- a/core/utils/lifecycle.js
+++ b/core/utils/lifecycle.js
@@ -1,0 +1,90 @@
+/**
+ * @module core/utils/lifecycle
+ * @flow
+ */
+
+const EventEmitter = require('events')
+
+/*::
+import type { Logger } from './logger'
+
+type State = 'done-stop' | 'will-start' | 'done-start' | 'will-stop'
+*/
+
+class LifeCycle extends EventEmitter {
+  /*::
+  currentState: State
+  log: Logger
+  */
+
+  constructor(logger /*: Logger */) {
+    super()
+    this.currentState = 'done-stop'
+    this.log = logger
+  }
+
+  canTransitionTo(state /*: State */) {
+    return this.currentState !== state
+  }
+
+  transitionTo(newState /*: State */) {
+    this.currentState = newState
+    this.emit(newState)
+    this.log.info(newState)
+  }
+
+  async transitionedTo(futureState /*: State */) {
+    return new Promise(resolve => {
+      if (this.currentState === futureState) resolve()
+      else this.once(futureState, resolve)
+    })
+  }
+
+  begin(endState /*: 'start' | 'stop' */) {
+    switch (endState) {
+      case 'start':
+        if (this.canTransitionTo('will-start')) {
+          this.transitionTo('will-start')
+        } else {
+          throw new Error(`Cannot begin ${endState}`)
+        }
+        break
+      case 'stop':
+        if (this.canTransitionTo('will-stop')) {
+          this.transitionTo('will-stop')
+        } else {
+          throw new Error(`Cannot begin ${endState}`)
+        }
+        break
+    }
+  }
+
+  end(endState /*: 'start' | 'stop' */) {
+    switch (endState) {
+      case 'start':
+        this.transitionTo('done-start')
+        break
+      case 'stop':
+        this.transitionTo('done-stop')
+        break
+    }
+  }
+
+  willStop() {
+    return ['will-stop', 'done-stop'].includes(this.currentState)
+  }
+
+  async stopped() {
+    await this.transitionedTo('done-stop')
+  }
+
+  willStart() {
+    return ['will-start', 'done-start'].includes(this.currentState)
+  }
+
+  async started() {
+    await this.transitionedTo('done-start')
+  }
+}
+
+module.exports = { LifeCycle }

--- a/gui/main.js
+++ b/gui/main.js
@@ -434,7 +434,7 @@ const startSync = async () => {
   })
   desktop.events.on('delete-file', removeFile)
 
-  desktop.startSync().catch(err => {
+  desktop.events.on('sync-error', err => {
     if (err.status === 402) {
       // Only show notification popup on the first check (the GUI will
       // include a warning anyway).
@@ -455,6 +455,8 @@ const startSync = async () => {
     }
     sendDiskUsage()
   })
+
+  desktop.startSync()
   sendDiskUsage()
 
   autoLaunch.isEnabled().then(enabled => {

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -75,7 +75,9 @@ class TestHelpers {
   }
 
   async syncAll() {
+    this._sync.lifecycle.end('start')
     await this._sync.sync(false)
+    this._sync.lifecycle.end('stop')
   }
 
   async pullAndSyncAll() {

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -41,7 +41,7 @@ describe('Remote', function() {
         .stub(global, 'fetch')
         .rejects(new FetchError('net::ERR_INTERNET_DISCONNECTED'))
       let eventsSpy = sinon.spy(this.events, 'emit')
-      await this.remote.start().started
+      await this.remote.start()
       eventsSpy.should.have.been.calledWith('offline')
       fetchStub.restore()
       // skip waiting for HEARTBEAT

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -43,14 +43,11 @@ describe('Sync', function() {
 
   describe('start', function() {
     beforeEach('instanciate sync', function() {
-      const ret = {
-        started: Promise.resolve(),
-        running: new Promise(() => {})
-      }
       this.local.start = sinon.stub().resolves()
       this.local.watcher.running = sinon.stub().resolves()
       this.local.stop = sinon.stub().resolves()
-      this.remote.start = sinon.stub().returns(ret)
+      this.remote.start = sinon.stub().resolves()
+      this.remote.watcher.running = sinon.stub().resolves()
       this.remote.stop = sinon.stub().resolves()
       this.sync.sync = sinon.stub().rejects(new Error('stopped'))
     })


### PR DESCRIPTION
We found out that we were not catching all errors coming from the remote watcher thus not alerting the user and not completely stopping the synchronization process.

We want to make sure this does not happen anymore and that other similar situations cannot happen.
To do so, we need to move away from the complex lifecycle management we have today in the watchers and sync modules.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
