### PR TITLE
core/remote/watcher: Restored docs are always added

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -334,7 +334,7 @@ class RemoteWatcher {
       return remoteChange.trashed(doc, was)
     }
 
-    if (!was || was.trashed) {
+    if (!was || was.deleted) {
       return remoteChange.added(doc)
     }
     if (was._id === doc._id && was.path === doc.path) {

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -145,6 +145,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  deleted() /*: this */ {
+    this.doc.deleted = true
+    return this
+  }
+
   updatedAt(date /*: Date */) /*: this */ {
     this.doc.updated_at = timestamp.fromDate(date).toISOString()
     return this

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -1820,6 +1820,38 @@ describe('RemoteWatcher', function() {
       should(addArgs[1]).have.properties(metadata.fromRemoteDoc(newDir))
     })
 
+    describe('restored file before trashing was synced', () => {
+      it('returns a FileAddition', function() {
+        const origFile = builders
+          .remoteFile()
+          .name('foo')
+          .trashed()
+          .shortRev(2)
+          .build()
+        const trashedFile = builders
+          .metafile()
+          .fromRemote(origFile)
+          .deleted()
+          .build()
+        const newFile = builders
+          .remoteFile(origFile)
+          .restored()
+          .shortRev(3)
+          .build()
+
+        should(
+          this.watcher.identifyChange(newFile, trashedFile, [], [])
+        ).have.properties({
+          sideName: 'remote',
+          type: 'FileAddition',
+          doc: builders
+            .metafile()
+            .fromRemote(newFile)
+            .build()
+        })
+      })
+    })
+
     describe('added file', () => {
       let addedRemoteFile
 


### PR DESCRIPTION
Since we introduced the deletion marker, documents that were trashed
on the remote Cozy and restored before the deletion could be applied
on the local filesystem (i.e. the new version of the PouchDB record
has been merged with the marker but the document still exists) would
be considered as moved instead of being considered as added.

We missed a condition in the remote watcher where we needed to check
for the presence of the marker because we were checking for the
presence of a `trashed` attribute.
However, this attribute does not have the same meaning and would
actually not be present on any record in the PouchDB database since
it's a remote CouchDB attribute set on trashed documents.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
