### PR TITLE
Release v3.21.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.21.0-beta.2 - 2020-04-28
+
+Improvements for all users:
+
+- We missed a spot when introducing the deletion marker in the previous beta
+  release which could lead to remote restorations being handled as movements if
+  the previous deletion was merged into the local PouchDB database but not
+  propagated to the local filesystem.
+  We haven't identified visible issues coming from this yet though.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.21.0-beta.1 - 2020-04-24
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.21.0-beta.1",
+  "version": "3.21.0-beta.2",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- We missed a spot when introducing the deletion marker in the
  previous beta release which could lead to remote restorations being
  handled as movements if the previous deletion was merged into the
  local PouchDB database but not propagated to the local filesystem.
  We haven't identified visible issues coming from this yet though.