### PR TITLE
core/local: Accept remote Notes updates on Windows

### DIFF
--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -4,6 +4,7 @@
 const Promise = require('bluebird')
 const _ = require('lodash')
 const should = require('should')
+const fse = require('fs-extra')
 
 const logger = require('../../core/utils/logger')
 
@@ -12,6 +13,8 @@ const TestHelpers = require('../support/helpers')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
+
+const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
 
 const log = logger({ component: 'mocha' })
 
@@ -36,6 +39,49 @@ describe('Update file', () => {
     await helpers.local.clean()
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
+  })
+
+  describe('remote note update', () => {
+    let note
+    beforeEach('create note', async () => {
+      note = await builders
+        .remoteFile()
+        .contentType(NOTE_MIME_TYPE)
+        .name('note.cozy-note')
+        .data('Initial content')
+        .timestamp(2018, 5, 15, 21, 1, 53)
+        .create()
+      await helpers.pullAndSyncAll()
+    })
+
+    it('updates the note content on the filesystem', async () => {
+      await builders
+        .remoteFile(note)
+        .data('updated content')
+        .update()
+      await helpers.pullAndSyncAll()
+
+      should(await helpers.local.syncDir.readFile('note.cozy-note')).eql(
+        'updated content'
+      )
+    })
+
+    it('leaves the note in read-only mode', async () => {
+      await builders
+        .remoteFile(note)
+        .data('updated content')
+        .update()
+      await helpers.pullAndSyncAll()
+
+      const expectedErrorCode =
+        process.platform === 'win32' ? /EPERM/ : /EACCES/
+      await should(
+        fse.access(
+          helpers.local.syncDir.abspath('note.cozy-note'),
+          fse.constants.F_OK | fse.constants.W_OK
+        )
+      ).be.rejectedWith(expectedErrorCode)
+    })
   })
 
   describe('local offline change with unsynced previous local change', () => {

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -92,4 +92,23 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder {
 
     return doc
   }
+
+  async update() /*: Promise<RemoteDoc> */ {
+    const cozy = this._ensureCozy()
+
+    const doc = jsonApiToRemoteDoc(
+      await cozy.files.updateById(this.remoteDoc._id, this._data, {
+        contentType: this.remoteDoc.mime,
+        dirID: this.remoteDoc.dir_id,
+        executable: this.remoteDoc.executable,
+        lastModifiedDate: this.remoteDoc.updated_at,
+        name: this.remoteDoc.name
+      })
+    )
+
+    const parentDir = await cozy.files.statById(doc.dir_id)
+    doc.path = posix.join(parentDir.attributes.path, doc.name)
+
+    return doc
+  }
 }

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -69,7 +69,11 @@ async function rootDirContents() {
 async function deleteAll() {
   const remoteDocs = await rootDirContents()
 
-  await Promise.all(remoteDocs.map(doc => cozy.files.trashById(doc._id)))
+  try {
+    await Promise.all(remoteDocs.map(doc => cozy.files.trashById(doc._id)))
+  } catch (err) {
+    if (err.status !== 400) throw err
+  }
 
   return cozy.files.clearTrash()
 }


### PR DESCRIPTION
To prevent users from breaking their Cozy Notes by updating them
locally, we decided to make their backup files read-only on the local
filesystem so that users would have to knowingly save any updates.

However, on Windows, this mechanism prevents us from overwriting a
backup file with a new remote version because our process doesn't have
write permissions either.

To circumvent this limitation, we temporarily add back write
permissions on Cozy Notes backup files when we are about to overwrite
them with a new version.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
