### PR TITLE
dev/remote: Accept COZY_URL variable for bootstrap

### DIFF
--- a/dev/remote/generate-test-env.js
+++ b/dev/remote/generate-test-env.js
@@ -5,7 +5,10 @@ const fse = require('fs-extra')
 const pkg = require('../../package.json')
 const automatedRegistration = require('./automated_registration')
 
-const cozyUrl = chooseCozyUrl(process.env.BUILD_JOB) || 'http://cozy.tools:8080'
+const cozyUrl =
+  chooseCozyUrl(process.env.BUILD_JOB) ||
+  process.env.COZY_URL ||
+  'http://cozy.tools:8080'
 const passphrase = process.env.COZY_PASSPHRASE || 'cozy'
 const storage = new cozy.MemoryStorage()
 


### PR DESCRIPTION
When using the `bootstrap:remote` command outside any CI environment,
the Cozy URL defaults to `https://cozy.tools.8080` but there are
situations where we might want to choose another URL instead (e.g.
when running tests on Windows where we can't use the dockerized
stack).

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
