### PR TITLE
core/pouch: byRecursivePath scopes results to given folder

### DIFF
--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -248,9 +248,9 @@ class Pouch {
   }
 
   // Return all the files and folders in this path, only at first level
-  byPath(path, callback) {
-    let params = {
-      key: path,
+  byPath(basePath, callback) {
+    const params = {
+      key: basePath === '' ? basePath : basePath + path.sep,
       include_docs: true
     }
     return this.getAll('byPath', params, callback)
@@ -263,7 +263,7 @@ class Pouch {
       params = { include_docs: true }
     } else {
       params = {
-        startkey: `${basePath}`,
+        startkey: `${basePath}${path.sep}`,
         endkey: `${basePath}${path.sep}\ufff0`,
         include_docs: true
       }
@@ -323,9 +323,10 @@ class Pouch {
     let query = `
       function (doc) {
         if ('docType' in doc) {
-          let parts = doc._id.split(${sep})
+          const parts = doc._id.split(${sep})
           parts.pop()
-          return emit(parts.join(${sep}), {_id: doc._id})
+          const basePath = parts.concat('').join(${sep})
+          return emit(basePath, {_id: doc._id})
         }
       }
     `

--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 const { assignId } = require('../../../core/metadata')
 const { Pouch } = require('../../../core/pouch')
 
@@ -35,14 +33,14 @@ module.exports = {
     return pouch.db.put(doc).asCallback(callback)
   },
 
-  createFolder(pouch, i, callback) {
+  createFolder(pouch, folderPath, callback) {
     let doc = {
-      path: path.join('my-folder', `folder-${i}`),
+      path: folderPath,
       docType: 'folder',
       updated_at: new Date(),
       tags: [],
       remote: {
-        _id: `123456789${i}`
+        _id: `123456789-${folderPath}`
       },
       sides: {
         local: 1,
@@ -53,15 +51,15 @@ module.exports = {
     return pouch.db.put(doc).asCallback(callback)
   },
 
-  createFile(pouch, i, callback) {
+  createFile(pouch, filePath, callback) {
     let doc = {
-      path: path.join('my-folder', `file-${i}`),
+      path: filePath,
       docType: 'file',
-      md5sum: `111111111111111111111111111111111111111${i}`,
+      md5sum: `111111111111111111111111111111111111111${filePath}`,
       updated_at: new Date(),
       tags: [],
       remote: {
-        _id: `1234567890${i}`
+        _id: `1234567890-${filePath}`
       },
       sides: {
         local: 1,

--- a/test/unit/pouch.js
+++ b/test/unit/pouch.js
@@ -294,7 +294,7 @@ describe('Pouch', function() {
     describe('getAll', () =>
       it('returns all the documents matching the query', async function() {
         let params = {
-          key: metadata.id('my-folder'),
+          key: metadata.id('my-folder') + path.sep,
           include_docs: true
         }
         const docs = await this.pouch.getAllAsync('byPath', params)
@@ -426,6 +426,24 @@ describe('Pouch', function() {
             tags: []
           })
         }
+      })
+
+      it('does not return the content of other folders starting with the same path', async function() {
+        // create my-folder/folder-11
+        const similarFolderPath = path.join('my-folder', 'folder-1 other')
+        await pouchHelpers.createFolder(this.pouch, similarFolderPath)
+        const similarFolderContentPath = path.join(
+          'my-folder',
+          'folder-1 other',
+          'file'
+        )
+        await pouchHelpers.createFolder(this.pouch, similarFolderContentPath)
+
+        const docs = await this.pouch.byRecursivePathAsync(
+          metadata.id(path.join('my-folder', 'folder-1'))
+        )
+        const paths = docs.map(d => d.path)
+        should(paths).not.containEql(similarFolderContentPath)
       })
     })
 

--- a/test/unit/pouch.js
+++ b/test/unit/pouch.js
@@ -24,8 +24,14 @@ describe('Pouch', function() {
   beforeEach('create folders and files', async function() {
     await pouchHelpers.createParentFolder(this.pouch)
     for (let i of [1, 2, 3]) {
-      await pouchHelpers.createFolder(this.pouch, i)
-      await pouchHelpers.createFile(this.pouch, i)
+      await pouchHelpers.createFolder(
+        this.pouch,
+        path.join('my-folder', `folder-${i}`)
+      )
+      await pouchHelpers.createFile(
+        this.pouch,
+        path.join('my-folder', `file-${i}`)
+      )
     }
   })
 
@@ -337,8 +343,9 @@ describe('Pouch', function() {
 
     describe('byChecksum', () =>
       it('gets all the files with this checksum', async function() {
-        let _id = metadata.id(path.join('my-folder', 'file-1'))
-        let checksum = '1111111111111111111111111111111111111111'
+        const filePath = path.join('my-folder', 'file-1')
+        const _id = metadata.id(filePath)
+        const checksum = `111111111111111111111111111111111111111${filePath}`
         const docs = await this.pouch.byChecksumAsync(checksum)
         docs.length.should.be.equal(1)
         docs[0]._id.should.equal(_id)
@@ -424,7 +431,8 @@ describe('Pouch', function() {
 
     describe('byRemoteId', function() {
       it('gets all the file with this remote id', async function() {
-        let id = '12345678901'
+        const filePath = path.join('my-folder', 'file-1')
+        const id = `1234567890-${filePath}`
         const doc = await this.pouch.byRemoteIdAsync(id)
         doc.remote._id.should.equal(id)
         should.exist(doc._id)
@@ -441,7 +449,8 @@ describe('Pouch', function() {
 
     describe('byRemoteIdMaybe', function() {
       it('does the same as byRemoteId() when document exists', async function() {
-        let id = '12345678901'
+        const filePath = path.join('my-folder', 'file-1')
+        const id = `1234567890-${filePath}`
         const doc = await this.pouch.byRemoteIdMaybeAsync(id)
         doc.remote._id.should.equal(id)
         should.exist(doc._id)

--- a/test/unit/pouch/migrations.js
+++ b/test/unit/pouch/migrations.js
@@ -3,6 +3,7 @@
 
 const should = require('should')
 const sinon = require('sinon')
+const path = require('path')
 
 const { PouchError } = require('../../../core/pouch/error')
 const {
@@ -32,8 +33,14 @@ describe('core/pouch/migrations', function() {
   beforeEach('create folders and files', async function() {
     await pouchHelpers.createParentFolder(this.pouch)
     for (let i of [1, 2, 3]) {
-      await pouchHelpers.createFolder(this.pouch, i)
-      await pouchHelpers.createFile(this.pouch, i)
+      await pouchHelpers.createFolder(
+        this.pouch,
+        path.join('my-folder', `folder-${i}`)
+      )
+      await pouchHelpers.createFile(
+        this.pouch,
+        path.join('my-folder', `file-${i}`)
+      )
     }
   })
 

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -67,8 +67,14 @@ describe('RemoteWatcher', function() {
     await pouchHelpers.createParentFolder(this.pouch)
     // FIXME: Tests pass without folder 3 & file 3
     for (let i of [1, 2, 3]) {
-      await pouchHelpers.createFolder(this.pouch, i)
-      await pouchHelpers.createFile(this.pouch, i)
+      await pouchHelpers.createFolder(
+        this.pouch,
+        path.join('my-folder', `folder-${i}`)
+      )
+      await pouchHelpers.createFile(
+        this.pouch,
+        path.join('my-folder', `file-${i}`)
+      )
     }
   })
 
@@ -1513,15 +1519,16 @@ describe('RemoteWatcher', function() {
     it('calls updateDoc when tags are updated', async function() {
       this.prep.updateFileAsync = sinon.stub()
       this.prep.updateFileAsync.resolves(null)
+      const filePath = path.join('my-folder', 'file-1')
       let remoteDoc /*: RemoteDoc */ = {
-        _id: '12345678901',
+        _id: `1234567890-${filePath}`,
         _rev: '2-abcdef',
         _type: FILES_DOCTYPE,
         dir_id: '23456789012',
         type: 'file',
         path: '/my-folder/file-1',
         name: 'file-1',
-        md5sum: '1111111111111111111111111111111111111111',
+        md5sum: `111111111111111111111111111111111111111${filePath}`,
         tags: ['foo', 'bar', 'baz'],
         updated_at: '2017-01-30T09:09:15.217662611+01:00',
         binary: {
@@ -1542,7 +1549,7 @@ describe('RemoteWatcher', function() {
 
       should(change.type).equal('FileUpdate')
       should(change.doc).have.properties({
-        path: path.normalize('my-folder/file-1'),
+        path: filePath,
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
@@ -1556,8 +1563,9 @@ describe('RemoteWatcher', function() {
     it('calls updateDoc when content is overwritten', async function() {
       this.prep.updateFileAsync = sinon.stub()
       this.prep.updateFileAsync.resolves(null)
+      const filePath = path.join('my-folder', 'file-1')
       let remoteDoc /*: RemoteDoc */ = {
-        _id: '12345678901',
+        _id: `1234567890-${filePath}`,
         _rev: '3-abcdef',
         _type: FILES_DOCTYPE,
         type: 'file',
@@ -1579,7 +1587,7 @@ describe('RemoteWatcher', function() {
 
       should(change.type).equal('FileUpdate')
       should(change.doc).have.properties({
-        path: path.normalize('my-folder/file-1'),
+        path: filePath,
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
@@ -1594,15 +1602,16 @@ describe('RemoteWatcher', function() {
     it('calls moveFile when file is renamed', async function() {
       this.prep.moveFileAsync = sinon.stub()
       this.prep.moveFileAsync.resolves(null)
+      const filePath = path.join('my-folder', 'file-2')
       let remoteDoc /*: RemoteDoc */ = {
-        _id: '12345678902',
+        _id: `1234567890-${filePath}`,
         _rev: '4-abcdef',
         _type: FILES_DOCTYPE,
         type: 'file',
         dir_id: 'whatever',
         path: '/my-folder',
         name: 'file-2-bis',
-        md5sum: '1111111111111111111111111111111111111112',
+        md5sum: `111111111111111111111111111111111111111${filePath}`,
         tags: [],
         updated_at: '2017-01-30T09:09:15.217662611+01:00'
       }
@@ -1619,12 +1628,12 @@ describe('RemoteWatcher', function() {
       // $FlowFixMe
       const src = change.was
       should(src).have.properties({
-        path: path.normalize('my-folder/file-2'),
+        path: filePath,
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
         remote: {
-          _id: '12345678902'
+          _id: `1234567890-${filePath}`
         }
       })
       const dst = change.doc
@@ -1644,15 +1653,16 @@ describe('RemoteWatcher', function() {
     it('calls moveFile when file is moved', async function() {
       this.prep.moveFileAsync = sinon.stub()
       this.prep.moveFileAsync.resolves(null)
+      const filePath = path.join('my-folder', 'file-2')
       let remoteDoc /*: RemoteDoc */ = {
-        _id: '12345678902',
+        _id: `1234567890-${filePath}`,
         _rev: '5-abcdef',
         _type: FILES_DOCTYPE,
         type: 'file',
         dir_id: 'whatever',
         path: '/another-folder/in/some/place',
         name: 'file-2-ter',
-        md5sum: '1111111111111111111111111111111111111112',
+        md5sum: `111111111111111111111111111111111111111${filePath}`,
         tags: [],
         updated_at: '2017-01-30T09:09:15.217662611+01:00',
         binary: {
@@ -1662,9 +1672,7 @@ describe('RemoteWatcher', function() {
           }
         }
       }
-      const was /*: Metadata */ = await this.pouch.db.get(
-        metadata.id(path.normalize('my-folder/file-2'))
-      )
+      const was /*: Metadata */ = await this.pouch.db.get(metadata.id(filePath))
       await this.pouch.db.put(was)
 
       const change /*: RemoteChange */ = this.watcher.identifyChange(
@@ -1679,12 +1687,12 @@ describe('RemoteWatcher', function() {
       // $FlowFixMe
       const src = change.was
       should(src).have.properties({
-        path: path.normalize('my-folder/file-2'),
+        path: filePath,
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
         remote: {
-          _id: '12345678902'
+          _id: `1234567890-${filePath}`
         }
       })
       const dst = change.doc


### PR DESCRIPTION
We found out that when merging a folder move, we could create new
PouchDB records based on records for documents that were not children
of the moved folder.
The source cause of this issue was that the `Pouch.byRecursivePath()`
method would list records whose `_id` started with the moved folder's
`_id` but not necessarily because their associated documents were in
the folder but because they were in a folder who had the same parent
as the moved folder and whose name would start with the moved folder's
name.

E.g. with the given hierarchy:
- `dir/file`
- `dir 2/subdir/subfile`

`Pouch.byRecursivePath('dir')` would list `dir` and `dir/file` as
expected but also `dir 2/subdir` and `dir 2/subdir/subfile`.

To know which documents to return, the method uses an inclusive
documents keys range as a PouchDB query parameter.
This range is string based and selects documents whose `_id` attribute
is within the range, meaning which starts with the range start key but
is no greater (string wise) than the range end key.

To make sure we would not select documents which are not the given
folder path, we need to add the path separator to the start key.
This means that the PouchDB design document building the view against
which the query is run needs to emit keys ending with the same path
separator.
This also means that the method can now only receive full folder paths
(but this is how it was used anyway).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
