### PR TITLE
dev: Use latest cozy-app-dev docker image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   cozy:
     container_name: cozy-desktop-stack
-    image: cozy/cozy-app-dev:1.2.8
+    image: cozy/cozy-app-dev:1.4.11
     ports:
       - "8080:8080"
       - "8025:8025"


### PR DESCRIPTION
This is needed to get the latest cozy-stack version including the the
new document revision in `referenced_by` additions response.
Without this update, our `RemoteCozy.addReferencedBy()` method does
not work and fails tests.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
