### PR TITLE
core/metadata: Use correct mime for Cozy Notes

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -35,7 +35,7 @@
 
 const _ = require('lodash')
 const { clone } = _
-const mime = require('mime')
+const mime = require('./utils/mime')
 const deepDiff = require('deep-diff').diff
 const path = require('path')
 

--- a/core/utils/mime.js
+++ b/core/utils/mime.js
@@ -1,0 +1,15 @@
+const mime = require('mime')
+const path = require('path')
+
+const { NOTE_MIME_TYPE } = require('../remote/constants')
+
+function lookup(filepath) {
+  if (path.extname(filepath) === '.cozy-note') {
+    return NOTE_MIME_TYPE
+  }
+  return mime.lookup(filepath)
+}
+
+module.exports = {
+  lookup
+}

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const mime = require('mime')
+const mime = require('../../../../core/utils/mime')
 const crypto = require('crypto')
 
 const BaseMetadataBuilder = require('./base')

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -33,6 +33,7 @@ const { Ignore } = require('../../core/ignore')
 const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const stater = require('../../core/local/stater')
 const timestamp = require('../../core/utils/timestamp')
+const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
 
 const { platform } = process
 
@@ -858,7 +859,31 @@ describe('metadata', function() {
         docType: 'file',
         md5sum,
         ino: stats.ino,
-        size: 29865
+        size: 29865,
+        mime: 'image/jpeg'
+      })
+      doc.should.have.property('updated_at')
+      should.not.exist(doc.executable)
+
+      const remote = { _id: 'foo', _rev: '456' }
+      should(
+        buildFile('chat-mignon.jpg', stats, md5sum, remote).remote
+      ).deepEqual(remote)
+    })
+
+    it('sets the correct MIME type for Cozy Notes', async function() {
+      const stats = await fse.stat(
+        path.join(__dirname, '../fixtures/chat-mignon.jpg')
+      )
+      const md5sum = '+HBGS7uN4XdB0blqLv5tFQ=='
+      const doc = buildFile('chat-mignon.cozy-note', stats, md5sum)
+      doc.should.have.properties({
+        path: 'chat-mignon.cozy-note',
+        docType: 'file',
+        md5sum,
+        ino: stats.ino,
+        size: 29865,
+        mime: NOTE_MIME_TYPE
       })
       doc.should.have.property('updated_at')
       should.not.exist(doc.executable)

--- a/test/unit/utils/mime.js
+++ b/test/unit/utils/mime.js
@@ -1,0 +1,22 @@
+/* @flow */
+/* eslint-env mocha */
+
+const sysMime = require('mime')
+const should = require('should')
+
+const mime = require('../../../core/utils/mime')
+
+const { NOTE_MIME_TYPE } = require('../../../core/remote/constants')
+
+describe('utils/mime', () => {
+  it('detects the Cozy Notes mime type', () => {
+    should(mime.lookup('My Note.cozy-note')).eql(NOTE_MIME_TYPE)
+  })
+
+  it('returns the same type as the sytem mime for other docs', () => {
+    const filePaths = ['DS100.jpg', 'Report.md', 'stats.xls']
+    const mimes = filePaths.map(filePath => mime.lookup(filePath))
+    const sysMimes = filePaths.map(filePath => sysMime.lookup(filePath))
+    should(mimes).eql(sysMimes)
+  })
+})


### PR DESCRIPTION
The Cozy Notes file extension `.cozy-note` is not a standard,
well-known, extension with its associated mime type detected by OSes
and mime lookup modules like the one we use.

This means we need to wrap our own custom lookup module around the
`mime` module so that we can return the `text/vnd.cozy.note+markdown`
mime type when the given path has a `.cozy-note` extension.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
