### PR TITLE
core/remote: Prevent updates of Notes on Cozy

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -12,6 +12,7 @@ const { posix, sep } = path
 const { RemoteCozy } = require('./cozy')
 const { RemoteWarningPoller } = require('./warning_poller')
 const { RemoteWatcher } = require('./watcher')
+const { NOTE_MIME_TYPE } = require('./constants')
 const { withContentLength } = require('../reader')
 const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
@@ -180,6 +181,14 @@ class Remote /*:: implements Reader, Writer */ {
     doc /*: Metadata */,
     old /*: ?Metadata */
   ) /*: Promise<void> */ {
+    if (doc.mime === NOTE_MIME_TYPE) {
+      log.error(
+        { path: doc.path, doc, old },
+        'Local note updates should not be propagated'
+      )
+      return
+    }
+
     const { path } = doc
     log.info({ path }, 'Uploading new file version...')
 


### PR DESCRIPTION
Cozy Notes are a special kind of documents. Their content is saved in
the associated CoucDB record's metadata. The associated file document
is a markdown export of the original content.
This is what the Desktop client synchronizes on the user's filesystem,
a markdown export.

The client does not have the ability to update Notes documents at the
moment (and probably never will by itself). If a user updates on their
local filesystem the content of `.cozy-note` file, we won't be able to
update the associated Note's content.

Until now, we were allowing the propagation of such updates to the
remote Cozy, breaking in the process the actual Note because we don't
have the required metadata. From there, the only option for the user
to get a working Note back is to create a new one and paste the
markdown content.

We want to avoid this situation and the first step is to prevent the
propagation of local updates to `.cozy-note` files to the remote Cozy.
This will prevent the client from breaking the Note but the document
will be desynchronized and the local content will be lost when
propagating the next remote change on the Note (i.e. update, move…).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
