### PR TITLE
core/merge: Allow trashing docs moved on same side

### DIFF
--- a/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
+++ b/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
@@ -3,11 +3,6 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  disabled: {
-    'atom/linux': 'Does not work with AtomWatcher yet.',
-    'local/darwin': 'Does not work with all flush points',
-    stopped: 'Does not work with AtomWatcher yet.'
-  },
   side: 'local',
   init: [
     { ino: 1, path: 'dst/' },


### PR DESCRIPTION
We recently decided that moving a document on one side (i.e. either on
the local filesystem or the remote Cozy) would cancel any trashing of
the same document on the other side (see 6c298b6).

However, we still want to trash documents which have been moved on the
same side without the move being synchronized yet. This is because the
user has deleted the document at its new location so we believe they
know what they're doing.

This part stopped working when we implemented the "protection" but we
did not catch this change in behavior because of issues with our tests
captures.
Now that the captures reflect the correct client behavior we can see
that trashing a document moved on the same side would not get
propagated and we can fix it. This is achieved by making sure we
cancel the trashing only if the current side is out of date (i.e. the
move happened on the other side).

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
