### PR TITLE
test/scenarios: Disable scenario on all platforms

### DIFF
--- a/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
+++ b/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
@@ -3,12 +3,8 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  disabled: {
-    'atom/linux': 'Does not work with AtomWatcher yet.',
-    'local/darwin': 'Does not work with all flush points',
-    stopped: 'Does not work with AtomWatcher yet.'
-  },
   side: 'local',
+  disabled: 'Does not work yet on all watchers',
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },


### PR DESCRIPTION
This scenario was not disabled on Windows while it won't work on this
platform as on any other platform since the Merge logic to handle it
is not in place.
