### PR TITLE
core/remote: Stop creating missing remote parent

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -111,7 +111,7 @@ class Remote /*:: implements Reader, Writer */ {
     log.info({ path }, 'Creating folder...')
 
     const [parentPath, name] = dirAndName(doc.path)
-    const parent /*: RemoteDoc */ = await this.remoteCozy.findOrCreateDirectoryByPath(
+    const parent /*: RemoteDoc */ = await this.remoteCozy.findDirectoryByPath(
       parentPath
     )
     let dir /*: RemoteDoc */

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -302,7 +302,11 @@ class Remote /*:: implements Reader, Writer */ {
     )
 
     const { overwrite } = newMetadata
-    if (overwrite && overwrite.remote._id !== oldMetadata.remote._id) {
+    if (
+      overwrite &&
+      overwrite.remote &&
+      overwrite.remote._id !== oldMetadata.remote._id
+    ) {
       const referencedBy = await this.remoteCozy.getReferencedBy(
         overwrite.remote._id
       )

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -19,6 +19,7 @@ const { ensureValidPath } = metadata
 const Prep = require('../../../core/prep')
 const remote = require('../../../core/remote')
 const { Remote } = remote
+const { DirectoryNotFound } = require('../../../core/remote/cozy')
 const { TRASH_DIR_ID } = require('../../../core/remote/constants')
 const timestamp = require('../../../core/utils/timestamp')
 
@@ -302,13 +303,14 @@ describe('remote.Remote', function() {
       })
     })
 
-    it('creates the parent folder when missing', async function() {
+    it('throws an error if the parent folder is missing', async function() {
       const doc /*: Metadata */ = builders
         .metadir()
         .path(path.join('foo', 'bar', 'qux'))
         .build()
-      await this.remote.addFolderAsync(doc)
-      await should(cozy.files.statByPath('/foo/bar')).be.fulfilled()
+      await should(this.remote.addFolderAsync(doc)).be.rejectedWith(
+        DirectoryNotFound
+      )
     })
   })
 


### PR DESCRIPTION
For a long time, we've been creating the remote parent it it was
missing when creating a new folder on the remote Cozy.
This was done to simplify the creation of complex hierarchies but
erroring out here would force a retry after other changes have been
propagating and the parent would probably be created at that point.

On the other hand, trying to pro-actively create the parent can lead
to errors when the parent of a change is issued from a move since we
won't be able to synchronize the parent moved (i.e. a document would
already exist at the target location and the stack would refuse the
move).
We can see this issue in the following scenarios:
- test/scenarios/create_dir_into_moved_one/local/darwin.json flushAfter=0
- test/scenarios/move_dir_and_update_subfile/local/darwin.json flushAfter=0
- test/scenarios/move_dir_and_update_subfile/local/darwin.json flushAfter=3
- test/scenarios/move_dir_and_update_subfile/local/darwin.json flushAfter=5

This change should not create issues as events for new parent folders
should be emitted anyway.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
