### PR TITLE
core/merge: Create conflict on local Note edit

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -488,19 +488,6 @@ class Local /*:: implements Reader, Writer */ {
     copy.path = backupPath
     return copy
   }
-
-  /** Rename a file/folder to resolve a conflict */
-  renameConflictingDoc(
-    doc /*: Metadata */,
-    newPath /*: string */,
-    callback /*: Callback */
-  ) {
-    log.info({ path: doc.path }, `Resolve a conflict: ${doc.path} → ${newPath}`)
-    let srcPath = path.join(this.syncPath, doc.path)
-    let dstPath = path.join(this.syncPath, newPath)
-    fse.rename(srcPath, dstPath, callback)
-    // TODO: Don't fire an event for the deleted file?
-  }
 }
 
 module.exports = Local

--- a/core/move.js
+++ b/core/move.js
@@ -58,7 +58,7 @@ function convertToDestinationAddition(
 ) {
   // Delete source
   if (src.moveTo) delete src.moveTo
-  metadata.markAsUnsyncable(side, src)
+  metadata.markAsUnsyncable(src)
 
   // Create destination
   if (dst.moveFrom) delete dst.moveFrom

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -405,19 +405,6 @@ class Remote /*:: implements Reader, Writer */ {
     }
     return flatSubdomains
   }
-
-  // TODO add tests
-  async renameConflictingDocAsync(
-    doc /*: Metadata */,
-    newPath /*: string */
-  ) /*: Promise<void> */ {
-    const { path } = doc
-    log.info({ path }, `Resolve a conflict: ${path} → ${newPath}`)
-    const newName = dirAndName(newPath)[1]
-    await this.remoteCozy.updateAttributesById(doc.remote._id, {
-      name: newName
-    })
-  }
 }
 
 /** Extract the remote parent path and leaf name from a local path */

--- a/core/writer.js
+++ b/core/writer.js
@@ -20,6 +20,5 @@ export interface Writer {
   assignNewRev (doc: Metadata): Promise<void>;
   trashAsync (doc: Metadata): Promise<void>;
   deleteFolderAsync (doc: Metadata): Promise<void>;
-  renameConflictingDocAsync (doc: Metadata, newPath: string): Promise<void>;
 }
 */

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -1,0 +1,221 @@
+/* @flow */
+/* eslint-env mocha */
+
+const should = require('should')
+const fse = require('fs-extra')
+const path = require('path')
+
+const Builders = require('../support/builders')
+const TestHelpers = require('../support/helpers')
+const configHelpers = require('../support/helpers/config')
+const cozyHelpers = require('../support/helpers/cozy')
+const pouchHelpers = require('../support/helpers/pouch')
+
+const { NOTE_MIME_TYPE, TRASH_DIR_ID } = require('../../core/remote/constants')
+
+describe('Note update', () => {
+  let builders, helpers
+
+  before(configHelpers.createConfig)
+  before(configHelpers.registerClient)
+  beforeEach(pouchHelpers.createDatabase)
+  beforeEach(cozyHelpers.deleteAll)
+
+  afterEach(pouchHelpers.cleanDatabase)
+  after(configHelpers.cleanConfig)
+
+  beforeEach(async function() {
+    builders = new Builders({ cozy: cozyHelpers.cozy })
+    helpers = TestHelpers.init(this)
+
+    await helpers.local.clean()
+    await helpers.local.setupTrash()
+    await helpers.remote.ignorePreviousChanges()
+  })
+
+  let note
+  beforeEach('create note', async () => {
+    note = await builders
+      .remoteFile()
+      .contentType(NOTE_MIME_TYPE)
+      .name('note.cozy-note')
+      .data('Initial content')
+      .timestamp(2018, 5, 15, 21, 1, 53)
+      .create()
+    await helpers.pullAndSyncAll()
+  })
+
+  describe('on remote Cozy', () => {
+    beforeEach('update remote note', async () => {
+      await builders
+        .remoteFile(note)
+        .data('updated content')
+        .update()
+      await helpers.pullAndSyncAll()
+    })
+
+    it('updates the note content on the filesystem', async () => {
+      should(await helpers.local.syncDir.readFile('note.cozy-note')).eql(
+        'updated content'
+      )
+    })
+
+    it('leaves the note in read-only mode', async () => {
+      const expectedErrorCode =
+        process.platform === 'win32' ? /EPERM/ : /EACCES/
+      await should(
+        fse.access(
+          helpers.local.syncDir.abspath('note.cozy-note'),
+          fse.constants.F_OK | fse.constants.W_OK
+        )
+      ).be.rejectedWith(expectedErrorCode)
+    })
+  })
+
+  describe('on local filesystem', () => {
+    beforeEach('update local note', async () => {
+      await helpers.local.syncDir.chmod('note.cozy-note', 0o777)
+      await helpers.local.syncDir.outputFile(
+        'note.cozy-note',
+        'updated content'
+      )
+      await helpers.flushLocalAndSyncAll()
+    })
+
+    it('renames the original remote note with a conflict suffix', async () => {
+      const updatedRemote = await helpers.remote.byIdMaybe(note._id)
+      should(updatedRemote)
+        .have.property('name')
+        .match(/-conflict-/)
+      should(updatedRemote).have.properties({
+        md5sum: note.md5sum,
+        dir_id: note.dir_id
+      })
+    })
+
+    it('uploads the new content to the Cozy', async () => {
+      should(await helpers.remote.readFile('note.cozy-note')).eql(
+        'updated content'
+      )
+    })
+  })
+})
+
+describe('Note move with update', () => {
+  let builders, helpers
+
+  before(configHelpers.createConfig)
+  before(configHelpers.registerClient)
+  beforeEach(pouchHelpers.createDatabase)
+  beforeEach(cozyHelpers.deleteAll)
+
+  afterEach(pouchHelpers.cleanDatabase)
+  after(configHelpers.cleanConfig)
+
+  beforeEach(async function() {
+    builders = new Builders({ cozy: cozyHelpers.cozy })
+    helpers = TestHelpers.init(this)
+
+    await helpers.local.clean()
+    await helpers.local.setupTrash()
+    await helpers.remote.ignorePreviousChanges()
+  })
+
+  let dst, note
+  beforeEach('create note', async () => {
+    dst = await builders
+      .remoteDir()
+      .name('dst')
+      .create()
+    note = await builders
+      .remoteFile()
+      .contentType(NOTE_MIME_TYPE)
+      .name('note.cozy-note')
+      .data('Initial content')
+      .timestamp(2018, 5, 15, 21, 1, 53)
+      .create()
+    await helpers.pullAndSyncAll()
+  })
+
+  context('on local filesystem', () => {
+    const srcPath = 'note.cozy-note'
+    const dstPath = path.normalize('dst/note.cozy-note')
+
+    beforeEach('move and update local note', async () => {
+      await helpers.local.syncDir.move(srcPath, dstPath)
+      await helpers.local.syncDir.chmod(dstPath, 0o777)
+      await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+      await helpers.flushLocalAndSyncAll()
+    })
+
+    it('moves the original remote note then rename it with a conflict suffix', async () => {
+      const updatedRemote = await helpers.remote.byIdMaybe(note._id)
+      should(updatedRemote)
+        .have.property('name')
+        .match(/-conflict-/)
+      should(updatedRemote).have.properties({
+        md5sum: note.md5sum,
+        dir_id: dst._id
+      })
+    })
+
+    it('uploads the new content to the Cozy at the target location', async () => {
+      should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+        'updated content'
+      )
+    })
+  })
+
+  describe('overwriting existing note at target location', () => {
+    const srcPath = 'note.cozy-note'
+    const dstPath = path.normalize('dst/note.cozy-note')
+
+    let existing
+    beforeEach('create note at target location', async () => {
+      existing = await builders
+        .remoteFile()
+        .inDir(dst)
+        .contentType(NOTE_MIME_TYPE)
+        .name('note.cozy-note')
+        .data('overwritten content')
+        .timestamp(2018, 5, 15, 21, 1, 53)
+        .create()
+      await helpers.pullAndSyncAll()
+    })
+    beforeEach('move and update local note', async () => {
+      await helpers.local.syncDir.chmod(dstPath, 0o777)
+      await helpers.local.syncDir.move(srcPath, dstPath, { overwrite: true })
+      await helpers.local.syncDir.chmod(dstPath, 0o777)
+      await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+      await helpers.flushLocalAndSyncAll()
+    })
+
+    context('on local filesystem', () => {
+      it('moves the original remote note then rename it with a conflict suffix', async () => {
+        const updatedRemote = await helpers.remote.byIdMaybe(note._id)
+        should(updatedRemote)
+          .have.property('name')
+          .match(/-conflict-/)
+        should(updatedRemote).have.properties({
+          md5sum: note.md5sum,
+          dir_id: dst._id
+        })
+      })
+
+      it('uploads the new content to the Cozy at the target location', async () => {
+        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+          'updated content'
+        )
+      })
+
+      it('sends the overwritten note to the trash', async () => {
+        should(await helpers.remote.byIdMaybe(existing._id)).have.properties({
+          md5sum: existing.md5sum,
+          name: existing.name,
+          dir_id: TRASH_DIR_ID,
+          trashed: true
+        })
+      })
+    })
+  })
+})

--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -155,7 +155,12 @@ class ContextDir {
     return fse.outputFile(this.abspath(target), data)
   }
 
-  async move(src /*: string */, dst /*: string */) {
+  async move(
+    src /*: string */,
+    dst /*: string */,
+    opts /*: { overwrite: boolean } */ = { overwrite: false }
+  ) {
+    if (opts.overwrite) await this.remove(dst)
     return fse.rename(this.abspath(src), this.abspath(dst))
   }
 

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -785,25 +785,4 @@ describe('Local', function() {
       )
     })
   })
-
-  describe('renameConflictingDoc', () =>
-    it('renames the file', async function() {
-      let doc = {
-        path: 'conflict/file',
-        updated_at: new Date('2015-10-08T05_05_09Z')
-      }
-      let newPath = 'conflict/file-conflict-2015-10-09T05_05_10Z'
-      let srcPath = syncDir.abspath(doc.path)
-      let dstPath = syncDir.abspath(newPath)
-      fse.ensureDirSync(path.dirname(srcPath))
-      fse.writeFileSync(srcPath, 'foobar')
-      await this.local.renameConflictingDocAsync(doc, newPath)
-      fse.existsSync(srcPath).should.be.false()
-      fse
-        .statSync(dstPath)
-        .isFile()
-        .should.be.true()
-      let enc = { encoding: 'utf-8' }
-      fse.readFileSync(dstPath, enc).should.equal('foobar')
-    }))
 })

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -84,8 +84,8 @@ describe('Merge', function() {
   beforeEach('instanciate merge', function() {
     this.side = 'local'
     this.merge = new Merge(this.pouch)
-    this.merge.local = { renameConflictingDocAsync: sinon.stub().resolves() }
-    this.merge.remote = { renameConflictingDocAsync: sinon.stub().resolves() }
+    this.merge.local = { moveAsync: sinon.stub().resolves() }
+    this.merge.remote = { moveAsync: sinon.stub().resolves() }
     builders = new Builders({ pouch: this.pouch })
   })
   afterEach('clean pouch', pouchHelpers.cleanDatabase)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -28,7 +28,12 @@ async function mergeSideEffects(
 ) {
   const { last_seq: lastSeq } = await pouch.db.changes({ since: 'now' })
 
-  sinon.spy(merge, 'resolveConflictAsync')
+  if (merge.resolveConflictAsync.restore) merge.resolveConflictAsync.restore()
+  const { resolveConflictAsync } = merge
+  sinon.stub(merge, 'resolveConflictAsync').callsFake((...args) => {
+    const clones = args.map(arg => _.cloneDeep(arg))
+    return resolveConflictAsync(...clones)
+  })
 
   await mergeCall()
 

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -1295,22 +1295,21 @@ describe('Merge', function() {
         this.merge.moveFileAsync('local', _.cloneDeep(doc), _.cloneDeep(was))
       )
 
+      const unsyncedFile = _.defaults(
+        {
+          sides: {},
+          _deleted: true
+        },
+        _.omit(was, ['_rev', 'remote'])
+      )
+      const fileAddition = _.defaults(
+        {
+          sides: { target: 1, local: 1 }
+        },
+        doc
+      )
       should(sideEffects).deepEqual({
-        savedDocs: [
-          _.defaults(
-            {
-              sides: increasedSides(was.sides, 'local', 1),
-              _deleted: true
-            },
-            _.omit(was, ['_rev'])
-          ),
-          _.defaults(
-            {
-              sides: { target: 1, local: 1 }
-            },
-            doc
-          )
-        ],
+        savedDocs: [unsyncedFile, fileAddition],
         resolvedConflicts: []
       })
     })
@@ -1689,24 +1688,22 @@ describe('Merge', function() {
         this.merge.moveFolderAsync('local', _.cloneDeep(doc), _.cloneDeep(was))
       )
 
-      const movedSrc = _.defaults(
+      const unsyncedFolder = _.defaults(
         {
-          sides: increasedSides(was.sides, 'local', 1),
+          sides: {},
           _deleted: true
         },
-        was
+        _.omit(was, ['_rev', 'fileid', 'remote'])
+      )
+      const folderAddition = _.defaults(
+        {
+          sides: { target: 1, local: 1 }
+        },
+        _.pick(was, ['ino']),
+        _.omit(doc, ['_rev', 'fileid'])
       )
       should(sideEffects).deepEqual({
-        savedDocs: [
-          _.omit(movedSrc, ['_rev', 'fileid']),
-          _.defaults(
-            {
-              sides: { target: 1, local: 1 }
-            },
-            _.pick(was, ['ino']),
-            _.omit(doc, ['_rev', 'fileid'])
-          )
-        ],
+        savedDocs: [unsyncedFolder, folderAddition],
         resolvedConflicts: []
       })
     })
@@ -2322,10 +2319,10 @@ describe('Merge', function() {
           ),
           _.defaults(
             {
-              sides: increasedSides(unsyncedFile.sides, this.side, 1),
+              sides: {},
               _deleted: true
             },
-            _.omit(unsyncedFile, ['_rev'])
+            _.omit(unsyncedFile, ['_rev', 'remote'])
           ),
           _.defaults(
             {
@@ -2386,10 +2383,10 @@ describe('Merge', function() {
           ),
           _.defaults(
             {
-              sides: { target: 2, [otherSide(this.side)]: 2 },
+              sides: {},
               _deleted: true
             },
-            _.omit(unsyncedFile, ['_rev']) // TODO: Compare _revs
+            _.omit(unsyncedFile, ['_rev', 'remote']) // TODO: Compare _revs
           ),
           _.defaults(
             {

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -6,7 +6,6 @@ const crypto = require('crypto')
 const EventEmitter = require('events')
 const fse = require('fs-extra')
 const _ = require('lodash')
-const { pick } = _
 const path = require('path')
 const sinon = require('sinon')
 const should = require('should')
@@ -892,28 +891,6 @@ describe('remote.Remote', function() {
       doc.path = 'dst-dir/foo' // File metadata was updated as part of the move
       await this.remote.assignNewRev(doc)
       should(doc).deepEqual(metadata.fromRemoteDoc(remote.dst.foo))
-    })
-  })
-
-  describe('renameConflictingDocAsync', () => {
-    it('renames the file/folder', async function() {
-      const remoteDoc /*: RemoteDoc */ = await builders
-        .remoteFile()
-        .name('cat9')
-        .create()
-      const src /*: Metadata */ = metadata.fromRemoteDoc(remoteDoc)
-      ensureValidPath(src)
-      const newPath = 'cat9-conflict-2015-12-01T01:02:03Z.jpg'
-      await this.remote.renameConflictingDocAsync(src, newPath)
-      const file /*: JsonApiDoc */ = await cozy.files.statById(remoteDoc._id)
-      should(file.attributes).have.properties(
-        _.merge(
-          {
-            name: newPath
-          },
-          pick(remoteDoc, ['dir_id', 'type', 'updated_at', 'size', 'md5sum'])
-        )
-      )
     })
   })
 })


### PR DESCRIPTION
Cozy Notes are a special kind of document. Their content lives within
their CouchDB record metadata and the associated file is only a
markdown export.
Besides, the stack is not able to re-import markdown into a Cozy Note
document for the moment.

This means that if a synchronized Cozy Note file is edited on the
user's local filesystem, we won't be able to import the new content
into the remote Cozy Note. On a side note, the client does not handle
remote records metadata so the edited CouchDB record will lose the
original Cozy Note content.

We've added some protections by forbidding the propagation of local
Note edits but this means the Note will be de-synchronized with
different contents locally and on the remote Cozy.
In case the Note is edited again, via the Cozy Note app this time, the
local content will be overwritten with the new markdown export and the
locally edited content will be lost.

To avoid losing this content we can create a conflict on local Notes
edits so that the original Note will keep its metadata and actual
content and a new markdown file will be uploaded to the remote Cozy
with the newly edited content.
Since users can keep their editor open when saving the new local
content, we can't change the name of the local file and have to rename
the remote file, thus the original Note.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
