### PR TITLE
core/local/index: Remove Notes read-only limit

### DIFF
--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 
 const should = require('should')
-const fse = require('fs-extra')
 const path = require('path')
 
 const Builders = require('../support/builders')
@@ -58,17 +57,6 @@ describe('Note update', () => {
       should(await helpers.local.syncDir.readFile('note.cozy-note')).eql(
         'updated content'
       )
-    })
-
-    it('leaves the note in read-only mode', async () => {
-      const expectedErrorCode =
-        process.platform === 'win32' ? /EPERM/ : /EACCES/
-      await should(
-        fse.access(
-          helpers.local.syncDir.abspath('note.cozy-note'),
-          fse.constants.F_OK | fse.constants.W_OK
-        )
-      ).be.rejectedWith(expectedErrorCode)
     })
   })
 


### PR DESCRIPTION
Synchronized Cozy Notes are a special kind of files because they're
only a markdown export of the actual Note's content.
When modifying this export, the actual Note is not updated and the
client can even break it since it won't send the entire metadata which
contains the actual content to the stack.

To help users in understanding those files should not be modified, we
thought that making them read-only would offer a good experience.

However, we've seen that some modifications can still be detected by
the Desktop client even without the user actually modifying the files
and also that the read-only limitation can be overridden by the user
anyway.
So we implemented some measures to avoid propagating those
modifications to the Cozy and create a conflicting document instead to
back up the new content on the remote server anyway.

Besides, we found out that the read-only limitation would also apply
to the Desktop client on Windows and was preventing us from
propagating remote Notes changes to the local disk.
To mitigate this, we added an extra step to the local `addFileAsync()`
method for Notes. We would change the file's permissions before
overwriting it with the new version and set back the read-only limit
on the new file.
We recently encountered a timing issue with this extra step that would
trigger a change even for the file's location with its old metadata
(e.g. its old version's size) which would eventually be propagated to
the remote Cozy as an actual metadata change, reverting the remote
metadata to its prior version.

Managing this timing issue seems a bit tricky and we decided that
removing the read-only limit would be easier. We're also not likely to
break Notes anymore with the conflict creation we introduced and we'll
want to import local modifications made to Notes in the future so this
seems like the right decision.

We'll need to change the existing files' permissions though. To avoid
creating events and trigger unnecessary changes we chose to migrate
the permissions only on Notes that are modified. Since changing the
old version's permissions would bring back the timing problem, we
settled for another solution: we'll try to overwrite the destination
file and if it does not work because of permissions, we'll remove the
destination file before moving the new one in its stead.
There still exist a change of seeing a timing issue with the deleted
event making its way to the `Merge` module but it's less likely
because the `overwrite` step of the Atom watcher applies a 400ms delay
on `deleted` events to merge them with `created` events on the same
path fired later and should thus merge the `deleted` event with the
`created` event fired by the new file version creation. For
comparison, the permissions timing issue is due to the lower 200ms
`await_write_finish` step delay.
We won't have any issue on macOS because the Chokidar watcher waits 7s
after the last local event has been fired before flushing all buffered
events and will merge the `deleted` and `created` events as well.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
