### PR TITLE
core/remote/index: Set rev after moving references

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -346,7 +346,11 @@ class Remote /*:: implements Reader, Writer */ {
       const referencedBy = await this.remoteCozy.getReferencedBy(
         overwrite.remote._id
       )
-      await this.remoteCozy.addReferencedBy(newRemoteDoc._id, referencedBy)
+      const { _rev } = await this.remoteCozy.addReferencedBy(
+        newRemoteDoc._id,
+        referencedBy
+      )
+      newMetadata.remote._rev = _rev
     }
   }
 

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -88,6 +88,12 @@ module.exports = class RemoteBaseBuilder {
     return this
   }
 
+  referencedBy(refs /*: Array<{ _id: string, _type: string }> */) /*: this */ {
+    // $FlowFixMe exists only in RemoteBuilders documents
+    this.remoteDoc.referenced_by = refs
+    return this
+  }
+
   build() /*: Object */ {
     return _.clone(this.remoteDoc)
   }

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -3,7 +3,8 @@
 
 require('../../../core/globals')
 
-const CozyClient = require('cozy-client-js').Client
+const OldCozyClient = require('cozy-client-js').Client
+const CozyClient = require('cozy-client').default
 
 const {
   FILES_DOCTYPE,
@@ -34,15 +35,26 @@ if (!process.env.COZY_STACK_TOKEN) {
 }
 
 // A cozy-client-js instance
-const cozy = new CozyClient({
+const cozy = new OldCozyClient({
   cozyURL: COZY_URL,
   token: process.env.COZY_STACK_TOKEN
 })
 
+// Build a new cozy-client instance from an old cozy-client-js instance
+const newClient = async (
+  oldClient /*: OldCozyClient */
+) /*: Promise<CozyClient>  */ => {
+  if (oldClient._oauth) {
+    return await CozyClient.fromOldOAuthClient(oldClient)
+  } else {
+    return await CozyClient.fromOldClient(oldClient)
+  }
+}
 
 module.exports = {
   COZY_URL,
   cozy,
+  newClient,
   deleteAll
 }
 

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -10,7 +10,6 @@ const {
   ROOT_DIR_ID,
   TRASH_DIR_ID
 } = require('../../../core/remote/constants')
-const Builders = require('../builders')
 
 // The URL of the Cozy instance used for tests
 const COZY_URL = process.env.COZY_URL || 'http://cozy.tools:8080'
@@ -40,15 +39,11 @@ const cozy = new CozyClient({
   token: process.env.COZY_STACK_TOKEN
 })
 
-// Facade for all the test data builders
-const builders = new Builders({ cozy })
 
 module.exports = {
   COZY_URL,
   cozy,
-  builders,
-  deleteAll,
-  createTheCouchdbFolder
+  deleteAll
 }
 
 // List files and directories in the root directory
@@ -76,15 +71,4 @@ async function deleteAll() {
   }
 
   return cozy.files.clearTrash()
-}
-
-// Creates a root directory named 'couchdb-folder', used in a lot of v2 tests.
-//
-// TODO: Use test data builders instead
-async function createTheCouchdbFolder() {
-  await builders
-    .remoteDir()
-    .name('couchdb-folder')
-    .inRootDir()
-    .create()
 }

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -20,10 +20,12 @@ const {
 } = require('../../../core/remote/cozy')
 
 const configHelpers = require('../../support/helpers/config')
-const { COZY_URL, builders, deleteAll } = require('../../support/helpers/cozy')
+const { COZY_URL, cozy, deleteAll } = require('../../support/helpers/cozy')
 const CozyStackDouble = require('../../support/doubles/cozy_stack')
+const Builders = require('../../support/builders')
 
 const cozyStackDouble = new CozyStackDouble()
+const builders = new Builders({ cozy })
 
 describe('core/remote/cozy', () => {
   describe('.handleCommonCozyErrors()', () => {
@@ -281,12 +283,10 @@ describe('RemoteCozy', function() {
   describe('findDirectoryByPath', function() {
     it('resolves when the directory exists remotely', async function() {
       const dir = await builders.remoteDir().create()
-      delete dir.cozyMetadata
       const subdir = await builders
         .remoteDir()
         .inDir(dir)
         .create()
-      delete subdir.cozyMetadata
 
       const foundDir = await remoteCozy.findDirectoryByPath(dir.path)
       should(foundDir).have.properties(dir)

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -27,12 +27,10 @@ const timestamp = require('../../../core/utils/timestamp')
 
 const configHelpers = require('../../support/helpers/config')
 const pouchHelpers = require('../../support/helpers/pouch')
-const {
-  cozy,
-  builders,
-  deleteAll,
-  createTheCouchdbFolder
-} = require('../../support/helpers/cozy')
+const { cozy, deleteAll } = require('../../support/helpers/cozy')
+const Builders = require('../../support/builders')
+
+const builders = new Builders({ cozy })
 
 /*::
 import type { Metadata } from '../../../core/metadata'
@@ -50,7 +48,13 @@ describe('remote.Remote', function() {
     this.remote = new Remote(this)
   })
   beforeEach(deleteAll)
-  beforeEach(createTheCouchdbFolder)
+  beforeEach('create the couchdb folder', async function() {
+    await builders
+      .remoteDir()
+      .name('couchdb-folder')
+      .inRootDir()
+      .create()
+  })
   after('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
 

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -767,6 +767,93 @@ describe('remote.Remote', function() {
         })
       })
     })
+
+    context('when overwriting an existing file', function() {
+      const existingRefs = [{ _id: 'blah', _type: 'io.cozy.photos.albums' }]
+
+      let existing /*: Metadata */
+      let old /*: Metadata */
+      let doc /*: Metadata */
+      let newDir /*: RemoteDoc */
+
+      beforeEach(async () => {
+        newDir = await builders
+          .remoteDir()
+          .name('moved-to')
+          .inRootDir()
+          .create()
+
+        const remote1 /*: RemoteDoc */ = await builders
+          .remoteFile()
+          .inDir(newDir)
+          .name('cat7.jpg')
+          .data('woof')
+          .referencedBy(existingRefs)
+          .create()
+        existing = metadata.fromRemoteDoc(remote1)
+
+        const remote2 /*: RemoteDoc */ = await builders
+          .remoteFile()
+          .name('cat6.jpg')
+          .data('meow')
+          .create()
+        old = metadata.fromRemoteDoc(remote2)
+
+        doc = _.defaults(
+          {
+            path: path.normalize('moved-to/cat7.jpg'),
+            name: 'cat7.jpg',
+            overwrite: existing,
+            remote: undefined
+          },
+          old
+        )
+      })
+
+      it('moves the file', async function() {
+        await this.remote.moveAsync(doc, old)
+
+        should(doc.remote._id).equal(old.remote._id)
+        should(doc.remote._rev).not.equal(old.remote._rev)
+        const file = await cozy.files.statById(doc.remote._id)
+        should(file).have.properties({
+          _id: old.remote._id,
+          _rev: doc.remote._rev
+        })
+        should(file.attributes).have.properties({
+          dir_id: newDir._id,
+          name: 'cat7.jpg',
+          type: 'file',
+          updated_at: doc.updated_at,
+          size: '4'
+        })
+      })
+
+      it('trashes the existing file at target location', async function() {
+        await this.remote.moveAsync(doc, old)
+
+        should(
+          (await cozy.files.statById(existing.remote._id)).attributes
+        ).have.property('trashed', true)
+      })
+
+      it('transfers the existing file references to the moved one', async function() {
+        await this.remote.moveAsync(doc, old)
+
+        should(
+          (await cozy.files.statById(doc.remote._id)).relationships
+            .referenced_by.data
+        ).eql(existingRefs.map(ref => ({ id: ref._id, type: ref._type })))
+      })
+
+      it('updates the doc revision', async function() {
+        await this.remote.moveAsync(doc, old)
+
+        should((await cozy.files.statById(doc.remote._id))._rev).eql(
+          doc.remote._rev
+        )
+      })
+    })
   })
 
   describe('trash', () => {

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -10,11 +10,10 @@ const { Remote } = require('../../../core/remote')
 
 const configHelpers = require('../../support/helpers/config')
 const pouchHelpers = require('../../support/helpers/pouch')
-const {
-  deleteAll,
-  createTheCouchdbFolder
-} = require('../../support/helpers/cozy')
+const cozyHelpers = require('../../support/helpers/cozy')
+const Builders = require('../../support/builders')
 
+const builders = new Builders({ cozy: cozyHelpers.cozy })
 /*::
 import type { Metadata } from '../../../core/metadata'
 import type { RemoteDoc, JsonApiDoc } from '../../../core/remote/document'
@@ -30,8 +29,14 @@ describe('Remote', function() {
     this.events = new EventEmitter()
     this.remote = new Remote(this)
   })
-  beforeEach(deleteAll)
-  beforeEach(createTheCouchdbFolder)
+  beforeEach(cozyHelpers.deleteAll)
+  beforeEach('create the couchdb folder', async function() {
+    await builders
+      .remoteDir()
+      .name('couchdb-folder')
+      .inRootDir()
+      .create()
+  })
   after('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
 

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -14,7 +14,8 @@ const configHelpers = require('../../support/helpers/config')
 const { posixifyPath } = require('../../support/helpers/context_dir')
 const { onPlatform, onPlatforms } = require('../../support/helpers/platform')
 const pouchHelpers = require('../../support/helpers/pouch')
-const { builders } = require('../../support/helpers/cozy')
+const cozyHelpers = require('../../support/helpers/cozy')
+const Builders = require('../../support/builders')
 
 const metadata = require('../../../core/metadata')
 const { FILES_DOCTYPE } = require('../../../core/remote/constants')
@@ -27,6 +28,7 @@ const { MergeMissingParentError } = require('../../../core/merge')
 const { RemoteWatcher } = require('../../../core/remote/watcher')
 
 const { assignId, ensureValidPath } = metadata
+const builders = new Builders({ cozy: cozyHelpers.cozy })
 
 /*::
 import type { RemoteChange } from '../../../core/remote/change'


### PR DESCRIPTION
When we propagate a local overwriting move, we want to keep the
references from the overwritten document and add them to the moved
one.

We therefore apply multiple operations on the remote version of the
moved document. This means we need to update the remote revision of
our local version of the document after each operation to be able to
run the next one.
However, after adding the new references, now the last operation of
our move, we would not update the revision.

This would prevent running other operations on the remote document
until the next remote watcher cycle (which would then update the
remote revision).
We would face this issue if the moved document was also locally edited
for example.

We simply update the remote revision on our document after
transferring the references and we added tests for the 
`Remote.moveAsync()` method, including a check on the revision.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
