### PR TITLE
core: Use more attributes to identify Cozy Notes

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -13,7 +13,7 @@ const move = require('./move')
 const { otherSide } = require('./side')
 const logger = require('./utils/logger')
 const timestamp = require('./utils/timestamp')
-const { NOTE_MIME_TYPE } = require('./remote/constants')
+const { isNote } = require('./utils/notes')
 
 /*::
 import type { IdConflictInfo } from './IdConflict'
@@ -306,7 +306,7 @@ class Merge {
         if (doc.mime == null) {
           doc.mime = file.mime
         }
-      } else if (side === 'local' && file.mime === NOTE_MIME_TYPE) {
+      } else if (side === 'local' && isNote(file)) {
         // We'll need a reference to the "overwritten" note during the conflict
         // resolution.
         doc.overwrite = file
@@ -449,11 +449,7 @@ class Merge {
           }
           await this.ensureParentExistAsync(side, doc)
 
-          if (
-            side === 'local' &&
-            doc.mime === NOTE_MIME_TYPE &&
-            doc.md5sum !== was.md5sum
-          ) {
+          if (side === 'local' && isNote(was) && doc.md5sum !== was.md5sum) {
             return this.resolveNoteConflict(doc, was)
           }
 
@@ -471,11 +467,7 @@ class Merge {
       } else {
         await this.ensureParentExistAsync(side, doc)
 
-        if (
-          side === 'local' &&
-          doc.mime === NOTE_MIME_TYPE &&
-          doc.md5sum !== was.md5sum
-        ) {
+        if (side === 'local' && isNote(was) && doc.md5sum !== was.md5sum) {
           return this.resolveNoteConflict(doc, was)
         }
 

--- a/core/merge.js
+++ b/core/merge.js
@@ -418,27 +418,6 @@ class Merge {
       return this.addFileAsync(side, doc)
     } else if (was.sides && was.sides[side]) {
       metadata.assignMaxDate(doc, was)
-      if (doc.size == null) {
-        doc.size = was.size
-      }
-      if (doc.class == null) {
-        doc.class = was.class
-      } // FIXME: Seems useless since metadata.buildFile adds it
-      if (doc.mime == null) {
-        doc.mime = was.mime
-      } // FIXME: Seems useless since metadata.buildFile adds it
-      if (doc.tags == null) {
-        doc.tags = was.tags || []
-      }
-      if (doc.ino == null) {
-        doc.ino = was.ino
-      }
-      if (doc.fileid == null) {
-        doc.fileid = was.fileid
-      }
-      if (doc.remote == null) {
-        doc.remote = was.remote
-      }
       move(side, was, doc)
 
       const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
@@ -523,18 +502,6 @@ class Merge {
     }
 
     metadata.assignMaxDate(doc, was)
-    if (doc.tags == null) {
-      doc.tags = was.tags || []
-    }
-    if (doc.ino == null) {
-      doc.ino = was.ino
-    }
-    if (doc.fileid == null) {
-      doc.fileid = was.fileid
-    }
-    if (doc.remote == null) {
-      doc.remote = was.remote
-    }
 
     const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
     if (folder) {

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -118,7 +118,8 @@ export type Metadata = {
   ino?: ?number,
   fileid?: ?string,
   moveFrom?: Metadata,
-  cozyMetadata?: Object
+  cozyMetadata?: Object,
+  metadata?: Object
 }
 */
 

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -45,7 +45,8 @@ export type RemoteDoc = {
   trashed?: true,
   type: string,
   updated_at: string,
-  cozyMetadata?: Object
+  cozyMetadata?: Object,
+  metadata?: Object
 }
 
 export type RemoteDeletion = {
@@ -84,7 +85,8 @@ export type JsonApiAttributes = {
   tags: string[],
   type: string,
   updated_at: string,
-  cozyMetadata?: Object
+  cozyMetadata?: Object,
+  metadata?: Object
 }
 
 export type JsonApiDoc = {
@@ -103,8 +105,7 @@ function jsonApiToRemoteDoc(json /*: JsonApiDoc */) /*: * */ {
     {
       _id: json._id,
       _rev: json._rev,
-      _type: json._type,
-      cozyMetadata: json.attributes.cozyMetadata
+      _type: json._type
     },
     json.attributes
   )

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -12,7 +12,7 @@ const { posix, sep } = path
 const { RemoteCozy } = require('./cozy')
 const { RemoteWarningPoller } = require('./warning_poller')
 const { RemoteWatcher } = require('./watcher')
-const { NOTE_MIME_TYPE } = require('./constants')
+const { isNote } = require('../utils/notes')
 const { withContentLength } = require('../reader')
 const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
@@ -181,7 +181,7 @@ class Remote /*:: implements Reader, Writer */ {
     doc /*: Metadata */,
     old /*: ?Metadata */
   ) /*: Promise<void> */ {
-    if (doc.mime === NOTE_MIME_TYPE) {
+    if (old && isNote(old)) {
       log.error(
         { path: doc.path, doc, old },
         'Local note updates should not be propagated'

--- a/core/utils/notes.js
+++ b/core/utils/notes.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+const { NOTE_MIME_TYPE } = require('../remote/constants')
+
+/*::
+import type { Metadata } from '../metadata'
+*/
+
+const isNote = (
+  doc /*: { mime?: string, metadata?: Object } */
+) /*: boolean %checks */ => {
+  return (
+    doc.mime === NOTE_MIME_TYPE &&
+    doc.metadata != null &&
+    doc.metadata.content != null &&
+    doc.metadata.schema != null &&
+    doc.metadata.title != null &&
+    doc.metadata.version != null
+  )
+}
+
+module.exports = {
+  isNote
+}

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -10,7 +10,7 @@ const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
 
-const { NOTE_MIME_TYPE, TRASH_DIR_ID } = require('../../core/remote/constants')
+const { TRASH_DIR_ID } = require('../../core/remote/constants')
 
 describe('Note update', () => {
   let builders, helpers
@@ -35,8 +35,7 @@ describe('Note update', () => {
   let note
   beforeEach('create note', async () => {
     note = await builders
-      .remoteFile()
-      .contentType(NOTE_MIME_TYPE)
+      .remoteNote()
       .name('note.cozy-note')
       .data('Initial content')
       .timestamp(2018, 5, 15, 21, 1, 53)
@@ -47,7 +46,7 @@ describe('Note update', () => {
   describe('on remote Cozy', () => {
     beforeEach('update remote note', async () => {
       await builders
-        .remoteFile(note)
+        .remoteNote(note)
         .data('updated content')
         .update()
       await helpers.pullAndSyncAll()
@@ -55,7 +54,7 @@ describe('Note update', () => {
 
     it('updates the note content on the filesystem', async () => {
       should(await helpers.local.syncDir.readFile('note.cozy-note')).eql(
-        'updated content'
+        'note\n\nupdated content'
       )
     })
   })
@@ -116,8 +115,7 @@ describe('Note move with update', () => {
       .name('dst')
       .create()
     note = await builders
-      .remoteFile()
-      .contentType(NOTE_MIME_TYPE)
+      .remoteNote()
       .name('note.cozy-note')
       .data('Initial content')
       .timestamp(2018, 5, 15, 21, 1, 53)
@@ -161,9 +159,8 @@ describe('Note move with update', () => {
     let existing
     beforeEach('create note at target location', async () => {
       existing = await builders
-        .remoteFile()
+        .remoteNote()
         .inDir(dst)
-        .contentType(NOTE_MIME_TYPE)
         .name('note.cozy-note')
         .data('overwritten content')
         .timestamp(2018, 5, 15, 21, 1, 53)

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -11,6 +11,8 @@ const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
 
 const { TRASH_DIR_ID } = require('../../core/remote/constants')
+const { isNote } = require('../../core/utils/notes')
+const metadata = require('../../core/metadata')
 
 let builders, helpers
 
@@ -77,6 +79,7 @@ describe('Cozy Note update', () => {
         md5sum: note.md5sum,
         dir_id: note.dir_id
       })
+      should(isNote(updatedRemote)).be.true()
     })
 
     it('uploads the new content to the Cozy', async () => {
@@ -123,6 +126,7 @@ describe('Cozy Note move with update', () => {
           md5sum: note.md5sum,
           dir_id: dst._id
         })
+        should(isNote(updatedRemote)).be.true()
       })
 
       it('uploads the new content to the Cozy at the target location', async () => {
@@ -162,12 +166,143 @@ describe('Cozy Note move with update', () => {
           md5sum: note.md5sum,
           dir_id: dst._id
         })
+        should(isNote(updatedRemote)).be.true()
       })
 
       it('uploads the new content to the Cozy at the target location', async () => {
         should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
           'updated content'
         )
+      })
+
+      it('sends the overwritten note to the trash', async () => {
+        should(await helpers.remote.byIdMaybe(existing._id)).have.properties({
+          md5sum: existing.md5sum,
+          name: existing.name,
+          dir_id: TRASH_DIR_ID,
+          trashed: true
+        })
+      })
+    })
+  })
+})
+
+describe('Markdown file with Cozy Note mime type update', () => {
+  let note
+  beforeEach('create note', async () => {
+    note = await builders
+      .remoteNote()
+      .name('note.cozy-note')
+      .data('Initial content')
+      .timestamp(2018, 5, 15, 21, 1, 53)
+      .create()
+    await helpers.pullAndSyncAll()
+  })
+  beforeEach('change note into markdown file', async function() {
+    const doc = await this.pouch.byIdMaybeAsync(metadata.id('note.cozy-note'))
+    // remove everything that makes a note a Cozy Note
+    await this.pouch.put({ ...doc, metadata: {} })
+  })
+
+  describe('on local filesystem', () => {
+    beforeEach('update local note', async () => {
+      await helpers.local.syncDir.outputFile(
+        'note.cozy-note',
+        'updated content'
+      )
+      await helpers.flushLocalAndSyncAll()
+    })
+
+    it('updates the remote file with the new content', async () => {
+      const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
+      should(updatedRemote).have.properties({
+        name: note.name,
+        dir_id: note.dir_id
+      })
+      should(await helpers.remote.readFile('note.cozy-note')).eql(
+        'updated content'
+      )
+      should(isNote(updatedRemote)).be.false()
+    })
+  })
+})
+
+describe('Markdown file with Cozy Note mime type move with update', () => {
+  let dst, note
+  beforeEach('create note', async () => {
+    dst = await builders
+      .remoteDir()
+      .name('dst')
+      .create()
+    note = await builders
+      .remoteNote()
+      .name('note.cozy-note')
+      .data('Initial content')
+      .timestamp(2018, 5, 15, 21, 1, 53)
+      .create()
+    await helpers.pullAndSyncAll()
+  })
+  beforeEach('change note into markdown file', async function() {
+    const doc = await this.pouch.byIdMaybeAsync(metadata.id('note.cozy-note'))
+    // remove everything that makes a note a Cozy Note
+    await this.pouch.put({ ...doc, metadata: {} })
+  })
+
+  describe('on local filesystem', () => {
+    const srcPath = 'note.cozy-note'
+    const dstPath = path.normalize('dst/note.cozy-note')
+
+    describe('to a free target location', () => {
+      beforeEach('move and update local note', async () => {
+        await helpers.local.syncDir.move(srcPath, dstPath)
+        await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+        await helpers.flushLocalAndSyncAll()
+      })
+
+      it('moves and updates the remote file with the new content', async () => {
+        const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
+        should(updatedRemote).have.properties({
+          name: note.name,
+          dir_id: dst._id
+        })
+        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+          'updated content'
+        )
+        should(isNote(updatedRemote)).be.false()
+      })
+    })
+
+    describe('overwriting existing note at target location', () => {
+      const srcPath = 'note.cozy-note'
+      const dstPath = path.normalize('dst/note.cozy-note')
+
+      let existing
+      beforeEach('create note at target location', async () => {
+        existing = await builders
+          .remoteNote()
+          .inDir(dst)
+          .name('note.cozy-note')
+          .data('overwritten content')
+          .timestamp(2018, 5, 15, 21, 1, 53)
+          .create()
+        await helpers.pullAndSyncAll()
+      })
+      beforeEach('move and update local note', async () => {
+        await helpers.local.syncDir.move(srcPath, dstPath, { overwrite: true })
+        await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+        await helpers.flushLocalAndSyncAll()
+      })
+
+      it('moves and updates the remote file with the new content', async () => {
+        const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
+        should(updatedRemote).have.properties({
+          name: note.name,
+          dir_id: dst._id
+        })
+        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+          'updated content'
+        )
+        should(isNote(updatedRemote)).be.false()
       })
 
       it('sends the overwritten note to the trash', async () => {

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -12,6 +12,7 @@ const DirMetadataBuilder = require('./metadata/dir')
 const FileMetadataBuilder = require('./metadata/file')
 const RemoteDirBuilder = require('./remote/dir')
 const RemoteFileBuilder = require('./remote/file')
+const RemoteNoteBuilder = require('./remote/note')
 const StreamBuilder = require('./stream')
 const AtomEventBuilder = require('./atom_event')
 
@@ -61,6 +62,10 @@ module.exports = class Builders {
     return new RemoteFileBuilder(this.cozy, old)
   }
 
+  remoteNote(old /*: ?RemoteDoc */) /*: RemoteNoteBuilder */ {
+    return new RemoteNoteBuilder(this.cozy, old)
+  }
+
   buildRemoteTree(
     paths /*: Array<string|[string, number]> */
   ) /*: { [string]: RemoteDoc } */ {
@@ -83,6 +88,12 @@ module.exports = class Builders {
 
       if (docPath.endsWith('/')) {
         remoteDocsByPath[docPath] = this.remoteDir()
+          .name(name)
+          .inDir(parentDir)
+          .shortRev(shortRev)
+          .build()
+      } else if (docPath.endsWith('cozy-note')) {
+        remoteDocsByPath[docPath] = this.remoteNote()
           .name(name)
           .inDir(parentDir)
           .shortRev(shortRev)

--- a/test/support/builders/remote/note.js
+++ b/test/support/builders/remote/note.js
@@ -1,0 +1,163 @@
+/* @flow */
+
+const crypto = require('crypto')
+const { posix } = require('path')
+
+const RemoteBaseBuilder = require('./base')
+const cozyHelpers = require('../../helpers/cozy')
+
+const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
+const {
+  FILES_DOCTYPE,
+  NOTE_MIME_TYPE
+} = require('../../../../core/remote/constants')
+
+/*::
+import type stream from 'stream'
+import type { Cozy } from 'cozy-client'
+import type { RemoteDoc } from '../../../../core/remote/document'
+*/
+
+// Used to generate readable unique filenames
+var fileNumber = 1
+
+const baseMetadata = {
+  content: {},
+  schema: {},
+  title: 'My note title',
+  version: 1
+}
+
+// Build a RemoteDoc representing a remote Cozy Note:
+//
+//     const note /*: RemoteDoc */ = builders.remoteNote().inDir(...).build()
+//
+// To actually create the corresponding note on the Cozy, use the async
+// #create() method instead:
+//
+//     const note /*: RemoteDoc */ = await builders.remoteNote().inDir(...).create()
+//
+module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder {
+  /*::
+  _title: string
+  _content: string
+  _data: string
+  */
+
+  constructor(cozy /*: Cozy */, old /*: ?RemoteDoc */) {
+    super(cozy, old)
+
+    if (!old) {
+      this.name(`remote-note-${fileNumber}`)
+      this.data(`My note title\n\nContent of remote note ${fileNumber}`)
+      this.remoteDoc.class = 'text'
+      this.remoteDoc.mime = NOTE_MIME_TYPE
+    } else {
+      this.name(old.name)
+      if (old.metadata) {
+        this.data(old.metadata.content.content[0].content[0].text)
+      }
+    }
+    this.remoteDoc.type = 'file'
+
+    fileNumber++
+  }
+
+  data(text /*: string */) /*: RemoteNoteBuilder */ {
+    this._content = text
+
+    return this
+  }
+
+  name(filename /*: string */) /*: this */ {
+    super.name(filename)
+    this._title = filename.split('.cozy-note')[0]
+
+    return this
+  }
+
+  _updateMetadata() {
+    if (this.remoteDoc.metadata == null) {
+      this.remoteDoc.metadata = baseMetadata
+    }
+
+    this.remoteDoc.metadata.title = this._title
+    this.remoteDoc.metadata.content = {
+      content: [
+        {
+          content: [
+            {
+              text: this._content,
+              type: 'text'
+            }
+          ],
+          type: 'paragraph'
+        }
+      ],
+      type: 'doc'
+    }
+  }
+
+  _updateExport() {
+    this._data = `${this._title}\n\n${this._content}`
+    this.remoteDoc.size = Buffer.from(this._data).length.toString()
+    this.remoteDoc.md5sum = crypto
+      .createHash('md5')
+      .update(this._data)
+      .digest()
+      .toString('base64')
+  }
+
+  build() /*: Object */ {
+    this._updateMetadata()
+    this._updateExport()
+
+    return super.build()
+  }
+
+  async create() /*: Promise<RemoteDoc> */ {
+    this._updateMetadata()
+    this._updateExport()
+
+    const client = await cozyHelpers.newClient(this._ensureCozy())
+    const files = client.collection(FILES_DOCTYPE)
+
+    const { data } = await files.createFile(this._data, {
+      name: this.remoteDoc.name,
+      dirId: this.remoteDoc.dir_id,
+      executable: this.remoteDoc.executable,
+      metadata: this.remoteDoc.metadata,
+      contentType: this.remoteDoc.mime,
+      lastModifiedDate: this.remoteDoc.updated_at
+    })
+    const doc = jsonApiToRemoteDoc(data)
+    doc._rev = data.meta.rev
+
+    const { data: parentDir } = await files.statById(doc.dir_id)
+    doc.path = posix.join(parentDir.attributes.path, doc.name)
+
+    return doc
+  }
+
+  async update() /*: Promise<RemoteDoc> */ {
+    this._updateMetadata()
+    this._updateExport()
+
+    const cozy = this._ensureCozy()
+
+    // FIXME: use new cozy-client updateFile() method once we can pass something
+    // else than HTML5 File objects as data.
+    const doc = jsonApiToRemoteDoc(
+      await cozy.files.updateById(this.remoteDoc._id, this._data, {
+        dirID: this.remoteDoc.dir_id,
+        lastModifiedDate: this.remoteDoc.updated_at,
+        name: this.remoteDoc.name
+      })
+    )
+
+    const parentDir = await cozy.files.statById(doc.dir_id)
+    doc.path = posix.join(parentDir.attributes.path, doc.name)
+
+    return doc
+  }
+}

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -9,6 +9,42 @@ const Builders = require('../support/builders')
 const builders = new Builders()
 
 describe('move', () => {
+  it('transfers all src attributes not already defined in dst', () => {
+    const src = builders
+      .metafile()
+      .path('src/file')
+      .data('hello')
+      .tags('qux')
+      .sides({ local: 2, remote: 1 })
+      .build()
+    src.metadata = {
+      test: 'kept metadata'
+    }
+    const dst = builders
+      .metafile()
+      .path('dst/file')
+      .noRemote()
+      .noTags()
+      .build()
+    should(dst.metadata).be.undefined()
+
+    move('local', src, dst)
+
+    should(dst).have.properties({
+      metadata: src.metadata,
+      tags: src.tags,
+      remote: src.remote
+    })
+    // PouchDB reserved attributes are not transfered
+    should(dst._id).not.eql(src._id)
+    should(dst._deleted).be.undefined()
+    should(dst._rev).be.undefined()
+    // defined attributes are not overwritten
+    should(dst).not.have.property('_deleted')
+    should(dst.md5sum).not.eql(src.md5sum)
+    should(dst.size).not.eql(src.size)
+  })
+
   describe('.child()', () => {
     it('ensures destination will be moved as part of its ancestor directory', () => {
       const src = builders

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -19,10 +19,7 @@ const Prep = require('../../../core/prep')
 const remote = require('../../../core/remote')
 const { Remote } = remote
 const { DirectoryNotFound } = require('../../../core/remote/cozy')
-const {
-  TRASH_DIR_ID,
-  NOTE_MIME_TYPE
-} = require('../../../core/remote/constants')
+const { TRASH_DIR_ID } = require('../../../core/remote/constants')
 const timestamp = require('../../../core/utils/timestamp')
 
 const configHelpers = require('../../support/helpers/config')
@@ -414,9 +411,8 @@ describe('remote.Remote', function() {
 
       it('does not send any request if the file is a Cozy Note', async function() {
         const created = await builders
-          .remoteFile()
+          .remoteNote()
           .name('My Note.cozy-note')
-          .contentType(NOTE_MIME_TYPE)
           .data('foo')
           .timestamp(2015, 11, 16, 16, 12, 1)
           .create()
@@ -453,8 +449,8 @@ describe('remote.Remote', function() {
           type: 'file',
           dir_id: created.dir_id,
           name: created.name,
-          md5sum: 'rL0Y20zC+Fzt72VPzMSk2A==',
-          updated_at: '2015-11-16T16:12:01Z'
+          md5sum: created.md5sum,
+          updated_at: created.updated_at
         })
         should(doc.remote._rev).equal(file._rev)
       })


### PR DESCRIPTION
We introduced 2 mechanisms to prevent users from breaking their remote
Cozy Notes:
- a local update to a Cozy Note file will not be propagated to the
  remote Cozy
- a local update to a Cozy Note file will generate a conflict where
  the renamed document is the remote Cozy Note and the local file is
  uploaded as is (i.e. a markdown file with a `.cozy-note` extension
  and a Cozy Note mime type)

Those 2 mechanisms work as expected when an actual Cozy Note export is
modified locally but they don't anymore if the resulting markdown file
is modified again.
In this situation, we'll keep creating new conflicts and if the
markdown file had not been uploaded already we'll get an error because
we'll try to rename its remote counterpart which does not exist yet.

We have this issue because we identify Cozy Notes solely on their mime
type which is the same on the resulting markdown file.
We need more criterias to identify actual Cozy Notes and
differentiate them from markdown files with a Cozy Note mime type.

Since actual Cozy Notes have their content stored within the
`metadata` attribute of their PouchDB and CouchDB records while
markdown files won't have it, we can rely on them to make the
difference.
We introduce a new `isNote()` utils function that looks at the stored
mime type and metadata attribute of a record and tells us whether it
represents an actual Cozy Note or a markdown file resulting from our
conflict mechanism.
We use this function in `Merge` to decide whether we need to create a
new conflict or not and in `Remote` to decide if we should propagate
the file update to the remote Cozy.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
