### PR TITLE
core/sync: Pause local watcher during local writes

### DIFF
--- a/core/local/atom/pause.js
+++ b/core/local/atom/pause.js
@@ -1,0 +1,67 @@
+/** This step bufferizes events while the watcher is paused.
+ *
+ * @module core/local/atom/pause
+ * @flow
+ */
+
+const STEP_NAME = 'pause'
+
+/*::
+import type Channel from './channel'
+import type EventEmitter from 'events'
+
+type WaitState = {
+  paused: boolean
+}
+*/
+
+module.exports = {
+  STEP_NAME,
+  loop,
+  initialState
+}
+
+function initialState() {
+  return { [STEP_NAME]: { paused: false } }
+}
+
+/** Bufferize event batches while the watcher is paused
+ *
+ * The watcher will be paused until the current synchronization cycle is done so
+ * that those events will have the latest stats and checksum values.
+ * This should avoid detecting erronous changes when the synchronization does
+ * multiple operations on the same documents.
+ *
+ * Return a new Channel where all buffered events will be pushed.
+ */
+function loop(
+  channel /*: Channel */,
+  opts /*: { events: EventEmitter, state: WaitState } */
+) /*: Channel */ {
+  opts.events.on('pause', () => {
+    opts.state.paused = true
+  })
+  opts.events.on('resume', () => {
+    opts.state.paused = false
+  })
+
+  return channel.asyncMap(async batch => {
+    await watcherResumed(opts)
+
+    return batch
+  })
+}
+
+async function watcherResumed(
+  opts /*: { events: EventEmitter, state: WaitState } */
+) {
+  return new Promise(resolve => {
+    if (!opts.state.paused) {
+      resolve(true)
+    } else {
+      opts.events.once('resume', () => {
+        resolve(true)
+      })
+    }
+  })
+}

--- a/core/local/atom/watcher.js
+++ b/core/local/atom/watcher.js
@@ -24,6 +24,7 @@ const _ = require('lodash')
 
 const checksumer = require('./../checksumer')
 const Producer = require('./producer')
+const pause = require('./pause')
 const addInfos = require('./add_infos')
 const filterIgnored = require('./filter_ignored')
 const fireLocatStartEvent = require('./fire_local_start_event')
@@ -69,6 +70,7 @@ const only = (platform, step) => platform === process.platform && step
 
 /** The steps for the current platform. */
 const steps = _.compact([
+  pause,
   addInfos,
   filterIgnored,
   fireLocatStartEvent,
@@ -166,6 +168,14 @@ class AtomWatcher {
       this._runningResolve()
       this._runningResolve = null
     }
+  }
+
+  pause() {
+    this.events.emit('pause')
+  }
+
+  resume() {
+    this.events.emit('resume')
   }
 }
 

--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -263,6 +263,14 @@ class LocalWatcher {
     })
   }
 
+  pause() {
+    this.buffer.switchMode('idle')
+  }
+
+  resume() {
+    this.buffer.switchMode('timeout')
+  }
+
   /* Helpers */
   async checksum(filePath /*: string */) /*: Promise<string> */ {
     const absPath = path.join(this.syncPath, filePath)

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -28,6 +28,8 @@ export interface Watcher {
   running: Promise<*>,
   start (): Promise<*>,
   stop (force: ?bool): Promise<*>,
+  pause (): void,
+  resume (): void,
 }
 
 export type LocalWatcherOptions = {

--- a/core/sync.js
+++ b/core/sync.js
@@ -330,6 +330,7 @@ class Sync {
           return
         }
       } else {
+        if (sideName === 'local') this.local.watcher.pause()
         await this.applyDoc(doc, side, sideName, rev)
       }
 
@@ -350,6 +351,7 @@ class Sync {
     } catch (err) {
       await this.handleApplyError(change, sideName, err)
     } finally {
+      this.local.watcher.resume()
       stopMeasure()
     }
   }

--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -3,6 +3,7 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },
@@ -10,8 +11,9 @@ module.exports = ({
   ],
   actions: [
     { type: 'mv', src: 'src/file', dst: 'dst/file' },
-    { type: 'wait', ms: 1500 },
-    { type: 'update_file', path: 'dst/file', content: 'updated content' }
+    { type: 'wait', ms: 500 },
+    { type: 'update_file', path: 'dst/file', content: 'updated content' },
+    { type: 'wait', ms: 1000 }
   ],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -26,5 +26,7 @@ module.exports = function stubSide() /*: Writer */ {
   }
   double.watcher = {}
   double.watcher.running = new Promise(() => {})
+  double.watcher.pause = sinon.stub().returns()
+  double.watcher.resume = sinon.stub().returns()
   return double
 }

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -35,7 +35,7 @@ describe('Local', function() {
   before('instanciate pouch', pouchHelpers.createDatabase)
   before('instanciate local', function() {
     this.prep = {}
-    this.events = {}
+    this.events = { emit: () => {}, on: () => {} }
     this.local = new Local(this)
 
     builders = new Builders({ pouch: this.pouch })


### PR DESCRIPTION
When we fetch multiple changes on the same document from the remote
Cozy, the Sync will apply them all one after the other.
For example, if a file was moved and updated, we'll move the file on
the local filesystem and then download the remote version to update
the local content.

Those actions are run after the PouchDB record for the document has
been updated to reflect the final expected state of the document
metadata.

However, the local watcher will receive events for each action when
it's executed. When it receives an event, it will fetch the document's
stats and calculate the checksum of files. In our example, it means
the event fired after the old file was moved will fetch the stats and
checksum of the old version, different from what is stored in PouchDB.
When the event reaches the Merge module, we'll detect an unexpected
file change from the new version to the old.

To avoid this timing issue we will pause the local watcher and buffer
events until all Sync actions have been executed on the local
filesystem so that when the watcher is resumed, the fetched stats and
checksums will reflect the final, expected state of the document.

The modified scenario does not fail without those changes.
However, if we run it in debug mode and observe the produced logs, we
can see that a file update is detected and merged without the pause
and that the file is found up-to-date with the pause.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
