### PR TITLE
core/local: Discard changes from remote propagation

### DIFF
--- a/core/sync.js
+++ b/core/sync.js
@@ -414,12 +414,17 @@ class Sync {
         }
         await this.doMove(side, doc, from)
       }
-      delete doc.moveFrom // the move succeeded, delete moveFrom before attempting overwrite
       if (
         !metadata.sameBinary(from, doc) ||
         (from.overwrite && !metadata.sameBinary(from.overwrite, doc))
       ) {
-        await side.overwriteFileAsync(doc, doc) // move & update
+        try {
+          await side.overwriteFileAsync(doc, doc) // move & update
+        } catch (err) {
+          // the move succeeded, delete moveFrom to avoid re-applying it
+          delete doc.moveFrom
+          throw err
+        }
       }
     } else if (isMarkedForDeletion(doc)) {
       log.debug({ path: doc.path }, `Applying ${doc.docType} deletion`)

--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -3,6 +3,7 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },
@@ -10,8 +11,9 @@ module.exports = ({
   ],
   actions: [
     { type: 'mv', src: 'src/file', dst: 'dst/file' },
-    { type: 'wait', ms: 1500 },
-    { type: 'update_file', path: 'dst/file', content: 'updated content' }
+    { type: 'wait', ms: 500 },
+    { type: 'update_file', path: 'dst/file', content: 'updated content' },
+    { type: 'wait', ms: 1000 }
   ],
   expected: {
     tree: ['dst/', 'dst/file', 'src/'],

--- a/test/unit/local/atom/await_write_finish.js
+++ b/test/unit/local/atom/await_write_finish.js
@@ -74,85 +74,83 @@ describe('core/local/atom/await_write_finish.loop()', () => {
       should(await heuristicIsEmpty(enhancedChannel)).be.true()
     })
 
-    describe('created→modified→modified with or without deleted', () => {
-      it('should reduce created→modified→modified to created', async () => {
-        const channel = new Channel()
-        const originalBatch = [
-          {
-            action: 'created',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          lastEventToCheckEmptyness
-        ]
-        originalBatch.forEach(event => {
-          channel.push([Object.assign({}, event)])
-        })
-        const enhancedChannel = awaitWriteFinish.loop(channel, {})
-        should(await enhancedChannel.pop()).eql([
-          {
-            // 3rd modified -> created
-            action: 'created',
-            awaitWriteFinish: {
-              previousEvents: [
-                {
-                  // 2nd modified -> created
-                  action: 'created'
-                },
-                {
-                  // 1st created
-                  action: 'created'
-                }
-              ]
-            },
-            kind: 'file',
-            path: __filename
-          }
-        ])
-        should(await heuristicIsEmpty(enhancedChannel)).be.true()
+    it('should reduce created→modified→modified to created', async () => {
+      const channel = new Channel()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      originalBatch.forEach(event => {
+        channel.push([Object.assign({}, event)])
       })
+      const enhancedChannel = awaitWriteFinish.loop(channel, {})
+      should(await enhancedChannel.pop()).eql([
+        {
+          // 3rd modified -> created
+          action: 'created',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                // 2nd modified -> created
+                action: 'created'
+              },
+              {
+                // 1st created
+                action: 'created'
+              }
+            ]
+          },
+          kind: 'file',
+          path: __filename
+        }
+      ])
+      should(await heuristicIsEmpty(enhancedChannel)).be.true()
+    })
 
-      it('should reduce created→modified→modified→deleted to empty', async () => {
-        const channel = new Channel()
-        const originalBatch = [
-          {
-            action: 'created',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'deleted',
-            kind: 'file',
-            path: __filename
-          },
-          lastEventToCheckEmptyness
-        ]
-        originalBatch.forEach(event => {
-          channel.push([Object.assign({}, event)])
-        })
-        const enhancedChannel = awaitWriteFinish.loop(channel, {})
-        should(await heuristicIsEmpty(enhancedChannel)).be.true()
+    it('should reduce created→modified→modified→deleted to empty', async () => {
+      const channel = new Channel()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'deleted',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      originalBatch.forEach(event => {
+        channel.push([Object.assign({}, event)])
       })
+      const enhancedChannel = awaitWriteFinish.loop(channel, {})
+      should(await heuristicIsEmpty(enhancedChannel)).be.true()
     })
 
     it('should reduce modified→modified to latest modified', async () => {
@@ -302,81 +300,79 @@ describe('core/local/atom/await_write_finish.loop()', () => {
       ])
     })
 
-    describe('created→modified→modified with or without deleted', () => {
-      it('should reduce created→modified→modified to created', async () => {
-        const channel = new Channel()
-        const originalBatch = [
-          {
-            action: 'created',
-            kind: 'file',
-            path: __filename
+    it('should reduce created→modified→modified to created', async () => {
+      const channel = new Channel()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      channel.push(_.cloneDeep(originalBatch))
+      const enhancedChannel = awaitWriteFinish.loop(channel, {})
+      should(await enhancedChannel.pop()).eql([
+        {
+          // 3rd modified -> created
+          action: 'created',
+          awaitWriteFinish: {
+            previousEvents: [
+              {
+                // 2nd modified -> created
+                action: 'created'
+              },
+              {
+                // 1st created
+                action: 'created'
+              }
+            ]
           },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          lastEventToCheckEmptyness
-        ]
-        channel.push(_.cloneDeep(originalBatch))
-        const enhancedChannel = awaitWriteFinish.loop(channel, {})
-        should(await enhancedChannel.pop()).eql([
-          {
-            // 3rd modified -> created
-            action: 'created',
-            awaitWriteFinish: {
-              previousEvents: [
-                {
-                  // 2nd modified -> created
-                  action: 'created'
-                },
-                {
-                  // 1st created
-                  action: 'created'
-                }
-              ]
-            },
-            kind: 'file',
-            path: __filename
-          },
-          lastEventToCheckEmptyness
-        ])
-      })
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ])
+    })
 
-      it('should reduce created→modified→modified→deleted to empty', async () => {
-        const channel = new Channel()
-        const originalBatch = [
-          {
-            action: 'created',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'modified',
-            kind: 'file',
-            path: __filename
-          },
-          {
-            action: 'deleted',
-            kind: 'file',
-            path: __filename
-          },
-          lastEventToCheckEmptyness
-        ]
-        channel.push(_.cloneDeep(originalBatch))
-        const enhancedChannel = awaitWriteFinish.loop(channel, {})
-        should(await enhancedChannel.pop()).eql([lastEventToCheckEmptyness])
-      })
+    it('should reduce created→modified→modified→deleted to empty', async () => {
+      const channel = new Channel()
+      const originalBatch = [
+        {
+          action: 'created',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'modified',
+          kind: 'file',
+          path: __filename
+        },
+        {
+          action: 'deleted',
+          kind: 'file',
+          path: __filename
+        },
+        lastEventToCheckEmptyness
+      ]
+      channel.push(_.cloneDeep(originalBatch))
+      const enhancedChannel = awaitWriteFinish.loop(channel, {})
+      should(await enhancedChannel.pop()).eql([lastEventToCheckEmptyness])
     })
 
     it('should reduce modified→modified to latest modified', async () => {


### PR DESCRIPTION
When we propagate remote changes to the local filesystem, the local watcher will receive events from the filesystem and try to merge those "changes".
In some situations like when a Cozy Note was moved and updated, we end up reverting the changes we are applying.

We try to be smarter about the local changes in 2 ways:
- be more aggressive in the way we aggregate events in the Atom watcher to limit irrelevant changes
- try and detect already applied moves to that we don't merge creations when dispatching local `renamed` events with no source PouchDB records

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
