### PR TITLE
core/merge: Remove Note metadata on conflicts

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -187,9 +187,10 @@ class Merge {
       delete doc.overwrite
     }
 
-    // We create it at the destination location
+    // We create it at the destination location as a normal local file
     metadata.markAsNew(doc)
     metadata.dissociateRemote(doc)
+    metadata.removeNoteMetadata(doc)
     return this.addFileAsync('local', doc)
   }
 

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -161,6 +161,7 @@ module.exports = {
   isUpToDate,
   isAtLeastUpToDate,
   removeActionHints,
+  removeNoteMetadata,
   dissociateRemote,
   markAsNew,
   markAsUnsyncable,
@@ -418,6 +419,15 @@ function removeActionHints(doc /*: Metadata */) {
   }
   if (doc.moveFrom) delete doc.moveFrom
   if (doc.moveTo) delete doc.moveTo
+}
+
+function removeNoteMetadata(doc /*: Metadata */) {
+  if (doc.metadata) {
+    if (doc.metadata.content) delete doc.metadata.content
+    if (doc.metadata.schema) delete doc.metadata.schema
+    if (doc.metadata.title) delete doc.metadata.title
+    if (doc.metadata.version) delete doc.metadata.version
+  }
 }
 
 function dissociateRemote(doc /*: Metadata */) {


### PR DESCRIPTION
When we detect a local Cozy Note export modification and create a
conflict, we want to mark the new markdown file as such and not a real
Cozy Note.

We won't change the file's extension in case the file is still open in
the user's editor and so we won't change the document's mime type
either. However, we'll remove the Cozy Note's content and schema
stored in the record's `metadata` attribute since the actual file's
content has changed and won't be re-imported as a Note.

Removing these attributes should give Drive Web hints that the file
should be displayed as a markdown file.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
