### PR TITLE
core: Refetch remote Cozy Notes after upgrade

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -307,11 +307,6 @@ class Merge {
         if (doc.mime == null) {
           doc.mime = file.mime
         }
-      } else if (side === 'local' && isNote(file)) {
-        // We'll need a reference to the "overwritten" note during the conflict
-        // resolution.
-        doc.overwrite = file
-        return this.resolveNoteConflict(doc)
       } else if (!file.deleted && !metadata.isAtLeastUpToDate(side, file)) {
         if (side === 'local') {
           // We have a merged but unsynced remote update.
@@ -338,6 +333,11 @@ class Merge {
           metadata.markSide('local', file, file)
           return this.pouch.put(file)
         }
+      } else if (side === 'local' && isNote(file)) {
+        // We'll need a reference to the "overwritten" note during the conflict
+        // resolution.
+        doc.overwrite = file
+        return this.resolveNoteConflict(doc)
       } else {
         doc.overwrite = file
       }

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -89,6 +89,32 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 2,
+    targetSchemaVersion: 3,
+    description: 'Marking Cozy Notes for refetch to avoid conflicts',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(
+        doc =>
+          doc.mime === 'text/vnd.cozy.note+markdown' &&
+          doc.metadata &&
+          doc.metadata.content &&
+          doc.sides &&
+          doc.sides.local &&
+          doc.sides.remote
+      )
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        if (doc.sides && doc.sides.local && doc.sides.remote) {
+          doc.sides.target =
+            Math.max(doc.sides.target, doc.sides.local, doc.sides.remote) + 1
+          doc.sides.remote = doc.sides.target
+        }
+        return doc
+      })
+    }
   }
 ]
 


### PR DESCRIPTION
The new Desktop release fixes a bug which lead to local Cozy Note exports not being updated on Windows when propagating a remote note update and the creation of a conflict when detecting a local modification on local exports to avoid breaking the remote note.

The association of the 2 would lead to the generation of conflicts for all exports that became unsynchronized because of the bug on Windows.

We want to avoid those dispensable conflicts and propose to rely on the unapplied remote update detection to forcefully download and replace the local export with the remote version.
We add a migration that fakes a remote update on all Cozy Note PouchDB records so that `Merge` will detect them and choose to discard the local modification it will receive from the initial scan after the release install.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
