### PR TITLE
core/merge: Keep existing metadata attribute

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -246,6 +246,9 @@ class Merge {
         if (doc.fileid == null) {
           doc.fileid = file.fileid
         }
+        if (file.metadata && doc.metadata == null) {
+          doc.metadata = file.metadata
+        }
         if (metadata.sameFile(file, doc)) {
           if (needsFileidMigration(file, doc.fileid)) {
             return this.migrateFileid(file, doc.fileid)
@@ -296,6 +299,9 @@ class Merge {
       }
       if (doc.fileid == null) {
         doc.fileid = file.fileid
+      }
+      if (file.metadata && doc.metadata == null) {
+        doc.metadata = file.metadata
       }
       if (metadata.sameBinary(file, doc)) {
         if (doc.size == null) {
@@ -387,6 +393,9 @@ class Merge {
       if (doc.fileid == null) {
         doc.fileid = folder.fileid
       }
+      if (folder.metadata && doc.metadata == null) {
+        doc.metadata = folder.metadata
+      }
       if (metadata.sameFolder(folder, doc)) {
         if (needsFileidMigration(folder, doc.fileid)) {
           return this.migrateFileid(folder, doc.fileid)
@@ -413,6 +422,7 @@ class Merge {
   ) /*: Promise<*> */ {
     log.debug({ path: doc.path, oldpath: was.path }, 'moveFileAsync')
     const { path } = doc
+
     if (!metadata.wasSynced(was) || was.deleted) {
       metadata.markAsUnsyncable(was)
       await this.pouch.put(was)
@@ -488,6 +498,7 @@ class Merge {
     newRemoteRevs /*: ?RemoteRevisionsByID */
   ) {
     log.debug({ path: doc.path, oldpath: was.path }, 'moveFolderAsync')
+
     if (!metadata.wasSynced(was)) {
       metadata.markAsUnsyncable(was)
       await this.pouch.put(was)

--- a/core/prep.js
+++ b/core/prep.js
@@ -152,13 +152,12 @@ class Prep {
     const { path } = doc
     metadata.ensureValidPath(doc)
     metadata.ensureValidPath(was)
+
     if (doc.path === was.path) {
       const msg = 'Invalid move'
       log.warn({ path, doc, was }, msg)
       throw new Error(msg)
-    }
-
-    if (!was._rev) {
+    } else if (!was._rev) {
       const msg = 'Missing rev'
       log.warn({ path, doc, was }, msg)
       throw new Error(msg)

--- a/test/support/builders/remote/note.js
+++ b/test/support/builders/remote/note.js
@@ -147,6 +147,7 @@ module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder {
 
     // FIXME: use new cozy-client updateFile() method once we can pass something
     // else than HTML5 File objects as data.
+    // FIXME: update note metadata
     const doc = jsonApiToRemoteDoc(
       await cozy.files.updateById(this.remoteDoc._id, this._data, {
         dirID: this.remoteDoc.dir_id,

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -7,7 +7,7 @@ const path = require('path')
 const conflictHelpers = require('./conflict')
 const cozyHelpers = require('./cozy')
 
-const { Remote } = require('../../../core/remote')
+const { Remote, dirAndName } = require('../../../core/remote')
 const { jsonApiToRemoteDoc } = require('../../../core/remote/document')
 const { TRASH_DIR_NAME } = require('../../../core/remote/constants')
 
@@ -16,6 +16,7 @@ import type cozy from 'cozy-client-js'
 import type { Pouch } from '../../../core/pouch'
 import type { RemoteOptions } from '../../../core/remote'
 import type { RemoteDoc } from '../../../core/remote/document'
+import type { Metadata } from '../../../core/metadata'
 */
 
 class RemoteTestHelpers {
@@ -156,6 +157,18 @@ class RemoteTestHelpers {
     } catch (err) {
       return null
     }
+  }
+
+  async move(id /*: string */, newPath /*: string */) {
+    const [newDirPath, newName] /*: [string, string] */ = dirAndName(newPath)
+    const newDir /*: RemoteDoc */ = await this.side.remoteCozy.findDirectoryByPath(
+      newDirPath
+    )
+    const attrs = {
+      name: newName,
+      ir_id: newDir._id
+    }
+    await this.side.remoteCozy.updateAttributesById(id, attrs, {})
   }
 }
 


### PR DESCRIPTION
Some PouchDB records may have a `metadata` attribute, generated by the
stack with domain specific information.
For example, this is used to store the actual content of a Cozy Note,
its title, its schema…

We use this information in the Desktop client to check if a document
with a Cozy Note mime type is an actual Cozy Note (i.e. it's not a
markdown file generated during a conflict).

When we update an existing PouchDB record (during a move, an update or
a metadata — any record attribute — update), we copy some attributes
over to the new record before the two are compared and the new one is
saved to PouchDB.
We were not copying the `metadata` attribute.

If the updated document was a Cozy Note, its record in PouchDB would
have lost crucial information and our checks would tell us it is not
an actual Cozy Note anymore.
This could lead to later local updates being propagated to the remote
Cozy instead of generating a conflict.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
