### PR TITLE
core/local/atom: Group close Renamed and Modified

### DIFF
--- a/core/local/atom/fire_local_start_event.js
+++ b/core/local/atom/fire_local_start_event.js
@@ -28,7 +28,7 @@ function loop(
   channel /*: Channel */,
   opts /*: { events: EventEmitter } */
 ) /*: Channel */ {
-  return channel.asyncMap(async events => {
+  return channel.map(events => {
     opts.events.emit('local-start')
     return events
   })


### PR DESCRIPTION
On Windows, when propagating compound remote move and update changes
to the local filesystem, we can see old file metadata being propagated
back to the Cozy.
This is an association of timing and state issues.

When we apply a file move on the local filesystem, we expect 2 events
to be fired:
- a `renamed` event (obviously fired because the file has a new path)
- a `modified` event fired for the permissions and/or dates changes

The Atom watcher manages to group those 2 events via its
`awaitWriteFinish` step because they're processed with little delay
between them (less than the step's 200ms timeout which triggers the
flush of waiting events).
However, on Windows, we can see a second `modified` event fired not so
long after the first one (something like 10-15ms later) but reaching
the `awaitWriteFinish` step much later, after the two previous events
have already been flushed.
In this situation, this `modified` event makes it all the way to the
`dispatch` step and gets merged as a file metadata update.

If the file was only moved, this has no effect as the stats and
checksum stored in this `modified` event are the same as the ones
stored in PouchDB.
However, in case the file was also modified, the stats (i.e. file
size, update time, inode…) stored on this `modified` event correspond
to the old file version (they were calculated juste after the file was
moved and before we replaced it with its new version).
In this case, the Merge module will see a difference between the
stored metadata and the ones coming from the event, thus triggering a
new change which will be propagated to the remote Cozy.
We'll see the file size go back to its previous value specifically.

The second `modified` event seems to be held up by another step,
`winIdenticalRenaming`, processing events before `awaitWriteFinish`.
Its long (500ms) delay is a good suspect. We could try to reduced this
delay but we would take the risk to break another behavior and the
events we're dealing with here don't even need to be held up by this
step in the first place.
Therefore, we will only hold up (and thus delay) events that come
after a `deleted` event which is the first event of the behavior
`winIdenticalRenaming` is meant to fix.

By flushing our `renamed` and `modified` events right away we can see
both `modified` events being grouped with the `renamed` event by
`awaitWriteFinish`, thus avoiding the unexpected file metadata change.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
