### PR TITLE
core/merge: Don't replace existing `overwrite`

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -233,7 +233,12 @@ class Merge {
       }
 
       if (!metadata.sameBinary(file, doc)) {
-        if (!file.deleted && !metadata.isAtLeastUpToDate(side, file)) {
+        if (side === 'local' && isNote(file)) {
+          // We'll need a reference to the "overwritten" note during the conflict
+          // resolution.
+          doc.overwrite = file
+          return this.resolveNoteConflict(doc)
+        } else if (!file.deleted && !metadata.isAtLeastUpToDate(side, file)) {
           if (side === 'local') {
             // We have a merged but unsynced remote update so we create a conflict.
             await this.resolveConflictAsync('local', file)
@@ -269,11 +274,6 @@ class Merge {
               return
             }
           }
-        } else if (side === 'local' && isNote(file)) {
-          // We'll need a reference to the "overwritten" note during the conflict
-          // resolution.
-          doc.overwrite = file
-          return this.resolveNoteConflict(doc)
         }
       }
 

--- a/core/merge.js
+++ b/core/merge.js
@@ -209,6 +209,12 @@ class Merge {
         // PouchDB attributes that will allow us to overwrite it.
         doc._id = file._id
         doc._rev = file._rev
+        if (side === 'local' && file.remote) {
+          doc.remote = file.remote
+        }
+        if (side === 'remote' && file.local) {
+          doc.local = file.local
+        }
       } else {
         // Otherwise we merge the relevant attributes
         doc = {
@@ -268,8 +274,6 @@ class Merge {
           // resolution.
           doc.overwrite = file
           return this.resolveNoteConflict(doc)
-        } else {
-          doc.overwrite = file
         }
       }
 
@@ -285,7 +289,7 @@ class Merge {
         }
         return null
       } else {
-        metadata.markSide(side, doc, file.deleted ? null : file)
+        metadata.markSide(side, doc, file)
         metadata.assignMaxDate(doc, file)
         return this.pouch.put(doc)
       }

--- a/core/merge.js
+++ b/core/merge.js
@@ -236,7 +236,7 @@ class Merge {
         if (side === 'local' && isNote(file)) {
           // We'll need a reference to the "overwritten" note during the conflict
           // resolution.
-          doc.overwrite = file
+          doc.overwrite = file.overwrite || file
           return this.resolveNoteConflict(doc)
         } else if (!file.deleted && !metadata.isAtLeastUpToDate(side, file)) {
           if (side === 'local') {
@@ -386,7 +386,7 @@ class Merge {
       const file /*: ?SavedMetadata */ = await this.pouch.bySyncedPath(doc.path)
       if (file) {
         if (file.deleted) {
-          doc.overwrite = file
+          doc.overwrite = file.overwrite || file
         }
 
         const idConflict /*: ?IdConflictInfo */ = IdConflict.detect(
@@ -409,7 +409,7 @@ class Merge {
           if (file.path === doc.path) {
             doc._id = file._id
             doc._rev = file._rev
-            doc.overwrite = file
+            doc.overwrite = file.overwrite || file
           }
 
           if (side === 'local' && isNote(was) && doc.md5sum !== was.md5sum) {
@@ -466,7 +466,7 @@ class Merge {
     const folder /*: ?SavedMetadata */ = await this.pouch.bySyncedPath(doc.path)
     if (folder) {
       if (folder.deleted) {
-        doc.overwrite = folder
+        doc.overwrite = folder.overwrite || folder
       }
 
       const idConflict /*: ?IdConflictInfo */ = IdConflict.detect(
@@ -489,7 +489,7 @@ class Merge {
         if (folder.path === doc.path) {
           doc._id = folder._id
           doc._rev = folder._rev
-          doc.overwrite = folder
+          doc.overwrite = folder.overwrite || folder
         }
         return this.moveFolderRecursivelyAsync(side, doc, was, newRemoteRevs)
       }
@@ -563,7 +563,7 @@ class Merge {
         if (dstChild) {
           dst._id = dstChild._id
           dst._rev = dstChild._rev
-          dst.overwrite = dstChild
+          dst.overwrite = dstChild.overwrite || dstChild
         }
       }
       // TODO: manage conflicts if not overwriting and docs exist at destination?

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -594,7 +594,9 @@ class Sync {
       if (
         doc.docType === 'file' &&
         (!metadata.sameBinary(from, doc) ||
-          (from.overwrite && !metadata.sameBinary(from.overwrite, doc)))
+          (from.local.docType === 'file' &&
+            from.remote.type === 'file' &&
+            !metadata.sameBinary(from.local, from.remote)))
       ) {
         try {
           await side.overwriteFileAsync(doc, doc) // move & update
@@ -643,14 +645,6 @@ class Sync {
             await side.updateFileMetadataAsync(doc)
           }
         } else {
-          // FIXME: with commit afd01767571915922a4f253beb2e53cc6eae4962, this
-          // block is unnecessary.
-          // However, we can't remove it already since some users could still be
-          // in a situation where they need it.
-          if (sideName === 'local' && !doc.overwrite) {
-            const copy = await this.local.createBackupCopyAsync(doc)
-            await this.local.trashAsync(copy)
-          }
           await side.overwriteFileAsync(doc, old)
           this.events.emit('transfer-started', _.clone(doc))
         }

--- a/test/scenarios/move_and_replace_file_with_update/atom/linux.json
+++ b/test/scenarios/move_and_replace_file_with_update/atom/linux.json
@@ -1,0 +1,44 @@
+[
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst/file1"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst/file1"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "dst/file2",
+      "oldPath": "src/file2"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst/file2"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst/file2"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "dst/file1",
+      "oldPath": "src/file1"
+    }
+  ]
+]

--- a/test/scenarios/move_and_replace_file_with_update/remote/changes.json
+++ b/test/scenarios/move_and_replace_file_with_update/remote/changes.json
@@ -1,0 +1,101 @@
+[
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e8597b337",
+    "_rev": "2-9f0dde48d1761e962fad43df9c735422"
+  },
+  {
+    "_id": "b6e003719af69912d43deb6e8597aff7",
+    "_rev": "3-b26d073ef82af0944d88e13f47c528c9",
+    "class": "text",
+    "cozyMetadata": {
+      "createdAt": "2021-02-04T18:33:19.494714203Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-02-04T18:33:21.143288534Z",
+      "updatedByApps": [
+        {
+          "date": "2021-02-04T18:33:21.143288534Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-02-04T18:33:19.494714203Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "b6e003719af69912d43deb6e856399fe",
+          "kind": "",
+          "name": "test-2"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-02-04T19:33:19Z",
+    "dir_id": "b6e003719af69912d43deb6e85978383",
+    "executable": false,
+    "md5sum": "peMo42/hVYOSS7d/xT4A9Q==",
+    "mime": "text/plain",
+    "name": "file2",
+    "size": "15",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2021-02-04T18:33:21.088Z",
+    "path": "/dst/file2"
+  },
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e8597a161",
+    "_rev": "3-9ca9598f3d1292b18d29807e7ed28fde"
+  },
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e8597a161/1-cf3ec6fe87f4ec34f5f8a1e521d9ca36",
+    "_rev": "2-339a505ad6e18af05f9bed2184a3f035"
+  },
+  {
+    "_id": "b6e003719af69912d43deb6e85979fd1",
+    "_rev": "2-cc76ed02d1ab2e231324477a4154232d",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2021-02-04T18:33:19.327659039Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-02-04T18:33:21.302850573Z",
+      "updatedByApps": [
+        {
+          "date": "2021-02-04T18:33:21.302850573Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-02-04T18:33:19.327659039Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "b6e003719af69912d43deb6e856399fe",
+          "kind": "",
+          "name": "test-2"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-02-04T19:33:19Z",
+    "dir_id": "b6e003719af69912d43deb6e85978383",
+    "executable": false,
+    "md5sum": "h6ZkLOpDwwkT5ONLC1gM1w==",
+    "mime": "application/octet-stream",
+    "name": "file1",
+    "size": "19",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2021-02-04T19:33:19Z",
+    "path": "/dst/file1"
+  }
+]

--- a/test/scenarios/move_and_replace_file_with_update/scenario.js
+++ b/test/scenarios/move_and_replace_file_with_update/scenario.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  useCaptures: false,
+  init: [
+    { ino: 1, path: 'dst/' },
+    { ino: 2, path: 'src/' },
+    { ino: 3, path: 'src/file1', content: 'overwriting content' },
+    { ino: 4, path: 'dst/file1', content: 'overwritten content' },
+    { ino: 3, path: 'src/file2', content: 'initial content' },
+    { ino: 4, path: 'dst/file2', content: 'overwritten content' }
+  ],
+  actions: [
+    { type: 'update_file', path: 'dst/file1', content: 'updated content' },
+    { type: 'mv', src: 'src/file2', dst: 'dst/file2' },
+    { type: 'wait', ms: 500 },
+    { type: 'update_file', path: 'dst/file2', content: 'updated content' },
+    { type: 'mv', src: 'src/file1', dst: 'dst/file1' },
+    { type: 'wait', ms: 1000 }
+  ],
+  expected: {
+    tree: ['dst/', 'dst/file1', 'dst/file2', 'src/'],
+    trash: ['file1', 'file2'],
+    contents: {
+      'dst/file1': 'overwriting content',
+      'dst/file2': 'updated content'
+    }
+  }
+} /*: Scenario */)

--- a/test/scenarios/update_delete_then_replace_file/atom/linux.json
+++ b/test/scenarios/update_delete_then_replace_file/atom/linux.json
@@ -1,0 +1,70 @@
+[
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "src/file1"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "src/file1"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "final/file2",
+      "oldPath": "src/file2"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src/file1"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "final/file2"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "src/file1"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "src/file1"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "final/file2"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "final/file2"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "final/file2",
+      "oldPath": "dst/file2"
+    }
+  ]
+]

--- a/test/scenarios/update_delete_then_replace_file/remote/changes.json
+++ b/test/scenarios/update_delete_then_replace_file/remote/changes.json
@@ -1,0 +1,111 @@
+[
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e859c9a36",
+    "_rev": "2-23d222cc16a652b7084fdced762e00d6"
+  },
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e859ca9b6",
+    "_rev": "4-3dcc64ce6027951807843c0811b17c2e"
+  },
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e859ca9b6/1-7a52c2b8dc109794b7f71f9ee9fd9f60",
+    "_rev": "2-453868e7d416ec148c9dfd59b75b410c"
+  },
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e859cb3bc",
+    "_rev": "4-38d0c050ddad16be24239631d7e8e0e1"
+  },
+  {
+    "_id": "b6e003719af69912d43deb6e859cb77f",
+    "_rev": "1-88f4742a0d6e40e784c4eb8b3321697b",
+    "class": "text",
+    "cozyMetadata": {
+      "createdAt": "2021-02-05T10:10:46.467398538Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-02-05T10:10:46.467398538Z",
+      "updatedByApps": [
+        {
+          "date": "2021-02-05T10:10:46.467398538Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-02-05T10:10:46.467398538Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "b6e003719af69912d43deb6e856399fe",
+          "kind": "",
+          "name": "test-2"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-02-05T10:10:46.447Z",
+    "dir_id": "b6e003719af69912d43deb6e859c9b82",
+    "executable": false,
+    "md5sum": "1sV3fusV3PwggiJAQYw/+g==",
+    "mime": "text/plain",
+    "name": "file1",
+    "size": "13",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2021-02-05T10:10:46.447Z",
+    "path": "/src/file1"
+  },
+  {
+    "_deleted": true,
+    "_id": "b6e003719af69912d43deb6e859cbe79",
+    "_rev": "2-8243da9bafd051da796432e4b224fc69"
+  },
+  {
+    "_id": "b6e003719af69912d43deb6e859c8795",
+    "_rev": "2-2dc6cd3b5f77a11b3d1774164ef57a8c",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2021-02-05T10:10:44.040683249Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-02-05T10:10:47.148293698Z",
+      "updatedByApps": [
+        {
+          "date": "2021-02-05T10:10:47.148293698Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-02-05T10:10:44.040683249Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "b6e003719af69912d43deb6e856399fe",
+          "kind": "",
+          "name": "test-2"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-02-05T11:10:44Z",
+    "dir_id": "b6e003719af69912d43deb6e859c8bf9",
+    "executable": false,
+    "md5sum": "1sV3fusV3PwggiJAQYw/+g==",
+    "mime": "application/octet-stream",
+    "name": "file2",
+    "size": "13",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2021-02-05T11:10:44Z",
+    "path": "/final/file2"
+  }
+]

--- a/test/scenarios/update_delete_then_replace_file/scenario.js
+++ b/test/scenarios/update_delete_then_replace_file/scenario.js
@@ -1,0 +1,51 @@
+/* @flow */
+
+const { runWithStoppedClient } = require('../../support/helpers/scenarios')
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  useCaptures: false,
+  disabled:
+    process.platform === 'linux' && runWithStoppedClient()
+      ? 'Does not work because inodes are reused and the initial diff misinterprets some changes as moves'
+      : undefined,
+  init: [
+    { ino: 1, path: 'dst/' },
+    { ino: 2, path: 'dst/file2', content: 'final content' },
+    { ino: 3, path: 'final/' },
+    { ino: 4, path: 'final/file2', content: 'replaced content' },
+    { ino: 5, path: 'src/' },
+    { ino: 6, path: 'src/file1', content: 'initial content' },
+    { ino: 7, path: 'src/file2', content: 'moved content' }
+  ],
+  actions: [
+    { type: 'update_file', path: 'src/file1', content: 'updated content' },
+    { type: 'mv', src: 'src/file2', dst: 'final/file2' },
+    { type: 'wait', ms: 500 },
+    { type: 'delete', path: 'src/file1' },
+    { type: 'delete', path: 'final/file2' },
+    { type: 'wait', ms: 500 },
+    { type: 'create_file', path: 'src/file1', content: 'final content' },
+    { type: 'create_file', path: 'final/file2', content: 'replacing content' },
+    { type: 'wait', ms: 500 },
+    { type: 'mv', src: 'dst/file2', dst: 'final/file2' },
+    { type: 'wait', ms: 1000 }
+  ],
+  expected: {
+    tree: ['dst/', 'final/', 'final/file2', 'src/', 'src/file1'],
+    remoteTrash: [
+      'file2', // src/file2
+      'file2 (__cozy__: ...)' // final/file2
+    ],
+    localTrash: [
+      'file2' // src/file2
+      // final/file2 is overwritten by the last move without being sent to the
+      // trash first since it's not necessary to do so on the local filesystem.
+    ],
+    contents: {
+      'src/file1': 'final content',
+      'final/file2': 'final content'
+    }
+  }
+} /*: Scenario */)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -253,13 +253,13 @@ describe('Merge', function() {
       )
 
       context(
-        'when a deleted local file record with the same path but different content exists',
+        'when a record with an unsynced local deletion and different content exists',
         () => {
           const filepath = 'BUZZ.JPG'
 
-          let synced, file
+          let remoteFile, deleted
           beforeEach('create a file', async function() {
-            const remoteFile = await builders
+            remoteFile = await builders
               .remoteFile()
               .inRootDir()
               .name(filepath)
@@ -267,22 +267,21 @@ describe('Merge', function() {
               .tags('foo')
               .contentType('image/jpeg')
               .build()
-            synced = await builders
+            const synced = await builders
               .metafile()
               .fromRemote(remoteFile)
               .upToDate()
               .create()
-            file = await builders
+            deleted = await builders
               .metafile(synced)
               .deleted()
               .changedSide('local')
               .create()
           })
 
-          it('overwrites the existing record', async function() {
+          it('updates the existing record', async function() {
             const newRemoteFile = await builders
-              // $FlowFixMe: synced.remote has the right type but Flow can't know it
-              .remoteFile(synced.remote)
+              .remoteFile(remoteFile)
               .data('updated content')
               .build()
             const doc = builders
@@ -299,11 +298,10 @@ describe('Merge', function() {
               savedDocs: [
                 _.defaults(
                   {
-                    overwrite: file,
-                    sides: {
-                      remote: 1,
-                      target: 1
-                    }
+                    // Remote side is increased by 2 to overcome the unsynced
+                    // local deletion.
+                    sides: increasedSides(deleted.sides, 'remote', 2),
+                    local: deleted.local
                   },
                   _.omit(doc, ['_id', '_rev'])
                 )
@@ -353,24 +351,10 @@ describe('Merge', function() {
               savedDocs: [
                 _.defaults(
                   {
-                    md5sum: doc.md5sum,
-                    size: doc.size,
-                    mime: doc.mime,
-                    class: doc.class,
-                    executable: doc.executable,
-                    tags: doc.tags,
-                    updated_at: doc.updated_at,
-                    overwrite: file,
                     sides: increasedSides(file.sides, 'remote', 1),
-                    remote: doc.remote,
-                    cozyMetadata: doc.cozyMetadata,
-                    // FIXME: $FlowFixMe not part of Metadata but still saved in PouchDB
-                    created_at: doc.created_at,
-                    // FIXME: $FlowFixMe not part of Metadata but still saved in PouchDB
-                    dir_id: doc.dir_id,
-                    // FIXME: $FlowFixMe not part of Metadata but still saved in PouchDB
-                    name: doc.name
+                    local: file.local
                   },
+                  doc,
                   _.omit(file, ['_id', '_rev', 'fileid'])
                 )
               ],
@@ -532,9 +516,9 @@ describe('Merge', function() {
       )
 
       context(
-        'when a deleted remote file record with the same path but different content exists',
+        'when a record with an unsynced remote deletion and different content exists',
         () => {
-          let synced, file
+          let synced, deleted
           beforeEach('create a file', async function() {
             const remoteFile = await builders
               .remoteFile()
@@ -549,14 +533,14 @@ describe('Merge', function() {
               .fromRemote(remoteFile)
               .upToDate()
               .create()
-            file = await builders
+            deleted = await builders
               .metafile(synced)
               .deleted()
               .changedSide('remote')
               .create()
           })
 
-          it('overwrites the existing record', async function() {
+          it('updates the existing record', async function() {
             const doc = await builders
               .metafile(synced)
               .data('local content')
@@ -571,11 +555,10 @@ describe('Merge', function() {
               savedDocs: [
                 _.defaults(
                   {
-                    overwrite: file,
-                    sides: {
-                      local: 1,
-                      target: 1
-                    }
+                    // Local side is increased by 2 to overcome the unsynced
+                    // remote deletion.
+                    sides: increasedSides(deleted.sides, 'local', 2),
+                    remote: deleted.remote
                   },
                   _.omit(doc, ['_id', '_rev'])
                 )
@@ -623,7 +606,6 @@ describe('Merge', function() {
                     size: doc.size,
                     updated_at: doc.updated_at,
                     sides: increasedSides(file.sides, 'local', 1),
-                    overwrite: file,
                     local: doc.local
                   },
                   _.omit(file, ['_id', '_rev', 'fileid'])
@@ -990,7 +972,7 @@ describe('Merge', function() {
     })
 
     context('on initial scan', function() {
-      it('overrides an unsynced local addition with a local update', async function() {
+      it('saves an offline update after an unsynced local addition', async function() {
         const initialFile = await builders
           .metafile()
           .sides({ local: 1 })
@@ -1013,8 +995,7 @@ describe('Merge', function() {
           savedDocs: [
             _.defaults(
               {
-                sides: increasedSides(initialFile.sides, 'local', 1),
-                overwrite: initialFile
+                sides: increasedSides(initialFile.sides, 'local', 1)
               },
               _.omit(offlineUpdate, ['_id', '_rev', 'fileid'])
             )
@@ -1023,20 +1004,16 @@ describe('Merge', function() {
         })
       })
 
-      it('overrides an unsynced local update with a new one', async function() {
+      it('saves an offline update after an unsynced local update', async function() {
         const initial = await builders
           .metafile()
           .path('yafile')
-          .sides({ local: 1 })
           .ino(37)
           .data('initial content')
-          .create()
-        const synced = await builders
-          .metafile(initial)
           .upToDate()
           .create()
         const firstUpdate = await builders
-          .metafile(synced)
+          .metafile(initial)
           .changedSide('local')
           .data('first update')
           .create()
@@ -1056,8 +1033,7 @@ describe('Merge', function() {
             _.defaultsDeep(
               {
                 sides: increasedSides(firstUpdate.sides, 'local', 1),
-                overwrite: firstUpdate,
-                remote: synced.remote
+                remote: initial.remote
               },
               _.omit(secondUpdate, ['_id', '_rev', 'fileid'])
             )
@@ -1066,7 +1042,7 @@ describe('Merge', function() {
         })
       })
 
-      it('does not overwrite an unsynced remote update with a locally unchanged file', async function() {
+      it('does nothing for an locally untouched file after an unsynced remote update', async function() {
         const synced = await builders
           .metafile()
           .data('previous content')
@@ -1074,7 +1050,6 @@ describe('Merge', function() {
           .create()
         await builders
           .metafile(synced)
-          .overwrite(synced)
           .data('remote update')
           .changedSide('remote')
           .create()
@@ -1093,7 +1068,9 @@ describe('Merge', function() {
         })
       })
 
-      it('does not overwrite an unsynced remote update with a locally updated file and creates a local conflict', async function() {
+      // XXX: This sides are increased on the remote update to make sure it will
+      // get synced.
+      it('creates a conflict for an oflline local update after an unsynced remote update', async function() {
         const synced = await builders
           .metafile()
           .data('initial content')
@@ -1101,7 +1078,6 @@ describe('Merge', function() {
           .create()
         const remoteUpdate = await builders
           .metafile(synced)
-          .overwrite(synced)
           .data('remote update')
           .changedSide('remote')
           .create()
@@ -1195,19 +1171,50 @@ describe('Merge', function() {
           _.defaults(
             {
               sides: increasedSides(file.sides, 'remote', 1),
-              local: file.local
+              remote: doc.remote,
+              tags: ['bar', 'baz']
             },
-            _.omit(doc, ['_id', '_rev', 'fileid'])
+            _.omit(file, ['_id', '_rev', 'fileid'])
           )
         ],
         resolvedConflicts: []
       })
     })
 
+    // XXX: Here we don't increase the sides as we don't want to propagate a
+    // simple change of modification date.
     it('updates the local metadata when content is the same', async function() {
       const doc = builders
         .metafile(file)
         .updatedAt(new Date())
+        .unmerged('local')
+        .build()
+
+      const sideEffects = await mergeSideEffects(this, () =>
+        this.merge.updateFileAsync('local', _.cloneDeep(doc))
+      )
+
+      should(sideEffects).deepEqual({
+        savedDocs: [
+          _.defaultsDeep(
+            {
+              local: { updated_at: doc.local.updated_at }
+            },
+            _.omit(file, ['_id', '_rev', 'fileid'])
+          )
+        ],
+        resolvedConflicts: []
+      })
+    })
+
+    it('sets the local metadata when it is missing', async function() {
+      // Remove local attribute for the test
+      delete file.local
+      const { rev } = await this.pouch.db.put(file)
+      file._rev = rev
+
+      const doc = builders
+        .metafile(file)
         .unmerged('local')
         .build()
 
@@ -1228,78 +1235,76 @@ describe('Merge', function() {
       })
     })
 
-    it('sets the local metadata when it is missing', async function() {
-      const mergedFile = await builders
-        .metafile()
-        .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
-        .upToDate()
-        .create()
-
-      // Remove local attribute for the test
-      delete mergedFile.local
-      const { rev } = await this.pouch.db.put(mergedFile)
-      mergedFile._rev = rev
-
-      const sameFile = builders
-        .metafile(mergedFile)
-        .unmerged('local')
-        .build()
-
-      const sideEffects = await mergeSideEffects(this, () =>
-        this.merge.updateFileAsync('local', _.cloneDeep(sameFile))
-      )
-
-      should(sideEffects).deepEqual({
-        savedDocs: [
-          _.defaults(
-            {
-              local: sameFile.local
-            },
-            _.omit(mergedFile, ['_id', '_rev', 'fileid'])
-          )
-        ],
-        resolvedConflicts: []
-      })
-    })
-
-    it('keeps an existing local metadata when it is not present in the new doc', async function() {
-      const initial = await builders
-        .metafile()
-        .data('initial content')
-        .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
-        .upToDate()
-        .create()
-      const update = builders
-        .metafile(initial)
+    it('keeps an existing local metadata for a remote update', async function() {
+      const doc = builders
+        .metafile(file)
         .data('updated content')
         .updatedAt(new Date())
         .unmerged('remote')
         .build()
 
       const sideEffects = await mergeSideEffects(this, () =>
-        this.merge.updateFileAsync('remote', _.cloneDeep(update))
+        this.merge.updateFileAsync('remote', _.cloneDeep(doc))
       )
 
       should(sideEffects).deepEqual({
         savedDocs: [
           _.defaultsDeep(
             {
-              sides: increasedSides(initial.sides, 'remote', 1),
-              local: initial.local,
-              overwrite: initial
+              sides: increasedSides(file.sides, 'remote', 1),
+              local: file.local
             },
-            _.omit(update, ['_id', '_rev', 'fileid'])
+            _.omit(doc, ['_id', '_rev', 'fileid'])
           )
         ],
         resolvedConflicts: []
       })
     })
 
-    it('overwrites the content when it was changed', async function() {
+    it('keeps an existing remote metadata for a local update', async function() {
       const doc = builders
         .metafile(file)
         .data('new content')
-        .tags('qux', 'quux')
+        .updatedAt(new Date())
+        .unmerged('local')
+        .build()
+
+      const sideEffects = await mergeSideEffects(this, () =>
+        this.merge.updateFileAsync('local', _.cloneDeep(doc))
+      )
+
+      should(sideEffects).deepEqual({
+        savedDocs: [
+          _.defaults(
+            {
+              sides: increasedSides(file.sides, 'local', 1),
+              remote: file.remote
+            },
+            _.omit(doc, ['_id', '_rev', 'fileid'])
+          )
+        ],
+        resolvedConflicts: []
+      })
+    })
+
+    it('keeps the overwrite attribute if it exists', async function() {
+      // Overwrite file with a move
+      const src = await builders
+        .metafile()
+        .moveTo(file.path)
+        .changedSide(this.side)
+        .create()
+      const dst = await builders
+        .metafile()
+        .moveFrom(src)
+        .path(file.path)
+        .overwrite(file)
+        .changedSide(this.side)
+        .create()
+
+      const doc = builders
+        .metafile(dst)
+        .data('final content')
         .unmerged(this.side)
         .build()
 
@@ -1311,9 +1316,10 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              sides: increasedSides(file.sides, this.side, 1),
+              sides: increasedSides(dst.sides, this.side, 1),
+              moveFrom: src,
               overwrite: file,
-              [otherSide(this.side)]: file[otherSide(this.side)]
+              [otherSide(this.side)]: dst[otherSide(this.side)]
             },
             _.omit(doc, ['_id', '_rev', 'fileid'])
           )


### PR DESCRIPTION
When a specific path is overwritten more than once before
synchronization, we need to keep track of the first overwritten record
as it contains the information we need to propagate its deletion to
the remote Cozy and transfer its references to the new document in its
stead.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
