### PR TITLE
core/merge: Save local file metadata separately

### DIFF
--- a/core/local/stater.js
+++ b/core/local/stater.js
@@ -14,7 +14,7 @@ if (process.platform === 'win32') {
 }
 
 /*::
-import type { Metadata } from '../metadata'
+import type { Metadata, MetadataLocalInfo } from '../metadata'
 import type { Callback } from '../utils/func'
 
 export type WinStats = {|
@@ -86,7 +86,10 @@ module.exports = {
     return this.isDirectory(stats) ? 'directory' : 'file'
   },
 
-  assignInoAndFileId(doc /*: Metadata */, stats /*: Stats */) {
+  assignInoAndFileId(
+    doc /*: Metadata|MetadataLocalInfo */,
+    stats /*: Stats */
+  ) {
     doc.ino = stats.ino
     if (typeof stats.fileid === 'string') {
       doc.fileid = stats.fileid

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -115,6 +115,30 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 3,
+    targetSchemaVersion: 4,
+    description: 'Generating files local Metadata info with current Metadata',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(doc => doc.docType === 'file')
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        doc.local = {
+          md5sum: doc.md5sum,
+          class: doc.class,
+          docType: 'file',
+          executable: doc.executable,
+          updated_at: doc.updated_at,
+          mime: doc.mime,
+          size: doc.size,
+          ino: doc.ino,
+          fileid: doc.fileid
+        }
+        return doc
+      })
+    }
   }
 ]
 

--- a/test/integration/executable.js
+++ b/test/integration/executable.js
@@ -57,8 +57,7 @@ describe('Executable handling', () => {
     onPlatforms(['darwin', 'linux'], () => {
       it('is executable everywhere', async () => {
         await syncDir.ensureFileMode('file', 0o777)
-        await helpers.local.scan()
-        await helpers.syncAll()
+        await helpers.flushLocalAndSyncAll()
 
         should(await executableStatus('file')).deepEqual({
           local: '777',
@@ -73,8 +72,7 @@ describe('Executable handling', () => {
   describe('adding a local non-executable file', () => {
     it('is non-executable anywhere', async () => {
       await syncDir.ensureFileMode('file', 0o666)
-      await helpers.local.scan()
-      await helpers.syncAll()
+      await helpers.flushLocalAndSyncAll()
 
       should(await executableStatus('file')).deepEqual({
         local:
@@ -93,6 +91,7 @@ describe('Executable handling', () => {
       await cozy.files.create('whatever content', { name: 'file' })
       await cozy.files.updateAttributesByPath('/file', { executable: true })
       await helpers.pullAndSyncAll()
+      await helpers.flushLocalAndSyncAll()
 
       should(await executableStatus('file')).deepEqual({
         local: platform === 'win32' ? WINDOWS_DEFAULT_MODE : '755', // assuming umask 022
@@ -107,6 +106,7 @@ describe('Executable handling', () => {
     it('is not executable anywhere', async () => {
       await cozy.files.create('whatever content', { name: 'file' })
       await helpers.pullAndSyncAll()
+      await helpers.flushLocalAndSyncAll()
 
       should(await executableStatus('file')).deepEqual({
         local: platform === 'win32' ? WINDOWS_DEFAULT_MODE : '644', // assuming umask 022
@@ -120,16 +120,14 @@ describe('Executable handling', () => {
   context('with a synced non-executable file', () => {
     beforeEach(async () => {
       await syncDir.ensureFileMode('file', 0o666)
-      await helpers.local.scan()
-      await helpers.syncAll()
+      await helpers.flushLocalAndSyncAll()
     })
 
     describe('making it executable locally', () => {
       onPlatforms(['darwin', 'linux'], () => {
         it('makes it executable everywhere', async () => {
           await syncDir.chmod('file', 0o766)
-          await helpers.local.scan()
-          await helpers.syncAll()
+          await helpers.flushLocalAndSyncAll()
 
           should(await executableStatus('file')).deepEqual({
             local: '766',
@@ -145,6 +143,7 @@ describe('Executable handling', () => {
       it('is executable everywhere, forcing 755 locally, except on Windows', async () => {
         await cozy.files.updateAttributesByPath('/file', { executable: true })
         await helpers.pullAndSyncAll()
+        await helpers.flushLocalAndSyncAll()
 
         should(await executableStatus('file')).deepEqual({
           local: platform === 'win32' ? WINDOWS_DEFAULT_MODE : '755',
@@ -167,8 +166,7 @@ describe('Executable handling', () => {
       onPlatforms(['darwin', 'linux'], () => {
         it('is non-executable everywhere', async () => {
           await syncDir.chmod('file', 0o644)
-          await helpers.local.scan()
-          await helpers.syncAll()
+          await helpers.flushLocalAndSyncAll()
 
           should(await executableStatus('file')).deepEqual({
             local: '644',
@@ -184,6 +182,7 @@ describe('Executable handling', () => {
       it('is non-executable everywhere', async () => {
         await cozy.files.updateAttributesByPath('/file', { executable: false })
         await helpers.pullAndSyncAll()
+        await helpers.flushLocalAndSyncAll()
 
         should(await executableStatus('file')).deepEqual({
           local: platform === 'win32' ? WINDOWS_DEFAULT_MODE : '644',

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -85,17 +85,8 @@ describe('Sync gets interrupted, initialScan occurs', () => {
 
       // but not sync (client restart)
 
-      await helpers.local.scan()
-      await helpers.syncAll()
-
-      await helpers.remote.pullChanges()
-      await helpers.syncAll()
-
-      // A conflict version is created
-      should(await helpers.trees()).deepEqual({
-        remote: ['file'],
-        local: ['/Trash/file.bck', 'file']
-      })
+      await helpers.flushLocalAndSyncAll()
+      await helpers.pullAndSyncAll()
 
       // Contents are kept untouched
       const resp = await helpers.remote.cozy.files.downloadById(doc.remote._id)

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -49,8 +49,8 @@ describe('Move', () => {
       src = await cozy.files.createDirectory({ name: 'src' })
       file = await cozy.files.create('foo', { name: 'file', dirID: src._id })
 
-      await helpers.remote.pullChanges()
-      await helpers.syncAll()
+      await helpers.pullAndSyncAll()
+      await helpers.flushLocalAndSyncAll()
       helpers.spyPouch()
     })
 
@@ -271,11 +271,9 @@ describe('Move', () => {
           'src/file',
           'updated file content'
         )
-        await helpers.local.scan()
-        await helpers.syncAll()
+        await helpers.flushLocalAndSyncAll()
         await helpers.local.syncDir.rename('src/file', 'file2')
-        await helpers.local.scan()
-        await helpers.syncAll()
+        await helpers.flushLocalAndSyncAll()
 
         should(await helpers.docByPath('src/file2')).match({
           remote: { _id: file._id }
@@ -290,8 +288,7 @@ describe('Move', () => {
 
       it('remote', async () => {
         await cozy.files.updateById(file._id, 'updated file content', {})
-        await helpers.remote.pullChanges()
-        await helpers.syncAll()
+        await helpers.pullAndSyncAll()
         const was = await pouch.byRemoteIdAsync(file._id)
         await helpers._remote.moveAsync(
           {
@@ -300,8 +297,7 @@ describe('Move', () => {
           },
           was
         )
-        await helpers.remote.pullChanges()
-        await helpers.syncAll()
+        await helpers.pullAndSyncAll()
 
         should(await helpers.docByPath('src/file2')).match({
           remote: { _id: file._id }
@@ -323,8 +319,7 @@ describe('Move', () => {
         )
         await helpers.local.scan()
         await helpers.local.syncDir.rename('src/file', 'file2')
-        await helpers.local.scan()
-        await helpers.syncAll()
+        await helpers.flushLocalAndSyncAll()
 
         should(await helpers.docByPath('src/file2')).match({
           remote: { _id: file._id }
@@ -348,8 +343,7 @@ describe('Move', () => {
           },
           was
         )
-        await helpers.remote.pullChanges()
-        await helpers.syncAll()
+        await helpers.pullAndSyncAll()
 
         should(await helpers.docByPath('src/file2')).match({
           remote: { _id: file._id }
@@ -833,8 +827,8 @@ describe('Move', () => {
           name: 'file',
           dirID: dir._id
         })
-        await helpers.remote.pullChanges()
-        await helpers.syncAll()
+        await helpers.pullAndSyncAll()
+        await helpers.flushLocalAndSyncAll()
       })
 
       it('local', async () => {

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -43,6 +43,7 @@ describe('Cozy Note update', () => {
       .timestamp(2018, 5, 15, 21, 1, 53)
       .create()
     await helpers.pullAndSyncAll()
+    await helpers.flushLocalAndSyncAll()
   })
 
   describe('on remote Cozy', () => {
@@ -268,6 +269,7 @@ describe('Markdown file with Cozy Note mime type update', () => {
       .timestamp(2018, 5, 15, 21, 1, 53)
       .create()
     await helpers.pullAndSyncAll()
+    await helpers.flushLocalAndSyncAll()
   })
   beforeEach('change note into markdown file', async function() {
     const doc = await this.pouch.byIdMaybeAsync(metadata.id('note.cozy-note'))

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -26,6 +26,7 @@ module.exports = class BaseMetadataBuilder {
   pouch: ?Pouch
   doc: Metadata
   old: ?Metadata
+  buildLocal: boolean
   */
 
   constructor(pouch /*: ?Pouch */, old /*: ?Metadata */) {
@@ -47,6 +48,7 @@ module.exports = class BaseMetadataBuilder {
       }
       this.doc = doc
     }
+    this.buildLocal = false // Default docType is folder
   }
 
   fromRemote(remoteDoc /*: RemoteDoc */) /*: this */ {
@@ -91,6 +93,12 @@ module.exports = class BaseMetadataBuilder {
      * buildDir to set remote to undefined
      */
     this.doc.remote = undefined
+    return this
+  }
+
+  noLocal() /*: this */ {
+    this.buildLocal = false
+    if (this.doc.local) delete this.doc.local
     return this
   }
 
@@ -234,6 +242,10 @@ module.exports = class BaseMetadataBuilder {
     // Don't detect incompatibilities according to syncPath for test data, to
     // prevent environment related failures.
     metadata.assignPlatformIncompatibilities(this.doc, '')
+
+    if (this.buildLocal && metadata.isAtLeastUpToDate('local', this.doc)) {
+      metadata.updateLocal(this.doc)
+    }
 
     return _.cloneDeep(this.doc)
   }

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -23,6 +23,7 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
     if (this.doc.md5sum == null) {
       this.data('')
     }
+    this.buildLocal = true
   }
 
   data(data /*: string */) /*: this */ {

--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -136,6 +136,10 @@ class ContextDir {
     await fse.chmod(this.abspath(target), mode)
   }
 
+  async utimes(target /*: string | {path: string} */, updatedAt /*: Date */) {
+    await fse.utimes(this.abspath(target), updatedAt, updatedAt)
+  }
+
   async ensureFileMode(
     target /*: string | {path: string} */,
     mode /*: number */

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -259,6 +259,7 @@ module.exports.init = async (
           trashed,
           useRealInodes
         })
+        // $FlowFixMe local attribute does not exist for folders yet
         const doc /*: Metadata */ = {
           _id: metadata.id(localPath),
           docType: 'folder',
@@ -326,9 +327,18 @@ module.exports.init = async (
           size: content.length,
           tags: [],
           remote: { _id: 'xxx', _rev: 'xxx' },
+          local: {
+            class: 'text',
+            docType: 'file',
+            md5sum,
+            mime: 'text/plain',
+            size: content.length,
+            updated_at: lastModifiedDate.toISOString()
+          },
           sides: { target: 2, local: 2, remote: 2 }
         }
         stater.assignInoAndFileId(doc, stats)
+        stater.assignInoAndFileId(doc.local, stats)
         if (!isOutside && remoteParent) {
           debug(
             `- create${trashed ? ' and trash' : ''} remote file: ${remotePath}`

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -1856,15 +1856,15 @@ describe('RemoteWatcher', function() {
           .shortRev(3)
           .build()
 
+        const doc = metadata.fromRemoteDoc(newFile)
+        metadata.assignId(doc)
+
         should(
           this.watcher.identifyChange(newFile, trashedFile, [], [])
         ).have.properties({
           sideName: 'remote',
           type: 'FileAddition',
-          doc: builders
-            .metafile()
-            .fromRemote(newFile)
-            .build()
+          doc
         })
       })
     })


### PR DESCRIPTION
We want to keep track of the current local state of files, whether
they're in sync or not.

At the moment, we store altogether in our PouchDB records the 3
different states of documents — local, remote and last synced — and a
few technical attributes that help us make sense of it all (e.g. which
side has received changes that need to be synchronized, what actions
need to be applied…).
This mechanism is limited because we don't store separately the values
of attributes on each side. For example, if a file's `size` has
changed on the remote Cozy and we've saved it in PouchDB, we've lost
the local file's `size`.
When loosing this information, it's harder for us to make sense of our
data and to make the right decision and even impossible to make some.

A good example of such an impossible decision to make can be described
by this scenario:
0. A file `a` is synchronized between the local filesystem and the
   remote Cozy
1. `a` is updated on the remote Cozy and thus its `md5sum` stored in
   PouchDB is changed
2. the client is stopped before the change is applied on the
   local filesystem

⇒ When the client is restarted, the local scan will generate an event
with the local, outdated, file `md5sum` which will be treated as an
update because we see a difference between the event's `md5sum` and
the one stored in PouchDB. We have no way to tell this was the
previous `md5sum` and this change should be discarded.

By storing the local state separately, we have this information and we
can use it to tell whether the detected local change is an actual one
or not by comparing the stored local state and the new one.

This commit only introduces local file states, the methods to update
them, to compare them with one another and the calls to keep them
up-to-date with the actual file's local state.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
