### PR TITLE
local/chokidar/analysis: Compare normalized paths

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -99,12 +99,12 @@ class LocalChangeMap {
     path /*: string */,
     callback /*: (LocalChange) => T */
   ) /*: ?T */ {
-    const change = this.changesByPath.get(path)
+    const change = this.changesByPath.get(path.normalize())
     if (change) return callback(change)
   }
 
   put(c /*: LocalChange */) {
-    this.changesByPath.set(c.path, c)
+    this.changesByPath.set(c.path.normalize(), c)
     if (typeof c.ino === 'number') this.changesByInode.set(c.ino, c)
     else this.changes.push(c)
   }
@@ -280,8 +280,8 @@ function sortBeforeSquash(changes /*: LocalChange[] */) {
   changes.sort((a, b) => {
     if (a.type === 'DirMove' || a.type === 'FileMove') {
       if (b.type === 'DirMove' || b.type === 'FileMove') {
-        if (a.path < b.path) return -1
-        else if (a.path > b.path) return 1
+        if (a.path.normalize() < b.path.normalize()) return -1
+        else if (a.path.normalize() > b.path.normalize()) return 1
         else return 0
       } else return -1
     } else if (b.type === 'DirMove' || b.type === 'FileMove') {

--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -300,24 +300,26 @@ function squashMoves(changes /*: LocalChange[] */) {
   const stopMeasure = measureTime('LocalWatcher#squashMoves')
 
   for (let i = 0; i < changes.length; i++) {
-    let a = changes[i]
+    const a = changes[i]
     if (a.type !== 'DirMove' && a.type !== 'FileMove') continue
+    const pathA = a.path.normalize()
+    const oldPathA = a.old && a.old.path.normalize()
 
     for (let j = i + 1; j < changes.length; j++) {
-      let b = changes[j]
+      const b = changes[j]
       if (b.type !== 'DirMove' && b.type !== 'FileMove') continue
+      const pathB = b.path.normalize()
+      const oldPathB = b.old && b.old.path.normalize()
 
       // inline of LocalChange.isChildMove
       if (
         a.type === 'DirMove' &&
-        (b.path.indexOf(a.path + path.sep) === 0 ||
-          (a.old && b.old && b.old.path.indexOf(a.old.path + path.sep) === 0))
+        (pathB.startsWith(pathA + path.sep) ||
+          (oldPathA && oldPathB && oldPathB.startsWith(oldPathA + path.sep)))
       ) {
         log.debug({ oldpath: b.old.path, path: b.path }, 'descendant move')
         a.wip = a.wip || b.wip
-        if (
-          b.path.substr(a.path.length) === b.old.path.substr(a.old.path.length)
-        ) {
+        if (pathB.substr(pathA.length) === oldPathB.substr(oldPathA.length)) {
           log.debug(
             { oldpath: b.old.path, path: b.path },
             'ignoring explicit child move'


### PR DESCRIPTION
We want to normalize paths with NFC when comparing them in `analysis`
so that equivalent paths which differ only by the norm they're encoded
with are found equal and we don't detect moves when there aren't.

On macOS, the local filesystem can automatically normalize UTF-8
characters in files and folders paths with the NFD norm.
Folders and files created on the remote Cozy will be normalized with
the NFC norm.
The same names encoded in different norms won't be equal from a
JavaScript string comparison standpoint.

On macOS, when a folder is moved or renamed, we receive two events from
the filesystem for the folder itself (i.e. `unlinkDir` with the old
path and `addDir` with the new path) that we will transform into a
`DirMove` change. We also receive two events for each child of the
moved folder (i.e. `unlink` and `add`), transformed in either
`DirMove` or `FileMove` changes.
Our Merge and Sync modules expect only the parent `DirMove` event so
we need to ignore the child moves. However, a child can also be moved
or renamed very close to the parent move and so we'll need to keep
that change.
To make the difference between the two situations, we compare the
parent and child old paths and new paths to see if the child has just
been moved along its parent.

This is where our normalization problems come in.

If the parent folder has been created on the remote Cozy, its path
saved in its PouchDB record will be normalized with NFC while its path
on the local filesystem will be normalized with NFD (we keep the NFC
path within PouchDB to avoid sending extraneous renamings to the
remote Cozy).
If it's renamed locally, its new path path as well as the child's new
path will be normalized with NFD.
Now to check that the child has not been renamed or moved within its
parent folder, we compare two strings:
- the child's new path minus the parent's new path
- the child's old path minus the parent's old path

We happen to have an issue when a child is added locally into a folder
created on the remote Cozy with UTF-8 characters within its name: the
child's path will be completely encoded with NFD in PouchDB while its
parent path will be encoded with NFC.

With that in mind, in our check above, the "new paths" string will
yield the expected result (i.e. the path to the child within its
parent) while the second string won't because the parent's old path
won't contain the exact parent's old path and both strings will then
be different.
In this case we'll detect the `FileMove` as a move within a move and
won't ignore it like we should leading to other issues down the road
like desynchronisation or conflicts.
By comparing normalized versions of all these strings we make sure the
normalization is not a differentiator and we don't detect non-existent
renamings or moves.
This does not change the way we store the paths.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
