### PR TITLE
local/chokidar/watcher: Normalize changes paths

### DIFF
--- a/core/local/chokidar/normalize_paths.js
+++ b/core/local/chokidar/normalize_paths.js
@@ -1,0 +1,109 @@
+/** Match LocalEvents paths with their existing normalization
+ *
+ * @module core/local/chokidar/normalize_paths
+ * @flow
+ */
+
+const Promise = require('bluebird')
+const path = require('path')
+
+const metadata = require('../../metadata')
+const logger = require('../../utils/logger')
+
+const log = logger({
+  component: 'chokidar/normalize_paths'
+})
+
+/*::
+import type {  } from './local_change'
+import type { Metadata } from '../../metadata'
+import type { Pouch } from '../../pouch'
+import type {
+  LocalChange,
+  LocalDirAddition,
+  LocalDirDeletion,
+  LocalDirMove,
+  LocalFileAddition,
+  LocalFileDeletion,
+  LocalFileMove,
+  LocalFileUpdate
+} from './local_change'
+
+type Change =
+  | LocalDirAddition
+  | LocalDirDeletion
+  | LocalDirMove
+  | LocalFileAddition
+  | LocalFileDeletion
+  | LocalFileMove
+  | LocalFileUpdate
+
+type NormalizePathsOpts = {
+  pouch: Pouch,
+}
+*/
+
+const step = async (
+  changes /*: LocalChange[] */,
+  { pouch } /*: NormalizePathsOpts */
+) /*: Promise<LocalChange[]> */ => {
+  const normalizedPaths = []
+
+  return new Promise.map(changes, async (
+    c /*: LocalChange */
+  ) /*: Promise<LocalChange> */ => {
+    if (c.type !== 'Ignored') {
+      const parentPath = path.dirname(c.path)
+      const parent =
+        parentPath !== '.'
+          ? await pouch.byIdMaybeAsync(metadata.id(parentPath))
+          : null
+      c.path = normalizedPath(c, parent, normalizedPaths)
+      normalizedPaths.push(c.path)
+    }
+
+    return c
+  })
+}
+
+const previouslyNormalizedPath = (
+  docPath /*: string */,
+  normalizedPaths /*: string[] */
+) /*: ?string */ =>
+  normalizedPaths.find(p => p.normalize() === docPath.normalize())
+
+const isNFD = string => string === string.normalize('NFD')
+
+const normalizedPath = (
+  change /*: Change */,
+  parent /*: ?Metadata */,
+  normalizedPaths /*: string[] */
+) /*: string */ => {
+  // Curent change's path parts
+  const name = path.basename(change.path)
+  const parentPath = path.dirname(change.path)
+
+  const normalizedParentPath = parent
+    ? parent.path
+    : parentPath != '.'
+    ? previouslyNormalizedPath(parentPath, normalizedPaths) || parentPath
+    : ''
+  const { old } = change
+  const normalizedName =
+    old && isNFD(name) && !isNFD(path.basename(old.path))
+      ? name.normalize('NFC')
+      : name
+  const normalizedPath = path.join(normalizedParentPath, normalizedName)
+
+  if (change.path !== normalizedPath) {
+    log.info(
+      { path: change.path, normalizedPath },
+      'normalizing local path to match existing doc and parent norms'
+    )
+  }
+  return normalizedPath
+}
+
+module.exports = {
+  step
+}

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -75,20 +75,14 @@ const step = async (
   events /*: ChokidarEvent[] */,
   { checksum, initialScan, pouch, syncPath } /*: PrepareEventsOpts */
 ) /*: Promise<LocalEvent[]> */ => {
-  const normalizedPaths = []
-
   return Promise.map(
     events,
     async (e /*: ChokidarEvent */) /*: Promise<?LocalEvent> */ => {
       const abspath = path.join(syncPath, e.path)
 
       const old = await oldMetadata(e, pouch)
-      const eventPath = normalizedPath(e, old, normalizedPaths)
-      normalizedPaths.push(eventPath)
-
       const e2 /*: Object */ = {
         ...e,
-        path: eventPath,
         old
       }
 
@@ -139,55 +133,6 @@ const step = async (
     },
     { concurrency: 50 }
   ).filter((e /*: ?LocalEvent */) => e != null)
-}
-
-const parentPathNormalized = (
-  childPath /*: string */,
-  normalizedPaths /*: string[] */
-) /*: ?string */ =>
-  normalizedPaths.find(
-    p => p.normalize() === path.dirname(childPath).normalize()
-  )
-
-const isNFD = string => string === string.normalize('NFD')
-
-const normalizedPath = (
-  event /*: ChokidarEvent */,
-  existing /*: ?Metadata */,
-  normalizedPaths /*: string[] */
-) /*: string */ => {
-  if (existing != null && existing.path != null) {
-    // Curent event's path parts
-    const name = path.basename(event.path)
-    const normalizedParentPath = parentPathNormalized(
-      event.path,
-      normalizedPaths
-    )
-    // Existing Pouch document's path parts
-    const existingName = path.basename(existing.path)
-    const existingParentPath = path.dirname(existing.path)
-
-    if (isNFD(name) && !isNFD(existingName)) {
-      const normalizedName = name.normalize('NFC')
-      log.info(
-        { path: event.path, existingPath: existing.path, normalizedName },
-        'normalizing local NFD path to match existing NFC path'
-      )
-
-      // We expect the parent path to have been normalized via other events.
-      // This might not be true if the parent's normalization hasn't been saved
-      // to PouchDB yet.
-      // So we look for a normalized parent path from a previous event and use
-      // it or use the existing parent path otherwise.
-      return normalizedParentPath
-        ? path.join(normalizedParentPath, normalizedName)
-        : existingParentPath != '.'
-        ? path.join(existingParentPath, normalizedName)
-        : normalizedName
-    }
-  }
-
-  return event.path
 }
 
 module.exports = {

--- a/test/unit/local/chokidar/normalize_paths.js
+++ b/test/unit/local/chokidar/normalize_paths.js
@@ -1,0 +1,1061 @@
+/* eslint-env mocha */
+
+const should = require('should')
+const path = require('path')
+
+const normalizePaths = require('../../../../core/local/chokidar/normalize_paths')
+
+const Builders = require('../../../support/builders')
+const configHelpers = require('../../../support/helpers/config')
+const pouchHelpers = require('../../../support/helpers/pouch')
+const { onPlatform } = require('../../../support/helpers/platform')
+
+const stepOptions = self => ({
+  pouch: self.pouch
+})
+
+onPlatform('darwin', () => {
+  describe('core/local/chokidar_steps/normalize_paths', () => {
+    let builders
+
+    before('instanciate config', configHelpers.createConfig)
+    beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+
+    beforeEach('set up builders', function() {
+      builders = new Builders({ pouch: this.pouch })
+    })
+
+    afterEach('clean pouch', pouchHelpers.cleanDatabase)
+    after('clean config directory', configHelpers.cleanConfig)
+
+    describe('added file in dir on filesystem normalizing with NFD', () => {
+      const dirPath = 'corrigés'.normalize('NFD')
+      const filename = 'Réussite'.normalize('NFD')
+
+      context('when parent is saved with NFC encoded path in Pouch', () => {
+        beforeEach(async function() {
+          await builders
+            .metadir()
+            .path(dirPath.normalize('NFC'))
+            .create()
+        })
+
+        it('normalizes only parent part of file path with NFC', async function() {
+          const changes = [
+            {
+              type: 'FileAddition',
+              path: path.join(dirPath, filename),
+              stats: { ino: 1 }
+            }
+          ]
+          const [change] = await normalizePaths.step(changes, stepOptions(this))
+          should(change).have.properties({
+            path: path.join(dirPath.normalize('NFC'), filename.normalize('NFD'))
+          })
+        })
+      })
+
+      context('when parent is saved with NFD encoded path in Pouch', () => {
+        beforeEach(async function() {
+          await builders
+            .metadir()
+            .path(dirPath.normalize('NFD'))
+            .create()
+        })
+
+        it('does not normalize parent part of file path with NFC', async function() {
+          const changes = [
+            {
+              type: 'FileAddition',
+              path: path.join(dirPath, filename),
+              stats: { ino: 1 }
+            }
+          ]
+          const [change] = await normalizePaths.step(changes, stepOptions(this))
+          should(change).have.properties({
+            path: path.join(dirPath.normalize('NFD'), filename.normalize('NFD'))
+          })
+        })
+      })
+    })
+
+    describe('changed file in dir on filesystem normalizing with NFD', () => {
+      const dirPath = 'corrigés'.normalize('NFD')
+      const filename = 'Réussite'.normalize('NFD')
+
+      context('when parent is saved with NFC encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(dirPath.normalize('NFC'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileUpdate',
+                path: path.join(dirPath, filename),
+                stats: { ino: 1 },
+                old: { path: file.path }
+              },
+              {
+                type: 'FileDeletion',
+                path: path.join(dirPath, filename),
+                old: { path: file.path }
+              }
+            ]
+            const resultByChangeType = {}
+            for (const change of changes) {
+              const [{ path }] = await normalizePaths.step(
+                [change],
+                stepOptions(this)
+              )
+              resultByChangeType[change.type] = { path }
+            }
+            should(resultByChangeType).deepEqual({
+              FileUpdate: {
+                path: file.path.normalize('NFC')
+              },
+              FileDeletion: {
+                path: file.path.normalize('NFC')
+              }
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes only parent part of file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileUpdate',
+                path: path.join(dirPath, filename),
+                stats: { ino: 1 },
+                old: { path: file.path }
+              },
+              {
+                type: 'FileDeletion',
+                path: path.join(dirPath, filename),
+                old: { path: file.path }
+              }
+            ]
+            const resultByChangeType = {}
+            for (const change of changes) {
+              const [{ path }] = await normalizePaths.step(
+                [change],
+                stepOptions(this)
+              )
+              resultByChangeType[change.type] = { path }
+            }
+            should(resultByChangeType).deepEqual({
+              FileUpdate: {
+                path: path.join(
+                  dirPath.normalize('NFC'),
+                  filename.normalize('NFD')
+                )
+              },
+              FileDeletion: {
+                path: path.join(
+                  dirPath.normalize('NFC'),
+                  filename.normalize('NFD')
+                )
+              }
+            })
+          })
+        })
+      })
+
+      context('when parent is saved with NFD encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(dirPath.normalize('NFD'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes only file name with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileUpdate',
+                path: path.join(dirPath, filename),
+                stats: { ino: 1 },
+                old: { path: file.path }
+              },
+              {
+                type: 'FileDeletion',
+                path: path.join(dirPath, filename),
+                old: { path: file.path }
+              }
+            ]
+            const resultByChangeType = {}
+            for (const change of changes) {
+              const [{ path }] = await normalizePaths.step(
+                [change],
+                stepOptions(this)
+              )
+              resultByChangeType[change.type] = { path }
+            }
+            should(resultByChangeType).deepEqual({
+              FileUpdate: {
+                path: path.join(
+                  dirPath.normalize('NFD'),
+                  filename.normalize('NFC')
+                )
+              },
+              FileDeletion: {
+                path: path.join(
+                  dirPath.normalize('NFD'),
+                  filename.normalize('NFC')
+                )
+              }
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('does not normalize file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileUpdate',
+                path: path.join(dirPath, filename),
+                stats: { ino: 1 },
+                old: { path: file.path }
+              },
+              {
+                type: 'FileDeletion',
+                path: path.join(dirPath, filename),
+                old: { path: file.path }
+              }
+            ]
+            const resultByChangeType = {}
+            for (const change of changes) {
+              const [{ path }] = await normalizePaths.step(
+                [change],
+                stepOptions(this)
+              )
+              resultByChangeType[change.type] = { path }
+            }
+            should(resultByChangeType).deepEqual({
+              FileUpdate: {
+                path: file.path.normalize('NFD')
+              },
+              FileDeletion: {
+                path: file.path.normalize('NFD')
+              }
+            })
+          })
+        })
+      })
+    })
+
+    describe('renamed dir with child on filesystem normalizing with NFD', () => {
+      const srcDirPath = 'énoncés'.normalize('NFD')
+      const dstDirPath = 'corrigés'.normalize('NFD')
+      const filename = 'Réussite'.normalize('NFD')
+
+      context('when parent is saved with NFC encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(srcDirPath.normalize('NFC'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes new dir and file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, filename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFC')
+            })
+            should(fileMove).have.properties({
+              path: path.join(dstDirPath, filename).normalize('NFC')
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes only parent part of file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, filename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFC')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFC'),
+                filename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+
+      context('when parent is saved with NFD encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(srcDirPath.normalize('NFD'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes file name with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, filename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFD')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFD'),
+                filename.normalize('NFC')
+              )
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, filename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('does not normalize new dir or file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, filename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFD')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFD'),
+                filename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+    })
+
+    describe('renamed file in dir on filesystem normalizing with NFD', () => {
+      const dirPath = 'corrigés'.normalize('NFD')
+      const srcFilename = 'Réussite'.normalize('NFD')
+      const dstFilename = 'Échec'.normalize('NFD')
+
+      context('when parent is saved with NFC encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(dirPath.normalize('NFC'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes new file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileMove',
+                path: path.join(dirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(fileMove).have.properties({
+              path: path.join(dirPath, dstFilename).normalize('NFC')
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes only parent part of file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileMove',
+                path: path.join(dirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(fileMove).have.properties({
+              path: path.join(
+                dirPath.normalize('NFC'),
+                dstFilename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+
+      context('when parent is saved with NFD encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(dirPath.normalize('NFD'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes file name with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileMove',
+                path: path.join(dirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(fileMove).have.properties({
+              path: path.join(
+                dirPath.normalize('NFD'),
+                dstFilename.normalize('NFC')
+              )
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('does not normalize new dir or file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'FileMove',
+                path: path.join(dirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(fileMove).have.properties({
+              path: path.join(
+                dirPath.normalize('NFD'),
+                dstFilename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+    })
+
+    describe('renamed file in renamed dir on filesystem normalizing with NFD', () => {
+      const srcDirPath = 'énoncés'.normalize('NFD')
+      const dstDirPath = 'corrigés'.normalize('NFD')
+      const srcFilename = 'Réussite'.normalize('NFD')
+      const dstFilename = 'Échec'.normalize('NFD')
+
+      context('when parent is saved with NFC encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(srcDirPath.normalize('NFC'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes new dir and file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFC')
+            })
+            should(fileMove).have.properties({
+              path: path.join(dstDirPath, dstFilename).normalize('NFC')
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes only parent part of file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFC')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFC'),
+                dstFilename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+
+      context('when parent is saved with NFD encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(srcDirPath.normalize('NFD'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFC')))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes file name with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFD')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFD'),
+                dstFilename.normalize('NFC')
+              )
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(path.join(dir.path, srcFilename.normalize('NFD')))
+              .data('initial content')
+              .create()
+          })
+
+          it('does not normalize new dir or file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFD')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFD'),
+                dstFilename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+    })
+
+    describe('moved file to renamed dir on filesystem normalizing with NFD', () => {
+      const srcDirPath = 'énoncés'.normalize('NFD')
+      const dstDirPath = 'corrigés'.normalize('NFD')
+      const srcFilename = 'Réussite'.normalize('NFD')
+      const dstFilename = 'Échec'.normalize('NFD')
+
+      context('when parent is saved with NFC encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(srcDirPath.normalize('NFC'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(srcFilename.normalize('NFC'))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes new dir and file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFC')
+            })
+            should(fileMove).have.properties({
+              path: path.join(dstDirPath, dstFilename).normalize('NFC')
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(srcFilename.normalize('NFD'))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes only parent part of file path with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFC')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFC'),
+                dstFilename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+
+      context('when parent is saved with NFD encoded path in Pouch', () => {
+        let dir
+        beforeEach(async function() {
+          dir = await builders
+            .metadir()
+            .path(srcDirPath.normalize('NFD'))
+            .create()
+        })
+
+        context('when file is saved with NFC encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(srcFilename.normalize('NFC'))
+              .data('initial content')
+              .create()
+          })
+
+          it('normalizes file name with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFD')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFD'),
+                dstFilename.normalize('NFC')
+              )
+            })
+          })
+        })
+
+        context('when file is saved with NFD encoded name in Pouch', () => {
+          let file
+          beforeEach(async function() {
+            file = await builders
+              .metafile()
+              .path(srcFilename.normalize('NFD'))
+              .data('initial content')
+              .create()
+          })
+
+          it('does not normalize new dir or file paths with NFC', async function() {
+            const changes = [
+              {
+                type: 'DirMove',
+                path: dstDirPath,
+                stats: { ino: 1 },
+                old: {
+                  path: dir.path
+                }
+              },
+              {
+                type: 'FileMove',
+                path: path.join(dstDirPath, dstFilename),
+                stats: { ino: 2 },
+                old: {
+                  path: file.path
+                }
+              }
+            ]
+            const [dirMove, fileMove] = await normalizePaths.step(
+              changes,
+              stepOptions(this)
+            )
+            should(dirMove).have.properties({
+              path: dstDirPath.normalize('NFD')
+            })
+            should(fileMove).have.properties({
+              path: path.join(
+                dstDirPath.normalize('NFD'),
+                dstFilename.normalize('NFD')
+              )
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
We'll correct paths normalization on local changes instead of local
events (i.e. after the analysis step) as well as improve the
correction by correcting paths of new documents when they're added
into an existing folder.

On macOS, saved paths in PouchDB records and actual paths on the
filesystem can differ by their UTF-8 normalization. Indeed, documents
created on the remote Cozy will always be normalized with NFC while
documents created locally **can** be normalized with NFD. This is the
case on HFS+ volumes for example.
The local normalization is done automatically and generates changes
that we don't want to propagate to the remote Cozy. This is why the
normalization can be different between PouchDB and the filesystem.

We'll consider that the local filesystem is applying an NFD
normalization to document names.

When a document is modified locally, the event's path will be
normalized with NFD. We have some logic to match this document with
its PouchDB record and "correct" the normalization if it was first
saved with an NFC encoded path.

However, this correction would only be applied if a document was
already saved in PouchDB and on local events.
The first restriction means that documents added in an existing folder
won't get their path corrected which can lead to file paths completely
encoded with NFD while their parent path is encoded with NFC in
PouchDB for example.
The second restriction means we can't correct moves and renamings
paths since those are made of two separate events (i.e. `unlink` and
`add` or `unlinkDir` and `addDir`).

Now that the `analysis` step compares event paths in their normalized
form, we can move the normalization correction into a new step coming
later and applied on local changes like `FileAddition` and `FileMove`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
