### PR TITLE
core/remote/watcher: Keep pouch path normalization

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -191,6 +191,8 @@ module.exports = {
   markAsNew,
   markAsUnsyncable,
   markAsUpToDate,
+  samePath,
+  areParentChildPaths,
   sameFolder,
   sameFile,
   sameFileIgnoreRev,
@@ -503,6 +505,34 @@ function assignMaxDate(doc /*: Metadata */, was /*: ?Metadata */) {
   const docUpdatedAt = new Date(doc.updated_at)
   if (docUpdatedAt < wasUpdatedAt) {
     doc.updated_at = was.updated_at
+  }
+}
+
+function samePath(
+  one /*: string|{path:string} */,
+  two /*: string|{path:string} */
+) {
+  const pathOne = typeof one === 'string' ? one : one.path
+  const pathTwo = typeof two === 'string' ? two : two.path
+
+  if (process.platform === 'darwin') {
+    return pathOne.normalize() === pathTwo.normalize()
+  } else {
+    return pathOne === pathTwo
+  }
+}
+
+function areParentChildPaths(
+  parent /*: string|{path:string} */,
+  child /*: string|{path:string} */
+) {
+  const parentPath = typeof parent === 'string' ? parent : parent.path
+  const childPath = typeof child === 'string' ? child : child.path
+
+  if (process.platform === 'darwin') {
+    return childPath.normalize().startsWith(parentPath.normalize() + path.sep)
+  } else {
+    return childPath.startsWith(parentPath + path.sep)
   }
 }
 

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -243,7 +243,11 @@ function isChildDestination(
   p /*: RemoteChange */,
   c /*: RemoteChange */
 ) /*: boolean %checks */ {
-  return isFolderMove(p) && isMove(c) && path.dirname(c.doc.path) === p.doc.path
+  return (
+    isFolderMove(p) &&
+    isMove(c) &&
+    metadata.samePath(path.dirname(c.doc.path), p.doc.path)
+  )
 }
 
 function isChildSource(
@@ -255,7 +259,7 @@ function isChildSource(
     isMove(c) &&
     p.was &&
     c.was &&
-    path.dirname(c.was.path) === p.was.path
+    metadata.samePath(path.dirname(c.was.path), p.was.path)
   )
 }
 
@@ -271,7 +275,7 @@ function isOnlyChildMove(
   return (
     isChildSource(p, c) &&
     isChildDestination(p, c) &&
-    path.basename(c.doc.path) === path.basename(c.was.path)
+    metadata.samePath(path.basename(c.doc.path), path.basename(c.was.path))
   )
 }
 
@@ -339,7 +343,7 @@ const deletedId = (a /*: RemoteChange */) /*: ?string */ =>
 const ignoredPath = (a /*: RemoteChange */) /*: ?string */ =>
   isIgnore(a) && typeof a.doc.path === 'string' ? a.doc.path : null
 const areParentChild = (p /*: ?string */, c /*: ?string */) /*: boolean */ =>
-  !!p && !!c && c.startsWith(p + path.sep)
+  !!p && !!c && metadata.areParentChildPaths(p, c)
 const areEqual = (a /*: ?string */, b /*: ?string */) /*: boolean */ =>
   !!a && !!b && a === b
 const lower = (p1 /*: ?string */, p2 /*: ?string */) /*: boolean */ =>

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -314,14 +314,14 @@ class RemoteWatcher {
           detail: `${docType} was created and trashed remotely`
         }
       }
+      const oldPath = was.path
       const previousMoveToSamePath = _.find(
         previousChanges,
         change =>
           (change.type === 'DescendantChange' ||
             change.type === 'FileMove' ||
             change.type === 'DirMove') &&
-          // $FlowFixMe
-          change.doc.path === was.path
+          metadata.samePath(change.doc, oldPath)
       )
 
       if (previousMoveToSamePath) {
@@ -340,7 +340,7 @@ class RemoteWatcher {
     if (!was || was.deleted) {
       return remoteChange.added(doc)
     }
-    if (was._id === doc._id && was.path === doc.path) {
+    if (was._id === doc._id && metadata.samePath(was, doc)) {
       if (
         doc.docType === 'file' &&
         doc.md5sum === was.md5sum &&

--- a/core/remote/watcher/normalizePaths.js
+++ b/core/remote/watcher/normalizePaths.js
@@ -1,0 +1,58 @@
+/* @flow */
+
+const path = require('path')
+const { Promise } = require('bluebird')
+
+const metadata = require('../../metadata')
+const { normalizedPath } = require('../../local/chokidar/normalize_paths')
+
+/*::
+import type { Pouch } from '../../pouch'
+import type { RemoteChange } from '../change'
+import type { Metadata } from '../../metadata'
+
+type NormalizePathsOpts = {
+  pouch: Pouch,
+}
+*/
+
+const normalizePaths = async (
+  changes /*: RemoteChange[] */,
+  { pouch } /*: NormalizePathsOpts */
+) /*: Promise<RemoteChange[]> */ => {
+  const normalizedPaths = []
+
+  return new Promise.mapSeries(changes, async (
+    c /*: RemoteChange */
+  ) /*: Promise<RemoteChange> */ => {
+    if (
+      c.type === 'FileAddition' ||
+      c.type === 'DirAddition' ||
+      c.type === 'FileUpdate' ||
+      c.type === 'FileMove' ||
+      c.type === 'DirMove' ||
+      c.type === 'DescendantChange'
+    ) {
+      const old =
+        c.type === 'FileMove' || c.type === 'DirMove'
+          ? c.was
+          : await pouch.byIdMaybeAsync(c.doc._id)
+      const parentPath = path.dirname(c.doc.path)
+      const parent =
+        parentPath !== '.'
+          ? await pouch.byIdMaybeAsync(metadata.id(parentPath))
+          : null
+      c.doc.path = normalizedPath(
+        c.doc.path,
+        old && old.path,
+        parent,
+        normalizedPaths
+      )
+      normalizedPaths.push(c.doc.path)
+    }
+
+    return c
+  })
+}
+
+module.exports = normalizePaths

--- a/core/remote/watcher/squashMoves.js
+++ b/core/remote/watcher/squashMoves.js
@@ -6,6 +6,7 @@
 const _ = require('lodash')
 const path = require('path')
 
+const metadata = require('../../metadata')
 const remoteChange = require('../change')
 
 const sideName = 'remote'
@@ -217,7 +218,7 @@ const squashMoves = (
     if (
       previousChange.type === 'FileTrashing' &&
       change.type === 'FileMove' &&
-      previousChange.was.path === change.doc.path
+      metadata.samePath(previousChange.was, change.doc)
     ) {
       _.assign(previousChange, {
         type: 'IgnoredChange',
@@ -230,7 +231,7 @@ const squashMoves = (
     if (
       previousChange.type === 'DirTrashing' &&
       change.type === 'DirMove' &&
-      previousChange.was.path === change.doc.path
+      metadata.samePath(previousChange.was, change.doc)
     ) {
       _.assign(previousChange, {
         type: 'IgnoredChange',

--- a/test/unit/regressions/850.js
+++ b/test/unit/regressions/850.js
@@ -1,3 +1,4 @@
+/* Fixes issue https://github.com/cozy-labs/cozy-desktop/issues/850 */
 /* eslint-env mocha */
 
 const fse = require('fs-extra')
@@ -16,111 +17,114 @@ const metadata = require('../../../core/metadata')
 
 const configHelpers = require('../../support/helpers/config')
 const pouchHelpers = require('../../support/helpers/pouch')
+const { onPlatform } = require('../../support/helpers/platform')
 
-describe('issue 850', function() {
-  this.timeout(10000)
+onPlatform('darwin', () => {
+  describe('issue 850', function() {
+    this.timeout(10000)
 
-  before('instanciate config', configHelpers.createConfig)
-  before('instanciate pouch', pouchHelpers.createDatabase)
-  before('instanciate local watcher', function() {
-    this.merge = new Merge(this.pouch)
-    this.local = {
-      start: sinon.stub().resolves(),
-      stop: sinon.stub().resolves()
-    }
-    this.remote = {
-      start: sinon.stub().returns({
-        started: Promise.resolve(),
-        running: new Promise(() => {})
-      }),
-      stop: sinon.stub().resolves()
-    }
-    this.events = new EventEmitter()
-    this.ignore = new Ignore([])
-    this.sync = new Sync(
-      this.pouch,
-      this.local,
-      this.remote,
-      this.ignore,
-      this.events
-    )
-    // this.sync.sync = sinon.stub().rejects(new Error('stopped'))
-    this.prep = new Prep(this.merge, this.ignore)
-    this.watcher = new Watcher(
-      this.syncPath,
-      this.prep,
-      this.pouch,
-      this.events
-    )
-  })
-  after('stop watcher and clean path', async function() {
-    this.watcher.stop(true)
-    this.watcher.checksumer.kill()
-    await fse.emptyDir(this.syncPath)
-  })
-  after('clean pouch', pouchHelpers.cleanDatabase)
-  after('clean config directory', configHelpers.cleanConfig)
-
-  before('create dst dir', async function() {
-    let dirPath = path.join(this.syncPath, 'dst')
-    await fse.mkdirp(dirPath)
-    let stat = await fse.stat(dirPath)
-    await this.pouch.put({
-      _id: metadata.id('dst'),
-      docType: 'folder',
-      updated_at: new Date(),
-      path: 'dst',
-      ino: stat.ino,
-      tags: [],
-      sides: { local: 1, remote: 1 },
-      remote: { _id: 'XXX', _rev: '1-abc' }
-    })
-    await this.sync.sync()
-  })
-
-  it('is fixed', async function() {
-    let filePath = path.join(this.syncPath, 'file')
-    let dstPath = path.join(this.syncPath, 'dst', 'file')
-    await fse.outputFile(filePath, 'whatever')
-    await this.watcher.onFlush([
-      ChokidarEvent.build('add', 'file', await fse.stat(filePath))
-    ])
-    await fse.rename(filePath, dstPath)
-
-    const doMove = async () => {
-      // let _resolve
-      // let ret = new Promise((resolve) => { _resolve = resolve })
-      // let oldLock = that.pouch.lock
-      // that.pouch.lock = async function () {
-      //   _resolve()
-      //   that.pouch.lock = oldLock
-      //   return that.pouch.lock()
-      // }
-      this.watcher.onFlush([
-        ChokidarEvent.build('add', 'dst/file', await fse.stat(dstPath)),
-        ChokidarEvent.build('unlink', 'file')
-      ])
-
-      return Promise.delay(2000)
-    }
-
-    this.remote.addFileAsync = async doc => {
-      await doMove() // move occurs while the file is uploading
-      // Promise.delay()
-      doc.remote = {
-        _id: 'fakeID',
-        _rev: '1-fakeRev'
+    before('instanciate config', configHelpers.createConfig)
+    before('instanciate pouch', pouchHelpers.createDatabase)
+    before('instanciate local watcher', function() {
+      this.merge = new Merge(this.pouch)
+      this.local = {
+        start: sinon.stub().resolves(),
+        stop: sinon.stub().resolves()
       }
-      return metadata.fromRemoteDoc({
-        type: 'file',
-        path: '/file',
-        updated_at: new Date(),
-        _id: 'fakeID',
-        _rev: '1-fakeRev',
-        size: '8'
-      })
-    }
+      this.remote = {
+        start: sinon.stub().returns({
+          started: Promise.resolve(),
+          running: new Promise(() => {})
+        }),
+        stop: sinon.stub().resolves()
+      }
+      this.events = new EventEmitter()
+      this.ignore = new Ignore([])
+      this.sync = new Sync(
+        this.pouch,
+        this.local,
+        this.remote,
+        this.ignore,
+        this.events
+      )
+      // this.sync.sync = sinon.stub().rejects(new Error('stopped'))
+      this.prep = new Prep(this.merge, this.ignore)
+      this.watcher = new Watcher(
+        this.syncPath,
+        this.prep,
+        this.pouch,
+        this.events
+      )
+    })
+    after('stop watcher and clean path', async function() {
+      this.watcher.stop(true)
+      this.watcher.checksumer.kill()
+      await fse.emptyDir(this.syncPath)
+    })
+    after('clean pouch', pouchHelpers.cleanDatabase)
+    after('clean config directory', configHelpers.cleanConfig)
 
-    await this.sync.sync() // create file
+    before('create dst dir', async function() {
+      let dirPath = path.join(this.syncPath, 'dst')
+      await fse.mkdirp(dirPath)
+      let stat = await fse.stat(dirPath)
+      await this.pouch.put({
+        _id: metadata.id('dst'),
+        docType: 'folder',
+        updated_at: new Date(),
+        path: 'dst',
+        ino: stat.ino,
+        tags: [],
+        sides: { local: 1, remote: 1 },
+        remote: { _id: 'XXX', _rev: '1-abc' }
+      })
+      await this.sync.sync()
+    })
+
+    it('is fixed', async function() {
+      let filePath = path.join(this.syncPath, 'file')
+      let dstPath = path.join(this.syncPath, 'dst', 'file')
+      await fse.outputFile(filePath, 'whatever')
+      await this.watcher.onFlush([
+        ChokidarEvent.build('add', 'file', await fse.stat(filePath))
+      ])
+      await fse.rename(filePath, dstPath)
+
+      const doMove = async () => {
+        // let _resolve
+        // let ret = new Promise((resolve) => { _resolve = resolve })
+        // let oldLock = that.pouch.lock
+        // that.pouch.lock = async function () {
+        //   _resolve()
+        //   that.pouch.lock = oldLock
+        //   return that.pouch.lock()
+        // }
+        this.watcher.onFlush([
+          ChokidarEvent.build('add', 'dst/file', await fse.stat(dstPath)),
+          ChokidarEvent.build('unlink', 'file')
+        ])
+
+        return Promise.delay(2000)
+      }
+
+      this.remote.addFileAsync = async doc => {
+        await doMove() // move occurs while the file is uploading
+        // Promise.delay()
+        doc.remote = {
+          _id: 'fakeID',
+          _rev: '1-fakeRev'
+        }
+        return metadata.fromRemoteDoc({
+          type: 'file',
+          path: '/file',
+          updated_at: new Date(),
+          _id: 'fakeID',
+          _rev: '1-fakeRev',
+          size: '8'
+        })
+      }
+
+      await this.sync.sync() // create file
+    })
   })
 })

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -426,7 +426,7 @@ describe('RemoteWatcher', function() {
 
   describe('analyse', () => {
     describe('case-only renaming', () => {
-      it('is identified as a move', function() {
+      it('is identified as a move', async function() {
         const oldRemote = builders
           .remoteFile()
           .name('foo')
@@ -443,7 +443,7 @@ describe('RemoteWatcher', function() {
           oldRemote
         )
 
-        const changes = this.watcher.analyse([newRemote], [oldDoc])
+        const changes = await this.watcher.analyse([newRemote], [oldDoc])
 
         should(changes.map(c => c.type)).deepEqual(['FileMove'])
         should(changes[0])
@@ -474,7 +474,7 @@ describe('RemoteWatcher', function() {
               .shortRev(2)
               .build()
 
-            const [change] = this.watcher.analyse([newRemote], [oldDoc])
+            const [change] = await this.watcher.analyse([newRemote], [oldDoc])
 
             should(change).have.property('type', 'FileUpdate')
             should(change.doc).have.property('path', oldDoc.path)
@@ -512,7 +512,7 @@ describe('RemoteWatcher', function() {
               .shortRev(2)
               .build()
 
-            const [dirChange, fileChange] = this.watcher.analyse(
+            const [dirChange, fileChange] = await this.watcher.analyse(
               [newRemoteDir, newRemoteFile],
               [oldDir, oldFile]
             )
@@ -553,7 +553,7 @@ describe('RemoteWatcher', function() {
                 .shortRev(2)
                 .build()
 
-              const [fileChange] = this.watcher.analyse(
+              const [fileChange] = await this.watcher.analyse(
                 [newRemoteFile],
                 [oldFile]
               )
@@ -599,7 +599,7 @@ describe('RemoteWatcher', function() {
                 .shortRev(2)
                 .build()
 
-              const [dirChange, fileChange] = this.watcher.analyse(
+              const [dirChange, fileChange] = await this.watcher.analyse(
                 [newRemoteDir, newRemoteFile],
                 [oldDir, oldFile]
               )
@@ -655,7 +655,7 @@ describe('RemoteWatcher', function() {
                 .shortRev(2)
                 .build()
 
-              const [dirChange, fileChange] = this.watcher.analyse(
+              const [dirChange, fileChange] = await this.watcher.analyse(
                 [newRemoteDir, newRemoteFile],
                 [oldDir, oldFile]
               )
@@ -698,7 +698,10 @@ describe('RemoteWatcher', function() {
                 .name('file')
                 .build()
 
-              const [fileChange] = this.watcher.analyse([newRemoteFile], [])
+              const [fileChange] = await this.watcher.analyse(
+                [newRemoteFile],
+                []
+              )
 
               should(fileChange).have.property('type', 'FileAddition')
               should(fileChange.doc).have.property(
@@ -734,7 +737,7 @@ describe('RemoteWatcher', function() {
                 .name('file')
                 .build()
 
-              const [dirChange, fileChange] = this.watcher.analyse(
+              const [dirChange, fileChange] = await this.watcher.analyse(
                 [newRemoteDir, newRemoteFile],
                 []
               )
@@ -794,7 +797,7 @@ describe('RemoteWatcher', function() {
                 .shortRev(2)
                 .build()
 
-              const [fileChange] = this.watcher.analyse(
+              const [fileChange] = await this.watcher.analyse(
                 [newRemoteFile],
                 [oldFile]
               )
@@ -859,9 +862,9 @@ describe('RemoteWatcher', function() {
           return props
         })
 
-      it('is detected when moved source is first', function() {
+      it('is detected when moved source is first', async function() {
         const remoteDocs = [srcFileMoved, dstFileTrashed]
-        const changes = this.watcher.analyse(remoteDocs, olds)
+        const changes = await this.watcher.analyse(remoteDocs, olds)
         should(relevantChangesProps(changes)).deepEqual([
           {
             type: 'FileMove',
@@ -876,9 +879,9 @@ describe('RemoteWatcher', function() {
         ])
       })
 
-      it('is detected when trashed destination is first', function() {
+      it('is detected when trashed destination is first', async function() {
         const remoteDocs = [dstFileTrashed, srcFileMoved]
-        const changes = this.watcher.analyse(remoteDocs, olds)
+        const changes = await this.watcher.analyse(remoteDocs, olds)
         should(relevantChangesProps(changes)).deepEqual([
           {
             type: 'FileMove',
@@ -945,9 +948,9 @@ describe('RemoteWatcher', function() {
 
       describe('when moved source is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('sorts the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', async function() {
             const remoteDocs = [srcFileMoved, dstFileTrashed]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'FileTrashing',
@@ -964,9 +967,9 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('sorts the move before the trashing', function() {
+          it('sorts the move before the trashing', async function() {
             const remoteDocs = [srcFileMoved, dstFileTrashed]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'FileTrashing',
@@ -985,9 +988,9 @@ describe('RemoteWatcher', function() {
 
       describe('when trashed destination is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('sorts the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', async function() {
             const remoteDocs = [dstFileTrashed, srcFileMoved]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'FileTrashing',
@@ -1004,9 +1007,9 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('sorts the move before the trashing', function() {
+          it('sorts the move before the trashing', async function() {
             const remoteDocs = [dstFileTrashed, srcFileMoved]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'FileTrashing',
@@ -1073,9 +1076,9 @@ describe('RemoteWatcher', function() {
           return props
         })
 
-      it('is detected when moved source is first', function() {
+      it('is detected when moved source is first', async function() {
         const remoteDocs = [srcMoved, dstTrashed]
-        const changes = this.watcher.analyse(remoteDocs, olds)
+        const changes = await this.watcher.analyse(remoteDocs, olds)
         should(relevantChangesProps(changes)).deepEqual([
           {
             type: 'DirMove',
@@ -1090,9 +1093,9 @@ describe('RemoteWatcher', function() {
         ])
       })
 
-      it('is detected when trashed destination is first', function() {
+      it('is detected when trashed destination is first', async function() {
         const remoteDocs = [dstTrashed, srcMoved]
-        const changes = this.watcher.analyse(remoteDocs, olds)
+        const changes = await this.watcher.analyse(remoteDocs, olds)
         should(relevantChangesProps(changes)).deepEqual([
           {
             type: 'DirMove',
@@ -1159,9 +1162,9 @@ describe('RemoteWatcher', function() {
 
       describe('when moved source is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('sorts the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', async function() {
             const remoteDocs = [srcMoved, dstTrashed]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'DirTrashing',
@@ -1178,9 +1181,9 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('sorts the trashing before the move ', function() {
+          it('sorts the trashing before the move ', async function() {
             const remoteDocs = [srcMoved, dstTrashed]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'DirTrashing',
@@ -1199,9 +1202,9 @@ describe('RemoteWatcher', function() {
 
       describe('when trashed destination is first', () => {
         onPlatforms(['win32', 'darwin'], () => {
-          it('sorts the trashing before the move to prevent id confusion', function() {
+          it('sorts the trashing before the move to prevent id confusion', async function() {
             const remoteDocs = [dstTrashed, srcMoved]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'DirTrashing',
@@ -1218,9 +1221,9 @@ describe('RemoteWatcher', function() {
         })
 
         onPlatform('linux', () => {
-          it('sorts the trashing before the move', function() {
+          it('sorts the trashing before the move', async function() {
             const remoteDocs = [dstTrashed, srcMoved]
-            const changes = this.watcher.analyse(remoteDocs, olds)
+            const changes = await this.watcher.analyse(remoteDocs, olds)
             should(relevantChangesProps(changes)).deepEqual([
               {
                 type: 'DirTrashing',
@@ -1239,7 +1242,7 @@ describe('RemoteWatcher', function() {
     })
 
     describe('descendantMoves', () => {
-      it('handles correctly descendantMoves', function() {
+      it('handles correctly descendantMoves', async function() {
         const remoteDir1 = builders
           .remoteDir()
           .name('src')
@@ -1303,7 +1306,7 @@ describe('RemoteWatcher', function() {
         }
 
         shouldBeExpected(
-          this.watcher.analyse(
+          await this.watcher.analyse(
             [
               updated(remoteFile, { path: '/dst/parent/child' }),
               updated(remoteDir2, { path: '/dst/parent' }),
@@ -1314,7 +1317,7 @@ describe('RemoteWatcher', function() {
         )
 
         shouldBeExpected(
-          this.watcher.analyse(
+          await this.watcher.analyse(
             [
               updated(remoteDir1, { name: 'dst', path: '/dst' }),
               updated(remoteDir2, { path: '/dst/parent' }),
@@ -1325,7 +1328,7 @@ describe('RemoteWatcher', function() {
         )
 
         shouldBeExpected(
-          this.watcher.analyse(
+          await this.watcher.analyse(
             [
               updated(remoteDir1, { name: 'dst', path: '/dst' }),
               updated(remoteFile, { path: '/dst/parent/child' }),


### PR DESCRIPTION
To avoid detecting invalid movements when a file or folder whose path is encoded with different normalizations between the local PouchDB record and the remote Cozy is edited on the Cozy we do 2 things:
- compare changes' paths using the same normalization (NFC by default) every where within the remote watcher
- keep the existing (as in saved in PouchDB) path normalization for existing documents and parent folders

The later change is more of a safety net.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
