### PR TITLE
core/merge: Compare only existing local states

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -323,7 +323,11 @@ class Merge {
         doc.local = file.local
       }
 
-      if (side === 'local' && metadata.sameFile(file.local, doc.local)) {
+      if (
+        side === 'local' &&
+        file.local &&
+        metadata.sameFile(file.local, doc.local)
+      ) {
         log.debug({ path: doc.path, doc, file }, 'Same local binary')
         if (!metadata.sameLocal(file.local, doc.local)) {
           metadata.updateLocal(file, doc.local)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -326,6 +326,33 @@ describe('Merge', function() {
       })
     })
 
+    it('sets the local metadata when it is missing', async function() {
+      const mergedFile = await builders
+        .metafile()
+        .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
+        .upToDate()
+        .remoteId(dbBuilders.id())
+        .noLocal()
+        .create()
+      const sameFile = builders.metafile(mergedFile).build()
+
+      const sideEffects = await mergeSideEffects(this, () =>
+        this.merge.addFileAsync('local', _.cloneDeep(sameFile))
+      )
+
+      should(sideEffects).deepEqual({
+        savedDocs: [
+          _.defaults(
+            {
+              local: sameFile.local
+            },
+            _.omit(mergedFile, ['_rev', 'fileid'])
+          )
+        ],
+        resolvedConflicts: []
+      })
+    })
+
     it('keeps an existing local metadata when it is not present in the new doc', async function() {
       const mergedFile = await builders
         .metafile()
@@ -731,6 +758,33 @@ describe('Merge', function() {
               local: doc.local
             },
             _.omit(file, ['_rev', 'fileid'])
+          )
+        ],
+        resolvedConflicts: []
+      })
+    })
+
+    it('sets the local metadata when it is missing', async function() {
+      const mergedFile = await builders
+        .metafile()
+        .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
+        .upToDate()
+        .remoteId(dbBuilders.id())
+        .noLocal()
+        .create()
+      const sameFile = builders.metafile(mergedFile).build()
+
+      const sideEffects = await mergeSideEffects(this, () =>
+        this.merge.updateFileAsync('local', _.cloneDeep(sameFile))
+      )
+
+      should(sideEffects).deepEqual({
+        savedDocs: [
+          _.defaults(
+            {
+              local: sameFile.local
+            },
+            _.omit(mergedFile, ['_rev', 'fileid'])
           )
         ],
         resolvedConflicts: []


### PR DESCRIPTION
We have recently introduced a local state for files via a `local`
attribute in their PouchDB records.

When the file is created on the local filesystem,  the local state
will be filled when the record is created.
On the other hand, when the file is created on the remote Cozy, the
state won't exist until the local watcher detects the file's creation
on the local filesystem and the generated `created` event is merged.

On Windows, this `created` event can be ignored if we're replacing an
existing document. We'd have a prior `deleted` event at the same
path and the two events would be grouped together by the
`winDetectMove` step into an `ignored` event. We don't have a
`renamed` event because the source and destination paths would be the
same and the result move would be invalid.
In this case, only the `modified` events following a newly downloaded
file creation (i.e. for the executable permission and dates changes)
would be dispatched.

In case of a file update, we were expecting the local state to already
exist but in our situation, it does not.
From there, when we try to compare the existing record's local state
(i.e. the missing one) and the newly built local state the
`Cannot read property "executable" of undefined` error is raised.

To avoid raising this error, we can simply check whether or not the
existing record has a local state before trying to compare it with the
new state.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
