### PR TITLE
pouch/migrations: Remove synchronized `moveFrom`s

### DIFF
--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -139,6 +139,26 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 4,
+    targetSchemaVersion: 5,
+    description: 'Removing moveFrom attribute of synced documents',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(
+        doc =>
+          doc.moveFrom &&
+          doc.sides &&
+          doc.sides.target === doc.sides.local &&
+          doc.sides.target === doc.sides.remote
+      )
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        if (doc.moveFrom) delete doc.moveFrom
+        return doc
+      })
+    }
   }
 ]
 


### PR DESCRIPTION
To give the `Sync` module the necessary hints that a given document
should be moved, we add a `moveFrom` attribute on the PouchDB record
describing its destination metadata.

Once the movement is synchronized, we delete this attribute for 2
reasons:
- to limit the records size and specifically their depth
- to make sure the `Sync` module won't read this hint again and try to
  perform the synchronize the movement once more

However, this final cleanup wasn't always performed. This means that
some users still have PouchDB records with a `moveFrom` attribute.

If those documents are not modified, this is not an issue. On the
other hand, a data migration could lead the `Sync` module to see a
change in the record and, seeing the attribute, try to perform the
move which will probably fail.
We've recently seen a lot of `Move destination already exists` errors
in Sentry which can illustrate this situation
(e.g. sentry.cozycloud.cc/sentry/cozy-desktop/issues/215790).

To avoid those situations we can, like we did for the `overwrite`
attribute which is also removed after a change has been synchronized,
create a data migration to cleanup all the `moveFrom` attributes left
on records considered as synchronized.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
