### PR TITLE
test: fix macOS normalization test

### DIFF
--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -78,7 +78,7 @@ describe('Case or encoding change', () => {
         case 'darwin':
           should(tree).deepEqual([
             'FOO/',
-            '\u00e9/' // 'é/'
+            'e\u0301/' // 'é/'
           ])
           break
 


### PR DESCRIPTION
This test fails now when it should have failed before, when we changed
the behavior of the remote watcher when a doc with a local NFD path is
modified on the remote Cozy where its path is normalized with NFC.

We used to accept normalization changes from the remote Cozy but we've
decided to keep the normalization first saved in Pouch.
In this test, the normalization first saved is NFD so we should not
see a path change.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
