### PR TITLE
core/merge: Move children with different normalization

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -642,7 +642,9 @@ class Merge {
     move(side, was, folder)
     let bulk = [was, folder]
 
-    const makeDestinationID = doc => doc._id.replace(was._id, folder._id)
+    const makeDestinationPath = doc =>
+      metadata.newChildPath(doc.path, was.path, folder.path)
+    const makeDestinationID = doc => metadata.id(makeDestinationPath(doc))
     const existingDstRevs = await this.pouch.getAllRevsAsync(
       docs.map(makeDestinationID)
     )
@@ -656,7 +658,7 @@ class Merge {
       let src = _.cloneDeep(doc)
       let dst = _.cloneDeep(doc)
       dst._id = makeDestinationID(doc)
-      dst.path = doc.path.replace(was.path, folder.path)
+      dst.path = makeDestinationPath(doc)
       // If the source needs to be overwritten, we'll take care of it during
       // Sync while it does not say anything about the existence of a document
       // at the destination.

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -193,6 +193,7 @@ module.exports = {
   markAsUpToDate,
   samePath,
   areParentChildPaths,
+  newChildPath,
   sameFolder,
   sameFile,
   sameFileIgnoreRev,
@@ -542,6 +543,19 @@ function areParentChildPaths(
   } else {
     return childPath.startsWith(parentPath + path.sep)
   }
+}
+
+function newChildPath(
+  oldChildPath /*: string */,
+  oldParentPath /*: string */,
+  newParentPath /*: string */
+) {
+  const parentParts = oldParentPath.split(path.sep)
+  const childParts = oldChildPath.split(path.sep)
+
+  // We keep only the old child parts that are within in the old parent path, no
+  // matter what their normalizations are within both paths.
+  return path.join(newParentPath, ...childParts.slice(parentParts.length))
 }
 
 const ensureExecutable = (one, two) => {

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -1228,4 +1228,128 @@ describe('metadata', function() {
       ])
     })
   })
+
+  describe('newChildPath', () => {
+    context(
+      'when both the parent part and the parent path are normalized with NFC',
+      () => {
+        it('replaces the parent part with its new value', () => {
+          const oldParentPath = 'énoncés'.normalize('NFC')
+          const newParentPath = 'Énoncés'
+          const childName = 'DS-1.pdf'
+          const oldChildPath = path.join(oldParentPath, childName)
+
+          should(
+            metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+          ).equal(path.join(newParentPath, childName))
+        })
+      }
+    )
+
+    context(
+      'when both the parent part and the parent path are normalized with NFD',
+      () => {
+        it('replaces the parent part with its new value', () => {
+          const oldParentPath = 'énoncés'.normalize('NFD')
+          const newParentPath = 'Énoncés'
+          const childName = 'DS-1.pdf'
+          const oldChildPath = path.join(oldParentPath, childName)
+
+          should(
+            metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+          ).equal(path.join(newParentPath, childName))
+        })
+      }
+    )
+
+    context(
+      'when the parent part is normalized with NFC and the parent path with NFD',
+      () => {
+        it('replaces the parent part with its new value', () => {
+          const oldParentPath = 'énoncés'.normalize('NFD')
+          const newParentPath = 'Énoncés'
+          const childName = 'DS-1.pdf'
+          const oldChildPath = path.join(
+            oldParentPath.normalize('NFC'),
+            childName
+          )
+
+          should(
+            metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+          ).equal(path.join(newParentPath, childName))
+        })
+      }
+    )
+
+    context(
+      'when the parent part is normalized with NFD and the parent path with NFC',
+      () => {
+        it('replaces the parent part with its new value', () => {
+          const oldParentPath = 'énoncés'.normalize('NFC')
+          const newParentPath = 'Énoncés'
+          const childName = 'DS-1.pdf'
+          const oldChildPath = path.join(
+            oldParentPath.normalize('NFD'),
+            childName
+          )
+
+          should(
+            metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+          ).equal(path.join(newParentPath, childName))
+        })
+      }
+    )
+
+    context('when the parent is moved', () => {
+      it('replaces the parent part with its new value', () => {
+        const oldParentPath = 'énoncés'.normalize('NFC')
+        const newParentPath = 'Économie/Énoncés'
+        const childName = 'DS-1.pdf'
+        const oldChildPath = path.join(
+          oldParentPath.normalize('NFD'),
+          childName
+        )
+
+        should(
+          metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+        ).equal(path.join(newParentPath, childName))
+      })
+    })
+
+    context('when ancestors have different normalizations', () => {
+      it('replaces the parent part with its new value', () => {
+        const ancestorPath = 'énoncés'.normalize('NFC')
+        const oldParentName = 'économie'.normalize('NFD')
+        const oldParentPath = path.join(
+          ancestorPath.normalize('NFD'),
+          oldParentName
+        )
+        const newParentPath = oldParentPath.replace(oldParentName, 'Économie')
+        const childName = 'DS-1.pdf'
+        const oldChildPath = path.join(ancestorPath, oldParentName, childName)
+
+        should(
+          metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+        ).equal(path.join(newParentPath, childName))
+      })
+
+      context('when the parent is moved', () => {
+        it('replaces the parent part with its new value', () => {
+          const ancestorPath = 'énoncés'.normalize('NFC')
+          const oldParentName = 'économie'.normalize('NFD')
+          const oldParentPath = path.join(
+            ancestorPath.normalize('NFD'),
+            oldParentName
+          )
+          const newParentPath = path.join(ancestorPath, 'L1', 'Économie')
+          const childName = 'DS-1.pdf'
+          const oldChildPath = path.join(ancestorPath, oldParentName, childName)
+
+          should(
+            metadata.newChildPath(oldChildPath, oldParentPath, newParentPath)
+          ).equal(path.join(newParentPath, childName))
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
When moving a folder whose path is normalized with a certain norm
(i.e. NFC or NFD) but its children's paths are normalized with another
one (at least the parent part), we want to make sure the new
children's paths are correctly computed (i.e. the parent part is
replaced with its new path) and that their id is in sync with their
new path.

When a folder is moved, we fetch all its descendants from PouchDB via
their ids, based on the folder's id (i.e. we look for every document
whose id starts with the folder id). In this case, the path
normalization doesn't matter because ids are re-normalized.
Once we have all the descendants records, we replace the folder part
in its descendants' paths with its new path. However, if the
normalization is different, the replacement won't work (the String
method won't find the substring to replace).

e.g.:
- We have the folder `énoncés/` formatted with NFC
- We have the file `énoncés/DS-1.pdf` where énoncés is formatted with
  NFD
When renaming `énoncés/` to `corrigés/`, the file's path won't be
changed while its id will be based on `corrigés/DS-1.pdf`.

Not changing the path when the id has changed can lead to a lot of
errors later since we base most of our logic to detect movements on
the path but access to the PouchDB records is done via the id.

We introduce the method `metadata.newChildPath()` which will replace
the old parent path with the new in the child path no matter waht the
normalizations are of the moved folder and its ancestors.
This way we make sure the children are correctly moved with their
parent and their id is kept in sync with their path.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
