### PR TITLE
Correct move inside move old path with normalization differences

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -35,6 +35,7 @@ const { getInode } = require('./local_event')
 const localChange = require('./local_change')
 const logger = require('../../utils/logger')
 const measureTime = require('../../utils/perfs')
+const metadata = require('../../metadata')
 
 /*::
 import type { LocalEvent } from './local_event'
@@ -339,7 +340,7 @@ function squashMoves(changes /*: LocalChange[] */) {
           }
         } else {
           log.debug({ oldpath: b.old.path, path: b.path }, 'move inside move')
-          b.old.path = b.old.path.replace(a.old.path, a.path)
+          b.old.path = metadata.newChildPath(b.old.path, a.old.path, a.path)
           b.needRefetch = true
         }
       }

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -137,7 +137,6 @@ module.exports = {
   isChildDestination,
   isChildMove,
   isOnlyChildMove,
-  applyMoveToPath,
   includeDescendant,
   applyMoveInsideMove,
   sort
@@ -279,19 +278,17 @@ function isOnlyChildMove(
   )
 }
 
-function applyMoveToPath(
-  a /*: RemoteDirMove|RemoteDescendantChange */,
-  p /*: string */
-) /*: string */ {
-  return p.replace(a.was.path, a.doc.path)
-}
-
 function applyMoveInsideMove(
   parentMove /*: RemoteDirMove|RemoteDescendantChange */,
   childMove /*: RemoteDirMove | RemoteFileMove */
 ) {
-  childMove.was.path = applyMoveToPath(parentMove, childMove.was.path)
   childMove.needRefetch = true
+  childMove.was.path = metadata.newChildPath(
+    childMove.was.path,
+    parentMove.was.path,
+    parentMove.doc.path
+  )
+  childMove.was._id = metadata.id(childMove.was.path)
 }
 
 const isDelete = (a /*: RemoteChange */) /*: boolean %checks */ =>

--- a/core/remote/watcher/squashMoves.js
+++ b/core/remote/watcher/squashMoves.js
@@ -111,6 +111,7 @@ const buildMoveInsideMove = (
 ) /*: RemoteFileMove|RemoteDirMove */ => {
   const correctedSrc /*: Metadata */ = _.clone(child.was)
   correctedSrc.path = path.join(parent.doc.path, path.basename(child.was.path))
+  correctedSrc._id = metadata.id(correctedSrc.path)
 
   if (child.type === 'FileMove') {
     return {


### PR DESCRIPTION
When events are buffered (either on macOS or the remote Cozy), and a child document is moved as well as its parent folder, we need to correct the old child path to make sure its movement can be merged and applied (its old path references its old parent path which is invalid after the parent has been moved).

If we have a normalization difference between the parent path and the parent path within the child path, then the correction won't work with a simple string replacement.

We propose a new method to correct the child's old path that is not affected by normalization differences in the parent paths.
We use it both for local, macOS, moves and remote moves although we couldn't build a meaningful test to show that we had issues with remote moves in moves.

The remote move in move application was introducing an incoherence in the old child between its `path` and `_id` however.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
