### PR TITLE
local/writer: Case change + udpate does not trash file

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -399,7 +399,7 @@ class Local /*:: implements Reader, Writer */ {
       `Moving ${old.docType}${doc.overwrite ? ' (with overwrite)' : ''}`
     )
 
-    if (doc.overwrite && doc.overwrite.path !== old.path) {
+    if (doc.overwrite && doc.overwrite._id !== old._id) {
       await this.trashAsync(doc.overwrite)
     }
 


### PR DESCRIPTION
We should not trash a file when propagating a combined case change and
content update on macOS and Windows.

When we merge an overwriting move, we use the `overwrite` PouchDB
attribute to keep track of the overwritten document (especially its
`path` and/or `_id`). The presence of this attribute is a hint for the
Sync module and will be used to trash the overwritten document before
moving the overwriting one to its new location.

However, we also use this attribute when we simply update a file. We
did this so that we could remove the attribute to give a hint to the
Sync module that the updated file should be backed up before in
certain situations.

So, to avoid trashing the file when we try to apply a move and a file
update, we compare the most recent version of the record and the
content of its `overwrite` attribute to decide whether this is an
overwriting move or not.
When we propagate such a move to the remote Cozy, we compare remote
ids.
When we propagate it to the local filesystem, we compare paths.

For the later to work, we need both paths to be perfectly equal.
This means no case or normalization differences on macOS and Windows.
To avoid trashing the file in those situations, we decided to compare
record ids since they're already built to be case and normalization
agnostic.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
