### PR TITLE
core/utils/timestamp: Round non-UTC remote dates

### DIFF
--- a/core/utils/timestamp.js
+++ b/core/utils/timestamp.js
@@ -77,8 +77,8 @@ function stringify(t /*: Timestamp */) {
 function roundedRemoteDate(isoDate /*: string */) /*: string */ {
   const date = new Date(isoDate)
 
-  const milliseconds = isoDate.split(/\.|Z/)[1]
-  if (milliseconds.length > 3) {
+  const [hasMilliseconds, milliseconds] = /\.(\d+)/.exec(isoDate) || [false, '']
+  if (hasMilliseconds && milliseconds.length > 3) {
     // In this situation (i.e. more than 3 milliseconds digits) we need to
     // "truncate" the date to fit our 3 milliseconds digits standard.
     //

--- a/test/unit/utils/timestamp.js
+++ b/test/unit/utils/timestamp.js
@@ -131,5 +131,17 @@ describe('timestamp', () => {
         '2016-01-01T00:00:00.000Z'
       )
     })
+
+    it('handles dates with timezones other than UTC', function() {
+      // All previous examples with a different timezone
+      const a = '2020-04-05T19:50:06+02:00'
+      const b = '2020-04-05T19:50:06.029+02:00'
+      const c = '2020-04-05T19:50:06.02+02:00'
+      const d = '2020-04-05T19:50:06.229928394+02:00'
+      should(timestamp.roundedRemoteDate(a)).equal('2020-04-05T17:50:06.000Z')
+      should(timestamp.roundedRemoteDate(b)).equal('2020-04-05T17:50:06.029Z')
+      should(timestamp.roundedRemoteDate(c)).equal('2020-04-05T17:50:06.020Z')
+      should(timestamp.roundedRemoteDate(d)).equal('2020-04-05T17:50:06.230Z')
+    })
   })
 })


### PR DESCRIPTION
We should correctly round dates sent by the remote Cozy whether they're
in UTC format or not.

We recently started to round the `created_at` and `updated_at` dates
coming from the remote Cozy to make sure we have the expected ISO
format in our PouchDB records.
However, we were expecting to receive dates in UTC only while we can
receive dates in other timezones.
When the timezone is not UTC, our rounding function raises an error
after trying to read the `length` of `undefined`.

This error is raised because our method to get the milliseconds part
of the date as a string relied on the presence of the letter `Z` at
the end of the date string.
When the timezone is not UTC, the string ends with the time offset and
the milliseconds part could be `undefined` if milliseconds were not
present in the date.

We propose a new method based on a regular expression looking for the
presence of a dot followed by digits. If those are present then we
extract the digits as the milliseconds string. If they're not present,
we assign an empty string to the milliseconds.
In both cases, we can safely look at the `length` of the milliseconds.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
