### PR TITLE
build: Change time stamping server

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -49,6 +49,9 @@ dmg:
 win:
   target:
   - nsis
+  # Comment out the following line if the Digicert server starts failing.
+  # Electron-Builder will then swtich back to the default Comodoca server.
+  rfc3161TimeStampServer: 'http://timestamp.digicert.com/'
 linux:
   target:
   - AppImage


### PR DESCRIPTION
The default comodoca.com time stamping server used by
`electron-builder` to sign our Windows binaries is failing us.
This prevents us from building new Windows releases.

We've switched to another server, provided by Digicert.
If we start seeing failures again, we can find other servers at
gist.github.com/Manouchehri/fd754e402d98430243455713efada710.

The current list contains:
- http://timestamp.globalsign.com/scripts/timstamp.dll
- timestamp.geotrust.com/tsa
- http://timestamp.comodoca.com/rfc3161
- http://timestamp.wosign.com
- http://tsa.startssl.com/rfc3161
- http://time.certum.pl
- http://timestamp.digicert.com
- freetsa.org
- http://dse200.ncipher.com/TSS/HttpTspServer
- http://tsa.safecreative.org
- http://zeitstempel.dfn.de
- ca.signfiles.com/tsa/get.aspx
- http://services.globaltrustfinder.com/adss/tsa
- tsp.iaik.tugraz.at/tsp/TspRequest
- http://timestamp.apple.com/ts01
- http://timestamp.entrust.net/TSS/RFC3161sha2TS

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
