### PR TITLE
deps: Bump Electron to v6.1.12

### DIFF
--- a/gui/js/components/UserActionRequiredDialog.js
+++ b/gui/js/components/UserActionRequiredDialog.js
@@ -15,7 +15,7 @@ module.exports = {
 }
 
 function show(err) {
-  const userChoice = dialog.showMessageBox(null, options(err))
+  const userChoice = dialog.showMessageBoxSync(null, options(err))
   if (userChoice === 0) opn(err.links.self)
   else log.warn({ userChoice }, 'Unexpected user choice')
 }

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -180,7 +180,7 @@ module.exports = class OnboardingWM extends WindowManager {
   onChooseFolder(event) {
     // FIXME: The modal may appear on background, either every time (e.g. Ubuntu)
     // or only the second time (e.g. Fedora)
-    let folders = dialog.showOpenDialog({
+    let folders = dialog.showOpenDialogSync({
       properties: ['openDirectory', 'createDirectory']
     })
     if (folders && folders.length > 0) {

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -1,7 +1,7 @@
 const electron = require('electron')
 const { dialog, shell } = electron
 const { spawn } = require('child_process')
-const { dirname, join } = require('path')
+const { join } = require('path')
 const autoLaunch = require('./autolaunch')
 const DASHBOARD_SCREEN_WIDTH = 330
 const DASHBOARD_SCREEN_HEIGHT = 830
@@ -192,24 +192,7 @@ module.exports = class TrayWM extends WindowManager {
   openPath(pathToOpen) {
     pathToOpen = join(this.desktop.config.syncPath, pathToOpen)
 
-    if (shell.showItemInFolder(pathToOpen)) return
-    if (shell.openItem(dirname(pathToOpen))) return
-
-    const spawnOpts = {
-      detached: true,
-      stdio: ['ignore', 'ignore', 'ignore']
-    }
-
-    switch (process.platform) {
-      case 'darwin':
-        spawn('open', ['-R', pathToOpen], spawnOpts)
-        break
-      case 'win32':
-        spawn('explorer.exe', ['/select,"' + pathToOpen + '"'], spawnOpts)
-        break
-      default:
-        spawn('xdg-open', [dirname(pathToOpen)], spawnOpts)
-    }
+    shell.showItemInFolder(pathToOpen)
   }
 
   onUnlink() {

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -234,19 +234,25 @@ module.exports = class TrayWM extends WindowManager {
     this.desktop
       .stopSync()
       .then(() => this.desktop.removeRemote())
-      .then(() => log.info('removed'))
+      .then(() => log.info('remote removed'))
       .then(() => this.doRestart())
       .catch(err => log.error(err))
   }
 
   doRestart() {
-    setTimeout(() => {
+    if (process.env.APPIMAGE) {
+      setTimeout(() => {
+        log.info('Exiting old client...')
+        this.app.exit(0)
+      }, 50)
+      const args = process.argv.slice(1).filter(a => a !== '--isHidden')
+      log.info({ args, cmd: process.argv[0] }, 'Starting new client...')
+      spawn(process.argv[0], args, { detached: true })
+    } else {
+      this.app.relaunch()
       log.info('Exiting old client...')
-      this.app.quit()
-    }, 50)
-    const args = process.argv.slice(1).filter(a => a !== '--isHidden')
-    log.info({ args, cmd: process.argv[0] }, 'Starting new client...')
-    spawn(process.argv[0], args, { detached: true })
+      this.app.exit(0)
+    }
   }
 }
 

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -226,7 +226,7 @@ module.exports = class TrayWM extends WindowManager {
       cancelId: 0,
       defaultId: 1
     }
-    const response = dialog.showMessageBox(this.win, options)
+    const response = dialog.showMessageBoxSync(this.win, options)
     if (response === 0) {
       this.send('cancel-unlink')
       return

--- a/gui/js/updater.window.js
+++ b/gui/js/updater.window.js
@@ -55,7 +55,7 @@ module.exports = class UpdaterWM extends WindowManager {
       // Make sure UI doesn't show up after timeout
       if (!this.skipped) {
         const shouldUpdate =
-          dialog.showMessageBox({
+          dialog.showMessageBoxSync({
             icon: path.resolve(__dirname, '..', 'images', 'icon.png'),
             title: 'Cozy Drive',
             message: 'Cozy Drive',

--- a/gui/main.js
+++ b/gui/main.js
@@ -107,7 +107,7 @@ const setupDesktop = async () => {
     } else if (err instanceof migrations.MigrationFailedError) {
       showMigrationError(err)
     } else {
-      dialog.showMessageBox(null, {
+      dialog.showMessageBoxSync(null, {
         type: 'error',
         message: err.message,
         buttons: [translate('AppMenu Close')]
@@ -185,7 +185,7 @@ const showInvalidConfigError = () => {
     buttons: [translate('Button Log out'), translate('Button Contact support')],
     defaultId: 0
   }
-  const userChoice = dialog.showMessageBox(null, options)
+  const userChoice = dialog.showMessageBoxSync(null, options)
   if (userChoice === 0) {
     desktop
       .removeConfig()
@@ -212,7 +212,7 @@ const showMigrationError = (err /*: Error */) => {
     buttons: [translate('Button Contact support')],
     defaultId: 0
   }
-  const userChoice = dialog.showMessageBox(null, options)
+  const userChoice = dialog.showMessageBoxSync(null, options)
   if (userChoice === 0) {
     helpWindow = new HelpWM(app, desktop)
     helpWindow.show()
@@ -239,7 +239,7 @@ const sendErrorToMainWindow = msg => {
       defaultId: 1
     }
     trayWindow.hide()
-    const userChoice = dialog.showMessageBox(null, options)
+    const userChoice = dialog.showMessageBoxSync(null, options)
     if (userChoice === 0) {
       desktop
         .stopSync()
@@ -264,7 +264,7 @@ const sendErrorToMainWindow = msg => {
       defaultId: 0
     }
     trayWindow.hide()
-    dialog.showMessageBox(null, options)
+    dialog.showMessageBoxSync(null, options)
     desktop
       .stopSync()
       .then(() => desktop.pouch.db.destroy())
@@ -288,7 +288,7 @@ const sendErrorToMainWindow = msg => {
       detail: translate('SyncDirEmpty Detail'),
       buttons: [translate('AppMenu Close')]
     }
-    dialog.showMessageBox(null, options)
+    dialog.showMessageBoxSync(null, options)
     desktop.stopSync().catch(err => log.error(err))
     return // no notification
   } else {
@@ -524,7 +524,7 @@ const openNote = async filePath => {
         'Could not display markdown content of note'
       )
 
-      dialog.showMessageBox(null, {
+      dialog.showMessageBoxSync(null, {
         type: 'error',
         message: translate('Error Unexpected error'),
         details: `${err.name}: ${err.message}`,
@@ -633,7 +633,7 @@ app.on('ready', async () => {
       desktop = new Desktop.App(process.env.COZY_DESKTOP_DIR)
     } catch (err) {
       if (err.message.match(/GLIBCXX/)) {
-        dialog.showMessageBox(null, {
+        dialog.showMessageBoxSync(null, {
           type: 'error',
           message: translate('Error Bad GLIBCXX version'),
           buttons: [translate('AppMenu Close')]

--- a/gui/styles/_two_panes.styl
+++ b/gui/styles/_two_panes.styl
@@ -105,6 +105,7 @@
   flex 1 0
   display flex
   flex-direction column
+  overflow-y auto
 
 .two-panes__menu
   @extend $tabs-base .coz-tab-list

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "debug-menu": "^0.6.1",
     "del": "^4.0.0",
     "devtron": "^1.4.0",
-    "electron": "5.0.0",
+    "electron": "^6.0.0",
     "electron-builder": "^21.2.0",
     "electron-mocha": "^8.1.2",
     "electron-notarize": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "stylus": "^0.54.5"
   },
   "optionalDependencies": {
-    "@gyselroth/windows-fsstat": "https://github.com/taratatach/node-windows-fsstat.git#support-node-12"
+    "@gyselroth/windows-fsstat": "https://github.com/taratatach/node-windows-fsstat.git"
   },
   "resolutions": {
     "chokidar": "3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,9 +127,9 @@
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-"@gyselroth/windows-fsstat@https://github.com/taratatach/node-windows-fsstat.git#support-node-12":
-  version "0.0.7"
-  resolved "https://github.com/taratatach/node-windows-fsstat.git#7b33c5d04e0107cd1c4b84def4a977c12d596be8"
+"@gyselroth/windows-fsstat@https://github.com/taratatach/node-windows-fsstat.git":
+  version "0.0.8"
+  resolved "https://github.com/taratatach/node-windows-fsstat.git#d5295cef25d2c258e0b99a312544b22f78056853"
   dependencies:
     nan "^2.14.0"
     node-gyp "^5.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,10 +1995,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-5.0.0.tgz#d8352e2c9625b3be0112ce0c1bf5c9b6f692557e"
-  integrity sha512-++emIe4vLihiYiAVL+E8DT5vSNVFEIuQCRxA+VfpDRVBcog85UB28vi4ogRmMOK3UffzKdWV6e1jqp3T0KpBoA==
+electron@^6.0.0:
+  version "6.1.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-6.1.12.tgz#a7aee6dfa75b57f32b3645ef8e14dcef6d5f31a9"
+  integrity sha512-RUPM8xJfTcm53V9EKMBhvpLu1+CQkmuvWDmVCypR5XbUG1OOrOLiKl0CqUZ9+tEDuOmC+DmzmJP2MZXScBU5IA==
   dependencies:
     "@types/node" "^10.12.18"
     electron-download "^4.1.0"


### PR DESCRIPTION
Upgrades Electron to v6.1.12 and applies the required changes to other dependencies and code to have the application work with the new Electron, Node and V8 versions.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
