### PR TITLE
gui: Fix account info display in Settings tab

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -157,6 +157,9 @@ const showWindow = bounds => {
       sendDiskUsage()
     }
     trayWindow.show(bounds).then(async () => {
+      const { cozyUrl, deviceName } = desktop.config
+      trayWindow.send('synchronization', cozyUrl, deviceName)
+
       const files = await lastFiles.list()
       for (const file of files) {
         trayWindow.send('transfer', file)
@@ -389,11 +392,6 @@ const sendDiskUsage = () => {
 }
 
 const startSync = async () => {
-  trayWindow.send(
-    'synchronization',
-    desktop.config.cozyUrl,
-    desktop.config.deviceName
-  )
   updateState('syncing')
   desktop.events.on('sync-status', status => {
     updateState('sync-status', status)


### PR DESCRIPTION
Similarly to the Recent files list display, the account information
displayed in the Settings tab are sent to the main window via
messages.
In the same fashion, those messages need to be sent after the window
has fully loaded otherwise they won't be received and the account
information will never be displayed.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
