### PR TITLE
gui/lastFiles: Securely persist last files list to disk

### DIFF
--- a/gui/js/lastfiles.js
+++ b/gui/js/lastfiles.js
@@ -13,7 +13,7 @@ const log = require('../../core/app').logger({
   component: 'GUI'
 })
 
-module.exports.init = desktop => {
+const init = desktop => {
   lastFilesPath = path.join(desktop.basePath, 'last-files')
   lastFiles = new Promise(resolve => {
     fs.readFile(lastFilesPath, 'utf-8', (err, data) => {
@@ -32,7 +32,7 @@ module.exports.init = desktop => {
   })
 }
 
-module.exports.persist = async () => {
+const persist = async () => {
   const data = JSON.stringify(await lastFiles)
   fs.writeFile(lastFilesPath, data, err => {
     if (err) {
@@ -41,13 +41,21 @@ module.exports.persist = async () => {
   })
 }
 
-module.exports.list = async () => await lastFiles
-module.exports.add = async file => {
+const list = async () => await lastFiles
+const add = async file => {
   const previousList = await lastFiles
   previousList.push(file)
   lastFiles = Promise.resolve(previousList.slice(-250))
 }
-module.exports.remove = async file => {
+const remove = async file => {
   const previousList = await lastFiles
   lastFiles = Promise.resolve(previousList.filter(f => f.path !== file.path))
+}
+
+module.exports = {
+  init,
+  list,
+  add,
+  remove,
+  persist
 }


### PR DESCRIPTION
Node's documentation states that it is unsafe to make multiple calls
to `fs.writeFile()` on the same file in parallel
(see https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).

However, this is precisely what we were doing when persisting our
last files JSON object to disk. We only make one call to
`fs.writeFile()` per `lastFiles.persist()` call but calls to
`persist` are made asynchronously and not awaited by the caller (for
GUI performance).
This is probably the reason why we're seing malformed JSON files
persisted to disk.

We'll now use an `async` queue in which we'll push calls to
`fs.writeFile()` so they'll be run sequentially. We still won't
await calls to `lastFiles.persist()` in the GUI.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
