### PR TITLE
core/sync: No move events for folders

### DIFF
--- a/core/sync.js
+++ b/core/sync.js
@@ -407,7 +407,9 @@ class Sync {
         await this.doAdd(side, doc)
       } else if (from.childMove) {
         await side.assignNewRev(doc)
-        this.events.emit('transfer-move', _.clone(doc), _.clone(from))
+        if (doc.docType === 'file') {
+          this.events.emit('transfer-move', _.clone(doc), _.clone(from))
+        }
       } else {
         if (from.moveFrom && from.moveFrom.childMove) {
           await side.assignNewRev(from)


### PR DESCRIPTION
We use events to communicate between the Sync module and our GUI and
update the list of recently synchronized files.
We should not be adding folders in this list at the moment.

However, it appears we were sending Move events for all child moves,
be it files or folders.
For other types of events, we're checking whether the synchronized
element is a file before sending a message to the GUI.

We're now doing the same for child moves.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
