### PR TITLE
gui: Show correct auto launch status

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -164,6 +164,10 @@ const showWindow = bounds => {
       for (const file of files) {
         trayWindow.send('transfer', file)
       }
+
+      autoLaunch.isEnabled().then(enabled => {
+        trayWindow.send('auto-launch', enabled)
+      })
     })
   }
 }
@@ -457,10 +461,6 @@ const startSync = async () => {
 
   desktop.startSync()
   sendDiskUsage()
-
-  autoLaunch.isEnabled().then(enabled => {
-    trayWindow.send('auto-launch', enabled)
-  })
 }
 
 const dumbhash = k =>


### PR DESCRIPTION
The auto launch status is computed asynchronously and sent to the Tray
window via an event.

However, if the window is not fully loaded and the Elm application not
ready to receive this message when it is sent then we'll miss it and
will display the default value which is `enabled`.

We're now sending the current status only after the window is shown so
we're sure it's ready to be received and processed.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
