### PR TITLE
Release v3.22.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.22.0-beta.6 - 2020-08-12
+
+Improvements for all users:
+
+- The autolaunch setting could be displayed as enabled when it was disabled from
+  the OS settings panel instead of the Cozy Desktop client settings.
+  We've made sure the interface shows the actual value of this setting and the
+  switch is off when the autolaunch is disabled.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.22.0-beta.5 - 2020-08-08
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.22.0-beta.5",
+  "version": "3.22.0-beta.6",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- The autolaunch setting could be displayed as enabled when it was
  disabled from the OS settings panel instead of the Cozy Desktop
  client settings.
  We've made sure the interface shows the actual value of this setting
  and the switch is off when the autolaunch is disabled.