### PR TITLE
gui: Don't automatically re-enable autolaunch

### DIFF
--- a/gui/js/autolaunch.js
+++ b/gui/js/autolaunch.js
@@ -23,19 +23,20 @@ if (process.env.APPIMAGE) {
   // after an app update.
   // See https://github.com/Teamwork/node-auto-launch/issues/92
 
-  // Check if there is an autolaunch entry with the app's path.
-  const pathAutoLaunchEnabled = autoLauncher.isEnabled()
-  // Remove it to avoid having multiple entries.
-  if (pathAutoLaunchEnabled) {
-    autoLauncher.disable()
-  }
   // Make sure the autolaunch entry will use the app's name.
   autoLauncher.opts.appName = APP_NAME
-  // Create an autolaunch entry with the app's name if there was an entry with
-  // the app's path.
-  if (pathAutoLaunchEnabled) {
-    autoLauncher.enable()
-  }
+
+  // Check if there is an autolaunch entry with the app's path.
+  autoLauncher.isEnabled().then(pathAutoLaunchEnabled => {
+    if (pathAutoLaunchEnabled) {
+      // Remove it to avoid having multiple entries.
+      autoLauncher.disable()
+
+      // Create an autolaunch entry with the app's name if there was an entry
+      // with the app's path.
+      autoLauncher.enable()
+    }
+  })
 }
 
 module.exports.isEnabled = () => autoLauncher.isEnabled()


### PR DESCRIPTION
We introduced a fix a while back to make sure the autolaunch
`.desktop` file created on Linux would use the app's name and not its
path since the path would contain the version by default and
autolaunch would thus break after each upgrade.

We tried to re-enable autolaunch with the app's name for users who had
it enabled with the app's path. We would check the return value of
`autoLauncher.isEnabled()` to decided whether we needed to do it but
this value is not a boolean as expected, it is a promise of a boolean.
This means that we would always try to re-enable autolaunch, at each
run, for users who wanted to disable it.

We're now waiting for the promise resolution and use the resolved
value to decide if we need to re-enable autolaunch.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
