### PR TITLE
pouch/migrations: Migrate changesfeed

### DIFF
--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -14,11 +14,11 @@ module.exports = {
     })
   },
 
-  createParentFolder(pouch, callback) {
+  createParentFolder(pouch) {
     let doc = {
       path: 'my-folder',
       docType: 'folder',
-      updated_at: new Date(),
+      updated_at: new Date().toISOString(),
       tags: [],
       remote: {
         _id: `XXX`,
@@ -30,14 +30,14 @@ module.exports = {
       }
     }
     assignId(doc)
-    return pouch.db.put(doc).asCallback(callback)
+    return pouch.db.put(doc).then(({ rev }) => ({ ...doc, _rev: rev }))
   },
 
-  createFolder(pouch, folderPath, callback) {
+  createFolder(pouch, folderPath) {
     let doc = {
       path: folderPath,
       docType: 'folder',
-      updated_at: new Date(),
+      updated_at: new Date().toISOString(),
       tags: [],
       remote: {
         _id: `123456789-${folderPath}`
@@ -48,15 +48,15 @@ module.exports = {
       }
     }
     assignId(doc)
-    return pouch.db.put(doc).asCallback(callback)
+    return pouch.db.put(doc).then(({ rev }) => ({ ...doc, _rev: rev }))
   },
 
-  createFile(pouch, filePath, callback) {
+  createFile(pouch, filePath) {
     let doc = {
       path: filePath,
       docType: 'file',
       md5sum: `111111111111111111111111111111111111111${filePath}`,
-      updated_at: new Date(),
+      updated_at: new Date().toISOString(),
       tags: [],
       remote: {
         _id: `1234567890-${filePath}`
@@ -67,6 +67,6 @@ module.exports = {
       }
     }
     assignId(doc)
-    return pouch.db.put(doc).asCallback(callback)
+    return pouch.db.put(doc).then(({ rev }) => ({ ...doc, _rev: rev }))
   }
 }


### PR DESCRIPTION
When migrating an existing database, we copy all existing documents,
migrate those that need to be, replace their old version in the
database copy and then replace the old database with the copy.
In this process, we lose an essential information: the list of changes
from the old database's changesfeed that were not already processed by
the Sync module.

These changes can be found by requesting the changesfeed starting with
the saved local sequence. However, since the sequence increases with
each change made on a document and the new database has not seen the
same number of changes, the old database's local sequence has no
meaning in the new database context.
This is why we were just setting the new database's local sequence to
the last update sequence of the new database.

From there, only the changes made after the migration will have a
sequence greater than the local sequence and thus be found by the Sync
module.
In case some changes were merged but not applied (or synced) before a
migration was run, those won't appear in the changesfeed the next time
the Sync module looks for changes to apply and will be "lost".

We might apply those changes if another change on the same document is
merged later but we can't guarantee it will happen or that the result
will be the expected one.

For this reason, we now fetch the changes with a sequence greater than
the local sequence before applying a migration and touch their
associated documents after the migration has been run so that they
will appear in the changesfeed again.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
