### PR TITLE
core/local: Initial scan keeps unsynced remote docs

### DIFF
--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -87,8 +87,7 @@ async function initialState(
   // which files/folders have been deleted, as it is stable even if the
   // file/folder has been moved or renamed
   const byInode /*: Map<number|string, Metadata> */ = new Map()
-  const docs = (await opts.pouch.allDocs() /*: Metadata[] */)
-    .filter(doc => !doc.deleted)
+  const docs /*: Metadata[] */ = await opts.pouch.initialScanDocs()
   // Make sure all paths are sorted in reverse path order so that missing
   // children will be deleted before missing parents and folders that would not
   // have any content are not trashed but completely deleted

--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -40,8 +40,7 @@ const detectOfflineUnlinkEvents = async (
 ) /*: Promise<{offlineEvents: Array<ChokidarEvent>, unappliedMoves: string[], emptySyncDir: boolean}> */ => {
   // Try to detect removed files & folders
   const events /*: Array<ChokidarEvent> */ = []
-  const docs = (await pouch.allDocs() /*: Metadata[] */)
-    .filter(doc => !doc.deleted)
+  const docs /*: Metadata[] */ = await pouch.initialScanDocs()
   const inInitialScan = doc =>
     initialScan.ids.indexOf(metadata.id(doc.path)) !== -1
 

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -152,10 +152,23 @@ class Pouch {
 
   /* Mini ODM */
 
-  async allDocs() /*: Promise<void> */ {
+  async allDocs() /*: Promise<Metadata[]> */ {
     const results = await this.db.allDocs({ include_docs: true })
     return Array.from(results.rows)
       .filter(row => !row.key.startsWith('_'))
+      .map(row => row.doc)
+  }
+
+  async initialScanDocs() /*: Promise<Metadata[]> */ {
+    const results = await this.db.allDocs({ include_docs: true })
+    return Array.from(results.rows)
+      .filter(
+        row =>
+          !row.key.startsWith('_') && // Filter out design docs
+          !row.doc.deleted && // Filter out docs already marked for deletion
+          row.doc.sides &&
+          row.doc.sides.local // Keep only docs that have existed locally
+      )
       .map(row => row.doc)
   }
 

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -32,11 +32,24 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       const fizz = await builders
         .metafile()
         .path('fizz')
         .ino(2)
+        .upToDate()
+        .create()
+      const bar = await builders
+        .metadir()
+        .path('bar')
+        .ino(3)
+        .sides({ local: 1 })
+        .create()
+      await builders
+        .metafile()
+        .path('baz')
+        .sides({ remote: 1 })
         .create()
 
       const state = await initialDiff.initialState(this)
@@ -46,7 +59,8 @@ describe('core/local/atom/initial_diff', () => {
         scannedPaths: new Set(),
         byInode: new Map([
           [foo.fileid || foo.ino, foo],
-          [fizz.fileid || fizz.ino, fizz]
+          [fizz.fileid || fizz.ino, fizz],
+          [bar.fileid || bar.ino, bar]
         ])
       })
     })
@@ -58,6 +72,7 @@ describe('core/local/atom/initial_diff', () => {
         .metadata()
         .path('foo')
         .ino(1)
+        .upToDate()
         .build()
       const waiting = [
         { batch: [], nbCandidates: 0, timeout: setTimeout(() => {}, 0) }
@@ -114,11 +129,13 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('fizz')
         .ino(2)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -165,16 +182,19 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('foo/baz')
         .ino(2)
+        .upToDate()
         .create()
       await builders
         .metadir()
         .path('bar')
         .ino(3)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -234,21 +254,25 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('bar')
         .ino(2)
+        .upToDate()
         .create()
       await builders
         .metadir()
         .path('fizz')
         .ino(3)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('buzz')
         .ino(4)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -297,11 +321,13 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('bar')
         .ino(2)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -340,11 +366,13 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('bar')
         .ino(2)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -383,11 +411,13 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .create()
       const bar = await builders
         .metafile()
         .path('bar')
         .ino(2)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -433,12 +463,14 @@ describe('core/local/atom/initial_diff', () => {
         .path('stillEmptyFile')
         .ino(2)
         .data('')
+        .upToDate()
         .create()
       const sameContentFile = await builders
         .metafile()
         .path('sameContentFile')
         .ino(3)
         .data('content')
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -481,6 +513,7 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('dir')
         .ino(1)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -506,6 +539,7 @@ describe('core/local/atom/initial_diff', () => {
         .path('updatedContent')
         .ino(2)
         .data('content')
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -531,6 +565,7 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('foo')
         .ino(1)
+        .upToDate()
         .build()
       await builders
         .metadir(wasDir)
@@ -542,6 +577,7 @@ describe('core/local/atom/initial_diff', () => {
         .metafile()
         .path('fizz')
         .ino(2)
+        .upToDate()
         .build()
       await builders
         .metafile(wasFile)
@@ -592,16 +628,19 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('parent')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metadir()
         .path('parent/foo')
         .ino(2)
+        .upToDate()
         .create()
       await builders
         .metadir()
         .path('parent/foo/bar')
         .ino(3)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -673,16 +712,19 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('parent')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metadir()
         .path('parent/foo')
         .ino(2)
+        .upToDate()
         .create()
       const missingDoc = await builders
         .metadir()
         .path('parent/foo/bar')
         .ino(3)
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -754,12 +796,14 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('parent')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('parent/foo')
         .ino(2)
         .data('initial content')
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -813,12 +857,14 @@ describe('core/local/atom/initial_diff', () => {
         .metadir()
         .path('parent')
         .ino(1)
+        .upToDate()
         .create()
       await builders
         .metafile()
         .path('parent/foo')
         .ino(2)
         .data('initial content')
+        .upToDate()
         .create()
 
       const state = await initialDiff.initialState({ pouch: this.pouch })
@@ -854,6 +900,32 @@ describe('core/local/atom/initial_diff', () => {
         fooScan,
         initialScanDone
       ])
+    })
+
+    it('does not delete unsynced remote additions', async function() {
+      await builders
+        .metadir()
+        .path('dir')
+        .ino(1)
+        .sides({ remote: 1 })
+        .create()
+      await builders
+        .metafile()
+        .path('file')
+        .ino(2)
+        .data('initial content')
+        .sides({ remote: 1 })
+        .create()
+
+      const state = await initialDiff.initialState({ pouch: this.pouch })
+
+      inputBatch([initialScanDone])
+
+      const events = await initialDiff
+        .loop(channel, { pouch: this.pouch, state })
+        .pop()
+
+      should(events).deepEqual([initialScanDone])
     })
   })
 })

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -34,22 +34,29 @@ onPlatform('darwin', () => {
       })
 
       it('detects deleted files and folders', async function() {
-        let folder1 = {
+        // Folder still exists
+        const folder1 = {
           _id: 'folder1',
           path: 'folder1',
-          docType: 'folder'
+          docType: 'folder',
+          sides: { target: 2, local: 2, remote: 2 }
         }
-        let folder2 = {
+        // Folder does not exist anymore
+        const folder2 = {
           _id: 'folder2',
           path: 'folder2',
-          docType: 'folder'
+          docType: 'folder',
+          sides: { target: 2, local: 2, remote: 2 }
         }
+        // Folder was already trashed remotely
         const folder3 = {
           _id: '.cozy_trash/folder3',
           path: '.cozy_trash/folder3',
           trashed: true,
-          docType: 'folder'
+          docType: 'folder',
+          sides: { target: 3, local: 2, remote: 3 }
         }
+        // Folder was moved locally
         const folder4 = {
           _id: 'folder4',
           path: 'folder4',
@@ -57,24 +64,40 @@ onPlatform('darwin', () => {
           moveFrom: {
             _id: 'folder1/folder4',
             path: 'folder1/folder4'
-          }
+          },
+          sides: { target: 3, local: 3, remote: 2 }
         }
-        let file1 = {
+        // Folder was already trashed remotely and marked for deletion
+        const folder5 = {
+          _id: '.cozy_trash/folder5',
+          path: '.cozy_trash/folder5',
+          deleted: true,
+          docType: 'folder',
+          sides: { target: 3, local: 2, remote: 3 }
+        }
+        // File still exists
+        const file1 = {
           _id: 'file1',
           path: 'file1',
-          docType: 'file'
+          docType: 'file',
+          sides: { target: 2, local: 2, remote: 2 }
         }
-        let file2 = {
+        // File does not exist anymore
+        const file2 = {
           _id: 'file2',
           path: 'file2',
-          docType: 'file'
+          docType: 'file',
+          sides: { target: 2, local: 2, remote: 2 }
         }
+        // File was trashed remotely
         const file3 = {
           _id: '.cozy_trash/folder3/file3',
           path: '.cozy_trash/folder3/file3',
           trashed: true,
-          docType: 'file'
+          docType: 'file',
+          sides: { target: 3, local: 2, remote: 3 }
         }
+        // File was moved locally
         const file4 = {
           _id: 'file4',
           path: 'file4',
@@ -82,17 +105,28 @@ onPlatform('darwin', () => {
           moveFrom: {
             _id: 'folder1/file4',
             path: 'folder1/file4'
-          }
+          },
+          sides: { target: 3, local: 3, remote: 2 }
+        }
+        // File was already deleted locally and marked for deletion
+        const file5 = {
+          _id: 'folder1/file5',
+          path: 'folder1/file5',
+          deleted: true,
+          docType: 'file',
+          sides: { target: 3, local: 3, remote: 2 }
         }
         for (let doc of [
           folder1,
           folder2,
           folder3,
           folder4,
+          folder5,
           file1,
           file2,
           file3,
-          file4
+          file4,
+          file5
         ]) {
           const { rev } = await this.pouch.db.put(doc)
           doc._rev = rev
@@ -127,6 +161,31 @@ onPlatform('darwin', () => {
           should(offlineEvents).deepEqual([])
         })
       }
+    })
+
+    it('does not detect unsynced remote additions as deleted docs', async function() {
+      await builders
+        .metadir()
+        .path('dir')
+        .ino(1)
+        .sides({ remote: 1 })
+        .create()
+      await builders
+        .metafile()
+        .path('file')
+        .ino(2)
+        .data('initial content')
+        .sides({ remote: 1 })
+        .create()
+
+      const initialScan = { ids: [] }
+
+      const { offlineEvents } = await detectOfflineUnlinkEvents(
+        initialScan,
+        this.pouch
+      )
+
+      should(offlineEvents).be.empty()
     })
   })
 })

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -8,12 +8,12 @@ const sinon = require('sinon')
 const _ = require('lodash')
 const { uniq } = _
 
-const metadata = require('../../core/metadata')
-const migrations = require('../../core/pouch/migrations')
+const metadata = require('../../../core/metadata')
+const migrations = require('../../../core/pouch/migrations')
 
-const Builders = require('../support/builders')
-const configHelpers = require('../support/helpers/config')
-const pouchHelpers = require('../support/helpers/pouch')
+const Builders = require('../../support/builders')
+const configHelpers = require('../../support/helpers/config')
+const pouchHelpers = require('../../support/helpers/pouch')
 
 describe('Pouch', function() {
   before('instanciate config', configHelpers.createConfig)


### PR DESCRIPTION
When starting the Desktop client, we need to guess what changes were
made to local files while it was stopped. To do so, we run a full scan
of the local synced folder, fetch all records from our PouchDB
database and compare them to find modifications, movements and
deletions.

In this context, deletions are inferred from the absence on the local
filesystem of a document for which we have a record in PouchDB.
In this case, we emit a `deleted` event for that document and leave
the rest to the other local watcher steps.

However, if the record was merged by the remote watcher and not
synchronized before the client was stopped, it is expected that the
document would not exist on the local filesystem yet (i.e. it has not
been downloaded at all).
To avoid emitting `deleted` events for such documents, we will filter
the records from PouchDB and keep only those for which we have a
`local` side. The presence of this side means the Sync module has
propagated the remote change to the local filesystem and we expect the
document to exist locally.

We also filter out records marked for deletion since the Sync module
will take care of them later.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
