### PR TITLE
test: Disable known failing trash integration test

### DIFF
--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -138,7 +138,11 @@ describe('Trash', () => {
         })
       })
 
-      context('after the file was moved on the local filesystem', () => {
+      // XXX: This behavior does not work anymore since the stack is now denying
+      // requests to move files that are in the Cozy trash.
+      // We'll need to go the extra mile and restore the file before moving it.
+      // See https://github.com/cozy/cozy-stack/commit/afa80ba65de265d5133974562014b89aae7b2836
+      context.skip('after the file was moved on the local filesystem', () => {
         it('does not trash the file on the local filesystem and restores it', async () => {
           await helpers.local.syncDir.move(
             path.normalize('parent/file'),


### PR DESCRIPTION
The Desktop client is supposed to cancel remote deletions of files
that were moved on the local filesystem at the same time.
However, the implementation of this behavior resulted in incoherent
metadata on the Cozy and the stack is now denying client requests to
move files that are in the Cozy trash.
See https://github.com/cozy/cozy-stack/commit/afa80ba65de265d5133974562014b89aae7b2836

We'll need to fix our implementation (probably by restoring the file
before moving it) but this is not the priority so we're only disabling
this test for the moment.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
