### PR TITLE
core/remote: Send body size with file modification

### DIFF
--- a/core/reader.js
+++ b/core/reader.js
@@ -7,36 +7,11 @@
  * @flow
  */
 
-// FIXME:
-// eslint-disable-next-line
-const stream = require('stream')
-
 /*::
+import type { Readable } from 'stream'
 import type { Metadata } from './metadata'
-*/
 
-class ReadableWithContentLength /*:: extends stream.Readable */ {
-  /*::
-  contentLength: ?number
-  */
-}
-
-function withContentLength(
-  s /*: stream.Readable */,
-  contentLength /*: ?number */
-) /*: ReadableWithContentLength */ {
-  const s2 /*: ReadableWithContentLength */ = (s /*: any */)
-  s2.contentLength = contentLength
-  return s2
-}
-
-/*::
 export interface Reader {
-  createReadStreamAsync (Metadata): Promise<ReadableWithContentLength>;
+  createReadStreamAsync (Metadata): Promise<Readable>;
 }
 */
-
-module.exports = {
-  ReadableWithContentLength,
-  withContentLength
-}

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -183,21 +183,23 @@ class RemoteCozy {
 
   createFile(
     data /*: Readable */,
-    options /*: {name: string,
+    options /*: {|name: string,
                  dirID?: ?string,
-                 contentType?: ?string,
-                 createdAt: ?string,
-                 updatedAt: ?string,
-                 executable: boolean} */
+                 contentType: string,
+                 contentLength: number,
+                 checksum: string,
+                 createdAt: string,
+                 updatedAt: string,
+                 executable: boolean|} */
   ) /*: Promise<RemoteDoc> */ {
     return this.client.files.create(data, options).then(this.toRemoteDoc)
   }
 
   createDirectory(
-    options /*: {name: string,
+    options /*: {|name: string,
                  dirID?: string,
-                 createdAt: ?string,
-                 updatedAt: ?string} */
+                 createdAt: string,
+                 updatedAt: string|} */
   ) /*: Promise<RemoteDoc> */ {
     return this.client.files.createDirectory(options).then(this.toRemoteDoc)
   }
@@ -205,9 +207,11 @@ class RemoteCozy {
   updateFileById(
     id /*: string */,
     data /*: Readable */,
-    options /*: {contentType?: ?string,
-                 updatedAt: ?string,
-                 executable: boolean} */
+    options /*: {|contentType: string,
+                 checksum: string,
+                 updatedAt: string,
+                 executable: boolean,
+                 ifMatch: string|} */
   ) /*: Promise<RemoteDoc> */ {
     return this.client.files
       .updateById(id, data, options)
@@ -216,8 +220,11 @@ class RemoteCozy {
 
   updateAttributesById(
     id /*: string */,
-    attrs /*: Object */,
-    options /*: ?{ifMatch?: string} */
+    attrs /*: {|name?: string,
+               dir_id?: string,
+               executable?: boolean,
+               updated_at: string|} */,
+    options /*: {|ifMatch: string|} */
   ) /*: Promise<RemoteDoc> */ {
     return this.client.files
       .updateAttributesById(id, attrs, options)
@@ -226,14 +233,14 @@ class RemoteCozy {
 
   trashById(
     id /*: string */,
-    options /*: ?{ifMatch: string} */
+    options /*: {|ifMatch: string|} */
   ) /*: Promise<RemoteDoc> */ {
     return this.client.files.trashById(id, options).then(this.toRemoteDoc)
   }
 
   destroyById(
     id /*: string */,
-    options /*: ?{ifMatch: string} */
+    options /*: {|ifMatch: string|} */
   ) /*: Promise<void> */ {
     return this.client.files.destroyById(id, options)
   }

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -208,6 +208,7 @@ class RemoteCozy {
     id /*: string */,
     data /*: Readable */,
     options /*: {|contentType: string,
+                 contentLength: number,
                  checksum: string,
                  updatedAt: string,
                  executable: boolean,

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -208,6 +208,7 @@ class Remote /*:: implements Reader, Writer */ {
       {
         checksum: doc.md5sum,
         executable: doc.executable || false,
+        contentLength: doc.size,
         contentType: doc.mime,
         updatedAt: doc.updated_at,
         ifMatch: old && old.remote ? old.remote._rev : ''

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -143,7 +143,7 @@ describe('Cozy Note move', () => {
 
     describe('to a free target location', () => {
       beforeEach('move local note', async () => {
-        await helpers.remote.move(note._id, dstPath)
+        await helpers.remote.move(note, dstPath)
         await helpers.pullAndSyncAll()
         await helpers.flushLocalAndSyncAll()
       })

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -311,9 +311,10 @@ describe('Platform incompatibilities', () => {
       path: '/dir2',
       updated_at: new Date().toISOString()
     }
+    const { name, dir_id, executable, updated_at } = newRemoteDoc
     await helpers.remote.side.remoteCozy.updateAttributesById(
       remoteDoc._id,
-      newRemoteDoc,
+      { name, dir_id, executable, updated_at },
       { ifMatch: remoteDoc._rev }
     )
     const dir2 = metadata.fromRemoteDoc(newRemoteDoc)

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -161,16 +161,17 @@ class RemoteTestHelpers {
     }
   }
 
-  async move(id /*: string */, newPath /*: string */) {
+  async move({ _id, updated_at } /*: RemoteDoc */, newPath /*: string */) {
     const [newDirPath, newName] /*: [string, string] */ = dirAndName(newPath)
     const newDir /*: RemoteDoc */ = await this.side.remoteCozy.findDirectoryByPath(
       newDirPath
     )
     const attrs = {
       name: newName,
-      ir_id: newDir._id
+      dir_id: newDir._id,
+      updated_at
     }
-    await this.side.remoteCozy.updateAttributesById(id, attrs, {})
+    await this.side.remoteCozy.updateAttributesById(_id, attrs, { ifMatch: '' })
   }
 }
 

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -11,7 +11,6 @@ const sinon = require('sinon')
 const should = require('should')
 const stream = require('stream')
 
-const { withContentLength } = require('../../../core/reader')
 const checksumer = require('../../../core/local/checksumer')
 const metadata = require('../../../core/metadata')
 const { ensureValidPath } = metadata
@@ -229,15 +228,11 @@ describe('remote.Remote', function() {
         .build()
       this.remote.other = {
         createReadStreamAsync() {
-          const empty = withContentLength(
-            new stream.Readable({
-              read: function() {
-                this.push(null)
-              }
-            }),
-            0
-          )
-          return empty
+          return new stream.Readable({
+            read: function() {
+              this.push(null)
+            }
+          })
         }
       }
       await this.remote.addFileAsync(doc)


### PR DESCRIPTION
We're witnessing a lot of timeout errors (i.e. 504 response status)
when users send file modification requests while we don't really see
them for file creation requests.

We're not completely sure about the actual cause of those timeouts but
the `Content-Length` header is not sent in modification requests and
we believe this can have a role in this situation.

We're now sending the header and we'll monitor errors to see if we see
something different, either a drop in error rate or different errors
(we are expecting to receive 412 response statuses meaning the content
we're sending does not reflect the headers value and thus that the
content has changed on the local filesystem between the time the
record was merged and the time we stated propagating the change to the
remote Cozy).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
