### PR TITLE
deps: Add @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "@atom/watcher": "https://github.com/taratatach/watcher.git",
+    "@babel/runtime": "7.6.2",
     "@sentry/electron": "^0.17.4",
     "async": "^2.6.2",
     "auto-bind": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"


### PR DESCRIPTION
`cozy-client` requires `@babel/runtime` modules from its distribution
file for NodeJS but does not declare it in its `package.json` file so
its not imported in our final build.

Once packaged by `electron-builder` the client can't find the modules
and fails to start.

Importing `@babel/runtime` as a direct dependency seems to fix the
problem.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
