### PR TITLE
gui/styles: Quote file types in stylus loop

### DIFF
--- a/gui/styles/_two_panes.styl
+++ b/gui/styles/_two_panes.styl
@@ -218,7 +218,7 @@
     background-size cover
     background-position center center
 
-    for mimetype in archive audio binary code contact cozy-note file folder image link pdf presentation spreadsheet text video
+    for mimetype in 'archive' 'audio' 'binary' 'code' 'contact' 'cozy-note' 'file' 'folder' 'image' 'link' 'pdf' 'presentation' 'spreadsheet' 'text' 'video'
         &.file-type-{mimetype}
             background-image url("./images/type-icons/icon-type-" + mimetype + ".svg")
 


### PR DESCRIPTION
The file type icons CSS rules are generated from a simple loop over
all the types we're supporting.
One of those types is `text`.

However, if those are not quoted, stylus will use the value of any
existing variable with that given name in interpolations instead of
the string itself.
Since we import the `button` component module from `cozy-ui` and a
`text` variable is defined in this module, the generated rule for this
file type was a mess and the associated icon would not be displayed in
the Recent list in the main window.

By quoting the types in the loop argument, we make sure those will be
interpreted as strings and not variables.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
