### PR TITLE
gui/updater: Fix infinite spinner style

### DIFF
--- a/gui/styles/_updater.styl
+++ b/gui/styles/_updater.styl
@@ -22,10 +22,8 @@
     margin-top: .5em
 
   .progress-spinner
-    @extend $icon-spin
-    background-image embedurl('./node_modules/cozy-ui/assets/icons/ui/spinner.svg')
-    fill: var(--primaryColor)
-    display: inline-block
+    @extend $spin
+    background-color: var(--primaryColor)
     width: 4em
     height: 4em
     translate: 0 50%


### PR DESCRIPTION
With the upgrade of `cozy-ui` spinners elements need to be styled
differently.
The Updater window spinner was not updated and was still using a
background image instead of a mask.

This is fixed by extending the new `$spin` mixin and using a
background color instead of a fill color.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
