### PR TITLE
core/remote/watcher: Normalize path sorted changes

### DIFF
--- a/core/local/chokidar/normalize_paths.js
+++ b/core/local/chokidar/normalize_paths.js
@@ -65,6 +65,13 @@ const step = async (
         normalizedPaths
       )
       normalizedPaths.push(c.path)
+
+      if (c.path !== normalizedPath) {
+        log.info(
+          { path: c.path, normalizedPath },
+          'normalizing local path to match existing doc and parent norms'
+        )
+      }
     }
 
     return c
@@ -100,15 +107,8 @@ const normalizedPath = (
       ? name.normalize('NFD')
       : name.normalize('NFC')
     : name
-  const normalizedPath = path.join(normalizedParentPath, normalizedName)
 
-  if (newPath !== normalizedPath) {
-    log.info(
-      { path: newPath, normalizedPath },
-      'normalizing local path to match existing doc and parent norms'
-    )
-  }
-  return normalizedPath
+  return path.join(normalizedParentPath, normalizedName)
 }
 
 module.exports = {

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -82,7 +82,7 @@ export type RemoteDirTrashing = {
 export type RemoteIgnoredChange = {
   sideName: 'remote',
   type: 'IgnoredChange',
-  doc: Metadata|RemoteDoc|RemoteDeletion,
+  doc: *,
   was?: Metadata,
   detail: string
 }
@@ -139,7 +139,8 @@ module.exports = {
   isOnlyChildMove,
   includeDescendant,
   applyMoveInsideMove,
-  sort
+  sort,
+  sortByPath
 }
 
 const sideName = 'remote'
@@ -459,4 +460,23 @@ const sortChanges = (a, b) => {
 function sort(changes /*: Array<RemoteChange> */) /*: Array<RemoteChange> */ {
   // return changes.sort(sortByPath).sort(sortByAction)
   return changes.sort(sortChanges)
+}
+
+function sortByPath(
+  changes /*: Array<RemoteChange> */
+) /*: Array<RemoteChange> */ {
+  return changes.sort((
+    { doc: aDoc } /*: RemoteChange */,
+    { doc: bDoc } /*: RemoteChange */
+  ) => {
+    if (!aDoc.path) return 1
+    if (!bDoc.path) return -1
+
+    const aPath = aDoc.path.normalize()
+    const bPath = bDoc.path.normalize()
+
+    if (aPath < bPath) return -1
+    if (aPath > bPath) return 1
+    return 0
+  })
 }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -169,6 +169,8 @@ class RemoteWatcher {
     const changes = this.identifyAll(remoteDocs, olds)
     log.trace('Done with analysis.')
 
+    remoteChange.sortByPath(changes)
+
     const normalizedChanges =
       process.platform === 'darwin'
         ? await normalizePaths(changes, {

--- a/core/remote/watcher/normalizePaths.js
+++ b/core/remote/watcher/normalizePaths.js
@@ -5,6 +5,11 @@ const { Promise } = require('bluebird')
 
 const metadata = require('../../metadata')
 const { normalizedPath } = require('../../local/chokidar/normalize_paths')
+const logger = require('../../utils/logger')
+
+const log = logger({
+  component: 'RemoteWatcher/normalize_paths'
+})
 
 /*::
 import type { Pouch } from '../../pouch'
@@ -49,6 +54,13 @@ const normalizePaths = async (
         normalizedPaths
       )
       normalizedPaths.push(c.doc.path)
+
+      if (c.doc.path !== normalizedPath) {
+        log.info(
+          { path: c.doc.path, normalizedPath },
+          'normalizing local path to match existing doc and parent norms'
+        )
+      }
     }
 
     return c

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -730,7 +730,7 @@ describe('RemoteWatcher', function() {
               const newRemoteDir = builders
                 .remoteDir()
                 .inDir(remoteParentDir)
-                .name('algébre'.normalize('NFC'))
+                .name('algèbre'.normalize('NFC'))
                 .build()
               const newRemoteFile = builders
                 .remoteFile()
@@ -754,6 +754,54 @@ describe('RemoteWatcher', function() {
                 path.join(parentDir.path, newRemoteDir.name, newRemoteFile.name)
               )
             })
+
+            context(
+              'with the folder creation ordered after the file creation',
+              () => {
+                it('is identified as an addition with old ancestor normalization', async function() {
+                  const remoteParentDir = builders
+                    .remoteDir()
+                    .name('énoncés'.normalize('NFC'))
+                    .build()
+                  const parentDir = await builders
+                    .metadir()
+                    .fromRemote(remoteParentDir)
+                    .path(remoteParentDir.path.normalize('NFD'))
+                    .create()
+
+                  const newRemoteDir = builders
+                    .remoteDir()
+                    .inDir(remoteParentDir)
+                    .name('algèbre'.normalize('NFC'))
+                    .build()
+                  const newRemoteFile = builders
+                    .remoteFile()
+                    .inDir(newRemoteDir)
+                    .name('file')
+                    .build()
+
+                  const [dirChange, fileChange] = await this.watcher.analyse(
+                    [newRemoteFile, newRemoteDir],
+                    []
+                  )
+
+                  should(dirChange).have.property('type', 'DirAddition')
+                  should(dirChange.doc).have.property(
+                    'path',
+                    path.join(parentDir.path, newRemoteDir.name)
+                  )
+                  should(fileChange).have.property('type', 'FileAddition')
+                  should(fileChange.doc).have.property(
+                    'path',
+                    path.join(
+                      parentDir.path,
+                      newRemoteDir.name,
+                      newRemoteFile.name
+                    )
+                  )
+                })
+              }
+            )
           }
         )
       })


### PR DESCRIPTION
On macOS, we normalize the paths of remote changes to make sure we
keep the normalization of existing PouchDB records and avoid issues
like conflicts.

However, this process requires that ancestor paths be normalized
before their descendants' paths and remote changes are not necessarily
in this order (e.g. in case a folder is added with content and then
renamed, the folder addition change will come after its content
addition).

To prevent normalization issues, we now sort changes by destination
path before normalizing those paths.

It should not affect the final order of changes but this is a risk as
we know the remote changes sort method is not fully accurate.
Tests are passing so we hope we won't see new changes order issues in
the future.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
