### PR TITLE
core/pouch: Modernize with native Promises

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -266,7 +266,7 @@ class App {
       level: 3
     })
     const logs = fse.createReadStream(LOG_FILE)
-    const pouchdbTree /*: Metadata[] */ = await this.pouch.treeAsync()
+    const pouchdbTree /*: Metadata[] */ = await this.pouch.tree()
 
     const logsSent = Promise.all([
       this.uploadFileToSupport(incidentID, 'logs.gz', logs.pipe(zipper)),
@@ -358,7 +358,7 @@ class App {
 
     this.instanciate()
 
-    await this.pouch.addAllViewsAsync()
+    await this.pouch.addAllViews()
     await this.pouch.runMigrations(migrations)
 
     if (wasUpdated && this.remote) {

--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -72,7 +72,7 @@ function loop(
               // Even if the doc is deleted, we probably have a better chance to
               // get the right kind by using its own.
               const doc /*: ?Metadata */ = event._id
-                ? await opts.pouch.byIdMaybeAsync(event._id)
+                ? await opts.pouch.byIdMaybe(event._id)
                 : null
               event.kind = doc ? kind(doc) : 'file'
             }

--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -146,7 +146,7 @@ actions = {
   },
 
   renamedfile: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(id(event.oldPath))
+    const was /*: ?Metadata */ = await pouch.byIdMaybe(id(event.oldPath))
     // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       if (await docWasAlreadyMoved(event.oldPath, event.path, pouch)) {
@@ -170,7 +170,7 @@ actions = {
 
     const doc = buildFile(event.path, event.stats, event.md5sum)
     if (event.overwrite) {
-      const existing = await pouch.byIdMaybeAsync(id(event.path))
+      const existing = await pouch.byIdMaybe(id(event.path))
       doc.overwrite = existing
     }
 
@@ -178,7 +178,7 @@ actions = {
   },
 
   renameddirectory: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(id(event.oldPath))
+    const was /*: ?Metadata */ = await pouch.byIdMaybe(id(event.oldPath))
     // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       if (await docWasAlreadyMoved(event.oldPath, event.path, pouch)) {
@@ -206,7 +206,7 @@ actions = {
 
     const doc = buildDir(event.path, event.stats)
     if (event.overwrite) {
-      const existing = await pouch.byIdMaybeAsync(id(event.path))
+      const existing = await pouch.byIdMaybe(id(event.path))
       doc.overwrite = existing
     }
 
@@ -214,7 +214,7 @@ actions = {
   },
 
   deletedfile: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(event._id)
+    const was /*: ?Metadata */ = await pouch.byIdMaybe(event._id)
     if (!was || was.deleted) {
       log.debug({ event }, 'Assuming file already removed')
       // The file was already marked as deleted in pouchdb
@@ -226,7 +226,7 @@ actions = {
   },
 
   deleteddirectory: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.byIdMaybeAsync(event._id)
+    const was /*: ?Metadata */ = await pouch.byIdMaybe(event._id)
     if (!was || was.deleted) {
       log.debug({ event }, 'Assuming dir already removed')
       // The dir was already marked as deleted in pouchdb
@@ -252,7 +252,7 @@ async function docWasAlreadyMoved(
   pouch /*: Pouch */
 ) /*: Promise<boolean> */ {
   try {
-    const existing = await pouch.getPreviousRevAsync(id(dst), 1)
+    const existing = await pouch.getPreviousRev(id(dst), 1)
     return existing && existing.moveFrom && existing.moveFrom.path === src
   } catch (err) {
     // Doc not found so it was not moved

--- a/core/local/atom/incomplete_fixer.js
+++ b/core/local/atom/incomplete_fixer.js
@@ -272,7 +272,7 @@ function step(
           // (e.g. a temporary document now renamed), we'll want to make sure the old
           // document is removed to avoid having 2 documents with the same inode.
           // We can do this by keeping the completing renamed event.
-          const incompleteForExistingDoc /*: ?Metadata */ = await opts.pouch.byIdMaybeAsync(
+          const incompleteForExistingDoc /*: ?Metadata */ = await opts.pouch.byIdMaybe(
             metadata.id(item.event.path)
           )
           if (

--- a/core/local/atom/overwrite.js
+++ b/core/local/atom/overwrite.js
@@ -22,10 +22,6 @@ type OverwriteState = {
   }
 }
 
-type PouchFunctions = {
-  byIdMaybeAsync: (string) => Promise<?Metadata>
-}
-
 type OverwriteOptions = {
   state: {
     [typeof STEP_NAME]: OverwriteState

--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -107,7 +107,7 @@ async function findDeletedInoById(
   id,
   pouch
 ) /*: Promise<?{ deletedIno: ?number|string }> */ {
-  const doc /*: ?Metadata */ = await pouch.byIdMaybeAsync(id)
+  const doc /*: ?Metadata */ = await pouch.byIdMaybe(id)
   if (doc && !doc.deleted) {
     return { deletedIno: doc.fileid || doc.ino }
   }
@@ -118,7 +118,7 @@ async function findDeletedInoRecentlyRenamed(
   pouch
 ) /*: Promise<?{ deletedIno: ?number|string, oldPaths: string[] }> */ {
   for (const [index, previousPath] of previousPaths.entries()) {
-    const doc /*: ?Metadata */ = await pouch.byIdMaybeAsync(id(previousPath))
+    const doc /*: ?Metadata */ = await pouch.byIdMaybe(id(previousPath))
     if (doc && !doc.deleted) {
       return {
         deletedIno: doc.fileid || doc.ino,

--- a/core/local/atom/win_identical_renaming.js
+++ b/core/local/atom/win_identical_renaming.js
@@ -29,7 +29,7 @@ type WinIdenticalRenamingState = {
 }
 
 type PouchFunctions = {
-  byIdMaybeAsync: (string) => Promise<?Metadata>
+  byIdMaybe: (string) => Promise<?Metadata>
 }
 
 type WinIdenticalRenamingOptions = {
@@ -87,11 +87,9 @@ const indexDeletedEvent = (event, state) => {
 }
 
 /** Possibly fix oldPath when event is identical renamed. */
-const fixIdenticalRenamed = async (event, { byIdMaybeAsync }) => {
+const fixIdenticalRenamed = async (event, { byIdMaybe }) => {
   if (event.path === event.oldPath) {
-    const doc /*: ?Metadata */ = event._id
-      ? await byIdMaybeAsync(event._id)
-      : null
+    const doc /*: ?Metadata */ = event._id ? await byIdMaybe(event._id) : null
 
     if (doc && !doc.deleted && doc.path !== event.oldPath) {
       _.set(event, [STEP_NAME, 'oldPathBeforeFix'], event.oldPath)

--- a/core/local/chokidar/normalize_paths.js
+++ b/core/local/chokidar/normalize_paths.js
@@ -56,7 +56,7 @@ const step = async (
       const parentPath = path.dirname(c.path)
       const parent =
         parentPath !== '.'
-          ? await pouch.byIdMaybeAsync(metadata.id(parentPath))
+          ? await pouch.byIdMaybe(metadata.id(parentPath))
           : null
       c.path = normalizedPath(
         c.path,

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -60,7 +60,7 @@ const oldMetadata = async (
   pouch /*: Pouch */
 ) /*: Promise<?Metadata> */ => {
   if (e.old) return e.old
-  const old /*: ?Metadata */ = await pouch.byIdMaybeAsync(metadata.id(e.path))
+  const old /*: ?Metadata */ = await pouch.byIdMaybe(metadata.id(e.path))
   if (old && !old.deleted) return old
 }
 

--- a/core/merge.js
+++ b/core/merge.js
@@ -200,7 +200,7 @@ class Merge {
   async addFileAsync(side /*: SideName */, doc /*: Metadata */) {
     log.debug({ path: doc.path }, 'addFileAsync')
     const { path } = doc
-    const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+    const file /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
     metadata.markSide(side, doc, file)
     metadata.assignMaxDate(doc, file)
 
@@ -291,7 +291,7 @@ class Merge {
   async updateFileAsync(side /*: SideName */, doc /*: Metadata */) {
     log.debug({ path: doc.path }, 'updateFileAsync')
     const { path } = doc
-    const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+    const file /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
     metadata.markSide(side, doc, file)
     if (file && file.docType === 'folder') {
       throw new Error("Can't resolve this conflict!")
@@ -427,7 +427,7 @@ class Merge {
   async putFolderAsync(side /*: SideName */, doc /*: * */) {
     log.debug({ path: doc.path }, 'putFolderAsync')
     const { path } = doc
-    const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+    const folder /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
     metadata.markSide(side, doc, folder)
     if (folder && folder.docType === 'file') {
       return this.resolveConflictAsync(side, doc)
@@ -493,7 +493,7 @@ class Merge {
       metadata.assignMaxDate(doc, was)
       move(side, was, doc)
 
-      const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+      const file /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
       if (file) {
         if (file.deleted) {
           doc.overwrite = file
@@ -581,7 +581,7 @@ class Merge {
 
     metadata.assignMaxDate(doc, was)
 
-    const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+    const folder /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
     if (folder) {
       if (folder.deleted) {
         doc.overwrite = folder
@@ -637,7 +637,7 @@ class Merge {
       { path: folder.path, oldpath: was.path },
       'moveFolderRecursivelyAsync'
     )
-    const docs = await this.pouch.byRecursivePathAsync(was._id)
+    const docs = await this.pouch.byRecursivePath(was._id)
 
     move(side, was, folder)
     let bulk = [was, folder]
@@ -645,7 +645,7 @@ class Merge {
     const makeDestinationPath = doc =>
       metadata.newChildPath(doc.path, was.path, folder.path)
     const makeDestinationID = doc => metadata.id(makeDestinationPath(doc))
-    const existingDstRevs = await this.pouch.getAllRevsAsync(
+    const existingDstRevs = await this.pouch.getAllRevs(
       docs.map(makeDestinationID)
     )
 
@@ -701,7 +701,7 @@ class Merge {
         // To avoid this, we'll update the moved children again to mark them as
         // child movements and remove any `overwrite` markers since the
         // overwrite will happen with their parent.
-        const dstChildren = await this.pouch.byRecursivePathAsync(folder._id)
+        const dstChildren = await this.pouch.byRecursivePath(folder._id)
         for (const dstChild of dstChildren) {
           if (
             !bulk.find(doc => doc._id === dstChild._id) &&
@@ -759,7 +759,7 @@ class Merge {
   ) /*: Promise<void> */ {
     const { path } = trashed
     log.debug({ path }, 'trashFileAsync')
-    const was /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(trashed._id)
+    const was /*: ?Metadata */ = await this.pouch.byIdMaybe(trashed._id)
     if (!was || was.deleted) {
       log.debug({ path }, 'Nothing to trash')
       return
@@ -798,7 +798,7 @@ class Merge {
   ) /*: Promise<*> */ {
     const { path } = trashed
     log.debug({ path }, 'trashFolderAsync')
-    const was /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(trashed._id)
+    const was /*: ?Metadata */ = await this.pouch.byIdMaybe(trashed._id)
     if (!was || was.deleted) {
       log.debug({ path }, 'Nothing to trash')
       return
@@ -808,7 +808,7 @@ class Merge {
       return
     }
     // Don't trash a folder if the other side has added a new file in it (or updated one)
-    let children = await this.pouch.byRecursivePathAsync(was._id)
+    let children = await this.pouch.byRecursivePath(was._id)
     children = children.reverse()
     for (let child of Array.from(children)) {
       if (
@@ -853,7 +853,7 @@ class Merge {
   // already been removed. This is not considered as an error.
   async deleteFileAsync(side /*: SideName */, doc /*: Metadata */) {
     log.debug({ path: doc.path }, 'deleteFileAsync')
-    const file /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+    const file /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
     if (!file || file.deleted) return null
     if (file.moveFrom) {
       // We don't want Sync to pick up this move hint and try to synchronize a
@@ -890,7 +890,7 @@ class Merge {
   // the folder is missing in pouchdb (error 404).
   async deleteFolderAsync(side /*: SideName */, doc /*: Metadata */) {
     log.debug({ path: doc.path }, 'deleteFolderAsync')
-    const folder /*: ?Metadata */ = await this.pouch.byIdMaybeAsync(doc._id)
+    const folder /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
     if (!folder || folder.deleted) return null
     if (folder.moveFrom) {
       // We don't want Sync to pick up this move hint and try to synchronize a
@@ -910,7 +910,7 @@ class Merge {
     side /*: SideName */,
     folder /*: Metadata */
   ) {
-    let docs = await this.pouch.byRecursivePathAsync(folder._id)
+    let docs = await this.pouch.byRecursivePath(folder._id)
     // In the changes feed, nested subfolder must be deleted
     // before their parents, hence the reverse order.
     docs = docs.reverse()

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -236,7 +236,7 @@ async function migrate(
           break
         case MIGRATION_RESULT_COMPLETE:
           await updateSchemaVersion(migration.targetSchemaVersion, migrationDB)
-          await pouch.resetDatabaseAsync()
+          await pouch.resetDatabase()
           await replicateDB(migrationDB, pouch.db)
           await pouch.touchDocs(unsyncedDocIds)
           break

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -99,7 +99,7 @@ class RemoteWatcher {
 
   async watch() {
     try {
-      const seq = await this.pouch.getRemoteSeqAsync()
+      const seq = await this.pouch.getRemoteSeq()
       const { last_seq, docs } = await this.remoteCozy.changes(seq)
       this.events.emit('online')
 
@@ -117,7 +117,7 @@ class RemoteWatcher {
         target = (await this.pouch.db.changes({ limit: 1, descending: true }))
           .last_seq
         this.events.emit('sync-target', target)
-        await this.pouch.setRemoteSeqAsync(last_seq)
+        await this.pouch.setRemoteSeq(last_seq)
       } finally {
         release()
         this.events.emit('remote-end')
@@ -446,9 +446,7 @@ class RemoteWatcher {
             'file was moved or renamed remotely'
           )
           if (change.needRefetch) {
-            change.was = await this.pouch.byRemoteIdMaybeAsync(
-              change.was.remote._id
-            )
+            change.was = await this.pouch.byRemoteIdMaybe(change.was.remote._id)
             change.was.childMove = false
           }
           await this.prep.moveFileAsync(sideName, change.doc, change.was)
@@ -463,7 +461,7 @@ class RemoteWatcher {
               'folder was moved or renamed remotely'
             )
             if (change.needRefetch) {
-              change.was = await this.pouch.byRemoteIdMaybeAsync(
+              change.was = await this.pouch.byRemoteIdMaybe(
                 change.was.remote._id
               )
               change.was.childMove = false

--- a/core/remote/watcher/normalizePaths.js
+++ b/core/remote/watcher/normalizePaths.js
@@ -41,11 +41,11 @@ const normalizePaths = async (
       const old =
         c.type === 'FileMove' || c.type === 'DirMove'
           ? c.was
-          : await pouch.byIdMaybeAsync(c.doc._id)
+          : await pouch.byIdMaybe(c.doc._id)
       const parentPath = path.dirname(c.doc.path)
       const parent =
         parentPath !== '.'
-          ? await pouch.byIdMaybeAsync(metadata.id(parentPath))
+          ? await pouch.byIdMaybe(metadata.id(parentPath))
           : null
       c.doc.path = normalizedPath(
         c.doc.path,

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -189,7 +189,7 @@ const setupConfig = () => {
 
 const setupPouch = async (config /*: * */) => {
   const pouch = new Pouch(config)
-  await pouch.addAllViewsAsync()
+  await pouch.addAllViews()
   return pouch
 }
 

--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -32,7 +32,7 @@ const localDoc = async (
   { config, pouch } /*: { config: Config, pouch: Pouch } */
 ) /*: Promise<Metadata> */ => {
   const relPath = path.relative(config.syncPath, filePath)
-  const doc = await pouch.byIdMaybeAsync(metadata.id(relPath))
+  const doc = await pouch.byIdMaybe(metadata.id(relPath))
   if (!doc || doc.deleted) {
     throw new CozyDocumentMissingError({
       cozyURL: config.cozyUrl,

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -69,7 +69,7 @@ describe('Conflict resolution', () => {
 
       // Update file remotely
       const remoteFile = await cozy.files.statByPath('/concurrent-edited')
-      await helpers.pouch.byRemoteIdMaybeAsync(remoteFile._id)
+      await helpers.pouch.byRemoteIdMaybe(remoteFile._id)
       await cozy.files.updateById(remoteFile._id, 'remote-content', {
         contentType: 'text/plain'
       })
@@ -128,7 +128,7 @@ describe('Conflict resolution', () => {
         'local update'
       )
       remoteFile = await cozy.files.statByPath(`/concurrent-edited`)
-      pouchFile = await helpers.pouch.byRemoteIdMaybeAsync(remoteFile._id)
+      pouchFile = await helpers.pouch.byRemoteIdMaybe(remoteFile._id)
       await cozy.files.updateById(remoteFile._id, 'remote update', {
         contentType: 'text/plain'
       })

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -77,7 +77,7 @@ describe('Sync gets interrupted, initialScan occurs', () => {
       await helpers.local.syncDir.outputFile(path, 'original content')
       await helpers.flushLocalAndSyncAll()
 
-      const doc = await this.pouch.byIdMaybeAsync(_id)
+      const doc = await this.pouch.byIdMaybe(_id)
       await cozy.files.updateById(doc.remote._id, 'remote content', {
         contentType: 'text/plain'
       })

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -56,7 +56,7 @@ describe('Move', () => {
     })
 
     it('local', async () => {
-      const oldFile = await pouch.byRemoteIdMaybeAsync(file._id)
+      const oldFile = await pouch.byRemoteIdMaybe(file._id)
       await prep.moveFileAsync(
         'local',
         _.merge(
@@ -87,7 +87,7 @@ describe('Move', () => {
     })
 
     it('remote', async () => {
-      const oldFile = await pouch.byRemoteIdMaybeAsync(file._id)
+      const oldFile = await pouch.byRemoteIdMaybe(file._id)
       await prep.moveFileAsync(
         'remote',
         _.merge(
@@ -131,7 +131,7 @@ describe('Move', () => {
       // We don't want the calls made above to show up in our expectations
       helpers.resetPouchSpy()
 
-      const oldFile = await pouch.byRemoteIdMaybeAsync(file._id)
+      const oldFile = await pouch.byRemoteIdMaybe(file._id)
       await prep.moveFileAsync(
         'local',
         _.merge(
@@ -186,7 +186,7 @@ describe('Move', () => {
 
     context('local to an ignored path', () => {
       it('trashes the file on the remote Cozy', async () => {
-        const oldFile = await pouch.byRemoteIdMaybeAsync(file._id)
+        const oldFile = await pouch.byRemoteIdMaybe(file._id)
         await prep.moveFileAsync(
           'local',
           _.merge(
@@ -216,7 +216,7 @@ describe('Move', () => {
       context('after a previous local move', () => {
         const intermediaryPath = path.normalize('dst/file-moved')
         beforeEach(async () => {
-          const oldFile = await pouch.byRemoteIdMaybeAsync(file._id)
+          const oldFile = await pouch.byRemoteIdMaybe(file._id)
           await prep.moveFileAsync(
             'local',
             _.merge(
@@ -232,7 +232,7 @@ describe('Move', () => {
         })
 
         it('trashes the file on the remote Cozy', async () => {
-          const oldFile = await pouch.byRemoteIdMaybeAsync(file._id)
+          const oldFile = await pouch.byRemoteIdMaybe(file._id)
           await prep.moveFileAsync(
             'local',
             _.merge(
@@ -290,7 +290,7 @@ describe('Move', () => {
       it('remote', async () => {
         await cozy.files.updateById(file._id, 'updated file content', {})
         await helpers.pullAndSyncAll()
-        const was = await pouch.byRemoteIdAsync(file._id)
+        const was = await pouch.byRemoteId(file._id)
         await helpers._remote.moveAsync(
           {
             ...was,
@@ -339,7 +339,7 @@ describe('Move', () => {
         it('moves and updates the file on the local filesystem', async () => {
           await cozy.files.updateById(file._id, 'updated file content', {})
           await helpers.remote.pullChanges()
-          const was = await pouch.byRemoteIdAsync(file._id)
+          const was = await pouch.byRemoteId(file._id)
           await helpers._remote.moveAsync(
             {
               ...was,
@@ -433,7 +433,7 @@ describe('Move', () => {
     })
 
     it('local', async () => {
-      const oldFolder = await pouch.byRemoteIdMaybeAsync(dir._id)
+      const oldFolder = await pouch.byRemoteIdMaybe(dir._id)
       const doc = builders
         .metadir()
         .path('parent/dst/dir')
@@ -507,13 +507,13 @@ describe('Move', () => {
       ])
 
       const subdir = await cozy.files.statByPath('/parent/dst/dir/subdir')
-      should(await helpers.pouch.byRemoteIdAsync(subdir._id))
+      should(await helpers.pouch.byRemoteId(subdir._id))
         .have.propertyByPath('remote', '_rev')
         .eql(subdir._rev)
     })
 
     it('from remote client', async () => {
-      const was = await pouch.byRemoteIdAsync(dir._id)
+      const was = await pouch.byRemoteId(dir._id)
       await helpers._remote.moveAsync(
         {
           ...was,
@@ -583,7 +583,7 @@ describe('Move', () => {
       // We don't want the calls made above to show up in our expectations
       helpers.resetPouchSpy()
 
-      const oldFolder = await pouch.byRemoteIdMaybeAsync(dir._id)
+      const oldFolder = await pouch.byRemoteIdMaybe(dir._id)
       const doc = builders
         .metadir()
         .path('parent/dst/dir')
@@ -653,7 +653,7 @@ describe('Move', () => {
       // parents which get completely erased from the Cozy since they're empty
       // when we finally trash them.
       it('trashes the folder content on the remote Cozy', async () => {
-        const oldFolder = await pouch.byRemoteIdMaybeAsync(dir._id)
+        const oldFolder = await pouch.byRemoteIdMaybe(dir._id)
         const doc = builders
           .metadir()
           .path('.system-tmp-cozy-drive/dir')
@@ -692,7 +692,7 @@ describe('Move', () => {
 
       context('after a previous local move', () => {
         beforeEach(async () => {
-          const oldFolder = await pouch.byRemoteIdMaybeAsync(dir._id)
+          const oldFolder = await pouch.byRemoteIdMaybe(dir._id)
           const doc = builders
             .metadir(oldFolder)
             .path('parent/dst/dir')
@@ -708,7 +708,7 @@ describe('Move', () => {
         // child moves rather than deletions and child moves are not applied (we
         // move their parent instead).
         it('trashes the folder content on the remote Cozy', async () => {
-          const oldFolder = await pouch.byRemoteIdMaybeAsync(dir._id)
+          const oldFolder = await pouch.byRemoteIdMaybe(dir._id)
           const doc = builders
             .metadir(oldFolder)
             .path('.system-tmp-cozy-drive/dir')
@@ -802,7 +802,7 @@ describe('Move', () => {
           'parent/src/dir/subdir/',
           'parent/src/dir/subdir/file'
         ])
-        const was = await pouch.byRemoteIdAsync(dir._id)
+        const was = await pouch.byRemoteId(dir._id)
         await helpers._remote.moveAsync(
           {
             ...was,
@@ -880,7 +880,7 @@ describe('Move', () => {
         ])
         await cozy.files.updateById(file._id, 'updated file content', {})
         await helpers.remote.pullChanges()
-        const was = await pouch.byRemoteIdAsync(dir._id)
+        const was = await pouch.byRemoteId(dir._id)
         await helpers._remote.moveAsync(
           {
             ...was,
@@ -968,7 +968,7 @@ describe('Move', () => {
           'parent/src/dir/subdir/',
           'parent/src/dir/subdir/file'
         ])
-        const was = await pouch.byRemoteIdAsync(dir._id)
+        const was = await pouch.byRemoteId(dir._id)
         await helpers._remote.moveAsync(
           {
             ...was,

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -63,7 +63,7 @@ describe('Cozy Note update', () => {
     })
 
     it('keeps the note metadata', async () => {
-      const updatedDoc = await helpers.pouch.byRemoteIdMaybeAsync(note._id)
+      const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
       // FIXME: check for metadata update once the builder can do it
       should(updatedDoc).have.property('metadata')
     })
@@ -98,7 +98,7 @@ describe('Cozy Note update', () => {
     })
 
     it('keeps the original note metadata', async () => {
-      const updatedDoc = await helpers.pouch.byRemoteIdMaybeAsync(note._id)
+      const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
       should(updatedDoc).have.property('metadata')
     })
   })
@@ -132,7 +132,7 @@ describe('Cozy Note move', () => {
       })
 
       it('keeps the note metadata', async () => {
-        const updatedDoc = await helpers.pouch.byRemoteIdMaybeAsync(note._id)
+        const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
         should(updatedDoc).have.property('metadata')
       })
     })
@@ -149,7 +149,7 @@ describe('Cozy Note move', () => {
       })
 
       it('keeps the note metadata', async () => {
-        const updatedDoc = await helpers.pouch.byRemoteIdMaybeAsync(note._id)
+        const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
         should(updatedDoc).have.property('metadata')
       })
     })
@@ -203,7 +203,7 @@ describe('Cozy Note move with update', () => {
       })
 
       it('keeps the original note metadata', async () => {
-        const updatedDoc = await helpers.pouch.byRemoteIdMaybeAsync(note._id)
+        const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
         should(updatedDoc).have.property('metadata')
       })
     })
@@ -273,7 +273,7 @@ describe('Markdown file with Cozy Note mime type update', () => {
     await helpers.flushLocalAndSyncAll()
   })
   beforeEach('change note into markdown file', async function() {
-    const doc = await this.pouch.byIdMaybeAsync(metadata.id('note.cozy-note'))
+    const doc = await this.pouch.byIdMaybe(metadata.id('note.cozy-note'))
     // remove everything that makes a note a Cozy Note
     await this.pouch.put({ ...doc, metadata: {} })
   })
@@ -317,7 +317,7 @@ describe('Markdown file with Cozy Note mime type move with update', () => {
     await helpers.pullAndSyncAll()
   })
   beforeEach('change note into markdown file', async function() {
-    const doc = await this.pouch.byIdMaybeAsync(metadata.id('note.cozy-note'))
+    const doc = await this.pouch.byIdMaybe(metadata.id('note.cozy-note'))
     // remove everything that makes a note a Cozy Note
     await this.pouch.put({ ...doc, metadata: {} })
   })

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -267,7 +267,7 @@ describe('Platform incompatibilities', () => {
     await helpers.pullAndSyncAll()
 
     // Simulate local move
-    const dir = await helpers.pouch.byRemoteIdAsync(remoteDocs['dir/']._id)
+    const dir = await helpers.pouch.byRemoteId(remoteDocs['dir/']._id)
     const dir2 = metadata.buildDir('dir2', {
       atime: new Date(),
       mtime: new Date(),
@@ -303,7 +303,7 @@ describe('Platform incompatibilities', () => {
 
     // Simulate remote move
     const remoteDoc /*: RemoteDoc */ = remoteDocs['dir/']
-    const dir = await helpers.pouch.byRemoteIdAsync(remoteDoc._id)
+    const dir = await helpers.pouch.byRemoteId(remoteDoc._id)
     const newRemoteDoc = {
       ...remoteDoc,
       _rev: '2-xxxxxx',

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -219,14 +219,14 @@ describe('Update file', () => {
         .create()
       await helpers.pullAndSyncAll()
       await helpers.flushLocalAndSyncAll()
-      const was = await pouch.byRemoteIdMaybeAsync(file._id)
+      const was = await pouch.byRemoteIdMaybe(file._id)
 
       const doc = _.defaults({ ino: was.ino + 1 }, was)
       metadata.updateLocal(doc)
       await prep.updateFileAsync('local', doc)
 
       await helpers.syncAll()
-      should(await pouch.byRemoteIdMaybeAsync(file._id))
+      should(await pouch.byRemoteIdMaybe(file._id))
         .have.propertyByPath('remote', '_rev')
         .not.eql(was.remote._rev)
 
@@ -246,7 +246,7 @@ describe('Update file', () => {
         .create()
       await helpers.pullAndSyncAll()
       await helpers.flushLocalAndSyncAll()
-      const was = await pouch.byRemoteIdMaybeAsync(file._id)
+      const was = await pouch.byRemoteIdMaybe(file._id)
       should(was).have.property('updated_at', '2018-05-15T21:01:53.000Z')
 
       await prep.updateFileAsync(
@@ -260,7 +260,7 @@ describe('Update file', () => {
         )
       )
       await helpers.syncAll()
-      const doc = await pouch.byRemoteIdMaybeAsync(file._id)
+      const doc = await pouch.byRemoteIdMaybe(file._id)
       should(doc.errors).be.undefined()
     })
   })

--- a/test/property/local_watcher/index.js
+++ b/test/property/local_watcher/index.js
@@ -51,7 +51,7 @@ describe('Local watcher', function() {
       expected = expected.map(item => item.replace(/\/$/, ''))
       expected = expected.map(item => path.normalize(id(item)))
       expected = expected.sort((a, b) => a.localeCompare(b))
-      let actual = await state.pouchdb.treeAsync()
+      let actual = await state.pouchdb.tree()
       actual = actual.filter(item => !item.startsWith('_design/'))
       actual = actual.sort((a, b) => a.localeCompare(b))
       should(actual).deepEqual(expected)
@@ -72,7 +72,7 @@ describe('Local watcher', function() {
           referenced = (stats.mode & fs.constants.S_IWGRP) !== 0
         }
         if (referenced) {
-          const doc = await state.pouchdb.byIdMaybeAsync(id(relpath))
+          const doc = await state.pouchdb.byIdMaybe(id(relpath))
           should(doc.remote).be.equal(stats.ino)
         }
       }

--- a/test/property/runner.js
+++ b/test/property/runner.js
@@ -36,7 +36,7 @@ async function step(state /*: Object */, op /*: Object */) {
         syncPath: state.dir.root
       }
       state.pouchdb = new Pouch(state.config)
-      await state.pouchdb.addAllViewsAsync()
+      await state.pouchdb.addAllViews()
     // break omitted intentionally
     case 'restart_watcher':
       {
@@ -139,7 +139,7 @@ async function step(state /*: Object */, op /*: Object */) {
             stats = await fse.stat(abspath)
           }
           release = await state.pouchdb.lock('test')
-          const doc = await state.pouchdb.byIdMaybeAsync(id(op.path))
+          const doc = await state.pouchdb.byIdMaybe(id(op.path))
           if (doc && !doc.sides.remote) {
             doc.sides.remote = doc.sides.local + 1
             doc.remote = stats.ino

--- a/test/regression/TRELLO_646_move_overridden_before_sync.js
+++ b/test/regression/TRELLO_646_move_overridden_before_sync.js
@@ -35,7 +35,7 @@ describe('TRELLO #646: Déplacement écrasé avant synchro (malgré la synchro p
   it('is broken', async function() {
     this.timeout(30000)
     const pouchTree = async () =>
-      _.chain(await this.pouch.byRecursivePathAsync(''))
+      _.chain(await this.pouch.byRecursivePath(''))
         .map('_id')
         .sort()
         .value()

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -184,7 +184,7 @@ class TestHelpers {
   }
 
   async metadataTree() {
-    return _.chain(await this.pouch.byRecursivePathAsync(''))
+    return _.chain(await this.pouch.byRecursivePath(''))
       .map(
         ({ docType, path }) =>
           posixifyPath(path) + (docType === 'folder' ? '/' : '')
@@ -194,7 +194,7 @@ class TestHelpers {
   }
 
   async incompatibleTree() {
-    return _.chain(await this.pouch.byRecursivePathAsync(''))
+    return _.chain(await this.pouch.byRecursivePath(''))
       .filter(doc => doc.incompatibilities)
       .map(
         ({ docType, path }) =>

--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -2,16 +2,14 @@ const { assignId } = require('../../../core/metadata')
 const { Pouch } = require('../../../core/pouch')
 
 module.exports = {
-  createDatabase(done) {
+  async createDatabase() {
     this.pouch = new Pouch(this.config)
-    return this.pouch.addAllViews(done)
+    await this.pouch.addAllViews()
   },
 
-  cleanDatabase(done) {
-    this.pouch.db.destroy(() => {
-      this.pouch = null
-      done()
-    })
+  async cleanDatabase() {
+    await this.pouch.db.destroy()
+    this.pouch = null
   },
 
   createParentFolder(pouch) {

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -39,7 +39,7 @@ class RemoteTestHelpers {
 
   async ignorePreviousChanges() {
     const { last_seq } = await this.side.remoteCozy.changes()
-    await this.pouch.setRemoteSeqAsync(last_seq)
+    await this.pouch.setRemoteSeq(last_seq)
   }
 
   async pullChanges() {

--- a/test/unit/local/atom/overwrite.js
+++ b/test/unit/local/atom/overwrite.js
@@ -42,7 +42,7 @@ describe('core/local/atom/overwrite', () => {
       inputChannel = new Channel()
       outputChannel = overwrite.loop(inputChannel, {
         pouch: {
-          byIdMaybeAsync: async id => _.cloneDeep(docs[id])
+          byIdMaybe: async id => _.cloneDeep(docs[id])
         },
         state: overwrite.initialState()
       })

--- a/test/unit/local/atom/win_identical_renaming.js
+++ b/test/unit/local/atom/win_identical_renaming.js
@@ -36,7 +36,7 @@ if (process.platform === 'win32') {
         inputChannel = new Channel()
         outputChannel = winIdenticalRenaming.loop(inputChannel, {
           pouch: {
-            byIdMaybeAsync: async id => _.cloneDeep(docs[id])
+            byIdMaybe: async id => _.cloneDeep(docs[id])
           },
           state: winIdenticalRenaming.initialState()
         })

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -19,20 +19,16 @@ onPlatform('darwin', () => {
     let builders
 
     before('instanciate config', configHelpers.createConfig)
-    before('instanciate pouch', pouchHelpers.createDatabase)
+    beforeEach('instanciate pouch', pouchHelpers.createDatabase)
 
     beforeEach('set up builders', function() {
       builders = new Builders({ pouch: this.pouch })
     })
 
-    after('clean pouch', pouchHelpers.cleanDatabase)
+    afterEach('clean pouch', pouchHelpers.cleanDatabase)
     after('clean config directory', configHelpers.cleanConfig)
 
     describe('.detectOfflineUnlinkEvents()', function() {
-      beforeEach('reset pouchdb', function(done) {
-        this.pouch.resetDatabase(done)
-      })
-
       it('detects deleted files and folders', async function() {
         // Folder still exists
         const folder1 = {

--- a/test/unit/local/chokidar/watcher.js
+++ b/test/unit/local/chokidar/watcher.js
@@ -324,9 +324,8 @@ onPlatform('darwin', () => {
         return
       }
 
-      beforeEach('reset pouchdb', function(done) {
-        this.pouch.resetDatabase(done)
-      })
+      beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+      afterEach('clean pouch', pouchHelpers.cleanDatabase)
 
       it.skip('deletes the source and adds the destination', function(done) {
         // This test does not create the file in pouchdb.
@@ -378,9 +377,8 @@ onPlatform('darwin', () => {
         return
       }
 
-      before('reset pouchdb', function(done) {
-        this.pouch.resetDatabase(done)
-      })
+      beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+      afterEach('clean pouch', pouchHelpers.cleanDatabase)
 
       it.skip('deletes the source and adds the destination', function(done) {
         // This test does not create the file in pouchdb.

--- a/test/unit/pouch/migrations.js
+++ b/test/unit/pouch/migrations.js
@@ -52,7 +52,7 @@ describe('core/pouch/migrations', function() {
   describe('currentSchemaVersion()', () => {
     context('without schema', () => {
       beforeEach('remove schema', async function() {
-        if (await this.pouch.byIdMaybeAsync(SCHEMA_DOC_ID)) {
+        if (await this.pouch.byIdMaybe(SCHEMA_DOC_ID)) {
           await this.pouch.db.put({ _id: SCHEMA_DOC_ID, _deleted: true })
         }
       })
@@ -96,7 +96,7 @@ describe('core/pouch/migrations', function() {
 
     context('without schema', () => {
       beforeEach('remove schema', async function() {
-        if (await this.pouch.byIdMaybeAsync(SCHEMA_DOC_ID)) {
+        if (await this.pouch.byIdMaybe(SCHEMA_DOC_ID)) {
           await this.pouch.db.put({ _id: SCHEMA_DOC_ID, _deleted: true })
         }
       })
@@ -240,7 +240,7 @@ describe('core/pouch/migrations', function() {
           it('does not save any docs', async function() {
             await migrate(migration, this.pouch)
 
-            const docs = await this.pouch.byRecursivePathAsync('')
+            const docs = await this.pouch.byRecursivePath('')
             const migratedDocs = docs.filter(d => d.migrated)
             should(migratedDocs).be.empty()
           })
@@ -255,7 +255,7 @@ describe('core/pouch/migrations', function() {
 
         context('and some docs needed to be migrated', () => {
           it('runs the migration on all affected docs', async function() {
-            const docs = await this.pouch.byRecursivePathAsync('')
+            const docs = await this.pouch.byRecursivePath('')
 
             await migrate(migration, this.pouch)
             should(migration.run).have.been.calledOnce()
@@ -265,7 +265,7 @@ describe('core/pouch/migrations', function() {
           it('saves the migrated docs', async function() {
             await migrate(migration, this.pouch)
 
-            const docs = await this.pouch.byRecursivePathAsync('')
+            const docs = await this.pouch.byRecursivePath('')
             const migratedDocs = docs.filter(d => d.migrated)
             should(migratedDocs.length).equal(docs.length)
           })
@@ -281,18 +281,16 @@ describe('core/pouch/migrations', function() {
             it('sets the localSeq to the last change seq', async function() {
               const expected = await this.pouch.db.changes({ since: 0 })
               await migrate(migration, this.pouch)
-              await should(this.pouch.getLocalSeqAsync()).be.fulfilledWith(
+              await should(this.pouch.getLocalSeq()).be.fulfilledWith(
                 expected.last_seq
               )
             })
 
             it('does not update the remoteSeq', async function() {
-              const expected = await this.pouch.getRemoteSeqAsync()
+              const expected = await this.pouch.getRemoteSeq()
 
               await migrate(migration, this.pouch)
-              await should(this.pouch.getRemoteSeqAsync()).be.fulfilledWith(
-                expected
-              )
+              await should(this.pouch.getRemoteSeq()).be.fulfilledWith(expected)
             })
 
             it('does not prevent synchronizing merged changes', async function() {
@@ -331,12 +329,12 @@ describe('core/pouch/migrations', function() {
             })
 
             it('reverts all changes', async function() {
-              const docs = await this.pouch.byRecursivePathAsync('')
+              const docs = await this.pouch.byRecursivePath('')
 
               await migrate(migration, this.pouch)
-              await should(
-                this.pouch.byRecursivePathAsync('')
-              ).be.fulfilledWith(docs)
+              await should(this.pouch.byRecursivePath('')).be.fulfilledWith(
+                docs
+              )
             })
 
             it('does not update the schema version', async function() {
@@ -351,21 +349,17 @@ describe('core/pouch/migrations', function() {
             })
 
             it('does not update the localSeq', async function() {
-              const expected = await this.pouch.getLocalSeqAsync()
+              const expected = await this.pouch.getLocalSeq()
 
               await migrate(migration, this.pouch)
-              await should(this.pouch.getLocalSeqAsync()).be.fulfilledWith(
-                expected
-              )
+              await should(this.pouch.getLocalSeq()).be.fulfilledWith(expected)
             })
 
             it('does not update the remoteSeq', async function() {
-              const expected = await this.pouch.getRemoteSeqAsync()
+              const expected = await this.pouch.getRemoteSeq()
 
               await migrate(migration, this.pouch)
-              await should(this.pouch.getRemoteSeqAsync()).be.fulfilledWith(
-                expected
-              )
+              await should(this.pouch.getRemoteSeq()).be.fulfilledWith(expected)
             })
           })
         })
@@ -386,7 +380,7 @@ describe('core/pouch/migrations', function() {
     context('with only valid docs', () => {
       let docs
       beforeEach('fetch and update docs', async function() {
-        docs = await this.pouch.byRecursivePathAsync('')
+        docs = await this.pouch.byRecursivePath('')
         docs.forEach(d => {
           d.migrated = true
         })
@@ -402,7 +396,7 @@ describe('core/pouch/migrations', function() {
       it('saves the new version of all documents', async function() {
         await save(docs, this.pouch.db)
 
-        const savedDocs = await this.pouch.byRecursivePathAsync('')
+        const savedDocs = await this.pouch.byRecursivePath('')
         const migratedDocs = savedDocs.filter(d => d.migrated)
         should(migratedDocs.length).equal(savedDocs.length)
       })
@@ -413,7 +407,7 @@ describe('core/pouch/migrations', function() {
 
       let docs
       beforeEach('fetch and update docs', async function() {
-        docs = await this.pouch.byRecursivePathAsync('')
+        docs = await this.pouch.byRecursivePath('')
         docs.forEach((d, index) => {
           d.migrated = true
           if (isCorruptedDoc(index)) d._rev = d._rev.replace(/\d/, '9')
@@ -439,7 +433,7 @@ describe('core/pouch/migrations', function() {
       it('saves the new version of all valid documents', async function() {
         await save(docs, this.pouch.db)
 
-        const maybeMigratedDocs = await this.pouch.byRecursivePathAsync('')
+        const maybeMigratedDocs = await this.pouch.byRecursivePath('')
         maybeMigratedDocs.forEach((md, index) => {
           if (isCorruptedDoc(index)) {
             should(md.migrated).be.undefined()
@@ -456,7 +450,7 @@ describe('core/pouch/migrations', function() {
 
     describe('affectedDocs()', () => {
       it('returns an empty array when all docs have sides.target', async function() {
-        const docs = await this.pouch.byRecursivePathAsync('').map(doc => {
+        const docs = (await this.pouch.byRecursivePath('')).map(doc => {
           doc.sides.target = 2
           return doc
         })
@@ -464,7 +458,7 @@ describe('core/pouch/migrations', function() {
       })
 
       it('returns only docs missing sides.target', async function() {
-        const docs = await this.pouch.byRecursivePathAsync('')
+        const docs = await this.pouch.byRecursivePath('')
         const incompleteDocs = docs.filter((doc, index) => index % 2 === 0)
         docs
           .filter((doc, index) => index % 2 === 1)
@@ -478,7 +472,7 @@ describe('core/pouch/migrations', function() {
 
     describe('run()', () => {
       it('sets sides.target with the short rev extracted from _rev', async function() {
-        const docs = await this.pouch.byRecursivePathAsync('')
+        const docs = await this.pouch.byRecursivePath('')
         const expected = docs.map(doc => ({
           ...doc,
           sides: {

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -147,13 +147,13 @@ describe('RemoteWatcher', function() {
     })
 
     beforeEach(function() {
-      sinon.stub(this.pouch, 'getRemoteSeqAsync')
-      sinon.stub(this.pouch, 'setRemoteSeqAsync')
+      sinon.stub(this.pouch, 'getRemoteSeq')
+      sinon.stub(this.pouch, 'setRemoteSeq')
       sinon.stub(this.watcher, 'pullMany')
       sinon.stub(this.remoteCozy, 'changes')
       sinon.spy(this.events, 'emit')
 
-      this.pouch.getRemoteSeqAsync.resolves(lastLocalSeq)
+      this.pouch.getRemoteSeq.resolves(lastLocalSeq)
       this.watcher.pullMany.resolves([])
       this.remoteCozy.changes.resolves(changes)
     })
@@ -162,8 +162,8 @@ describe('RemoteWatcher', function() {
       this.events.emit.restore()
       this.remoteCozy.changes.restore()
       this.watcher.pullMany.restore()
-      this.pouch.setRemoteSeqAsync.restore()
-      this.pouch.getRemoteSeqAsync.restore()
+      this.pouch.setRemoteSeq.restore()
+      this.pouch.getRemoteSeq.restore()
     })
 
     it('pulls the changed files/dirs', async function() {
@@ -175,7 +175,7 @@ describe('RemoteWatcher', function() {
 
     it('updates the last update sequence in local db', async function() {
       await this.watcher.watch()
-      this.pouch.setRemoteSeqAsync.should.be
+      this.pouch.setRemoteSeq.should.be
         .calledOnce()
         .and.be.calledWithExactly(lastRemoteSeq)
     })
@@ -267,7 +267,7 @@ describe('RemoteWatcher', function() {
 
       it('updates the last update sequence in local db', async function() {
         await this.watcher.watch()
-        this.pouch.setRemoteSeqAsync.should.be
+        this.pouch.setRemoteSeq.should.be
           .calledOnce()
           .and.be.calledWithExactly(lastRemoteSeq)
       })
@@ -379,9 +379,9 @@ describe('RemoteWatcher', function() {
       })
 
       it('does not update the remote sequence', async function() {
-        const remoteSeq = await this.pouch.getRemoteSeqAsync()
+        const remoteSeq = await this.pouch.getRemoteSeq()
         await this.watcher.pullMany(remoteDocs).catch(() => {})
-        should(this.pouch.getRemoteSeqAsync()).be.fulfilledWith(remoteSeq)
+        should(this.pouch.getRemoteSeq()).be.fulfilledWith(remoteSeq)
       })
     })
 
@@ -1975,7 +1975,7 @@ describe('RemoteWatcher', function() {
           }
         }
       }
-      const was = await this.pouch.byRemoteIdAsync(remoteDoc._id)
+      const was = await this.pouch.byRemoteId(remoteDoc._id)
 
       const change /*: RemoteChange */ = this.watcher.identifyChange(
         _.clone(remoteDoc),
@@ -2014,7 +2014,7 @@ describe('RemoteWatcher', function() {
         updated_at: '2017-01-30T09:09:15.217662611+01:00',
         tags: ['foo', 'bar', 'baz']
       }
-      const was = await this.pouch.byRemoteIdAsync(remoteDoc._id)
+      const was = await this.pouch.byRemoteId(remoteDoc._id)
 
       const change /*: RemoteChange */ = this.watcher.identifyChange(
         _.clone(remoteDoc),
@@ -2055,7 +2055,7 @@ describe('RemoteWatcher', function() {
         updated_at: '2017-01-30T09:09:15.217662611+01:00'
       }
 
-      const was = await this.pouch.byRemoteIdMaybeAsync(remoteDoc._id)
+      const was = await this.pouch.byRemoteIdMaybe(remoteDoc._id)
       const change /*: RemoteChange */ = this.watcher.identifyChange(
         _.clone(remoteDoc),
         was,

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -160,7 +160,7 @@ describe('Sync', function() {
 
     it('waits for and applies available changes', async function() {
       const apply = sinon.stub(this.sync, 'apply')
-      apply.callsFake(change => this.pouch.setLocalSeqAsync(change.seq))
+      apply.callsFake(change => this.pouch.setLocalSeq(change.seq))
 
       const doc1 = {
         _id: 'doc1',
@@ -287,7 +287,7 @@ describe('Sync', function() {
           remote: 4
         }
       })
-      should(await this.pouch.getLocalSeqAsync()).equal(123)
+      should(await this.pouch.getLocalSeq()).equal(123)
     })
 
     it('calls applyDoc for a modified folder', async function() {
@@ -315,7 +315,7 @@ describe('Sync', function() {
           remote: 4
         }
       })
-      should(await this.pouch.getLocalSeqAsync()).equal(124)
+      should(await this.pouch.getLocalSeq()).equal(124)
     })
 
     it('calls addFileAsync for an added file', async function() {
@@ -375,7 +375,7 @@ describe('Sync', function() {
           .data('updated content')
           .create()
 
-        await this.pouch.setLocalSeqAsync(previousSeq)
+        await this.pouch.setLocalSeq(previousSeq)
       })
 
       const applyChange = async function() {
@@ -394,7 +394,7 @@ describe('Sync', function() {
         })
 
         it('saves seq to skip the change', async function() {
-          should(await this.pouch.getLocalSeqAsync()).equal(seq)
+          should(await this.pouch.getLocalSeq()).equal(seq)
         })
       })
     })


### PR DESCRIPTION
The promisification of asynchronous `Pouch` methods brings a naming
difference between the method definition and its references which
makes it harder to search for them across the whole repository.

The promisification was necessary when Promises were not fully
supported and built into NodeJS but this is not true anymore so we can
now move to native Promises and get rid of the promisification.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
