### PR TITLE
test: Modernize tests by using updated data builders

### DIFF
--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -43,6 +43,7 @@ export type RemoteDoc = {
   size?: string,
   tags: string[],
   trashed?: true,
+  restore_path?: string,
   type: string,
   created_at: string,
   updated_at: string,

--- a/core/utils/timestamp.js
+++ b/core/utils/timestamp.js
@@ -10,6 +10,7 @@ export type Timestamp = Date
 
 module.exports = {
   build,
+  spread,
   current,
   fromDate,
   sameDate,
@@ -28,6 +29,19 @@ function build(
   second /*: number */
 ) /*: Timestamp */ {
   return new Date(Date.UTC(year, month - 1, day, hour, minute, second))
+}
+
+function spread(date /*: string|Date|Timestamp */) /*: number[] */ {
+  const timestamp = new Date(date)
+  const year = timestamp.getFullYear()
+  const month = timestamp.getMonth()
+  const day = timestamp.getDate()
+  const hours = timestamp.getHours()
+  const minutes = timestamp.getMinutes()
+  const seconds = timestamp.getSeconds()
+  const milliseconds = timestamp.getMilliseconds()
+
+  return [year, month, day, hours, minutes, seconds, milliseconds]
 }
 
 function current() /*: Timestamp */ {

--- a/test/scenarios/add_delete_dir_and_file/remote/changes.json
+++ b/test/scenarios/add_delete_dir_and_file/remote/changes.json
@@ -1,12 +1,12 @@
 [
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0553ebd7",
-    "_rev": "3-d5fc4b17f0ac0ea5063ac161b523eadb"
+    "_id": "b6f32dd442095bfe2c3639f240d5f920",
+    "_rev": "3-f0ec12ab87d783e8068aa9322d7bc12b"
   },
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0553f95f",
-    "_rev": "3-d2070249d957386fa2c81686918164c1"
+    "_id": "b6f32dd442095bfe2c3639f240d5fa07",
+    "_rev": "3-9dbcd5d50194bc450bb792b77ca4bf1c"
   }
 ]

--- a/test/scenarios/add_file/remote/changes.json
+++ b/test/scenarios/add_file/remote/changes.json
@@ -1,34 +1,34 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05540161",
-    "_rev": "1-66ef6c4bfeb516e4bc0c1e4e81a6d00e",
+    "_id": "b6f32dd442095bfe2c3639f240d6077d",
+    "_rev": "1-a4b439ffb568ebfb07c661dd5f75a2ba",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:03.404641897Z",
+      "createdAt": "2020-10-03T12:55:49.83171091Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:03.404641897Z",
+      "updatedAt": "2020-10-03T12:55:49.83171091Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:03.404641897Z",
+          "date": "2020-10-03T12:55:49.83171091Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:03.404641897Z",
+      "uploadedAt": "2020-10-03T12:55:49.83171091Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:03.404635418Z",
+    "created_at": "2020-10-03T12:55:49.81Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
@@ -38,7 +38,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:03.404635418Z",
+    "updated_at": "2020-10-03T12:55:49.81Z",
     "path": "/file"
   }
 ]

--- a/test/scenarios/add_trash_dir/remote/changes.json
+++ b/test/scenarios/add_trash_dir/remote/changes.json
@@ -1,29 +1,29 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05540181",
-    "_rev": "2-01edeff4f8cad28970bab85632a2d53b",
+    "_id": "b6f32dd442095bfe2c3639f240d609d9",
+    "_rev": "2-ac10fa461c82797e7657ca1961e4a5d6",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:04.619204012Z",
+      "createdAt": "2020-10-03T12:55:55.861807049Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:06.161911704Z",
+      "updatedAt": "2020-10-03T12:55:57.439582008Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:06.161911704Z",
+          "date": "2020-10-03T12:55:57.439582008Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:04.61919986Z",
+    "created_at": "2020-10-03T12:55:55.861803066Z",
     "dir_id": "io.cozy.files.trash-dir",
     "name": "dir",
     "path": "/.cozy_trash/dir",
     "restore_path": "/",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:04.61919986Z"
+    "updated_at": "2020-10-03T12:55:55.861803066Z"
   }
 ]

--- a/test/scenarios/add_trash_file/remote/changes.json
+++ b/test/scenarios/add_trash_file/remote/changes.json
@@ -1,34 +1,34 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a055409a3",
-    "_rev": "2-e2f16247bf67ba1b3bccab247fea9d96",
+    "_id": "b6f32dd442095bfe2c3639f240d60e3b",
+    "_rev": "2-52fc44208dcfb12afe434dd380ddc5e4",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:07.052698969Z",
+      "createdAt": "2020-10-03T12:56:05.792317347Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:08.609982952Z",
+      "updatedAt": "2020-10-03T12:56:07.359115896Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:08.609982952Z",
+          "date": "2020-10-03T12:56:07.359115896Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:07.052698969Z",
+      "uploadedAt": "2020-10-03T12:56:05.792317347Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:07.052691065Z",
+    "created_at": "2020-10-03T12:56:05.739Z",
     "dir_id": "io.cozy.files.trash-dir",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
@@ -39,7 +39,7 @@
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:07.052691065Z",
+    "updated_at": "2020-10-03T12:56:05.739Z",
     "path": "/.cozy_trash/file"
   }
 ]

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/remote/changes.json
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/remote/changes.json
@@ -1,87 +1,87 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05541410",
-    "_rev": "1-7a6c984157c8caf168bbe8aa33f84d8f",
+    "_id": "b6f32dd442095bfe2c3639f240d6155c",
+    "_rev": "1-730727392eb3faf828966a7d9876d4fd",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:09.679765749Z",
+      "createdAt": "2020-10-03T12:56:15.09609933Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:09.679765749Z",
+      "updatedAt": "2020-10-03T12:56:15.09609933Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:09.679765749Z",
+          "date": "2020-10-03T12:56:15.09609933Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:09.679761319Z",
+    "created_at": "2020-10-03T12:56:15.096094466Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "JOHN",
     "path": "/JOHN",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:09.679761319Z"
+    "updated_at": "2020-10-03T12:56:15.096094466Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a055422fb",
-    "_rev": "1-887543cebb2da2bd772f91379055cce8",
+    "_id": "b6f32dd442095bfe2c3639f240d61e99",
+    "_rev": "1-a032474bf6f97fbe3bea2a915e571740",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:09.936990841Z",
+      "createdAt": "2020-10-03T12:56:15.196174026Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:09.936990841Z",
+      "updatedAt": "2020-10-03T12:56:15.196174026Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:09.936990841Z",
+          "date": "2020-10-03T12:56:15.196174026Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:09.936985755Z",
-    "dir_id": "a5f50206697951be5992df4a05541410",
+    "created_at": "2020-10-03T12:56:15.19616766Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d6155c",
     "name": "exact-same-subdir",
     "path": "/JOHN/exact-same-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:09.936985755Z"
+    "updated_at": "2020-10-03T12:56:15.19616766Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554246d",
-    "_rev": "1-186ee25c8983f8dd94b9a746a8bbdb75",
+    "_id": "b6f32dd442095bfe2c3639f240d626ce",
+    "_rev": "1-371973a786d9d65af4c3f2574b95e5cf",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:09.978128282Z",
+      "createdAt": "2020-10-03T12:56:15.239203422Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:09.978128282Z",
+      "updatedAt": "2020-10-03T12:56:15.239203422Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:09.978128282Z",
+          "date": "2020-10-03T12:56:15.239203422Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:09.978128282Z",
+      "uploadedAt": "2020-10-03T12:56:15.239203422Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:09.978111198Z",
-    "dir_id": "a5f50206697951be5992df4a055422fb",
+    "created_at": "2020-10-03T12:56:15.212Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d61e99",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
     "mime": "text/plain",
@@ -90,40 +90,40 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:09.978111198Z",
+    "updated_at": "2020-10-03T12:56:15.212Z",
     "path": "/JOHN/exact-same-subdir/a.txt"
   },
   {
-    "_id": "a5f50206697951be5992df4a05542f36",
-    "_rev": "1-59b0b92df08ce3b89a158e1339e2403a",
+    "_id": "b6f32dd442095bfe2c3639f240d630e3",
+    "_rev": "1-d5ac80517e471bc99329656a41f3fc3a",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.028287008Z",
+      "createdAt": "2020-10-03T12:56:15.292603683Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.028287008Z",
+      "updatedAt": "2020-10-03T12:56:15.292603683Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.028287008Z",
+          "date": "2020-10-03T12:56:15.292603683Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:10.028287008Z",
+      "uploadedAt": "2020-10-03T12:56:15.292603683Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:10.028281535Z",
-    "dir_id": "a5f50206697951be5992df4a055422fb",
+    "created_at": "2020-10-03T12:56:15.263Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d61e99",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
     "mime": "text/plain",
@@ -132,118 +132,118 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:10.028281535Z",
+    "updated_at": "2020-10-03T12:56:15.263Z",
     "path": "/JOHN/exact-same-subdir/b.txt"
   },
   {
-    "_id": "a5f50206697951be5992df4a05543deb",
-    "_rev": "1-f2a80e18d265d596e808c29f4e204129",
+    "_id": "b6f32dd442095bfe2c3639f240d63afb",
+    "_rev": "1-df4572242f0150b95cc1dfe6a5b23301",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.10331962Z",
+      "createdAt": "2020-10-03T12:56:15.373309531Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.10331962Z",
+      "updatedAt": "2020-10-03T12:56:15.373309531Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.10331962Z",
+          "date": "2020-10-03T12:56:15.373309531Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:10.103314276Z",
-    "dir_id": "a5f50206697951be5992df4a05541410",
+    "created_at": "2020-10-03T12:56:15.373304796Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d6155c",
     "name": "other-subdir-JOHN-1",
     "path": "/JOHN/other-subdir-JOHN-1",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:10.103314276Z"
+    "updated_at": "2020-10-03T12:56:15.373304796Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554406f",
-    "_rev": "1-646357f107776fb39b3c0046b4228adf",
+    "_id": "b6f32dd442095bfe2c3639f240d63d45",
+    "_rev": "1-10886138b6d0f94dc9f26764a275aa91",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.163216451Z",
+      "createdAt": "2020-10-03T12:56:15.426754647Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.163216451Z",
+      "updatedAt": "2020-10-03T12:56:15.426754647Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.163216451Z",
+          "date": "2020-10-03T12:56:15.426754647Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:10.163210274Z",
+    "created_at": "2020-10-03T12:56:15.426749983Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "john",
     "path": "/john",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:10.163210274Z"
+    "updated_at": "2020-10-03T12:56:15.426749983Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05544e51",
-    "_rev": "1-7a7cde005852e0853d41cb0c3002455f",
+    "_id": "b6f32dd442095bfe2c3639f240d644e2",
+    "_rev": "1-e04e3329f100047c39ab1eeee0201208",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.239250876Z",
+      "createdAt": "2020-10-03T12:56:15.495708894Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.239250876Z",
+      "updatedAt": "2020-10-03T12:56:15.495708894Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.239250876Z",
+          "date": "2020-10-03T12:56:15.495708894Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:10.239241362Z",
-    "dir_id": "a5f50206697951be5992df4a0554406f",
+    "created_at": "2020-10-03T12:56:15.495704319Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d63d45",
     "name": "exact-same-subdir",
     "path": "/john/exact-same-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:10.239241362Z"
+    "updated_at": "2020-10-03T12:56:15.495704319Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05544e9b",
-    "_rev": "1-29a1bdbcc2d5d64b54e0e5a5013eb6f1",
+    "_id": "b6f32dd442095bfe2c3639f240d65373",
+    "_rev": "1-4bf916a48ad6df4124989b9aa247502a",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.292772842Z",
+      "createdAt": "2020-10-03T12:56:15.538252579Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.292772842Z",
+      "updatedAt": "2020-10-03T12:56:15.538252579Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.292772842Z",
+          "date": "2020-10-03T12:56:15.538252579Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:10.292772842Z",
+      "uploadedAt": "2020-10-03T12:56:15.538252579Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:10.292766062Z",
-    "dir_id": "a5f50206697951be5992df4a05544e51",
+    "created_at": "2020-10-03T12:56:15.512Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d644e2",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
     "mime": "text/plain",
@@ -252,40 +252,40 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:10.292766062Z",
+    "updated_at": "2020-10-03T12:56:15.512Z",
     "path": "/john/exact-same-subdir/a.txt"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554575e",
-    "_rev": "1-d7ff606e379739f4f056357a1742e545",
+    "_id": "b6f32dd442095bfe2c3639f240d65f04",
+    "_rev": "1-6121668e05768865061b9c2fcde064b0",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.365053446Z",
+      "createdAt": "2020-10-03T12:56:15.588379623Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.365053446Z",
+      "updatedAt": "2020-10-03T12:56:15.588379623Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.365053446Z",
+          "date": "2020-10-03T12:56:15.588379623Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:10.365053446Z",
+      "uploadedAt": "2020-10-03T12:56:15.588379623Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:10.365046374Z",
-    "dir_id": "a5f50206697951be5992df4a05544e51",
+    "created_at": "2020-10-03T12:56:15.561Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d644e2",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
     "mime": "text/plain",
@@ -294,33 +294,33 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:10.365046374Z",
+    "updated_at": "2020-10-03T12:56:15.561Z",
     "path": "/john/exact-same-subdir/b.txt"
   },
   {
-    "_id": "a5f50206697951be5992df4a05545812",
-    "_rev": "1-f12b285284078db7ba5487ac29840734",
+    "_id": "b6f32dd442095bfe2c3639f240d66303",
+    "_rev": "1-320f998cfbedb95ee6d8bb359e6f822f",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:10.450955759Z",
+      "createdAt": "2020-10-03T12:56:15.662825709Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:10.450955759Z",
+      "updatedAt": "2020-10-03T12:56:15.662825709Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:10.450955759Z",
+          "date": "2020-10-03T12:56:15.662825709Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:10.450949963Z",
-    "dir_id": "a5f50206697951be5992df4a0554406f",
+    "created_at": "2020-10-03T12:56:15.662821367Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d63d45",
     "name": "other-subdir-john-2",
     "path": "/john/other-subdir-john-2",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:10.450949963Z"
+    "updated_at": "2020-10-03T12:56:15.662821367Z"
   }
 ]

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/remote/changes.json
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/remote/changes.json
@@ -1,87 +1,87 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05545eae",
-    "_rev": "1-e699520b5ae0eabe388a5ff155739f26",
+    "_id": "b6f32dd442095bfe2c3639f240d66dff",
+    "_rev": "1-919eecf0fd583adbec82760fe388bdab",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:11.787638069Z",
+      "createdAt": "2020-10-03T12:56:23.710434397Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:11.787638069Z",
+      "updatedAt": "2020-10-03T12:56:23.710434397Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:11.787638069Z",
+          "date": "2020-10-03T12:56:23.710434397Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:11.787633019Z",
+    "created_at": "2020-10-03T12:56:23.71042995Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "FOO",
     "path": "/FOO",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:11.787633019Z"
+    "updated_at": "2020-10-03T12:56:23.71042995Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554615f",
-    "_rev": "1-906bcdb96a2b0575918cdb9f9500b14b",
+    "_id": "b6f32dd442095bfe2c3639f240d67216",
+    "_rev": "1-2c71d84541b4993f354340ccef494890",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:11.885916578Z",
+      "createdAt": "2020-10-03T12:56:23.780940261Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:11.885916578Z",
+      "updatedAt": "2020-10-03T12:56:23.780940261Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:11.885916578Z",
+          "date": "2020-10-03T12:56:23.780940261Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:11.885912312Z",
-    "dir_id": "a5f50206697951be5992df4a05545eae",
+    "created_at": "2020-10-03T12:56:23.780934233Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d66dff",
     "name": "subdir",
     "path": "/FOO/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:11.885912312Z"
+    "updated_at": "2020-10-03T12:56:23.780934233Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554687e",
-    "_rev": "1-458bc2b80e7cd660485e110e2e313175",
+    "_id": "b6f32dd442095bfe2c3639f240d6778c",
+    "_rev": "1-d8c4a281578a86f272cf747a11b13bd5",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:11.935050694Z",
+      "createdAt": "2020-10-03T12:56:23.819438222Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:11.935050694Z",
+      "updatedAt": "2020-10-03T12:56:23.819438222Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:11.935050694Z",
+          "date": "2020-10-03T12:56:23.819438222Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:11.935050694Z",
+      "uploadedAt": "2020-10-03T12:56:23.819438222Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:11.935045706Z",
-    "dir_id": "a5f50206697951be5992df4a0554615f",
+    "created_at": "2020-10-03T12:56:23.795Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d67216",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
     "mime": "text/plain",
@@ -90,39 +90,39 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:11.935045706Z",
+    "updated_at": "2020-10-03T12:56:23.795Z",
     "path": "/FOO/subdir/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a05546977",
-    "_rev": "1-b735f1d2b31514002b48750ed53cdb07",
+    "_id": "b6f32dd442095bfe2c3639f240d678ab",
+    "_rev": "1-21fb74ef98a2317b8d4191282c005e71",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:11.996945703Z",
+      "createdAt": "2020-10-03T12:56:23.86733506Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:11.996945703Z",
+      "updatedAt": "2020-10-03T12:56:23.86733506Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:11.996945703Z",
+          "date": "2020-10-03T12:56:23.86733506Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:11.996945703Z",
+      "uploadedAt": "2020-10-03T12:56:23.86733506Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:11.996938739Z",
+    "created_at": "2020-10-03T12:56:23.841Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
@@ -132,7 +132,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:11.996938739Z",
+    "updated_at": "2020-10-03T12:56:23.841Z",
     "path": "/foo"
   }
 ]

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/changes.json
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/changes.json
@@ -1,35 +1,35 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05548740",
-    "_rev": "1-a04707b5a1b637609954bb4d547dbbc8",
+    "_id": "b6f32dd442095bfe2c3639f240d68b36",
+    "_rev": "1-d851c3c1fada7fd0b2b6ed3770138888",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:14.918588197Z",
+      "createdAt": "2020-10-03T12:56:31.794890746Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:14.918588197Z",
+      "updatedAt": "2020-10-03T12:56:31.794890746Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:14.918588197Z",
+          "date": "2020-10-03T12:56:31.794890746Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:14.918588197Z",
+      "uploadedAt": "2020-10-03T12:56:31.794890746Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:14.918576275Z",
-    "dir_id": "a5f50206697951be5992df4a05547aae",
+    "created_at": "2020-10-03T12:56:31.769Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d685f6",
     "executable": false,
     "md5sum": "ihJ0JyvnormYrQkI6TUGyg==",
     "mime": "text/plain",
@@ -38,7 +38,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:14.918576275Z",
+    "updated_at": "2020-10-03T12:56:31.769Z",
     "path": "/Impôts Gérard/AccuséRéception.pdf"
   }
 ]

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/remote/changes.json
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/remote/changes.json
@@ -1,35 +1,35 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05549b94",
-    "_rev": "1-135d6a9b6873fee940edf47615e2b441",
+    "_id": "b6f32dd442095bfe2c3639f240d6951d",
+    "_rev": "1-b21ed24fce094ba5c80b36e2f5be80b4",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:15.988417232Z",
+      "createdAt": "2020-10-03T12:56:39.613158505Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:15.988417232Z",
+      "updatedAt": "2020-10-03T12:56:39.613158505Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:15.988417232Z",
+          "date": "2020-10-03T12:56:39.613158505Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:15.988417232Z",
+      "uploadedAt": "2020-10-03T12:56:39.613158505Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:15.988411391Z",
-    "dir_id": "a5f50206697951be5992df4a05548f1f",
+    "created_at": "2020-10-03T12:56:39.587Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d693f4",
     "executable": false,
     "md5sum": "ihJ0JyvnormYrQkI6TUGyg==",
     "mime": "text/plain",
@@ -38,7 +38,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:15.988411391Z",
+    "updated_at": "2020-10-03T12:56:39.587Z",
     "path": "/Impôts Gérard/AccuséRéception.pdf"
   }
 ]

--- a/test/scenarios/create_dir_into_moved_one/remote/changes.json
+++ b/test/scenarios/create_dir_into_moved_one/remote/changes.json
@@ -1,54 +1,54 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0554a581",
-    "_rev": "2-9cb34abb41381289ede89ee184336385",
+    "_id": "b6f32dd442095bfe2c3639f240d6a0fe",
+    "_rev": "2-014f8f9f1e0cb7fb784ac110235e5019",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:16.941425723Z",
+      "createdAt": "2020-10-03T12:56:39.919107298Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:17.76209502Z",
+      "updatedAt": "2020-10-03T12:56:47.293287859Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:17.76209502Z",
+          "date": "2020-10-03T12:56:47.293287859Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:16.941419884Z",
-    "dir_id": "a5f50206697951be5992df4a05549c16",
+    "created_at": "2020-09-03T14:56:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d69918",
     "name": "dir1",
     "path": "/dst/dir1",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:16.941419884Z"
+    "updated_at": "2020-09-03T14:56:39Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554ad80",
-    "_rev": "1-28cb8e0b228573a863fccb823d3ca1c3",
+    "_id": "b6f32dd442095bfe2c3639f240d6aaeb",
+    "_rev": "1-e36abd2b0d094044390244e3d9297514",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:17.865458538Z",
+      "createdAt": "2020-10-03T12:56:47.387765801Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:17.865458538Z",
+      "updatedAt": "2020-10-03T12:56:47.387765801Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:17.865458538Z",
+          "date": "2020-10-03T12:56:47.387765801Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:17.865452146Z",
-    "dir_id": "a5f50206697951be5992df4a0554a581",
+    "created_at": "2020-10-03T12:56:47.387760165Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d6a0fe",
     "name": "dir2",
     "path": "/dst/dir1/dir2",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:17.865452146Z"
+    "updated_at": "2020-10-03T12:56:47.387760165Z"
   }
 ]

--- a/test/scenarios/create_dirs/remote/changes.json
+++ b/test/scenarios/create_dirs/remote/changes.json
@@ -1,54 +1,54 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0554b7ba",
-    "_rev": "1-3d34585c28655d568d85b4a6b28d2616",
+    "_id": "b6f32dd442095bfe2c3639f240d6be2a",
+    "_rev": "1-fcfda20bd8495ae9e3d0fcf27062a5af",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:19.83880901Z",
+      "createdAt": "2020-10-03T12:57:02.803701872Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:19.83880901Z",
+      "updatedAt": "2020-10-03T12:57:02.803701872Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:19.83880901Z",
+          "date": "2020-10-03T12:57:02.803701872Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:19.838802731Z",
+    "created_at": "2020-10-03T12:57:02.803698701Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "foo",
     "path": "/foo",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:19.838802731Z"
+    "updated_at": "2020-10-03T12:57:02.803698701Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0554b8b9",
-    "_rev": "1-f27b31d31308c27025d574bf9a04a679",
+    "_id": "b6f32dd442095bfe2c3639f240d6c757",
+    "_rev": "1-b3930b192da8775bc7a9e0623df179ff",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:19.911719919Z",
+      "createdAt": "2020-10-03T12:57:02.871511187Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:19.911719919Z",
+      "updatedAt": "2020-10-03T12:57:02.871511187Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:19.911719919Z",
+          "date": "2020-10-03T12:57:02.871511187Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:19.911713048Z",
-    "dir_id": "a5f50206697951be5992df4a0554b7ba",
+    "created_at": "2020-10-03T12:57:02.871506729Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d6be2a",
     "name": "bar",
     "path": "/foo/bar",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:19.911713048Z"
+    "updated_at": "2020-10-03T12:57:02.871506729Z"
   }
 ]

--- a/test/scenarios/delete_dir_permanently/remote/changes.json
+++ b/test/scenarios/delete_dir_permanently/remote/changes.json
@@ -1,22 +1,22 @@
 [
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0554ca18",
-    "_rev": "3-497ee6f29dea552a0c1ac48dcdb23369"
+    "_id": "b6f32dd442095bfe2c3639f240d6d68e",
+    "_rev": "3-ccec5a5837e730e69d23f54a1982fed6"
   },
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0554d523",
-    "_rev": "3-bc2489267046181bdc6525f2518826f1"
+    "_id": "b6f32dd442095bfe2c3639f240d6da49",
+    "_rev": "3-18171aa507120bcb74e6ba6d9cca7c2b"
   },
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0554e3c6",
-    "_rev": "3-c4916ecec7b742a823369f51621c8499"
+    "_id": "b6f32dd442095bfe2c3639f240d6de62",
+    "_rev": "3-097988a4e1593b26106b8666bb0d017a"
   },
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0554f197",
-    "_rev": "3-3ac24c0592ed4ff8c6369480dfb2cb77"
+    "_id": "b6f32dd442095bfe2c3639f240d6e239",
+    "_rev": "3-afa133f95f9b6bbaea4ad6b22d1e4cc3"
   }
 ]

--- a/test/scenarios/delete_file_permanently/remote/changes.json
+++ b/test/scenarios/delete_file_permanently/remote/changes.json
@@ -1,7 +1,7 @@
 [
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0554fc0f",
-    "_rev": "3-0209470fa9f5f79605213a465313c416"
+    "_id": "b6f32dd442095bfe2c3639f240d6fce8",
+    "_rev": "3-2261c8a777d15df3f25bbefb75fa2ccb"
   }
 ]

--- a/test/scenarios/index.js
+++ b/test/scenarios/index.js
@@ -48,7 +48,7 @@ type FSWaitAction = {|
   ms: number
 |}
 
-type FSAction
+export type FSAction
   = FSAddDirAction
   | FSCreateFileAction
   | FSDeleteAction
@@ -98,6 +98,7 @@ export type ScenarioInit = Array<{|
 |}>
 
 export type Scenario = {|
+  name?: string,
   platforms?: Array<'win32'|'darwin'|'linux'>,
   side?: SideName,
   disabled?: ScenarioCompletelyDisabled | ScenarioTestsDisabled,

--- a/test/scenarios/move_a_to_b_and_create_a/remote/changes.json
+++ b/test/scenarios/move_a_to_b_and_create_a/remote/changes.json
@@ -1,76 +1,76 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a055502ec",
-    "_rev": "2-301a52cb4a86081945a23086b1569597",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d6fdf2",
+    "_rev": "2-329a6d71a7cd686a7119b09d72b30fe1",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:22.63401752Z",
+      "createdAt": "2020-10-03T12:57:18.833290925Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:23.38906142Z",
+      "updatedAt": "2020-10-03T12:57:25.996861242Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:23.38906142Z",
+          "date": "2020-10-03T12:57:25.996861242Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:22.63401752Z",
+      "uploadedAt": "2020-10-03T12:57:18.833290925Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:22.634011872Z",
+    "created_at": "2020-09-03T14:57:18Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "ODcNVuPhFNc+vt1qx7GQKA==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "b",
     "size": "15",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:22.634011872Z",
+    "updated_at": "2020-09-03T14:57:18Z",
     "path": "/b"
   },
   {
-    "_id": "a5f50206697951be5992df4a05551066",
-    "_rev": "1-2fed0710bedf28b671ec90c3bb7884e0",
+    "_id": "b6f32dd442095bfe2c3639f240d70507",
+    "_rev": "1-bd6b1834af900bb3018365ba244ae967",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:23.459771922Z",
+      "createdAt": "2020-10-03T12:57:26.039536357Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:23.459771922Z",
+      "updatedAt": "2020-10-03T12:57:26.039536357Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:23.459771922Z",
+          "date": "2020-10-03T12:57:26.039536357Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:23.459771922Z",
+      "uploadedAt": "2020-10-03T12:57:26.039536357Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:23.45976738Z",
+    "created_at": "2020-10-03T12:57:26.012Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "lsFcK7KSEZO/KQ34zYXiug==",
@@ -80,7 +80,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:23.45976738Z",
+    "updated_at": "2020-10-03T12:57:26.012Z",
     "path": "/a"
   }
 ]

--- a/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/remote/changes.json
+++ b/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/remote/changes.json
@@ -1,54 +1,54 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05551a85",
-    "_rev": "2-2bfcf496741475ddff1f96b5cc5cd850",
+    "_id": "b6f32dd442095bfe2c3639f240d70b31",
+    "_rev": "2-c2e06a990189304e336b993427685fd1",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:23.693303075Z",
+      "createdAt": "2020-10-03T12:57:26.273669468Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:24.643082171Z",
+      "updatedAt": "2020-10-03T12:57:33.89317453Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:24.643082171Z",
+          "date": "2020-10-03T12:57:33.89317453Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:23.69329717Z",
+    "created_at": "2020-09-03T14:57:26Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "c",
     "path": "/c",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:23.69329717Z"
+    "updated_at": "2020-09-03T14:57:26Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05552c4d",
-    "_rev": "2-0448070b946e3e994120a0891e8894d0",
+    "_id": "b6f32dd442095bfe2c3639f240d71cec",
+    "_rev": "2-27ca391335338f16b9811ea5c7551070",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:23.805791527Z",
+      "createdAt": "2020-10-03T12:57:26.351033151Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:26.211419711Z",
+      "updatedAt": "2020-10-03T12:57:35.4764456Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:26.211419711Z",
+          "date": "2020-10-03T12:57:35.4764456Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:23.805784531Z",
+    "created_at": "2020-09-03T14:57:26Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "a",
     "path": "/a",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:23.805784531Z"
+    "updated_at": "2020-09-03T14:57:26Z"
   }
 ]

--- a/test/scenarios/move_and_trash_dir/remote/changes.json
+++ b/test/scenarios/move_and_trash_dir/remote/changes.json
@@ -1,71 +1,71 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05555985",
-    "_rev": "2-8e483ae435c2674114993fdcdf3018cc",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d74d4f",
+    "_rev": "2-60ad0997a451c81f458ef881ccff304e",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:26.798106473Z",
+      "createdAt": "2020-10-03T12:57:35.779364172Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:26.798106473Z",
+      "updatedAt": "2020-10-03T12:57:35.779364172Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:26.798106473Z",
+          "date": "2020-10-03T12:57:35.779364172Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:26.798106473Z",
+      "uploadedAt": "2020-10-03T12:57:35.779364172Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:26.798097117Z",
-    "dir_id": "a5f50206697951be5992df4a0555577b",
+    "created_at": "2020-09-03T14:57:35Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7445a",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "8",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:26.798097117Z",
+    "updated_at": "2020-09-03T14:57:35Z",
     "path": "/.cozy_trash/subdir/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a0555577b",
-    "_rev": "3-29299ed84ee61aa785ac89c972f44c47",
+    "_id": "b6f32dd442095bfe2c3639f240d7445a",
+    "_rev": "3-9e46d80e2da6a4e47b98fa2d6e2f9f64",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:26.748339933Z",
+      "createdAt": "2020-10-03T12:57:35.757419782Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:29.374630364Z",
+      "updatedAt": "2020-10-03T12:57:44.633825924Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:29.374630364Z",
+          "date": "2020-10-03T12:57:44.633825924Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:26.748333088Z",
+    "created_at": "2020-09-03T14:57:35Z",
     "dir_id": "io.cozy.files.trash-dir",
     "name": "subdir",
     "path": "/.cozy_trash/subdir",
     "restore_path": "/dst",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:26.748333088Z"
+    "updated_at": "2020-09-03T14:57:35Z"
   }
 ]

--- a/test/scenarios/move_and_trash_file/remote/changes.json
+++ b/test/scenarios/move_and_trash_file/remote/changes.json
@@ -1,45 +1,45 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05557496",
-    "_rev": "3-c40778622195d8f94619d282ac72c299",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d76334",
+    "_rev": "3-bdca32b5188674dac3b7c62814915cba",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:31.392700957Z",
+      "createdAt": "2020-10-03T12:57:46.467935332Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:33.712335172Z",
+      "updatedAt": "2020-10-03T12:57:55.078056975Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:33.712335172Z",
+          "date": "2020-10-03T12:57:55.078056975Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:31.392700957Z",
+      "uploadedAt": "2020-10-03T12:57:46.467935332Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:31.39269461Z",
+    "created_at": "2020-09-03T14:57:46Z",
     "dir_id": "io.cozy.files.trash-dir",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "restore_path": "/dst",
     "size": "8",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:31.39269461Z",
+    "updated_at": "2020-09-03T14:57:46Z",
     "path": "/.cozy_trash/file"
   }
 ]

--- a/test/scenarios/move_and_update_file/remote/changes.json
+++ b/test/scenarios/move_and_update_file/remote/changes.json
@@ -1,35 +1,35 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05559848",
-    "_rev": "3-e1880e44ac3fd830af62130fe4629d3c",
+    "_id": "b6f32dd442095bfe2c3639f240d7826d",
+    "_rev": "3-f637fd31a9148bc486d04e26f0e3b19d",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:35.621907719Z",
+      "createdAt": "2020-10-03T12:57:56.910709114Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:37.910937986Z",
+      "updatedAt": "2020-10-03T12:58:04.258710692Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:37.910937986Z",
+          "date": "2020-10-03T12:58:04.258710692Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:35.621907719Z",
+      "uploadedAt": "2020-10-03T12:57:56.910709114Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:35.621901481Z",
-    "dir_id": "a5f50206697951be5992df4a05557f3b",
+    "created_at": "2020-09-03T14:57:56Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d76e23",
     "executable": false,
     "md5sum": "peMo42/hVYOSS7d/xT4A9Q==",
     "mime": "text/plain",
@@ -38,7 +38,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:37.910926505Z",
+    "updated_at": "2020-10-03T12:58:04.201Z",
     "path": "/dst/file"
   }
 ]

--- a/test/scenarios/move_dir_a_to_b_to_c_to_b/remote/changes.json
+++ b/test/scenarios/move_dir_a_to_b_to_c_to_b/remote/changes.json
@@ -1,28 +1,28 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05559d22",
-    "_rev": "4-04643ad82c82df2f0913e8714cc64259",
+    "_id": "b6f32dd442095bfe2c3639f240d79eb9",
+    "_rev": "4-304c1b228f900279220a87412566acbc",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:39.972169381Z",
+      "createdAt": "2020-10-03T12:58:05.609145568Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:43.990029173Z",
+      "updatedAt": "2020-10-03T12:58:15.897367392Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:43.990029173Z",
+          "date": "2020-10-03T12:58:15.897367392Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:39.972164614Z",
-    "dir_id": "a5f50206697951be5992df4a0555995f",
+    "created_at": "2020-09-03T14:58:05Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d78fe3",
     "name": "B",
     "path": "/src/B",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:39.972164614Z"
+    "updated_at": "2020-09-03T14:58:05Z"
   }
 ]

--- a/test/scenarios/move_dir_and_replace_subfile/remote/changes.json
+++ b/test/scenarios/move_dir_and_replace_subfile/remote/changes.json
@@ -1,104 +1,104 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0555a998",
-    "_rev": "2-2eb03161658e79654e03a07daaa96b7a",
+    "_id": "b6f32dd442095bfe2c3639f240d7a0cf",
+    "_rev": "2-9d92cf6163f270dd0c38e08c99dc5c5a",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:45.742861643Z",
+      "createdAt": "2020-10-03T12:58:17.623963179Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:46.595401727Z",
+      "updatedAt": "2020-10-03T12:58:24.521725433Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:46.595401727Z",
+          "date": "2020-10-03T12:58:24.521725433Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:45.742856023Z",
+    "created_at": "2020-09-03T14:58:17Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "dst",
     "path": "/dst",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:45.742856023Z"
+    "updated_at": "2020-09-03T14:58:17Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0555b920",
-    "_rev": "2-5ea0a01e838b1ebe02d7c85e7288c6f2",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d7ac48",
+    "_rev": "2-eba50316c824e8f7a5045d62d2d10713",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:45.786867858Z",
+      "createdAt": "2020-10-03T12:58:17.665852582Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:48.231663609Z",
+      "updatedAt": "2020-10-03T12:58:26.176477248Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:48.231663609Z",
+          "date": "2020-10-03T12:58:26.176477248Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:45.786867858Z",
+      "uploadedAt": "2020-10-03T12:58:17.665852582Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:45.786861486Z",
+    "created_at": "2020-09-03T14:58:17Z",
     "dir_id": "io.cozy.files.trash-dir",
     "executable": false,
     "md5sum": "ODcNVuPhFNc+vt1qx7GQKA==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "restore_path": "/dst",
     "size": "15",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:45.786861486Z",
+    "updated_at": "2020-09-03T14:58:17Z",
     "path": "/.cozy_trash/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a0555c239",
-    "_rev": "2-5b983a0e24c4f06a9b364d34bd68ba11",
+    "_id": "b6f32dd442095bfe2c3639f240d7b633",
+    "_rev": "2-30fc6f1ddcc5b62eb45c3215acefc02e",
     "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:48.144188798Z",
+      "createdAt": "2020-10-03T12:58:26.091216958Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:48.308622885Z",
+      "updatedAt": "2020-10-03T12:58:26.252185855Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:48.308622885Z",
+          "date": "2020-10-03T12:58:26.252185855Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:48.144188798Z",
+      "uploadedAt": "2020-10-03T12:58:26.091216958Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:48.144182664Z",
-    "dir_id": "a5f50206697951be5992df4a0555a998",
+    "created_at": "2020-10-03T12:58:26.049Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7a0cf",
     "executable": false,
     "md5sum": "lsFcK7KSEZO/KQ34zYXiug==",
     "mime": "application/octet-stream",
@@ -107,7 +107,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:48.144182664Z",
+    "updated_at": "2020-10-03T12:58:26.049Z",
     "path": "/dst/file"
   }
 ]

--- a/test/scenarios/move_dir_and_update_subfile/remote/changes.json
+++ b/test/scenarios/move_dir_and_update_subfile/remote/changes.json
@@ -1,61 +1,61 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0555c2ef",
-    "_rev": "2-8a0b88a6e0dade55210f989baf7d02f9",
+    "_id": "b6f32dd442095bfe2c3639f240d7c19a",
+    "_rev": "2-5088061a354a546137babc0f7aa13494",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:48.543383233Z",
+      "createdAt": "2020-10-03T12:58:26.484915846Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:49.352867264Z",
+      "updatedAt": "2020-10-03T12:58:33.691631647Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:49.352867264Z",
+          "date": "2020-10-03T12:58:33.691631647Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:48.543378488Z",
+    "created_at": "2020-09-03T14:58:26Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "dst",
     "path": "/dst",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:48.543378488Z"
+    "updated_at": "2020-09-03T14:58:26Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0555c9bb",
-    "_rev": "2-ee1bfd7753d79b578b880a7cb5c871fb",
+    "_id": "b6f32dd442095bfe2c3639f240d7c242",
+    "_rev": "2-3a0ab76ab681c6ff70f29495930182e9",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:48.582527247Z",
+      "createdAt": "2020-10-03T12:58:26.510302985Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:50.913085255Z",
+      "updatedAt": "2020-10-03T12:58:35.248445343Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:50.913085255Z",
+          "date": "2020-10-03T12:58:35.248445343Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:48.582527247Z",
+      "uploadedAt": "2020-10-03T12:58:26.510302985Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:48.582520893Z",
-    "dir_id": "a5f50206697951be5992df4a0555c2ef",
+    "created_at": "2020-09-03T14:58:26Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7c19a",
     "executable": false,
     "md5sum": "peMo42/hVYOSS7d/xT4A9Q==",
     "mime": "text/plain",
@@ -64,7 +64,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:50.913075937Z",
+    "updated_at": "2020-10-03T12:58:35.216Z",
     "path": "/dst/file"
   }
 ]

--- a/test/scenarios/move_dir_from_the_outside/scenario.js
+++ b/test/scenarios/move_dir_from_the_outside/scenario.js
@@ -3,6 +3,7 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  side: 'local',
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: '../outside/dir/' },

--- a/test/scenarios/move_dir_into_created_one/remote/changes.json
+++ b/test/scenarios/move_dir_into_created_one/remote/changes.json
@@ -1,54 +1,54 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0555f659",
-    "_rev": "1-ceaec863b9d3427a955eff3e4a52e543",
+    "_id": "b6f32dd442095bfe2c3639f240d7c778",
+    "_rev": "1-07dabb15918f105f01ac7c0eddbbeb20",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:56.657129548Z",
+      "createdAt": "2020-10-03T12:58:42.724966381Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:56.657129548Z",
+      "updatedAt": "2020-10-03T12:58:42.724966381Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:56.657129548Z",
+          "date": "2020-10-03T12:58:42.724966381Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:56.657123756Z",
+    "created_at": "2020-10-03T12:58:42.724962919Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "dir2",
     "path": "/dir2",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:56.657123756Z"
+    "updated_at": "2020-10-03T12:58:42.724962919Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0555f350",
-    "_rev": "2-4ef32e8c90275cdf05d23a77e87c2811",
+    "_id": "b6f32dd442095bfe2c3639f240d7c4a1",
+    "_rev": "2-c67ebcc271c7d708dadcf4c17db37a63",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:55.870716567Z",
+      "createdAt": "2020-10-03T12:58:35.515928593Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:56.716139526Z",
+      "updatedAt": "2020-10-03T12:58:42.778326546Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:56.716139526Z",
+          "date": "2020-10-03T12:58:42.778326546Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:55.870710573Z",
-    "dir_id": "a5f50206697951be5992df4a0555f659",
+    "created_at": "2020-09-03T14:58:35Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7c778",
     "name": "dir1",
     "path": "/dir2/dir1",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:55.870710573Z"
+    "updated_at": "2020-09-03T14:58:35Z"
   }
 ]

--- a/test/scenarios/move_dir_parent_and_child/remote/changes.json
+++ b/test/scenarios/move_dir_parent_and_child/remote/changes.json
@@ -1,148 +1,148 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a055607c4",
-    "_rev": "2-fde359aac189297eadec4881dab92674",
+    "_id": "b6f32dd442095bfe2c3639f240d7d122",
+    "_rev": "2-704351219d40a425d7e4ee708191354c",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:57.031420191Z",
+      "createdAt": "2020-10-03T12:58:43.045115655Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:58.131742762Z",
+      "updatedAt": "2020-10-03T12:58:51.371051737Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:58.131742762Z",
+          "date": "2020-10-03T12:58:51.371051737Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:57.031413722Z",
-    "dir_id": "a5f50206697951be5992df4a0555fa7a",
+    "created_at": "2020-09-03T14:58:43Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7cb08",
     "name": "dst",
     "path": "/parent/dst",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:57.031413722Z"
+    "updated_at": "2020-09-03T14:58:43Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05561557",
-    "_rev": "3-310bb166225288b8479b7aea5b1c3455",
+    "_id": "b6f32dd442095bfe2c3639f240d7e775",
+    "_rev": "3-162153c709df853867dfacaa96488486",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:57.231746652Z",
+      "createdAt": "2020-10-03T12:58:43.111577872Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:57.231746652Z",
+      "updatedAt": "2020-10-03T12:58:43.111577872Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:57.231746652Z",
+          "date": "2020-10-03T12:58:43.111577872Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:57.231740991Z",
-    "dir_id": "a5f50206697951be5992df4a055608d2",
+    "created_at": "2020-09-03T14:58:43Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7db98",
     "name": "empty-subdir",
     "path": "/parent/dst/dir2/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:57.231740991Z"
+    "updated_at": "2020-09-03T14:58:43Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0556186b",
-    "_rev": "3-4f41d7ecf688af1e0f698c13baf84cdc",
+    "_id": "b6f32dd442095bfe2c3639f240d7efad",
+    "_rev": "3-d31b35e3158460bdcbb658ce5733d5f7",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:57.377173616Z",
+      "createdAt": "2020-10-03T12:58:43.147553871Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:57.377173616Z",
+      "updatedAt": "2020-10-03T12:58:43.147553871Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:57.377173616Z",
+          "date": "2020-10-03T12:58:43.147553871Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:57.37716683Z",
-    "dir_id": "a5f50206697951be5992df4a055608d2",
+    "created_at": "2020-09-03T14:58:43Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7db98",
     "name": "subdir",
     "path": "/parent/dst/dir2/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:57.37716683Z"
+    "updated_at": "2020-09-03T14:58:43Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a055608d2",
-    "_rev": "3-0d826a7ef69c1637c4c0b2ea1f98cc3e",
+    "_id": "b6f32dd442095bfe2c3639f240d7db98",
+    "_rev": "3-6b2f15e24d173d37e7fdefbaf8d20628",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:57.122772551Z",
+      "createdAt": "2020-10-03T12:58:43.06860534Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:58.215361437Z",
+      "updatedAt": "2020-10-03T12:58:51.458402039Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:58.215361437Z",
+          "date": "2020-10-03T12:58:51.458402039Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:57.122766024Z",
-    "dir_id": "a5f50206697951be5992df4a055607c4",
+    "created_at": "2020-09-03T14:58:43Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7d122",
     "name": "dir2",
     "path": "/parent/dst/dir2",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:57.122766024Z"
+    "updated_at": "2020-09-03T14:58:43Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05562001",
-    "_rev": "2-37229e04e6cd2788eac651118c7b3a6f",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d7f468",
+    "_rev": "2-9af07941aa20a8bd3f6946376545975a",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:57.42162658Z",
+      "createdAt": "2020-10-03T12:58:43.181511747Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:58.317915495Z",
+      "updatedAt": "2020-10-03T12:58:51.62186488Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:58.317915495Z",
+          "date": "2020-10-03T12:58:51.62186488Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:37:57.42162658Z",
+      "uploadedAt": "2020-10-03T12:58:43.181511747Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:37:57.421618604Z",
-    "dir_id": "a5f50206697951be5992df4a0556186b",
+    "created_at": "2020-09-03T14:58:43Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7efad",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file2",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:37:57.421618604Z",
+    "updated_at": "2020-09-03T14:58:43Z",
     "path": "/parent/dst/dir2/subdir/file2"
   }
 ]

--- a/test/scenarios/move_dir_reversed_events/remote/changes.json
+++ b/test/scenarios/move_dir_reversed_events/remote/changes.json
@@ -1,28 +1,28 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a055634c3",
-    "_rev": "2-aa3c7bbb35020979f71563de7561ca0b",
+    "_id": "b6f32dd442095bfe2c3639f240d81b2c",
+    "_rev": "2-e6203061c8f042ee7ab8b604e406d318",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:37:58.772622778Z",
+      "createdAt": "2020-10-03T12:58:51.972637424Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:37:59.577250786Z",
+      "updatedAt": "2020-10-03T12:59:01.301737907Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:37:59.577250786Z",
+          "date": "2020-10-03T12:59:01.301737907Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:37:58.772615367Z",
-    "dir_id": "a5f50206697951be5992df4a055625b4",
+    "created_at": "2020-09-03T14:58:51Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d7fecf",
     "name": "dir",
     "path": "/dst/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:37:58.772615367Z"
+    "updated_at": "2020-09-03T14:58:51Z"
   }
 ]

--- a/test/scenarios/move_dir_successive_same_level/remote/changes.json
+++ b/test/scenarios/move_dir_successive_same_level/remote/changes.json
@@ -1,80 +1,80 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05567614",
-    "_rev": "3-41c65ec44bf1b278a78a42c0e12f8451",
+    "_id": "b6f32dd442095bfe2c3639f240d847fa",
+    "_rev": "3-3b9838fef7877a44bd0b422552341c16",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:00.628105832Z",
+      "createdAt": "2020-10-03T12:59:01.694446735Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:00.628105832Z",
+      "updatedAt": "2020-10-03T12:59:01.694446735Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:00.628105832Z",
+          "date": "2020-10-03T12:59:01.694446735Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:00.6280976Z",
-    "dir_id": "a5f50206697951be5992df4a05566e6b",
+    "created_at": "2020-09-03T14:59:01Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d83ce3",
     "name": "empty-subdir",
     "path": "/parent/dst2/dir/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:00.6280976Z"
+    "updated_at": "2020-09-03T14:59:01Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a055679e5",
-    "_rev": "3-2615ae0a0acf4f9c9b2c1cd2e26c0cb1",
+    "_id": "b6f32dd442095bfe2c3639f240d8539d",
+    "_rev": "3-6423a9ec8d4621265d84a8f52dbe05b5",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:00.892015423Z",
+      "createdAt": "2020-10-03T12:59:01.715973705Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:00.892015423Z",
+      "updatedAt": "2020-10-03T12:59:01.715973705Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:00.892015423Z",
+          "date": "2020-10-03T12:59:01.715973705Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:00.892007644Z",
-    "dir_id": "a5f50206697951be5992df4a05566e6b",
+    "created_at": "2020-09-03T14:59:01Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d83ce3",
     "name": "subdir",
     "path": "/parent/dst2/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:00.892007644Z"
+    "updated_at": "2020-09-03T14:59:01Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05566e6b",
-    "_rev": "3-880577504c1e508e31815585b098494b",
+    "_id": "b6f32dd442095bfe2c3639f240d83ce3",
+    "_rev": "3-969d81eafb9fcca83d03129bca029883",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:00.471225445Z",
+      "createdAt": "2020-10-03T12:59:01.667793899Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:02.110240397Z",
+      "updatedAt": "2020-10-03T12:59:09.607106867Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:02.110240397Z",
+          "date": "2020-10-03T12:59:09.607106867Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:00.471215241Z",
-    "dir_id": "a5f50206697951be5992df4a05565633",
+    "created_at": "2020-09-03T14:59:01Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d82e21",
     "name": "dir",
     "path": "/parent/dst2/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:00.471215241Z"
+    "updated_at": "2020-09-03T14:59:01Z"
   }
 ]

--- a/test/scenarios/move_dir_successive_with_delay/remote/changes.json
+++ b/test/scenarios/move_dir_successive_with_delay/remote/changes.json
@@ -1,80 +1,80 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0556a20b",
-    "_rev": "3-96d179d01e26fccafcf07d8a6365de00",
+    "_id": "b6f32dd442095bfe2c3639f240d89022",
+    "_rev": "3-740a2ce8504a195fc049da49fd529ef6",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:04.957886273Z",
+      "createdAt": "2020-10-03T12:59:10.218697335Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:04.957886273Z",
+      "updatedAt": "2020-10-03T12:59:10.218697335Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:04.957886273Z",
+          "date": "2020-10-03T12:59:10.218697335Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:04.957877434Z",
-    "dir_id": "a5f50206697951be5992df4a05569547",
+    "created_at": "2020-09-03T14:59:10Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d881ba",
     "name": "empty-subdir",
     "path": "/parent/dst2/dir/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:04.957877434Z"
+    "updated_at": "2020-09-03T14:59:10Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0556a8af",
-    "_rev": "3-ebb166eb71659d5c3c82d158bcfead96",
+    "_id": "b6f32dd442095bfe2c3639f240d891ba",
+    "_rev": "3-960c48185a633778c842bbf1e40b9265",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:05.056859591Z",
+      "createdAt": "2020-10-03T12:59:10.25443986Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:05.056859591Z",
+      "updatedAt": "2020-10-03T12:59:10.25443986Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:05.056859591Z",
+          "date": "2020-10-03T12:59:10.25443986Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:05.056854215Z",
-    "dir_id": "a5f50206697951be5992df4a05569547",
+    "created_at": "2020-09-03T14:59:10Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d881ba",
     "name": "subdir",
     "path": "/parent/dst2/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:05.056854215Z"
+    "updated_at": "2020-09-03T14:59:10Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05569547",
-    "_rev": "3-eb0cb3c43436e2fb5b15687944b80f58",
+    "_id": "b6f32dd442095bfe2c3639f240d881ba",
+    "_rev": "3-644668be31fde42b66ef1a867eed33e3",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:03.98686749Z",
+      "createdAt": "2020-10-03T12:59:10.193337299Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:06.910699366Z",
+      "updatedAt": "2020-10-03T12:59:18.737512445Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:06.910699366Z",
+          "date": "2020-10-03T12:59:18.737512445Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:03.986862491Z",
-    "dir_id": "a5f50206697951be5992df4a055686a4",
+    "created_at": "2020-09-03T14:59:10Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d87b09",
     "name": "dir",
     "path": "/parent/dst2/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:03.986862491Z"
+    "updated_at": "2020-09-03T14:59:10Z"
   }
 ]

--- a/test/scenarios/move_dir_with_content/remote/changes.json
+++ b/test/scenarios/move_dir_with_content/remote/changes.json
@@ -1,80 +1,80 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0556d136",
-    "_rev": "2-25f7d2833cca115d05db3618d3e6f601",
+    "_id": "b6f32dd442095bfe2c3639f240d8ac95",
+    "_rev": "2-ef98813c4c263fb9d2b87891de94654f",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:08.179637284Z",
+      "createdAt": "2020-10-03T12:59:19.155478001Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:08.179637284Z",
+      "updatedAt": "2020-10-03T12:59:19.155478001Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:08.179637284Z",
+          "date": "2020-10-03T12:59:19.155478001Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:08.17963132Z",
-    "dir_id": "a5f50206697951be5992df4a0556c57c",
+    "created_at": "2020-09-03T14:59:19Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8a51d",
     "name": "empty-subdir",
     "path": "/parent/dst/dir/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:08.17963132Z"
+    "updated_at": "2020-09-03T14:59:19Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0556dd9b",
-    "_rev": "2-89bd20eaaf0bbae3a69a23dcfb622be2",
+    "_id": "b6f32dd442095bfe2c3639f240d8b4bc",
+    "_rev": "2-8ff90c7820a7aa0e603aab131450cfc5",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:08.307223076Z",
+      "createdAt": "2020-10-03T12:59:19.192165157Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:08.307223076Z",
+      "updatedAt": "2020-10-03T12:59:19.192165157Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:08.307223076Z",
+          "date": "2020-10-03T12:59:19.192165157Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:08.307217463Z",
-    "dir_id": "a5f50206697951be5992df4a0556c57c",
+    "created_at": "2020-09-03T14:59:19Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8a51d",
     "name": "subdir",
     "path": "/parent/dst/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:08.307217463Z"
+    "updated_at": "2020-09-03T14:59:19Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0556c57c",
-    "_rev": "2-07c6ff39bbc09ea001de0999c9b377fe",
+    "_id": "b6f32dd442095bfe2c3639f240d8a51d",
+    "_rev": "2-ae245eb961c908d6ef3cabd1b9acdaee",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:08.071711445Z",
+      "createdAt": "2020-10-03T12:59:19.12488365Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:09.059895655Z",
+      "updatedAt": "2020-10-03T12:59:26.739028255Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:09.059895655Z",
+          "date": "2020-10-03T12:59:26.739028255Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:08.071706462Z",
-    "dir_id": "a5f50206697951be5992df4a0556c0de",
+    "created_at": "2020-09-03T14:59:19Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8a140",
     "name": "dir",
     "path": "/parent/dst/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:08.071706462Z"
+    "updated_at": "2020-09-03T14:59:19Z"
   }
 ]

--- a/test/scenarios/move_file/remote/changes.json
+++ b/test/scenarios/move_file/remote/changes.json
@@ -1,44 +1,44 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0557ba77",
-    "_rev": "2-2f06740222b8e98c76cfb0a4a36ea8cb",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d96d17",
+    "_rev": "2-e5bfbffe362e0afdb2b0d8e79cf3d91f",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:25.782443787Z",
+      "createdAt": "2020-10-03T13:00:14.366000905Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:26.737343524Z",
+      "updatedAt": "2020-10-03T13:00:21.759568204Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:26.737343524Z",
+          "date": "2020-10-03T13:00:21.759568204Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:25.782443787Z",
+      "uploadedAt": "2020-10-03T13:00:14.366000905Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:25.782438336Z",
-    "dir_id": "a5f50206697951be5992df4a0557a539",
+    "created_at": "2020-09-03T15:00:14Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d95457",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:25.782438336Z",
+    "updated_at": "2020-09-03T15:00:14Z",
     "path": "/dst/file"
   }
 ]

--- a/test/scenarios/move_file_a_to_b_to_c_to_b/remote/changes.json
+++ b/test/scenarios/move_file_a_to_b_to_c_to_b/remote/changes.json
@@ -1,44 +1,44 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0556f6ff",
-    "_rev": "4-3410da3839d8dab5407efa9174988178",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d8d7a6",
+    "_rev": "4-dadf8323edddd1b40a734d4927259433",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:09.453839536Z",
+      "createdAt": "2020-10-03T12:59:27.035733397Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:13.566541398Z",
+      "updatedAt": "2020-10-03T12:59:38.215491248Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:13.566541398Z",
+          "date": "2020-10-03T12:59:38.215491248Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:09.453839536Z",
+      "uploadedAt": "2020-10-03T12:59:27.035733397Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:09.453835165Z",
-    "dir_id": "a5f50206697951be5992df4a0556f210",
+    "created_at": "2020-09-03T14:59:27Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8d067",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "B",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:09.453835165Z",
+    "updated_at": "2020-09-03T14:59:27Z",
     "path": "/src/B"
   }
 ]

--- a/test/scenarios/move_file_inside_move/remote/changes.json
+++ b/test/scenarios/move_file_inside_move/remote/changes.json
@@ -1,164 +1,164 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0557345c",
-    "_rev": "2-38503330d12cec2f25f50c50745351fd",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d9049b",
+    "_rev": "2-6583ad1197650f4e544da2a1634805aa",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:16.239335644Z",
+      "createdAt": "2020-10-03T12:59:40.130492604Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:17.440554629Z",
+      "updatedAt": "2020-10-03T12:59:46.983428214Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:17.440554629Z",
+          "date": "2020-10-03T12:59:46.983428214Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:16.239335644Z",
+      "uploadedAt": "2020-10-03T12:59:40.130492604Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:16.23932761Z",
-    "dir_id": "a5f50206697951be5992df4a05572781",
+    "created_at": "2020-09-03T14:59:40Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8ff93",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "filerenamed",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:16.23932761Z",
+    "updated_at": "2020-09-03T14:59:40Z",
     "path": "/parent/dst/dir/subdir/filerenamed"
   },
   {
-    "_id": "a5f50206697951be5992df4a05572761",
-    "_rev": "2-2d543e54f28a12e092cf4009f4a11b4f",
+    "_id": "b6f32dd442095bfe2c3639f240d8fa97",
+    "_rev": "2-a4f330553c58a037ec572d50452ea2b8",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:16.00647014Z",
+      "createdAt": "2020-10-03T12:59:40.08741172Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:16.00647014Z",
+      "updatedAt": "2020-10-03T12:59:40.08741172Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:16.00647014Z",
+          "date": "2020-10-03T12:59:40.08741172Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:16.006458302Z",
-    "dir_id": "a5f50206697951be5992df4a05571a2b",
+    "created_at": "2020-09-03T14:59:40Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8f5d6",
     "name": "empty-subdir",
     "path": "/parent/dst/dir/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:16.006458302Z"
+    "updated_at": "2020-09-03T14:59:40Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05572781",
-    "_rev": "2-a78444161d8e5956fafd1eb64e5802f3",
+    "_id": "b6f32dd442095bfe2c3639f240d8ff93",
+    "_rev": "2-20b15d4a487ed2e3a01055517c00fdf8",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:16.176332145Z",
+      "createdAt": "2020-10-03T12:59:40.110089387Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:16.176332145Z",
+      "updatedAt": "2020-10-03T12:59:40.110089387Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:16.176332145Z",
+          "date": "2020-10-03T12:59:40.110089387Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:16.176326957Z",
-    "dir_id": "a5f50206697951be5992df4a05571a2b",
+    "created_at": "2020-09-03T14:59:40Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8f5d6",
     "name": "subdir",
     "path": "/parent/dst/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:16.176326957Z"
+    "updated_at": "2020-09-03T14:59:40Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05571a2b",
-    "_rev": "2-1b1773c04f1fa748ca7abad9c3c95b56",
+    "_id": "b6f32dd442095bfe2c3639f240d8f5d6",
+    "_rev": "2-fa08394750487625b91a9995b3924e0e",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:15.847645298Z",
+      "createdAt": "2020-10-03T12:59:40.063395674Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:17.525057155Z",
+      "updatedAt": "2020-10-03T12:59:47.041525075Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:17.525057155Z",
+          "date": "2020-10-03T12:59:47.041525075Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:15.84763535Z",
-    "dir_id": "a5f50206697951be5992df4a0557098f",
+    "created_at": "2020-09-03T14:59:40Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8eb3a",
     "name": "dir",
     "path": "/parent/dst/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:15.84763535Z"
+    "updated_at": "2020-09-03T14:59:40Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a055741d9",
-    "_rev": "2-82bc9162de901ab456514f7dd32424d3",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d904ff",
+    "_rev": "2-45e5cc1fda705dbc527d51edef0084cf",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:16.383702059Z",
+      "createdAt": "2020-10-03T12:59:40.202676647Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:17.627236821Z",
+      "updatedAt": "2020-10-03T12:59:47.119715644Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:17.627236821Z",
+          "date": "2020-10-03T12:59:47.119715644Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:16.383702059Z",
+      "uploadedAt": "2020-10-03T12:59:40.202676647Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:16.383691831Z",
-    "dir_id": "a5f50206697951be5992df4a05572781",
+    "created_at": "2020-09-03T14:59:40Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d8ff93",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "filerenamed2",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:16.383691831Z",
+    "updated_at": "2020-09-03T14:59:40Z",
     "path": "/parent/dst/dir/subdir/filerenamed2"
   }
 ]

--- a/test/scenarios/move_file_reversed_events/remote/changes.json
+++ b/test/scenarios/move_file_reversed_events/remote/changes.json
@@ -1,44 +1,44 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05576227",
-    "_rev": "2-8dfd1b04c3926e24b92be1aa6428a2e2",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d91b9d",
+    "_rev": "2-fec2a4a3b9a058aae1e39328827a2c6f",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:18.120475081Z",
+      "createdAt": "2020-10-03T12:59:47.472365141Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:19.362433871Z",
+      "updatedAt": "2020-10-03T12:59:55.041672475Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:19.362433871Z",
+          "date": "2020-10-03T12:59:55.041672475Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:18.120475081Z",
+      "uploadedAt": "2020-10-03T12:59:47.472365141Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:18.120467628Z",
-    "dir_id": "a5f50206697951be5992df4a05574548",
+    "created_at": "2020-09-03T14:59:47Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d907ad",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:18.120467628Z",
+    "updated_at": "2020-09-03T14:59:47Z",
     "path": "/dst/file"
   }
 ]

--- a/test/scenarios/move_file_successive/remote/changes.json
+++ b/test/scenarios/move_file_successive/remote/changes.json
@@ -1,44 +1,44 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05579f38",
-    "_rev": "3-26c5c46c500ec2027c08e8f540ca65e2",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d94d58",
+    "_rev": "3-78b832383eeedee86e5c2da8db1678fd",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:22.763881032Z",
+      "createdAt": "2020-10-03T13:00:05.141144794Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:25.341827912Z",
+      "updatedAt": "2020-10-03T13:00:14.019526605Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:25.341827912Z",
+          "date": "2020-10-03T13:00:14.019526605Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:22.763881032Z",
+      "uploadedAt": "2020-10-03T13:00:05.141144794Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:22.763874543Z",
-    "dir_id": "a5f50206697951be5992df4a05579179",
+    "created_at": "2020-09-03T15:00:05Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d945e2",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:22.763874543Z",
+    "updated_at": "2020-09-03T15:00:05Z",
     "path": "/dst2/file"
   }
 ]

--- a/test/scenarios/move_file_successive_2/remote/changes.json
+++ b/test/scenarios/move_file_successive_2/remote/changes.json
@@ -1,44 +1,44 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0557852e",
-    "_rev": "3-58956f1cea041e9ee85252d0bb4a7705",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d93e66",
+    "_rev": "3-b6a27d983db09ee1da9a0576f6623c19",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:19.793195892Z",
+      "createdAt": "2020-10-03T12:59:55.396172016Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:22.16936355Z",
+      "updatedAt": "2020-10-03T13:00:04.618362435Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:22.16936355Z",
+          "date": "2020-10-03T13:00:04.618362435Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:19.793195892Z",
+      "uploadedAt": "2020-10-03T12:59:55.396172016Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:19.793187266Z",
-    "dir_id": "a5f50206697951be5992df4a05576cce",
+    "created_at": "2020-09-03T14:59:55Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d92cdb",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:19.793187266Z",
+    "updated_at": "2020-09-03T14:59:55Z",
     "path": "/dst2/file"
   }
 ]

--- a/test/scenarios/move_files_a_to_c_and_b_to_a/remote/changes.json
+++ b/test/scenarios/move_files_a_to_c_and_b_to_a/remote/changes.json
@@ -1,86 +1,86 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0557c19f",
-    "_rev": "2-238a2c3ea1a3c9b990d278c5e998ca0d",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d96db7",
+    "_rev": "2-ca065acf50b63e9f225fa06db5cf071a",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:27.013826708Z",
+      "createdAt": "2020-10-03T13:00:22.067899701Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:27.922515961Z",
+      "updatedAt": "2020-10-03T13:00:29.713761413Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:27.922515961Z",
+          "date": "2020-10-03T13:00:29.713761413Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:27.013826708Z",
+      "uploadedAt": "2020-10-03T13:00:22.067899701Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:27.013819525Z",
+    "created_at": "2020-09-03T15:00:22Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "2BFLNhiF7lSJflLOIwjidA==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "c",
     "size": "9",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:27.013819525Z",
+    "updated_at": "2020-09-03T15:00:22Z",
     "path": "/c"
   },
   {
-    "_id": "a5f50206697951be5992df4a0557c99f",
-    "_rev": "2-dde291de1752b2347903233a8a0189da",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d97255",
+    "_rev": "2-95444d3ca45fa3715aa60e8286391852",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:27.066840704Z",
+      "createdAt": "2020-10-03T13:00:22.11201078Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:29.522695832Z",
+      "updatedAt": "2020-10-03T13:00:31.288314923Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:29.522695832Z",
+          "date": "2020-10-03T13:00:31.288314923Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:27.066840704Z",
+      "uploadedAt": "2020-10-03T13:00:22.11201078Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:27.06683423Z",
+    "created_at": "2020-09-03T15:00:22Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "zU5qwNTiTHAqtGmltep7LA==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "a",
     "size": "9",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:27.06683423Z",
+    "updated_at": "2020-09-03T15:00:22Z",
     "path": "/a"
   }
 ]

--- a/test/scenarios/move_from_inside_move/remote/changes.json
+++ b/test/scenarios/move_from_inside_move/remote/changes.json
@@ -1,80 +1,80 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a055806cd",
-    "_rev": "2-ec01703ee712e4838a7718265ecb6e1c",
+    "_id": "b6f32dd442095bfe2c3639f240d9aaaa",
+    "_rev": "2-950126fa0f7a18306ce47e0060593f5f",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:30.382243292Z",
+      "createdAt": "2020-10-03T13:00:31.591637605Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:30.382243292Z",
+      "updatedAt": "2020-10-03T13:00:31.591637605Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:30.382243292Z",
+          "date": "2020-10-03T13:00:31.591637605Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:30.382222101Z",
-    "dir_id": "a5f50206697951be5992df4a0557f850",
+    "created_at": "2020-09-03T15:00:31Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d99cce",
     "name": "empty-subdir",
     "path": "/parent/dst/dir/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:30.382222101Z"
+    "updated_at": "2020-09-03T15:00:31Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0557f850",
-    "_rev": "2-800c9ebee9a57342305507a4e049b915",
+    "_id": "b6f32dd442095bfe2c3639f240d99cce",
+    "_rev": "2-4764af5fdfdc71964ca24ae1025d1046",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:30.227951303Z",
+      "createdAt": "2020-10-03T13:00:31.569319834Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:31.406224123Z",
+      "updatedAt": "2020-10-03T13:00:38.801368294Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:31.406224123Z",
+          "date": "2020-10-03T13:00:38.801368294Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:30.227943259Z",
-    "dir_id": "a5f50206697951be5992df4a0557daa3",
+    "created_at": "2020-09-03T15:00:31Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d98524",
     "name": "dir",
     "path": "/parent/dst/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:30.227943259Z"
+    "updated_at": "2020-09-03T15:00:31Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0558114a",
-    "_rev": "3-a0b529347f938d281c020d3d07bda07c",
+    "_id": "b6f32dd442095bfe2c3639f240d9ac9b",
+    "_rev": "3-4cefafbdb29668e0e0599599f8545c2a",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:30.507982595Z",
+      "createdAt": "2020-10-03T13:00:31.612696125Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:31.516602547Z",
+      "updatedAt": "2020-10-03T13:00:38.884197995Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:31.516602547Z",
+          "date": "2020-10-03T13:00:38.884197995Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:30.507972435Z",
-    "dir_id": "a5f50206697951be5992df4a0557dd74",
+    "created_at": "2020-09-03T15:00:31Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d991b7",
     "name": "subdir",
     "path": "/parent/dst2/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:30.507972435Z"
+    "updated_at": "2020-09-03T15:00:31Z"
   }
 ]

--- a/test/scenarios/move_overwriting_dir/trashed_first/remote/changes.json
+++ b/test/scenarios/move_overwriting_dir/trashed_first/remote/changes.json
@@ -1,301 +1,301 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05582a30",
-    "_rev": "2-8a9463cfff271f9047c96b6964d9fb0f",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d9dbec",
+    "_rev": "2-48625f1c1e4a3a2cb1a6dad6cb69030e",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.13804409Z",
+      "createdAt": "2020-10-03T13:00:39.245494554Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.13804409Z",
+      "updatedAt": "2020-10-03T13:00:39.245494554Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.13804409Z",
+          "date": "2020-10-03T13:00:39.245494554Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:32.13804409Z",
+      "uploadedAt": "2020-10-03T13:00:39.245494554Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:32.138032082Z",
-    "dir_id": "a5f50206697951be5992df4a05581f73",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d9c065",
     "executable": false,
     "md5sum": "UJ/0v/8wp3EDqsNAaOpGxw==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "11",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:32.138032082Z",
+    "updated_at": "2020-09-03T15:00:39Z",
     "path": "/.cozy_trash/dir/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a05582ad6",
-    "_rev": "2-21bfd5ed825a474b7a0c110a2063c74a",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d9e2ad",
+    "_rev": "2-6b17b87b24f4ab0b786cd207b821aa5f",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.194697562Z",
+      "createdAt": "2020-10-03T13:00:39.31439444Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.194697562Z",
+      "updatedAt": "2020-10-03T13:00:39.31439444Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.194697562Z",
+          "date": "2020-10-03T13:00:39.31439444Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:32.194697562Z",
+      "uploadedAt": "2020-10-03T13:00:39.31439444Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:32.194691711Z",
-    "dir_id": "a5f50206697951be5992df4a05581f73",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d9c065",
     "executable": false,
     "md5sum": "ndnQzRrbboul79N7msmEuw==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file3",
     "size": "15",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:32.194691711Z",
+    "updated_at": "2020-09-03T15:00:39Z",
     "path": "/.cozy_trash/dir/file3"
   },
   {
-    "_id": "a5f50206697951be5992df4a05583919",
-    "_rev": "2-f654c1e496c67fabfdf0b072510423c2",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d9f0a9",
+    "_rev": "2-78b3951515a1830f8b496989a7233356",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.245084561Z",
+      "createdAt": "2020-10-03T13:00:39.372224088Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.245084561Z",
+      "updatedAt": "2020-10-03T13:00:39.372224088Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.245084561Z",
+          "date": "2020-10-03T13:00:39.372224088Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:32.245084561Z",
+      "uploadedAt": "2020-10-03T13:00:39.372224088Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:32.245078382Z",
-    "dir_id": "a5f50206697951be5992df4a0558226f",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d9cefb",
     "executable": false,
     "md5sum": "jU4Y6A/2fBDWG1mL0zm3rA==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "15",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:32.245078382Z",
+    "updated_at": "2020-09-03T15:00:39Z",
     "path": "/.cozy_trash/dir/subdir/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a055843df",
-    "_rev": "2-0a4834e3a4cba1b41adf05b81cce293a",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240d9fbc9",
+    "_rev": "2-1008cc9ca87e266de4087202de4417e3",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.299739623Z",
+      "createdAt": "2020-10-03T13:00:39.423209937Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.299739623Z",
+      "updatedAt": "2020-10-03T13:00:39.423209937Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.299739623Z",
+          "date": "2020-10-03T13:00:39.423209937Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:32.299739623Z",
+      "uploadedAt": "2020-10-03T13:00:39.423209937Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:32.299733544Z",
-    "dir_id": "a5f50206697951be5992df4a0558226f",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d9cefb",
     "executable": false,
     "md5sum": "54jxLOxUQw8Pi+OCwdYnSA==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file5",
     "size": "19",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:32.299733544Z",
+    "updated_at": "2020-09-03T15:00:39Z",
     "path": "/.cozy_trash/dir/subdir/file5"
   },
   {
-    "_id": "a5f50206697951be5992df4a0558226f",
-    "_rev": "2-c6f8a53e530522dc10207d36b0747934",
+    "_id": "b6f32dd442095bfe2c3639f240d9cefb",
+    "_rev": "2-f63da3f06aee679d77fea0ad0513332b",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.096128642Z",
+      "createdAt": "2020-10-03T13:00:39.210506558Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.096128642Z",
+      "updatedAt": "2020-10-03T13:00:39.210506558Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.096128642Z",
+          "date": "2020-10-03T13:00:39.210506558Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:32.09612289Z",
-    "dir_id": "a5f50206697951be5992df4a05581f73",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d9c065",
     "name": "subdir",
     "path": "/.cozy_trash/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:32.09612289Z"
+    "updated_at": "2020-09-03T15:00:39Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05581f73",
-    "_rev": "2-b23e2f9a2f9ad0dc717d779bc294fe08",
+    "_id": "b6f32dd442095bfe2c3639f240d9c065",
+    "_rev": "2-3242d81cb0ad1b64e517d6f54f6f55a3",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.010397858Z",
+      "createdAt": "2020-10-03T13:00:39.181542001Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:33.726212516Z",
+      "updatedAt": "2020-10-03T13:00:47.333794174Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:33.726212516Z",
+          "date": "2020-10-03T13:00:47.333794174Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:32.010391337Z",
+    "created_at": "2020-09-03T15:00:39Z",
     "dir_id": "io.cozy.files.trash-dir",
     "name": "dir",
     "path": "/.cozy_trash/dir",
     "restore_path": "/dst",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:32.010391337Z"
+    "updated_at": "2020-09-03T15:00:39Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05586755",
-    "_rev": "2-316974383e27931090cbfdde5440a3e8",
+    "_id": "b6f32dd442095bfe2c3639f240da1189",
+    "_rev": "2-a38c5525e1b2dab8b9ece087d643af90",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.572760532Z",
+      "createdAt": "2020-10-03T13:00:39.518194908Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.572760532Z",
+      "updatedAt": "2020-10-03T13:00:39.518194908Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.572760532Z",
+          "date": "2020-10-03T13:00:39.518194908Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:32.572749232Z",
-    "dir_id": "a5f50206697951be5992df4a05585e3d",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da1004",
     "name": "subdir",
     "path": "/dst/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:32.572749232Z"
+    "updated_at": "2020-09-03T15:00:39Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a055889e3",
-    "_rev": "2-c9ac17fbcd3229811fa2814a2920bc5d",
+    "_id": "b6f32dd442095bfe2c3639f240da3586",
+    "_rev": "2-875c0c5390ccf5e32751890ce11c6609",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.897426712Z",
+      "createdAt": "2020-10-03T13:00:39.746605331Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:32.897426712Z",
+      "updatedAt": "2020-10-03T13:00:39.746605331Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:32.897426712Z",
+          "date": "2020-10-03T13:00:39.746605331Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:32.897420908Z",
-    "dir_id": "a5f50206697951be5992df4a05586755",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da1189",
     "name": "subsub",
     "path": "/dst/dir/subdir/subsub",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:32.897420908Z"
+    "updated_at": "2020-09-03T15:00:39Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05585e3d",
-    "_rev": "2-172c7fd480404e5b63f3f771e38fc929",
+    "_id": "b6f32dd442095bfe2c3639f240da1004",
+    "_rev": "2-498963a1dd06f662f68cfe74890e5247",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:32.479903873Z",
+      "createdAt": "2020-10-03T13:00:39.493995137Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:33.83935079Z",
+      "updatedAt": "2020-10-03T13:00:47.41997183Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:33.83935079Z",
+          "date": "2020-10-03T13:00:47.41997183Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:32.4798988Z",
-    "dir_id": "a5f50206697951be5992df4a05581f2d",
+    "created_at": "2020-09-03T15:00:39Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240d9b965",
     "name": "dir",
     "path": "/dst/dir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:32.4798988Z"
+    "updated_at": "2020-09-03T15:00:39Z"
   }
 ]

--- a/test/scenarios/move_overwriting_file/trashed_first/remote/changes.json
+++ b/test/scenarios/move_overwriting_file/trashed_first/remote/changes.json
@@ -1,87 +1,87 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05589a84",
-    "_rev": "2-1ee9f61285478a04d418bc90e1a8217b",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240da3f3e",
+    "_rev": "2-c6203fda606adac3a3bde93f37dab21f",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:34.268596076Z",
+      "createdAt": "2020-10-03T13:00:47.781067863Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:35.243226108Z",
+      "updatedAt": "2020-10-03T13:00:55.326804613Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:35.243226108Z",
+          "date": "2020-10-03T13:00:55.326804613Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:34.268596076Z",
+      "uploadedAt": "2020-10-03T13:00:47.781067863Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:34.268591866Z",
+    "created_at": "2020-09-03T15:00:47Z",
     "dir_id": "io.cozy.files.trash-dir",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "restore_path": "/dst",
     "size": "8",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:34.268591866Z",
+    "updated_at": "2020-09-03T15:00:47Z",
     "path": "/.cozy_trash/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a0558a71b",
-    "_rev": "2-ff31dc2dea8a0ca69585ffcdedcf44d5",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240da56da",
+    "_rev": "2-37497fe0f03fc377c9e8f9127911fec8",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:34.414153524Z",
+      "createdAt": "2020-10-03T13:00:47.853575138Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:35.269493763Z",
+      "updatedAt": "2020-10-03T13:00:55.355053437Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:35.269493763Z",
+          "date": "2020-10-03T13:00:55.355053437Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:34.414153524Z",
+      "uploadedAt": "2020-10-03T13:00:47.853575138Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:34.414147233Z",
-    "dir_id": "a5f50206697951be5992df4a05588c51",
+    "created_at": "2020-09-03T15:00:47Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da38b3",
     "executable": false,
     "md5sum": "R3OzgnleJa90MA+cEwOYew==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "11",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:34.414147233Z",
+    "updated_at": "2020-09-03T15:00:47Z",
     "path": "/dst/file"
   }
 ]

--- a/test/scenarios/move_two_dirs/remote/changes.json
+++ b/test/scenarios/move_two_dirs/remote/changes.json
@@ -1,54 +1,54 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0558d153",
-    "_rev": "2-26166238167ae7951c4b396ec46ac041",
+    "_id": "b6f32dd442095bfe2c3639f240da8e61",
+    "_rev": "2-8fea2c2b7a284e577b0e80471575657a",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:39.689443795Z",
+      "createdAt": "2020-10-03T13:01:05.302691695Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:40.755769266Z",
+      "updatedAt": "2020-10-03T13:01:12.61133301Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:40.755769266Z",
+          "date": "2020-10-03T13:01:12.61133301Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:39.689436773Z",
-    "dir_id": "a5f50206697951be5992df4a0558de57",
+    "created_at": "2020-09-03T15:01:05Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da9fd6",
     "name": "dir1",
     "path": "/dst/dir1",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:39.689436773Z"
+    "updated_at": "2020-09-03T15:01:05Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0558da2f",
-    "_rev": "2-481724b4e1ee7bf6da6d097b050a1bdc",
+    "_id": "b6f32dd442095bfe2c3639f240da9c33",
+    "_rev": "2-1781dc79ade9e7481308945a5809542d",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:39.760999149Z",
+      "createdAt": "2020-10-03T13:01:05.325598003Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:42.346426701Z",
+      "updatedAt": "2020-10-03T13:01:14.192510917Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:42.346426701Z",
+          "date": "2020-10-03T13:01:14.192510917Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:39.76099491Z",
-    "dir_id": "a5f50206697951be5992df4a0558de57",
+    "created_at": "2020-09-03T15:01:05Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da9fd6",
     "name": "dir2",
     "path": "/dst/dir2",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:39.76099491Z"
+    "updated_at": "2020-09-03T15:01:05Z"
   }
 ]

--- a/test/scenarios/move_two_dirs_same_prefix/remote/changes.json
+++ b/test/scenarios/move_two_dirs_same_prefix/remote/changes.json
@@ -1,54 +1,54 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0558b94f",
-    "_rev": "2-ae2f61c5d723bfbc675e4157a5c164d3",
+    "_id": "b6f32dd442095bfe2c3639f240da65c5",
+    "_rev": "2-ee9a4fb9eb9bdc8f81da15d7247d12b7",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:35.691398432Z",
+      "createdAt": "2020-10-03T13:00:55.774410867Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:37.697672255Z",
+      "updatedAt": "2020-10-03T13:01:03.424525492Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:37.697672255Z",
+          "date": "2020-10-03T13:01:03.424525492Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:35.691394189Z",
-    "dir_id": "a5f50206697951be5992df4a0558cbc3",
+    "created_at": "2020-09-03T15:00:55Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da712f",
     "name": "dir1",
     "path": "/dst/dir1",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:35.691394189Z"
+    "updated_at": "2020-09-03T15:00:55Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0558bebb",
-    "_rev": "2-d3af6bdde5d198da6bf820858c92dc77",
+    "_id": "b6f32dd442095bfe2c3639f240da6adb",
+    "_rev": "2-b38a58be659636bc6f24f4bd2e7a304c",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:35.760249654Z",
+      "createdAt": "2020-10-03T13:00:55.795931207Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:39.258443429Z",
+      "updatedAt": "2020-10-03T13:01:04.998589089Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:39.258443429Z",
+          "date": "2020-10-03T13:01:04.998589089Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:35.760245816Z",
-    "dir_id": "a5f50206697951be5992df4a0558cbc3",
+    "created_at": "2020-09-03T15:00:55Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240da712f",
     "name": "dir12",
     "path": "/dst/dir12",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:35.760245816Z"
+    "updated_at": "2020-09-03T15:00:55Z"
   }
 ]

--- a/test/scenarios/move_two_files/remote/changes.json
+++ b/test/scenarios/move_two_files/remote/changes.json
@@ -1,86 +1,86 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0558efb9",
-    "_rev": "2-5fe3527183cee7182a13a55ec4781747",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240daab7a",
+    "_rev": "2-a83d23125458f2bf037272eb0347187f",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:42.677863202Z",
+      "createdAt": "2020-10-03T13:01:14.565669257Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:43.566355052Z",
+      "updatedAt": "2020-10-03T13:01:21.964819813Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:43.566355052Z",
+          "date": "2020-10-03T13:01:21.964819813Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:42.677863202Z",
+      "uploadedAt": "2020-10-03T13:01:14.565669257Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:42.677854336Z",
-    "dir_id": "a5f50206697951be5992df4a0558f54f",
+    "created_at": "2020-09-03T15:01:14Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240dab900",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file1",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:42.677854336Z",
+    "updated_at": "2020-09-03T15:01:14Z",
     "path": "/dst/file1"
   },
   {
-    "_id": "a5f50206697951be5992df4a0558f370",
-    "_rev": "2-59bb77562553da83043f3348e47952f9",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240daae82",
+    "_rev": "2-5e03354afb489a3ee0c043fe2191f707",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:42.730137403Z",
+      "createdAt": "2020-10-03T13:01:14.627397078Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:45.154932027Z",
+      "updatedAt": "2020-10-03T13:01:23.552327993Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:45.154932027Z",
+          "date": "2020-10-03T13:01:23.552327993Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:42.730137403Z",
+      "uploadedAt": "2020-10-03T13:01:14.627397078Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:42.730132413Z",
-    "dir_id": "a5f50206697951be5992df4a0558f54f",
+    "created_at": "2020-09-03T15:01:14Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240dab900",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file2",
     "size": "8",
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:42.730132413Z",
+    "updated_at": "2020-09-03T15:01:14Z",
     "path": "/dst/file2"
   }
 ]

--- a/test/scenarios/replace_dir_with_file/remote/changes.json
+++ b/test/scenarios/replace_dir_with_file/remote/changes.json
@@ -1,39 +1,39 @@
 [
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0558fa3c",
-    "_rev": "3-c77ef97b7a85c651a2e3c1b130a82d34"
+    "_id": "b6f32dd442095bfe2c3639f240dab910",
+    "_rev": "3-62c2dc6c4e4af3de8536c5b69feaf64c"
   },
   {
-    "_id": "a5f50206697951be5992df4a055906c7",
-    "_rev": "1-33627ec1933b11fca46e00f6ab1c16ff",
+    "_id": "b6f32dd442095bfe2c3639f240dabbf0",
+    "_rev": "1-1efac497d0994a35775df932498668a4",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:46.224083907Z",
+      "createdAt": "2020-10-03T13:01:31.186360202Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:46.224083907Z",
+      "updatedAt": "2020-10-03T13:01:31.186360202Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:46.224083907Z",
+          "date": "2020-10-03T13:01:31.186360202Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:46.224083907Z",
+      "uploadedAt": "2020-10-03T13:01:31.186360202Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:46.224077142Z",
+    "created_at": "2020-10-03T13:01:31.162Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
@@ -43,7 +43,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:46.224077142Z",
+    "updated_at": "2020-10-03T13:01:31.162Z",
     "path": "/foo"
   }
 ]

--- a/test/scenarios/replace_file_with_dir/remote/changes.json
+++ b/test/scenarios/replace_file_with_dir/remote/changes.json
@@ -1,33 +1,33 @@
 [
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a0559129a",
-    "_rev": "3-cb03aaab85ff216764dc9a694c398312"
+    "_id": "b6f32dd442095bfe2c3639f240dabced",
+    "_rev": "3-9c68b868af93412009dd6aae6d97b22d"
   },
   {
-    "_id": "a5f50206697951be5992df4a0559150e",
-    "_rev": "1-663a0ff9c28d80e66b825c8bd13f436b",
+    "_id": "b6f32dd442095bfe2c3639f240dac04e",
+    "_rev": "1-0763d0e0cd5416b7fc5193e937a7705c",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:48.007016495Z",
+      "createdAt": "2020-10-03T13:01:39.328875938Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:48.007016495Z",
+      "updatedAt": "2020-10-03T13:01:39.328875938Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:48.007016495Z",
+          "date": "2020-10-03T13:01:39.328875938Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:48.007012786Z",
+    "created_at": "2020-10-03T13:01:39.328864344Z",
     "dir_id": "io.cozy.files.root-dir",
     "name": "foo",
     "path": "/foo",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:48.007012786Z"
+    "updated_at": "2020-10-03T13:01:39.328864344Z"
   }
 ]

--- a/test/scenarios/replace_file_with_file/remote/changes.json
+++ b/test/scenarios/replace_file_with_file/remote/changes.json
@@ -1,39 +1,39 @@
 [
   {
     "_deleted": true,
-    "_id": "a5f50206697951be5992df4a05591d75",
-    "_rev": "3-193c9f0cb7e1802da0cfe4ad22fdf1dc"
+    "_id": "b6f32dd442095bfe2c3639f240dace8f",
+    "_rev": "3-393242eeb0c4eae886ad037dd4a29d79"
   },
   {
-    "_id": "a5f50206697951be5992df4a05592560",
-    "_rev": "1-3e08bc1432274d10960132fa928d6c21",
+    "_id": "b6f32dd442095bfe2c3639f240dad896",
+    "_rev": "1-e6b318221e560443a6117f2a007d75fa",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:48.966680138Z",
+      "createdAt": "2020-10-03T13:01:47.249747366Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:48.966680138Z",
+      "updatedAt": "2020-10-03T13:01:47.249747366Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:48.966680138Z",
+          "date": "2020-10-03T13:01:47.249747366Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:48.966680138Z",
+      "uploadedAt": "2020-10-03T13:01:47.249747366Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:48.966673973Z",
+    "created_at": "2020-10-03T13:01:47.216Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "lsFcK7KSEZO/KQ34zYXiug==",
@@ -43,7 +43,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:48.966673973Z",
+    "updated_at": "2020-10-03T13:01:47.216Z",
     "path": "/file"
   }
 ]

--- a/test/scenarios/trash_dir_with_content/remote/changes.json
+++ b/test/scenarios/trash_dir_with_content/remote/changes.json
@@ -1,123 +1,123 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a05599fb9",
-    "_rev": "2-2582f37b626f98b47409732437cb2408",
-    "class": "text",
+    "_id": "b6f32dd442095bfe2c3639f240db31e7",
+    "_rev": "2-a8b00ddf812f85bfc619fa958c90764f",
+    "class": "files",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:51.146639065Z",
+      "createdAt": "2020-10-03T13:01:56.403985205Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:51.146639065Z",
+      "updatedAt": "2020-10-03T13:01:56.403985205Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:51.146639065Z",
+          "date": "2020-10-03T13:01:56.403985205Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:51.146639065Z",
+      "uploadedAt": "2020-10-03T13:01:56.403985205Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:51.146633032Z",
-    "dir_id": "a5f50206697951be5992df4a0559953f",
+    "created_at": "2020-09-03T15:01:56Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240db2b14",
     "executable": false,
     "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
-    "mime": "text/plain",
+    "mime": "application/octet-stream",
     "name": "file",
     "size": "8",
     "tags": [],
     "trashed": true,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:51.146633032Z",
+    "updated_at": "2020-09-03T15:01:56Z",
     "path": "/.cozy_trash/dir/subdir/file"
   },
   {
-    "_id": "a5f50206697951be5992df4a05598a50",
-    "_rev": "2-548f9d9c632fdde7631ee1add4c59daa",
+    "_id": "b6f32dd442095bfe2c3639f240db2674",
+    "_rev": "2-c99a13157b6e7261cceefe3d612c1571",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:51.027974241Z",
+      "createdAt": "2020-10-03T13:01:56.329258536Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:51.027974241Z",
+      "updatedAt": "2020-10-03T13:01:56.329258536Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:51.027974241Z",
+          "date": "2020-10-03T13:01:56.329258536Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:51.02796988Z",
-    "dir_id": "a5f50206697951be5992df4a05597b1c",
+    "created_at": "2020-09-03T15:01:56Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240db1741",
     "name": "empty-subdir",
     "path": "/.cozy_trash/dir/empty-subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:51.02796988Z"
+    "updated_at": "2020-09-03T15:01:56Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a0559953f",
-    "_rev": "2-c6e937b861bf55c3db8d81514b85fed0",
+    "_id": "b6f32dd442095bfe2c3639f240db2b14",
+    "_rev": "2-610d130e292b5c77021ef52710045658",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:51.108222282Z",
+      "createdAt": "2020-10-03T13:01:56.369093407Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:51.108222282Z",
+      "updatedAt": "2020-10-03T13:01:56.369093407Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:51.108222282Z",
+          "date": "2020-10-03T13:01:56.369093407Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:51.108217392Z",
-    "dir_id": "a5f50206697951be5992df4a05597b1c",
+    "created_at": "2020-09-03T15:01:56Z",
+    "dir_id": "b6f32dd442095bfe2c3639f240db1741",
     "name": "subdir",
     "path": "/.cozy_trash/dir/subdir",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:51.108217392Z"
+    "updated_at": "2020-09-03T15:01:56Z"
   },
   {
-    "_id": "a5f50206697951be5992df4a05597b1c",
-    "_rev": "2-3db7402f2c94429be4571b8e130a25dc",
+    "_id": "b6f32dd442095bfe2c3639f240db1741",
+    "_rev": "2-a33ebbd56ce97145ba29869cdef44f29",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:50.74058938Z",
+      "createdAt": "2020-10-03T13:01:56.288042207Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:52.784026881Z",
+      "updatedAt": "2020-10-03T13:02:04.037701968Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:52.784026881Z",
+          "date": "2020-10-03T13:02:04.037701968Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ]
     },
-    "created_at": "2020-05-11T10:38:50.740584326Z",
+    "created_at": "2020-09-03T15:01:56Z",
     "dir_id": "io.cozy.files.trash-dir",
     "name": "dir",
     "path": "/.cozy_trash/dir",
     "restore_path": "/parent",
     "tags": [],
     "type": "directory",
-    "updated_at": "2020-05-11T10:38:50.740584326Z"
+    "updated_at": "2020-09-03T15:01:56Z"
   }
 ]

--- a/test/scenarios/update_file/remote/changes.json
+++ b/test/scenarios/update_file/remote/changes.json
@@ -1,34 +1,34 @@
 [
   {
-    "_id": "a5f50206697951be5992df4a0559a518",
-    "_rev": "2-498a1bb511466ce9fc7ade94d645bc89",
+    "_id": "b6f32dd442095bfe2c3639f240db4269",
+    "_rev": "2-18e846f064cda63da0f4a8c55b2e2494",
     "class": "text",
     "cozyMetadata": {
-      "createdAt": "2020-05-11T10:38:53.093473713Z",
+      "createdAt": "2020-10-03T13:02:04.378204286Z",
       "createdByApp": "cozy-desktop",
       "createdOn": "http://cozy.tools:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
-      "updatedAt": "2020-05-11T10:38:54.69980415Z",
+      "updatedAt": "2020-10-03T13:02:10.779502498Z",
       "updatedByApps": [
         {
-          "date": "2020-05-11T10:38:54.69980415Z",
+          "date": "2020-10-03T13:02:10.779502498Z",
           "instance": "http://cozy.tools:8080/",
           "slug": "cozy-desktop"
         }
       ],
-      "uploadedAt": "2020-05-11T10:38:53.093473713Z",
+      "uploadedAt": "2020-10-03T13:02:04.378204286Z",
       "uploadedBy": {
         "oauthClient": {
-          "id": "a5f50206697951be5992df4a05007005",
+          "id": "b6f32dd442095bfe2c3639f240758316",
           "kind": "",
-          "name": "test"
+          "name": "test-8"
         },
         "slug": "cozy-desktop"
       },
       "uploadedOn": "http://cozy.tools:8080/"
     },
-    "created_at": "2020-05-11T10:38:53.093468237Z",
+    "created_at": "2020-09-03T15:02:04Z",
     "dir_id": "io.cozy.files.root-dir",
     "executable": false,
     "md5sum": "lsFcK7KSEZO/KQ34zYXiug==",
@@ -38,7 +38,7 @@
     "tags": [],
     "trashed": false,
     "type": "file",
-    "updated_at": "2020-05-11T10:38:54.699795573Z",
+    "updated_at": "2020-10-03T13:02:10.758Z",
     "path": "/file"
   }
 ]

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -57,9 +57,18 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  moveTo(path /*: string */) /*: this */ {
+    this.doc.moveTo = metadata.id(path)
+    this.doc._deleted = true
+    return this
+  }
+
   moveFrom(was /*: Metadata */) /*: this */ {
-    this.doc.moveFrom = _.defaultsDeep({ moveTo: this.doc._id }, was)
-    this.noRev()
+    if (!was.moveTo) throw new Error('Missing moveTo attribute on was')
+
+    this.doc = _.cloneDeep(_.omit(was, ['_id', '_rev', '_deleted', 'moveTo']))
+    this.doc.moveFrom = was
+
     return this
   }
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -101,11 +101,6 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  noTags() /*: this */ {
-    delete this.doc.tags
-    return this
-  }
-
   incompatible() /*: this */ {
     const { platform } = process
 
@@ -231,9 +226,8 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  type(mime /*: string */) /*: this */ {
-    this.doc.class = mime.split('/')[0]
-    this.doc.mime = mime
+  noTags() /*: this */ {
+    delete this.doc.tags
     return this
   }
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -152,6 +152,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  erased() /*: this */ {
+    this.doc._deleted = true
+    return this
+  }
+
   updatedAt(date /*: string|Date */) /*: this */ {
     this.doc.updated_at = typeof date === 'string' ? date : date.toISOString()
     return this

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -236,6 +236,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
+  errors(count /*: number */) /*: this */ {
+    this.doc.errors = count
+    return this
+  }
+
   build() /*: Metadata */ {
     // Don't detect incompatibilities according to syncPath for test data, to
     // prevent environment related failures.

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -35,4 +35,10 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
       .toString('base64')
     return this
   }
+
+  type(mime /*: string */) /*: this */ {
+    this.doc.class = mime.split('/')[0]
+    this.doc.mime = mime
+    return this
+  }
 }

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -26,7 +26,7 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
     this.buildLocal = true
   }
 
-  data(data /*: string */) /*: this */ {
+  data(data /*: string | Buffer */) /*: this */ {
     this.doc.size = Buffer.from(data).length
     this.doc.md5sum = crypto
       .createHash('md5')
@@ -39,6 +39,21 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   type(mime /*: string */) /*: this */ {
     this.doc.class = mime.split('/')[0]
     this.doc.mime = mime
+    return this
+  }
+
+  // Should only be used to build invalid docs. Prefer using `data()`.
+  size(newSize /*: number */) /*: this */ {
+    this.doc.size = newSize
+    return this
+  }
+
+  executable(isExecutable /*: boolean */) /*: this */ {
+    if (!isExecutable && this.doc.executable) {
+      delete this.doc.executable
+    } else if (isExecutable) {
+      this.doc.executable = isExecutable
+    }
     return this
   }
 }

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -59,6 +59,8 @@ module.exports = class RemoteBaseBuilder {
   }
 
   trashed() /*: this */ {
+    this.remoteDoc.trashed = true
+    this.remoteDoc.restore_path = posix.dirname(this.remoteDoc.path)
     return this.inDir({
       _id: TRASH_DIR_ID,
       path: `/${TRASH_DIR_NAME}`
@@ -66,7 +68,19 @@ module.exports = class RemoteBaseBuilder {
   }
 
   restored() /*: this */ {
+    if (this.remoteDoc.trashed) delete this.remoteDoc.trashed
+    if (this.remoteDoc.restore_path) delete this.remoteDoc.restore_path
     return this.inRootDir()
+  }
+
+  tags(...tags /*: string[] */) /*: this */ {
+    this.remoteDoc.tags = tags
+    return this
+  }
+
+  noTags() /*: this */ {
+    delete this.remoteDoc.tags
+    return this
   }
 
   shortRev(revNumber /*: number */) /*: this */ {

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -81,6 +81,12 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder {
     return this
   }
 
+  // Should only be used to build invalid docs. Prefer using `data()`.
+  size(newSize /*: string */) /*: this */ {
+    this.remoteDoc.size = newSize
+    return this
+  }
+
   dataFromFile(path /*: string */) /*: RemoteFileBuilder */ {
     return this.data(fs.createReadStream(path))
   }

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -9,6 +9,7 @@ const proxy = require('../../../gui/js/proxy')
 
 let originalNet
 const setupGlobalProxy = async () => {
+  await app.whenReady()
   originalNet = await proxy.setup(app, {}, session, '')
 }
 const resetGlobalProxy = async () => {

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -447,14 +447,14 @@ describe('core/local/atom/dispatch.loop()', function() {
         const src = await builders
           .metafile()
           .path(filePath)
+          .moveTo(newFilePath)
           .ino(1)
           .create()
-        this.pouch.put({ ...src, _deleted: true })
 
         const dst = await builders
-          .metafile(src)
-          .path(newFilePath)
+          .metafile()
           .moveFrom(src)
+          .path(newFilePath)
           .updatedAt(updatedAt)
           .create()
         // Simulate Sync removing the moveFrom attribute after propagating the
@@ -680,14 +680,14 @@ describe('core/local/atom/dispatch.loop()', function() {
         const src = await builders
           .metadir()
           .path(directoryPath)
+          .moveTo(newDirectoryPath)
           .ino(1)
           .create()
-        this.pouch.put({ ...src, _deleted: true })
 
         const dst = await builders
-          .metadir(src)
-          .path(newDirectoryPath)
+          .metadir()
           .moveFrom(src)
+          .path(newDirectoryPath)
           .updatedAt(updatedAt)
           .create()
         // Simulate Sync removing the moveFrom attribute after propagating the

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -564,25 +564,27 @@ describe('core/local/atom/initial_diff', () => {
       const wasDir = builders
         .metadir()
         .path('foo')
+        .moveTo('foo2')
         .ino(1)
         .upToDate()
         .build()
       await builders
-        .metadir(wasDir)
-        .path('foo2')
+        .metadir()
         .moveFrom(wasDir)
+        .path('foo2')
         .changedSide('remote')
         .create()
       const wasFile = builders
         .metafile()
         .path('fizz')
+        .moveTo('fizz2')
         .ino(2)
         .upToDate()
         .build()
       await builders
-        .metafile(wasFile)
-        .path('fizz2')
+        .metafile()
         .moveFrom(wasFile)
+        .path('fizz2')
         .changedSide('remote')
         .create()
 

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -31,102 +31,83 @@ onPlatform('darwin', () => {
     describe('.detectOfflineUnlinkEvents()', function() {
       it('detects deleted files and folders', async function() {
         // Folder still exists
-        const folder1 = {
-          _id: 'folder1',
-          path: 'folder1',
-          docType: 'folder',
-          sides: { target: 2, local: 2, remote: 2 }
-        }
+        await builders
+          .metadir()
+          .path('folder1')
+          .upToDate()
+          .create()
         // Folder does not exist anymore
-        const folder2 = {
-          _id: 'folder2',
-          path: 'folder2',
-          docType: 'folder',
-          sides: { target: 2, local: 2, remote: 2 }
-        }
+        const folder2 = await builders
+          .metadir()
+          .path('folder2')
+          .upToDate()
+          .create()
         // Folder was already trashed remotely
-        const folder3 = {
-          _id: '.cozy_trash/folder3',
-          path: '.cozy_trash/folder3',
-          trashed: true,
-          docType: 'folder',
-          sides: { target: 3, local: 2, remote: 3 }
-        }
+        await builders
+          .metadir()
+          .path('.cozy_trash/folder3')
+          .trashed()
+          .changedSide('remote')
+          .create()
         // Folder was moved locally
-        const folder4 = {
-          _id: 'folder4',
-          path: 'folder4',
-          docType: 'folder',
-          moveFrom: {
-            _id: 'folder1/folder4',
-            path: 'folder1/folder4'
-          },
-          sides: { target: 3, local: 3, remote: 2 }
-        }
+        const srcFolder4 = await builders
+          .metadir()
+          .path('folder1/folder4')
+          .moveTo('folder4')
+          .upToDate()
+          .create()
+        const folder4 = await builders
+          .metadir()
+          .moveFrom(srcFolder4)
+          .path('folder4')
+          .changedSide('local')
+          .create()
         // Folder was already trashed remotely and marked for deletion
-        const folder5 = {
-          _id: '.cozy_trash/folder5',
-          path: '.cozy_trash/folder5',
-          deleted: true,
-          docType: 'folder',
-          sides: { target: 3, local: 2, remote: 3 }
-        }
+        await builders
+          .metadir()
+          .path('.cozy_trash/folder5')
+          .deleted()
+          .changedSide('remote')
+          .create()
         // File still exists
-        const file1 = {
-          _id: 'file1',
-          path: 'file1',
-          docType: 'file',
-          sides: { target: 2, local: 2, remote: 2 }
-        }
+        builders
+          .metafile()
+          .path('file1')
+          .upToDate()
+          .create()
         // File does not exist anymore
-        const file2 = {
-          _id: 'file2',
-          path: 'file2',
-          docType: 'file',
-          sides: { target: 2, local: 2, remote: 2 }
-        }
+        const file2 = await builders
+          .metafile()
+          .path('file2')
+          .upToDate()
+          .create()
         // File was trashed remotely
-        const file3 = {
-          _id: '.cozy_trash/folder3/file3',
-          path: '.cozy_trash/folder3/file3',
-          trashed: true,
-          docType: 'file',
-          sides: { target: 3, local: 2, remote: 3 }
-        }
+        builders
+          .metafile()
+          .path('.cozy_trash/folder3/file3')
+          .trashed()
+          .changedSide('remote')
+          .create()
         // File was moved locally
-        const file4 = {
-          _id: 'file4',
-          path: 'file4',
-          docType: 'file',
-          moveFrom: {
-            _id: 'folder1/file4',
-            path: 'folder1/file4'
-          },
-          sides: { target: 3, local: 3, remote: 2 }
-        }
+        const srcFile4 = await builders
+          .metafile()
+          .path('folder1/file4')
+          .moveTo('file4')
+          .upToDate()
+          .create()
+        const file4 = await builders
+          .metafile()
+          .moveFrom(srcFile4)
+          .path('file4')
+          .changedSide('local')
+          .create()
         // File was already deleted locally and marked for deletion
-        const file5 = {
-          _id: 'folder1/file5',
-          path: 'folder1/file5',
-          deleted: true,
-          docType: 'file',
-          sides: { target: 3, local: 3, remote: 2 }
-        }
-        for (let doc of [
-          folder1,
-          folder2,
-          folder3,
-          folder4,
-          folder5,
-          file1,
-          file2,
-          file3,
-          file4,
-          file5
-        ]) {
-          const { rev } = await this.pouch.db.put(doc)
-          doc._rev = rev
-        }
+        builders
+          .metafile()
+          .path('folder1/file5')
+          .deleted()
+          .changedSide('local')
+          .create()
         const initialScan = { ids: ['folder1', 'file1'].map(metadata.id) }
 
         const { offlineEvents } = await detectOfflineUnlinkEvents(

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -461,27 +461,26 @@ describe('Local', function() {
 
   describe('updateFileMetadata', () => {
     it('updates metadata', async function() {
-      let doc = {
-        path: 'file-to-update',
-        docType: 'file',
-        updated_at: new Date('2015-11-10T05:06:07Z')
-      }
-      let filePath = syncDir.abspath(doc.path)
+      const doc = builders
+        .metafile()
+        .path('file-to-update')
+        .updatedAt('2015-11-10T05:06:07Z')
+        .build()
+      const filePath = syncDir.abspath(doc.path)
       fse.ensureFileSync(filePath)
       await this.local.updateFileMetadataAsync(doc, {})
       fse.existsSync(filePath).should.be.true()
       let mtime = +fse.statSync(filePath).mtime
-      mtime.should.equal(+doc.updated_at)
+      mtime.should.equal(+new Date(doc.updated_at))
     })
   })
 
   describe('updateFolder', () => {
     it('calls addFolder', async function() {
-      let doc = {
-        path: 'a-folder-to-update',
-        docType: 'folder',
-        updated_at: new Date()
-      }
+      const doc = builders
+        .metadir()
+        .path('a-folder-to-update')
+        .build()
       sinon.stub(this.local, 'addFolderAsync').resolves()
       await this.local.updateFolderAsync(doc, {})
       this.local.addFolderAsync.calledWith(doc).should.be.true()

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -3063,11 +3063,12 @@ describe('Merge', function() {
       const old = await builders
         .metafile()
         .path('FILE')
+        .moveTo('MOVED')
         .data('content')
         .sides({ [this.side]: 1 })
         .create()
       const doc = await builders
-        .metafile(old)
+        .metafile()
         .moveFrom(old)
         .path('MOVED')
         .sides({ [this.side]: 2 })
@@ -3187,10 +3188,11 @@ describe('Merge', function() {
       const old = await builders
         .metadir()
         .path('FOLDER')
+        .moveTo('MOVED')
         .sides({ [this.side]: 1 })
         .create()
       const doc = await builders
-        .metadir(old)
+        .metadir()
         .moveFrom(old)
         .path('MOVED')
         .sides({ [this.side]: 1 })

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -41,7 +41,7 @@ describe('metadata', function() {
 
   describe('.fromRemoteDoc()', () => {
     it('builds the metadata for a remote file', () => {
-      let remoteDoc /*: RemoteDoc */ = {
+      const remoteDoc /*: RemoteDoc */ = {
         _id: '12',
         _rev: '34',
         _type: FILES_DOCTYPE,
@@ -62,7 +62,7 @@ describe('metadata', function() {
         },
         someUnusedProperty: 'unused value'
       }
-      let doc /*: Metadata */ = metadata.fromRemoteDoc(remoteDoc)
+      const doc /*: Metadata */ = metadata.fromRemoteDoc(remoteDoc)
 
       should(doc).deepEqual({
         md5sum: 'N7UdGUp1E+RbVvZSTy1R8g==',
@@ -87,8 +87,10 @@ describe('metadata', function() {
       })
 
       remoteDoc.executable = true
-      doc = metadata.fromRemoteDoc(remoteDoc)
-      should(doc.executable).equal(true)
+      should(metadata.fromRemoteDoc(remoteDoc)).have.property(
+        'executable',
+        true
+      )
     })
 
     it('builds the metadata for a remote dir', () => {
@@ -391,63 +393,48 @@ describe('metadata', function() {
 
   describe('sameFolder', () => {
     it('returns true if the folders are the same', function() {
-      let a = {
-        _id: 'FOO/BAR',
-        docType: 'folder',
-        path: 'foo/bar',
-        updated_at: '2015-12-01T11:22:56.517Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        },
-        ino: 234
-      }
-      let b = {
-        _id: 'FOO/BAR',
-        docType: 'folder',
-        path: 'FOO/BAR',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        },
-        ino: 234
-      }
-      let c = {
-        _id: 'FOO/BAR',
-        docType: 'folder',
-        path: 'FOO/BAR',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux', 'courge'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        }
-      }
-      let d = {
-        _id: 'FOO/BAR',
-        docType: 'folder',
-        path: 'FOO/BAR',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux', 'courge'],
-        remote: {
-          id: '123',
-          rev: '8-901'
-        }
-      }
-      let e = {
-        _id: 'FOO/BAZ',
-        docType: 'folder',
-        path: 'FOO/BAZ',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        }
-      }
+      const a = builders
+        .metadir()
+        .ino(234)
+        .path('foo/bar')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const b = builders
+        .metadir()
+        .ino(234)
+        .path('FOO/BAR')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:57.000Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const c = builders
+        .metadir()
+        .path('FOO/BAR')
+        .tags('qux', 'courge')
+        .updatedAt('2015-12-01T11:22:57.000Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const d = builders
+        .metadir()
+        .path('FOO/BAR')
+        .tags('qux', 'courge')
+        .updatedAt('2015-12-01T11:22:57.000Z')
+        .remoteId('123')
+        .remoteRev('8-901')
+        .build()
+      const e = builders
+        .metadir()
+        .path('FOO/BAZ')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:57.000Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
       const g = _.merge({}, a, { ino: a.ino + 2 })
       sameFolder(a, a).should.be.true()
       sameFolder(a, b).should.be.false()
@@ -482,19 +469,16 @@ describe('metadata', function() {
     })
 
     it('does not fail when a property is absent on one side and undefined on the other', function() {
-      let a = {
-        _id: 'FOO/BAR',
-        docType: 'folder',
-        path: 'foo/bar',
-        updated_at: '2015-12-01T11:22:56.517Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        },
-        ino: 234,
-        trashed: false
-      }
+      const a = builders
+        .metadir()
+        .path('foo/bar')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .ino(234)
+        .trashed(false)
+        .build()
 
       _.each(
         ['path', 'docType', 'remote', 'tags', 'trashed', 'ino'],
@@ -531,85 +515,71 @@ describe('metadata', function() {
 
   describe('sameFile', function() {
     it('returns true if the files are the same', function() {
-      let a = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'foo/bar',
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:56.517Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        },
-        ino: 1
-      }
-      let b = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'FOO/BAR',
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        },
-        ino: 1
-      }
-      let c = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'FOO/BAR',
-        md5sum: '000000047681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        }
-      }
-      let d = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'FOO/BAR',
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '8-901'
-        }
-      }
-      let e = {
-        _id: 'FOO/BAZ',
-        docType: 'file',
-        path: 'FOO/BAZ',
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:57.000Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        }
-      }
-      let f = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'foo/bar',
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:56.517Z',
-        size: 12345,
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        }
-      }
-      const g = _.merge({}, a, { ino: a.ino + 1 })
-      const h = _.merge({}, a, {
-        remote: _.merge({}, a.remote, { _id: '321' })
-      })
+      const a = builders
+        .metafile()
+        .path('foo/bar')
+        .ino(1)
+        .data('some data')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const b = builders
+        .metafile()
+        .path('FOO/BAR')
+        .ino(1)
+        .data('some data')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const c = builders
+        .metafile()
+        .path('FOO/BAR')
+        .data('other data')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const d = builders
+        .metafile()
+        .path('FOO/BAR')
+        .data('some data')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('8-901')
+        .build()
+      const e = builders
+        .metafile()
+        .path('FOO/BAZ')
+        .data('some data')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const f = builders
+        .metafile()
+        .path('foo/bar')
+        .data('some data')
+        .size(12345)
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const g = builders
+        .metafile(a)
+        .ino(a.ino + 1)
+        .build()
+      const h = builders
+        .metafile(a)
+        .remoteId('321')
+        .build()
       sameFile(a, a).should.be.true()
       sameFile(a, b).should.be.false()
       sameFile(a, c).should.be.false()
@@ -651,23 +621,20 @@ describe('metadata', function() {
     })
 
     it('does not fail when one file has executable: undefined', function() {
-      let a = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'foo/bar',
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        updated_at: '2015-12-01T11:22:56.517Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        }
-      }
-      let b = _.clone(a)
+      const a = builders
+        .metafile()
+        .path('foo/bar')
+        .data('some data')
+        .tags('qux')
+        .updatedAt('2015-12-01T11:22:56.517Z')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
+      const b = _.clone(a)
       b.executable = undefined
-      let c = _.clone(a)
+      const c = _.clone(a)
       c.executable = false
-      let d = _.clone(a)
+      const d = _.clone(a)
       d.executable = true
       sameFile(a, b).should.be.true()
       sameFile(a, c).should.be.true()
@@ -678,22 +645,18 @@ describe('metadata', function() {
     })
 
     it('does not fail when a property is absent on one side and undefined on the other', function() {
-      let a = {
-        _id: 'FOO/BAR',
-        docType: 'file',
-        path: 'foo/bar',
-        ino: 23452,
-        md5sum: '9440ca447681546bd781d6a5166d18737223b3f6',
-        size: 22,
-        updated_at: '2015-12-01T11:22:56.517Z',
-        tags: ['qux'],
-        remote: {
-          id: '123',
-          rev: '4-567'
-        },
-        trashed: false,
-        executable: false
-      }
+      const a = builders
+        .metafile()
+        .path('foo/bar')
+        .ino(23452)
+        .data('some data')
+        .trashed(false)
+        .executable(false)
+        .tags('qux')
+        .updatedAt('9440ca447681546bd781d6a5166d18737223b3f6')
+        .remoteId('123')
+        .remoteRev('4-567')
+        .build()
 
       _.each(
         [
@@ -740,32 +703,27 @@ describe('metadata', function() {
 
   describe('sameBinary', function() {
     it('returns true for two docs with the same checksum', function() {
-      let one = {
+      const one = {
         docType: 'file',
         md5sum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
       }
-      let two = {
+      const two = {
         docType: 'file',
         md5sum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
       }
-      let ret = sameBinary(one, two)
-      ret.should.be.true()
+      should(sameBinary(one, two)).be.true()
     })
 
-    it('returns false for two different documents', function() {
-      let one = {
+    it('returns false for two docs with different checksums', function() {
+      const one = {
         docType: 'file',
         md5sum: 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc'
       }
-      let two = {
+      const two = {
         docType: 'file',
-        md5sum: '2082e7f715f058acab2398d25d135cf5f4c0ce41',
-        remote: {
-          _id: 'f00b4r'
-        }
+        md5sum: '2082e7f715f058acab2398d25d135cf5f4c0ce41'
       }
-      let ret = sameBinary(one, two)
-      ret.should.be.false()
+      should(sameBinary(one, two)).be.false()
     })
   })
 

--- a/test/unit/remote/change.js
+++ b/test/unit/remote/change.js
@@ -3,9 +3,11 @@
 const path = require('path')
 const should = require('should')
 
-const metadata = require('../../../core/metadata')
 const remoteChange = require('../../../core/remote/change')
 const { onPlatforms } = require('../../support/helpers/platform')
+const Builders = require('../../support/builders')
+
+const builders = new Builders()
 
 describe('sorter()', () => {
   describe('with identical additions', () => {
@@ -365,46 +367,41 @@ describe('sorter()', () => {
     })
 
     it('when there are other changes', () => {
-      const deletedPath = '.cozy_trash/fichier.pptx'
-      const createdPath = '1_Dossier/fichier.pptx'
+      const deletedPath = path.normalize('.cozy_trash/fichier.pptx')
+      const createdPath = path.normalize('1_Dossier/fichier.pptx')
 
       const changes = [
         {
           type: 'DirAddition',
-          doc: {
-            path: '2_Dossier/2_SousDossier/SousSousDossier',
-            docType: 'folder',
-            _id: metadata.id('2_Dossier/2_SousDossier/SousSousDossier')
-          }
+          doc: builders
+            .metadir()
+            .path('2_Dossier/2_SousDossier/SousSousDossier')
+            .build()
         },
         {
           type: 'FileAddition',
-          doc: {
-            path: '2_Dossier/1_SousDossier/fichier.xml',
-            docType: 'file',
-            _id: metadata.id('2_Dossier/1_SousDossier/fichier.xml')
-          }
+          doc: builders
+            .metafile()
+            .path('2_Dossier/1_SousDossier/fichier.xml')
+            .build()
         },
         {
           type: 'FileTrashing',
-          doc: {
-            path: deletedPath,
-            docType: 'file',
-            _id: metadata.id(deletedPath)
-          },
-          was: {
-            path: createdPath,
-            docType: 'file',
-            _id: metadata.id(createdPath)
-          }
+          doc: builders
+            .metafile()
+            .path(deletedPath)
+            .build(),
+          was: builders
+            .metafile()
+            .path(createdPath)
+            .build()
         },
         {
           type: 'FileAddition',
-          doc: {
-            path: createdPath,
-            docType: 'file',
-            _id: metadata.id(createdPath)
-          }
+          doc: builders
+            .metafile()
+            .path(createdPath)
+            .build()
         }
       ]
 
@@ -925,17 +922,26 @@ describe('sortByPath', () => {
     const one = {
       type: 'IgnoredChange',
       doc: { _id: 'whatever', _rev: '2-xxx', _deleted: true },
-      was: { path: path.normalize('spreadsheet') },
+      was: builders
+        .metafile()
+        .path('spreadsheet')
+        .build(),
       detail: 'Deleted document'
     }
     const two = {
-      doc: { path: path.normalize('doc') },
+      doc: builders
+        .metafile()
+        .path('doc')
+        .build(),
       type: 'FileAddition'
     }
     const three = {
       type: 'IgnoredChange',
       doc: { _id: 'whatever', _rev: '2-xxx', _deleted: true },
-      was: { path: path.normalize('dir') },
+      was: builders
+        .metadir()
+        .path('dir')
+        .build(),
       detail: 'Deleted document'
     }
 

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* @flow */
 
 const _ = require('lodash')
 const sinon = require('sinon')
@@ -30,6 +31,7 @@ describe('Sync', function() {
     this.sync = new Sync(
       this.pouch,
       this.local,
+      // $FlowFixMe the remote stub is not recognized as a Remote instance
       this.remote,
       this.ignore,
       this.events
@@ -56,9 +58,9 @@ describe('Sync', function() {
 
     it('starts the metadata replication of both sides', async function() {
       await this.sync.start()
-      should(this.local.start).be.calledOnce()
-      should(this.remote.start).be.calledOnce()
-      should(this.sync.sync).be.calledOnce()
+      should(this.local.start).have.been.calledOnce()
+      should(this.remote.start).have.been.calledOnce()
+      should(this.sync.sync).have.been.calledOnce()
     })
 
     context('if local watcher fails to start', () => {
@@ -68,17 +70,17 @@ describe('Sync', function() {
 
       it('does not start replication', async function() {
         await this.sync.start()
-        should(this.sync.sync).not.be.called()
+        should(this.sync.sync).not.have.been.called()
       })
 
       it('does not start remote watcher', async function() {
         await this.sync.start()
-        should(this.remote.start).not.be.called()
+        should(this.remote.start).not.have.been.called()
       })
 
       it('stops local watcher', async function() {
         await this.sync.start()
-        should(this.local.stop).be.calledOnce()
+        should(this.local.stop).have.been.calledOnce()
       })
 
       it('emits a sync error', async function() {
@@ -94,22 +96,22 @@ describe('Sync', function() {
 
       it('does not start replication', async function() {
         await this.sync.start()
-        should(this.sync.sync).not.be.called()
+        should(this.sync.sync).not.have.been.called()
       })
 
       it('starts local watcher', async function() {
         await this.sync.start()
-        should(this.local.start).be.calledOnce()
+        should(this.local.start).have.been.calledOnce()
       })
 
       it('stops local watcher', async function() {
         await this.sync.start()
-        should(this.local.stop).be.calledOnce()
+        should(this.local.stop).have.been.calledOnce()
       })
 
       it('stops remote watcher', async function() {
         await this.sync.start()
-        should(this.remote.stop).be.calledOnce()
+        should(this.remote.stop).have.been.calledOnce()
       })
 
       it('emits a sync error', async function() {
@@ -125,17 +127,17 @@ describe('Sync', function() {
 
       it('stops replication', async function() {
         await this.sync.start()
-        should(this.sync.stop).be.calledOnce()
+        should(this.sync.stop).have.been.calledOnce()
       })
 
       it('stops local watcher', async function() {
         await this.sync.start()
-        should(this.local.stop).be.calledOnce()
+        should(this.local.stop).have.been.calledOnce()
       })
 
       it('stops remote watcher', async function() {
         await this.sync.start()
-        should(this.remote.stop).be.calledOnce()
+        should(this.remote.stop).have.been.calledOnce()
       })
 
       it('emits a sync error', async function() {
@@ -162,18 +164,16 @@ describe('Sync', function() {
       const apply = sinon.stub(this.sync, 'apply')
       apply.callsFake(change => this.pouch.setLocalSeq(change.seq))
 
-      const doc1 = {
-        _id: 'doc1',
-        docType: 'file',
-        sides: { target: 1, local: 1 }
-      }
-      const doc2 = {
-        _id: 'doc2',
-        docType: 'folder',
-        sides: { target: 1, remote: 1 }
-      }
-      await this.pouch.db.put(doc1)
-      await this.pouch.db.put(doc2)
+      const doc1 = await builders
+        .metafile()
+        .path('doc1')
+        .sides({ local: 1 })
+        .create()
+      const doc2 = await builders
+        .metadir()
+        .path('doc2')
+        .sides({ remote: 1 })
+        .create()
 
       await this.sync.sync()
 
@@ -185,38 +185,31 @@ describe('Sync', function() {
 
   describe('apply', function() {
     it('does nothing for an ignored document', async function() {
-      let change = {
+      const change = {
         seq: 121,
-        doc: {
-          _id: 'ignored',
-          docType: 'folder',
-          sides: {
-            target: 1,
-            local: 1
-          }
-        }
+        doc: await builders
+          .metadir()
+          .path('ignored')
+          .sides({ local: 1 })
+          .create()
       }
       this.sync.applyDoc = sinon.spy()
       await this.sync.apply(change)
-      this.sync.applyDoc.called.should.be.false()
+      should(this.sync.applyDoc).have.not.been.called()
     })
 
     it('does nothing for an up-to-date document', async function() {
-      let change = {
+      const change = {
         seq: 122,
-        doc: {
-          _id: 'foo',
-          docType: 'folder',
-          sides: {
-            target: 2,
-            local: 2,
-            remote: 2
-          }
-        }
+        doc: await builders
+          .metadir()
+          .path('foo')
+          .upToDate()
+          .create()
       }
       this.sync.applyDoc = sinon.spy()
       await this.sync.apply(change)
-      this.sync.applyDoc.called.should.be.false()
+      should(this.sync.applyDoc).have.not.been.called()
     })
 
     it('does nothing for an up-to-date _deleted document', async function() {
@@ -237,45 +230,39 @@ describe('Sync', function() {
     it('trashes a locally deleted file or folder', async function() {
       const change = {
         seq: 145,
-        doc: {
-          _id: 'foo',
-          path: 'foo',
-          sides: {
-            target: 2,
-            local: 2,
-            remote: 1
-          },
-          remote: {
-            _id: '1234567890',
-            _rev: '1-39dj39ek39'
-          },
-          trashed: true
-        }
+        doc: await builders
+          .metadata()
+          .path('foo')
+          .trashed()
+          .changedSide('local')
+          .create()
       }
 
       this.sync.trashWithParentOrByItself = sinon.stub().resolves(true)
       await this.sync.apply(change)
-      should(this.sync.trashWithParentOrByItself.called).be.true()
+      should(this.sync.trashWithParentOrByItself).have.been.called()
     })
 
     it('calls applyDoc for a modified file', async function() {
-      let change = {
+      const initial = await builders
+        .metafile()
+        .path('foo/bar')
+        .data('initial content')
+        .upToDate()
+        .create()
+
+      const change = {
         seq: 123,
-        doc: {
-          _id: 'foo/bar',
-          docType: 'file',
-          md5sum: '0000000000000000000000000000000000000000',
-          sides: {
-            target: 3,
-            local: 3,
-            remote: 2
-          },
-          remote: { _id: 'XXX', _rev: '2-abc' }
-        }
+        doc: await builders
+          .metafile(initial)
+          .overwrite(initial)
+          .data('updated content')
+          .changedSide('local')
+          .create()
       }
       await this.sync.apply(change)
       should(await this.pouch.db.get(change.doc._id)).have.properties({
-        _id: 'foo/bar',
+        path: initial.path,
         docType: 'file',
         sides: {
           target: 4,
@@ -287,23 +274,23 @@ describe('Sync', function() {
     })
 
     it('calls applyDoc for a modified folder', async function() {
-      let change = {
+      const initial = await builders
+        .metadir()
+        .path('foo/baz')
+        .upToDate()
+        .create()
+
+      const change = {
         seq: 124,
-        doc: {
-          _id: 'foo/baz',
-          docType: 'folder',
-          tags: [],
-          sides: {
-            target: 3,
-            local: 3,
-            remote: 2
-          },
-          remote: { _id: 'XXX', _rev: '2-abc' }
-        }
+        doc: await builders
+          .metadir(initial)
+          .tags('qux')
+          .changedSide('local')
+          .create()
       }
       await this.sync.apply(change)
       should(await this.pouch.db.get(change.doc._id)).have.properties({
-        _id: 'foo/baz',
+        path: initial.path,
         docType: 'folder',
         sides: {
           target: 4,
@@ -315,39 +302,29 @@ describe('Sync', function() {
     })
 
     it('calls addFileAsync for an added file', async function() {
-      let doc = {
-        _id: 'foo/bar',
-        _rev: '1-abcdef0123456789',
-        md5sum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
-        docType: 'file',
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
+      const doc = await builders
+        .metafile()
+        .path('foo/bar')
+        .data('file content')
+        .sides({ local: 1 })
+        .create()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
       this.remote.addFileAsync.calledWith(doc).should.be.true()
     })
 
     it('calls overwriteFileAsync for an overwritten file', async function() {
-      let doc = {
-        _id: 'overwrite/foo/bar',
-        md5sum: '391f7abfca1124c3ca937e5f85687352bcd9f261',
-        docType: 'file',
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
-      const created = await this.pouch.db.put(doc)
-      doc._rev = created.rev
-      doc.md5sum = '389dd709c94a6a7ea56e1d55cbf65eef31b9bc5e'
-      doc.sides = {
-        target: 2,
-        local: 2,
-        remote: 1
-      }
-      await this.pouch.db.put(doc)
+      const initial = await builders
+        .metafile()
+        .path('overwrite/foo/bar')
+        .data('initial content')
+        .upToDate()
+        .create()
+      const doc = await builders
+        .metafile(initial)
+        .overwrite(initial)
+        .data('updated content')
+        .changedSide('local')
+        .create()
       await this.sync.applyDoc(doc, this.remote, 'remote', 1)
       this.remote.updateFileMetadataAsync.called.should.be.false()
       this.remote.overwriteFileAsync.calledWith(doc).should.be.true()
@@ -409,7 +386,7 @@ describe('Sync', function() {
         .create()
       const updated = await builders
         .metafile(synced)
-        .tags(['courge'])
+        .tags('courge')
         .changedSide('local')
         .create()
 
@@ -424,99 +401,67 @@ describe('Sync', function() {
     })
 
     it('calls moveAsync for a moved file', async function() {
-      let was = {
-        _id: 'foo/bar',
-        _rev: '3-9876543210',
-        _deleted: true,
-        moveTo: 'foo/baz',
-        docType: 'file',
-        tags: ['qux'],
-        sides: {
-          target: 3,
-          local: 3,
-          remote: 2
-        }
-      }
-      let doc = {
-        _id: 'foo/baz',
-        _rev: '1-abcdef',
-        moveFrom: was,
-        docType: 'file',
-        tags: ['qux'],
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
+      const was = await builders
+        .metafile()
+        .path('foo/bar')
+        .moveTo('foo/baz')
+        .tags('qux')
+        .changedSide('local')
+        .create()
+      const doc = await builders
+        .metafile()
+        .moveFrom(was)
+        .path('foo/baz')
+        .create()
+
       await this.sync.applyDoc(was, this.remote, 'remote', 2)
-      this.remote.trashAsync.called.should.be.false()
+      should(this.remote.trashAsync).not.have.been.called()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
-      this.remote.addFileAsync.called.should.be.false()
-      this.remote.moveAsync.calledWith(doc, was).should.be.true()
+      should(this.remote.addFileAsync).not.have.been.called()
+      should(this.remote.moveAsync).have.been.calledWith(doc, was)
     })
 
     it('calls moveAsync and overwriteFileAsync for a moved-updated file', async function() {
-      let was = {
-        _id: 'foo/bar',
-        _rev: '3-9876543210',
-        _deleted: true,
-        moveTo: 'foo/baz',
-        md5sum: 'wasMD5',
-        docType: 'file',
-        tags: ['qux'],
-        sides: {
-          target: 3,
-          local: 3,
-          remote: 2
-        }
-      }
-      let doc = {
-        _id: 'foo/baz',
-        _rev: '1-abcdef',
-        moveFrom: was,
-        md5sum: 'newMD5',
-        docType: 'file',
-        tags: ['qux'],
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
+      const was = await builders
+        .metafile()
+        .path('foo/bar')
+        .data('initial content')
+        .moveTo('foo/baz')
+        .tags('qux')
+        .changedSide('local')
+        .create()
+      const doc = await builders
+        .metafile()
+        .moveFrom(was)
+        .path('foo/baz')
+        .data('updated content')
+        .changedSide('local')
+        .create()
+
       await this.sync.applyDoc(was, this.remote, 'remote', 2)
-      this.remote.trashAsync.called.should.be.false()
+      should(this.remote.trashAsync).not.have.been.called()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
-      this.remote.addFileAsync.called.should.be.false()
-      this.remote.moveAsync.calledWith(doc, was).should.be.true()
-      this.remote.overwriteFileAsync.calledWith(doc).should.be.true()
+      should(this.remote.addFileAsync).not.have.been.called()
+      should(this.remote.moveAsync).have.been.calledWith(doc, was)
+      should(this.remote.overwriteFileAsync).have.been.calledWith(doc)
     })
 
     it('does not break when move works but not update', async function() {
-      let was = {
-        _id: 'foo/bar2',
-        _deleted: true,
-        moveTo: 'foo/baz',
-        md5sum: 'wasMD5',
-        docType: 'file',
-        tags: ['qux'],
-        sides: {
-          target: 3,
-          local: 3,
-          remote: 2
-        }
-      }
-      let doc = {
-        _id: 'foo/baz2',
-        moveFrom: was,
-        md5sum: 'newMD5',
-        docType: 'file',
-        tags: ['qux'],
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
-      was._rev = (await this.pouch.db.put(was)).rev
-      doc._rev = (await this.pouch.db.put(doc)).rev
+      const was = await builders
+        .metafile()
+        .path('foo/bar2')
+        .moveTo('foo/baz2')
+        .data('initial content')
+        .tags('qux')
+        .changedSide('local')
+        .create()
+      const doc = await builders
+        .metafile()
+        .moveFrom(was)
+        .path('foo/baz2')
+        .data('updated content')
+        .changedSide('local')
+        .create()
 
       // re-stubs overwriteFileAsync to fail
       this.remote.overwriteFileAsync = sinon
@@ -531,7 +476,7 @@ describe('Sync', function() {
       this.remote.moveAsync.calledWith(doc, was).should.be.true()
       this.remote.overwriteFileAsync.calledWith(doc).should.be.true()
 
-      const newMetadata = await this.pouch.db.get('foo/baz2')
+      const newMetadata = await this.pouch.db.get(doc._id)
       should(newMetadata).not.have.property('moveFrom')
       should(newMetadata).have.property('errors')
 
@@ -539,126 +484,92 @@ describe('Sync', function() {
       this.remote.overwriteFileAsync = sinon.stub().resolves()
     })
 
-    it('calls trashAsync for a deleted file', async function() {
-      let doc = {
-        _id: 'foo/baz',
-        _rev: '4-1234567890',
-        deleted: true,
-        docType: 'file',
-        sides: {
-          target: 2,
-          local: 1,
-          remote: 2
-        }
-      }
+    it('calls trashAsync for a deleted synced file', async function() {
+      const doc = await builders
+        .metafile()
+        .path('foo/baz')
+        .deleted()
+        .changedSide('remote')
+        .create()
       await this.sync.applyDoc(doc, this.local, 'local', 1)
       this.local.trashAsync.calledWith(doc).should.be.true()
     })
 
-    it('does nothing for a deleted file that was not added', async function() {
-      let doc = {
-        _id: 'tmp/fooz',
-        _rev: '2-1234567890',
-        deleted: true,
-        docType: 'file',
-        sides: {
-          target: 2,
-          local: 2
-        }
-      }
+    it('does nothing for a deleted file that was not synced', async function() {
+      const doc = await builders
+        .metafile()
+        .path('tmp/fooz')
+        .deleted()
+        .sides({ local: 2 })
+        .create()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
       this.remote.trashAsync.called.should.be.false()
     })
 
     it('calls addFolderAsync for an added folder', async function() {
-      let doc = {
-        _id: 'foobar/bar',
-        _rev: '1-abcdef0123456789',
-        docType: 'folder',
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
+      const doc = await builders
+        .metadir()
+        .path('foobar/bar')
+        .sides({ local: 1 })
+        .create()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
       this.remote.addFolderAsync.calledWith(doc).should.be.true()
     })
 
-    xit('calls updateFolderAsync for an updated folder', async function() {
-      let doc = {
-        _id: 'foobar/bar',
-        _rev: '2-abcdef9876543210',
-        docType: 'folder',
-        tags: ['qux'],
-        sides: {
-          target: 2,
-          local: 1,
-          remote: 2
-        }
-      }
-      await this.sync.applyDoc(doc, this.local, 'local', 1)
+    it('calls updateFolderAsync for an updated folder', async function() {
+      const initial = await builders
+        .metadir()
+        .path('foobar/baz')
+        .upToDate()
+        .create()
+      const doc = await builders
+        .metadir(initial)
+        .tags('qux')
+        .changedSide('remote')
+        .create()
+      await this.sync.applyDoc(doc, this.local, 'local', 2)
       this.local.updateFolderAsync.calledWith(doc).should.be.true()
     })
 
     it('calls moveAsync for a moved folder', async function() {
-      let was = {
-        _id: 'foobar/bar',
-        _rev: '3-9876543210',
-        deleted: true,
-        moveTo: 'foobar/baz',
-        docType: 'folder',
-        tags: ['qux'],
-        sides: {
-          target: 3,
-          local: 3,
-          remote: 2
-        }
-      }
-      let doc = {
-        _id: 'foobar/baz',
-        _rev: '1-abcdef',
-        moveFrom: was,
-        docType: 'folder',
-        tags: ['qux'],
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
+      const was = await builders
+        .metadir()
+        .path('foobar/bar')
+        .tags('qux')
+        .moveTo('foobar/baz')
+        .changedSide('local')
+        .create()
+      const doc = await builders
+        .metadir()
+        .moveFrom(was)
+        .path('foobar/baz')
+        .changedSide('local')
+        .create()
       await this.sync.applyDoc(was, this.remote, 'remote', 2)
-      this.remote.trashAsync.called.should.be.false()
+      should(this.remote.trashAsync).not.have.been.called()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
-      this.remote.addFolderAsync.called.should.be.false()
-      this.remote.moveAsync.calledWith(doc, was).should.be.true()
+      should(this.remote.addFolderAsync).not.have.been.called()
+      should(this.remote.moveAsync).have.been.calledWith(doc, was)
     })
 
-    it('calls trashAsync for a deleted folder', async function() {
-      let doc = {
-        _id: 'foobar/baz',
-        _rev: '4-1234567890',
-        deleted: true,
-        docType: 'folder',
-        sides: {
-          target: 2,
-          local: 1,
-          remote: 2
-        }
-      }
+    it('calls trashAsync for a deleted synced folder', async function() {
+      const doc = await builders
+        .metadir()
+        .path('foobar/baz')
+        .deleted()
+        .changedSide('remote')
+        .create()
       await this.sync.applyDoc(doc, this.local, 'local', 1)
       this.local.deleteFolderAsync.calledWith(doc).should.be.true()
     })
 
     it('does nothing for a deleted folder that was not added', async function() {
-      let doc = {
-        _id: 'tmp/foobaz',
-        _rev: '2-1234567890',
-        deleted: true,
-        docType: 'folder',
-        sides: {
-          target: 2,
-          local: 2
-        }
-      }
+      const doc = await builders
+        .metadir()
+        .path('tmp/foobaz')
+        .deleted()
+        .sides({ local: 2 })
+        .create()
       await this.sync.applyDoc(doc, this.remote, 'remote', 0)
       this.remote.trashAsync.called.should.be.false()
     })
@@ -666,15 +577,11 @@ describe('Sync', function() {
 
   describe('updateErrors', function() {
     it('retries on first local -> remote sync error', async function() {
-      let doc = {
-        _id: 'first/failure',
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
-      const infos = await this.pouch.db.put(doc)
-      doc._rev = infos.rev
+      const doc = await builders
+        .metadata()
+        .path('first/failure')
+        .sides({ local: 1 })
+        .create()
 
       await this.sync.updateErrors({ doc }, 'remote')
 
@@ -797,76 +704,55 @@ describe('Sync', function() {
 
   describe('selectSide', function() {
     it('selects the local side if remote is up-to-date', function() {
-      let doc = {
-        _id: 'selectSide/1',
-        _rev: '1-0123456789',
-        docType: 'file',
-        sides: {
-          target: 1,
-          remote: 1
-        }
-      }
-      let [side, name, rev] = this.sync.selectSide(doc)
+      const doc1 = builders
+        .metafile()
+        .path('selectSide/1')
+        .sides({ remote: 1 })
+        .build()
+      let [side, name, rev] = this.sync.selectSide(doc1)
       side.should.equal(this.sync.local)
       name.should.equal('local')
       rev.should.equal(0)
-      doc = {
-        _id: 'selectSide/2',
-        _rev: '3-0123456789',
-        docType: 'file',
-        sides: {
-          target: 3,
-          remote: 3,
-          local: 2
-        }
-      }
-      ;[side, name, rev] = this.sync.selectSide(doc)
+
+      const doc2 = builders
+        .metafile()
+        .path('selectSide/2')
+        .sides({ local: 2, remote: 3 })
+        .build()
+      ;[side, name, rev] = this.sync.selectSide(doc2)
       side.should.equal(this.sync.local)
       name.should.equal('local')
       rev.should.equal(2)
     })
 
     it('selects the remote side if local is up-to-date', function() {
-      let doc = {
-        _id: 'selectSide/3',
-        _rev: '1-0123456789',
-        docType: 'file',
-        sides: {
-          target: 1,
-          local: 1
-        }
-      }
-      let [side, name, rev] = this.sync.selectSide(doc)
+      const doc1 = builders
+        .metafile()
+        .path('selectSide/3')
+        .sides({ local: 1 })
+        .build()
+      let [side, name, rev] = this.sync.selectSide(doc1)
       side.should.equal(this.sync.remote)
       name.should.equal('remote')
       rev.should.equal(0)
-      doc = {
-        _id: 'selectSide/4',
-        _rev: '4-0123456789',
-        docType: 'file',
-        sides: {
-          target: 4,
-          remote: 3,
-          local: 4
-        }
-      }
-      ;[side, name, rev] = this.sync.selectSide(doc)
+
+      const doc2 = builders
+        .metafile()
+        .path('selectSide/4')
+        .sides({ local: 4, remote: 3 })
+        .build()
+      ;[side, name, rev] = this.sync.selectSide(doc2)
       side.should.equal(this.sync.remote)
       name.should.equal('remote')
       rev.should.equal(3)
     })
 
     it('returns an empty array if both sides are up-to-date', function() {
-      let doc = {
-        _id: 'selectSide/5',
-        _rev: '5-0123456789',
-        docType: 'file',
-        sides: {
-          target: 5,
-          remote: 5,
-          local: 5
-        }
-      }
+      const doc = builders
+        .metafile()
+        .path('selectSide/5')
+        .sides({ local: 5, remote: 5 })
+        .build()
       let [side, name, rev] = this.sync.selectSide(doc)
       should.not.exist(side)
       should.not.exist(name)

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -686,19 +686,12 @@ describe('Sync', function() {
     })
 
     it('retries on second remote -> local sync error', async function() {
-      let doc = {
-        _id: 'second/failure',
-        errors: 1,
-        sides: {
-          target: 4,
-          local: 2,
-          remote: 4
-        }
-      }
-      let infos = await this.pouch.db.put(doc)
-      doc._rev = infos.rev
-      infos = await this.pouch.db.put(doc)
-      doc._rev = infos.rev
+      const doc = await builders
+        .metadata()
+        .path('second/failure')
+        .errors(1)
+        .sides({ local: 2, remote: 4 })
+        .create()
 
       await this.sync.updateErrors({ doc }, 'local')
 
@@ -710,20 +703,18 @@ describe('Sync', function() {
     })
 
     it('stops retrying after 3 errors', async function() {
-      let doc = {
-        _id: 'third/failure',
-        errors: 3,
-        sides: {
-          target: 4,
-          remote: 4
-        }
-      }
-      const infos = await this.pouch.db.put(doc)
-      doc._rev = infos.rev
+      const doc = await builders
+        .metadata()
+        .path('third/failure')
+        .errors(3)
+        .sides({ remote: 4 })
+        .create()
+
       await this.sync.updateErrors({ doc }, 'local')
+
       const actual = await this.pouch.db.get(doc._id)
-      actual.errors.should.equal(3)
-      actual._rev.should.equal(doc._rev)
+      should(actual.errors).equal(3)
+      should(actual._rev).equal(doc._rev)
       should(metadata.isUpToDate('remote', actual)).be.true()
     })
   })

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -220,22 +220,18 @@ describe('Sync', function() {
     })
 
     it('does nothing for an up-to-date _deleted document', async function() {
-      let change = {
+      const change = {
         seq: 122,
-        doc: {
-          _id: 'foo',
-          docType: 'folder',
-          _deleted: true,
-          sides: {
-            target: 2,
-            local: 2,
-            remote: 2
-          }
-        }
+        doc: await builders
+          .metadir()
+          .path('foo')
+          .erased()
+          .upToDate()
+          .create()
       }
       this.sync.applyDoc = sinon.spy()
       await this.sync.apply(change)
-      this.sync.applyDoc.called.should.be.false()
+      should(this.sync.applyDoc).have.not.been.called()
     })
 
     it('trashes a locally deleted file or folder', async function() {
@@ -887,37 +883,23 @@ describe('Sync', function() {
     })
 
     it('returns an empty array if a local only doc is erased', function() {
-      let doc = {
-        _id: 'selectSide/5',
-        _rev: '5-0123456789',
-        _deleted: true,
-        docType: 'file',
-        sides: {
-          target: 5,
-          local: 5
-        }
-      }
-      let [side, name, rev] = this.sync.selectSide(doc)
-      should.not.exist(side)
-      should.not.exist(name)
-      should.not.exist(rev)
+      const doc = builders
+        .metafile()
+        .path('selectSide/5')
+        .erased()
+        .sides({ local: 5 })
+        .build()
+      should(this.sync.selectSide(doc)).deepEqual([])
     })
 
     it('returns an empty array if a remote only doc is erased', function() {
-      let doc = {
-        _id: 'selectSide/5',
-        _rev: '5-0123456789',
-        _deleted: true,
-        docType: 'file',
-        sides: {
-          target: 5,
-          remote: 5
-        }
-      }
-      let [side, name, rev] = this.sync.selectSide(doc)
-      should.not.exist(side)
-      should.not.exist(name)
-      should.not.exist(rev)
+      const doc = builders
+        .metafile()
+        .path('selectSide/5')
+        .erased()
+        .sides({ remote: 5 })
+        .build()
+      should(this.sync.selectSide(doc)).deepEqual([])
     })
   })
 })


### PR DESCRIPTION
Documents built by hand in some tests were not always reflecting the
latest changes made to local, synced and remote documents' schemas.

To make sure they'll stay up-to-date, we'll use data builders to create test
documents.
We made additions and updates to the data builders themselves to be able to
build all kinds of documents and metadata objects.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
