### PR TITLE
core/metadata: Store remote doc in `Metadata`

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -354,8 +354,8 @@ class Local /*:: implements Reader, Writer */ {
     await this.addFolderAsync(doc)
   }
 
-  async assignNewRev(doc /*: Metadata */) /*: Promise<void> */ {
-    log.info({ path: doc.path }, 'Local assignNewRev = noop')
+  async assignNewRemote(doc /*: Metadata */) /*: Promise<void> */ {
+    log.info({ path: doc.path }, 'Local assignNewRemote = noop')
   }
 
   /** Move a file or folder. In case of a file, content is unchanged.

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -234,10 +234,7 @@ function fromRemoteDoc(remoteDoc /*: RemoteDoc */) /*: Metadata */ {
     docType: localDocType(remoteDoc.type),
     created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
     updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at),
-    remote: {
-      _id: remoteDoc._id,
-      _rev: remoteDoc._rev
-    }
+    remote: _.cloneDeep(remoteDoc)
   }
 
   if (remoteDoc.size) {

--- a/core/sync.js
+++ b/core/sync.js
@@ -406,13 +406,13 @@ class Sync {
       if (from.incompatibilities && sideName === 'local') {
         await this.doAdd(side, doc)
       } else if (from.childMove) {
-        await side.assignNewRev(doc)
+        await side.assignNewRemote(doc)
         if (doc.docType === 'file') {
           this.events.emit('transfer-move', _.clone(doc), _.clone(from))
         }
       } else {
         if (from.moveFrom && from.moveFrom.childMove) {
-          await side.assignNewRev(from)
+          await side.assignNewRemote(from)
         }
         await this.doMove(side, doc, from)
       }

--- a/core/writer.js
+++ b/core/writer.js
@@ -17,7 +17,7 @@ export interface Writer {
   updateFileMetadataAsync (doc: Metadata, old: Metadata): Promise<void>;
   updateFolderAsync (doc: Metadata, old: Metadata): Promise<void>;
   moveAsync (doc: Metadata, from: Metadata): Promise<void>;
-  assignNewRev (doc: Metadata): Promise<void>;
+  assignNewRemote (doc: Metadata): Promise<void>;
   trashAsync (doc: Metadata): Promise<void>;
   deleteFolderAsync (doc: Metadata): Promise<void>;
 }

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -13,7 +13,7 @@ const METHODS = [
   'updateFileMetadataAsync',
   'updateFolderAsync',
   'moveAsync',
-  'assignNewRev',
+  'assignNewRemote',
   'trashAsync',
   'deleteFolderAsync',
   'renameConflictingDocAsync'

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -74,10 +74,7 @@ describe('metadata', function() {
         name: 'bar',
         path: 'foo/bar',
         dir_id: '56',
-        remote: {
-          _id: '12',
-          _rev: '34'
-        },
+        remote: remoteDoc,
         size: 78,
         tags: ['foo'],
         cozyMetadata: {
@@ -116,10 +113,7 @@ describe('metadata', function() {
         path: 'foo/bar',
         name: 'bar',
         dir_id: '56',
-        remote: {
-          _id: '12',
-          _rev: '34'
-        },
+        remote: remoteDoc,
         tags: ['foo']
       })
     })

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -1896,10 +1896,7 @@ describe('RemoteWatcher', function() {
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
-        remote: {
-          _id: remoteDoc._id,
-          _rev: remoteDoc._rev
-        }
+        remote: remoteDoc
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
     })
@@ -1927,10 +1924,7 @@ describe('RemoteWatcher', function() {
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
-        remote: {
-          _id: remoteDoc._id,
-          _rev: remoteDoc._rev
-        }
+        remote: remoteDoc
       })
     })
 
@@ -1957,10 +1951,7 @@ describe('RemoteWatcher', function() {
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
-        remote: {
-          _id: remoteDoc._id,
-          _rev: remoteDoc._rev
-        }
+        remote: remoteDoc
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
     })
@@ -1989,10 +1980,7 @@ describe('RemoteWatcher', function() {
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
-        remote: {
-          _id: remoteDoc._id,
-          _rev: remoteDoc._rev
-        }
+        remote: remoteDoc
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
     })
@@ -2026,10 +2014,7 @@ describe('RemoteWatcher', function() {
         docType: 'file',
         md5sum: remoteDoc.md5sum,
         tags: remoteDoc.tags,
-        remote: {
-          _id: remoteDoc._id,
-          _rev: remoteDoc._rev
-        }
+        remote: remoteDoc
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
     })


### PR DESCRIPTION
The `remote` attribute of `Metadata` objects, stored locally in
PouchDB, only includes the `_id` and `_rev` of the associated remote
document.
We've started storing most of the other remote attributes in the main
section of the `Metadata` object but we're missing an opportunity to
make comparisons between the most recent remote state of a document
and the latest known remote state from any part of the synchronization
process.
We're forced to make those comparisons in the remote watcher while we
could benefit from them in the Merge or Sync modules.
Besides, storing the entire remote document means we have access to
all remote attributes and won't need to make further changes in the
future to access new attributes.

This commit only adds the entire remote document to `Metadata` objects
without making use of the newly stored attributes.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
