### PR TITLE
core/local: Build local metadata for folders

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -745,6 +745,7 @@ function buildDir(
   if (stats.fileid) {
     doc.fileid = stats.fileid
   }
+  updateLocal(doc)
   return doc
 }
 
@@ -833,7 +834,7 @@ function updateLocal(doc /*: Metadata */, newLocal /*: ?Object */ = {}) {
   // This is the case for `executable` and we need to provide a default falsy
   // value to override the `newLocal` executable value in all cases.
   doc.local = _.pick(
-    _.defaults(newLocal, { executable: false }, doc),
+    _.defaults(newLocal, isFile(doc) ? { executable: false } : {}, doc),
     LOCAL_ATTRIBUTES
   )
 }

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -159,6 +159,25 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 5,
+    targetSchemaVersion: 6,
+    description: 'Generating folders local Metadata info with current Metadata',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(doc => doc.docType === 'folders')
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        doc.local = {
+          docType: 'folder',
+          updated_at: doc.updated_at,
+          ino: doc.ino,
+          fileid: doc.fileid
+        }
+        return doc
+      })
+    }
   }
 ]
 

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -14,190 +14,86 @@ const { TRASH_DIR_ID } = require('../../core/remote/constants')
 const { isNote } = require('../../core/utils/notes')
 const metadata = require('../../core/metadata')
 
-let builders, helpers
+describe('Update', () => {
+  let builders, helpers
 
-before(configHelpers.createConfig)
-before(configHelpers.registerClient)
-beforeEach(pouchHelpers.createDatabase)
-beforeEach(cozyHelpers.deleteAll)
+  before(configHelpers.createConfig)
+  before(configHelpers.registerClient)
+  beforeEach(pouchHelpers.createDatabase)
+  beforeEach(cozyHelpers.deleteAll)
 
-afterEach(pouchHelpers.cleanDatabase)
-after(configHelpers.cleanConfig)
+  afterEach(pouchHelpers.cleanDatabase)
+  after(configHelpers.cleanConfig)
 
-beforeEach(async function() {
-  builders = new Builders({ cozy: cozyHelpers.cozy, pouch: this.pouch })
-  helpers = TestHelpers.init(this)
+  beforeEach(async function() {
+    builders = new Builders({ cozy: cozyHelpers.cozy, pouch: this.pouch })
+    helpers = TestHelpers.init(this)
 
-  await helpers.local.clean()
-  await helpers.local.setupTrash()
-  await helpers.remote.ignorePreviousChanges()
-})
-
-describe('Cozy Note update', () => {
-  let note
-  beforeEach('create note', async () => {
-    note = await builders
-      .remoteNote()
-      .name('note.cozy-note')
-      .data('Initial content')
-      .createdAt(2018, 5, 15, 21, 1, 53)
-      .create()
-    await helpers.pullAndSyncAll()
-    await helpers.flushLocalAndSyncAll()
+    await helpers.local.clean()
+    await helpers.local.setupTrash()
+    await helpers.remote.ignorePreviousChanges()
   })
 
-  describe('on remote Cozy', () => {
-    beforeEach('update remote note', async () => {
-      await builders
-        .remoteNote(note)
-        .data('updated content')
-        .update()
+  describe('Cozy Note', () => {
+    let note
+    beforeEach('create note', async () => {
+      note = await builders
+        .remoteNote()
+        .name('note.cozy-note')
+        .data('Initial content')
+        .createdAt(2018, 5, 15, 21, 1, 53)
+        .create()
       await helpers.pullAndSyncAll()
       await helpers.flushLocalAndSyncAll()
     })
 
-    it('updates the note content on the filesystem', async () => {
-      should(await helpers.local.syncDir.readFile('note.cozy-note')).eql(
-        'note\n\nupdated content'
-      )
-    })
-
-    it('keeps the note metadata', async () => {
-      const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
-      // FIXME: check for metadata update once the builder can do it
-      should(updatedDoc).have.property('metadata')
-    })
-  })
-
-  describe('on local filesystem', () => {
-    beforeEach('update local note', async () => {
-      await helpers.local.syncDir.outputFile(
-        'note.cozy-note',
-        'updated content'
-      )
-      await helpers.flushLocalAndSyncAll()
-      await helpers.pullAndSyncAll()
-    })
-
-    it('renames the original remote note with a conflict suffix', async () => {
-      const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
-      should(updatedRemote)
-        .have.property('name')
-        .match(/-conflict-/)
-      should(updatedRemote).have.properties({
-        md5sum: note.md5sum,
-        dir_id: note.dir_id
-      })
-      should(isNote(updatedRemote)).be.true()
-    })
-
-    it('uploads the new content to the Cozy', async () => {
-      should(await helpers.remote.readFile('note.cozy-note')).eql(
-        'updated content'
-      )
-    })
-
-    it('keeps the original note metadata', async () => {
-      const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
-      should(updatedDoc).have.property('metadata')
-    })
-  })
-})
-
-describe('Cozy Note move', () => {
-  let note
-  beforeEach('create note', async () => {
-    await builders
-      .remoteDir()
-      .name('dst')
-      .create()
-    note = await builders
-      .remoteNote()
-      .name('note.cozy-note')
-      .data('Initial content')
-      .createdAt(2018, 5, 15, 21, 1, 53)
-      .create()
-    await helpers.pullAndSyncAll()
-  })
-
-  describe('on local filesystem', () => {
-    const srcPath = 'note.cozy-note'
-    const dstPath = path.normalize('dst/note.cozy-note')
-
-    describe('to a free target location', () => {
-      beforeEach('move local note', async () => {
-        await helpers.local.syncDir.move(srcPath, dstPath)
-        await helpers.flushLocalAndSyncAll()
+    describe('on remote Cozy', () => {
+      beforeEach('update remote note', async () => {
+        await builders
+          .remoteNote(note)
+          .data('updated content')
+          .update()
         await helpers.pullAndSyncAll()
+        await helpers.flushLocalAndSyncAll()
+      })
+
+      it('updates the note content on the filesystem', async () => {
+        should(await helpers.local.syncDir.readFile('note.cozy-note')).eql(
+          'note\n\nupdated content'
+        )
       })
 
       it('keeps the note metadata', async () => {
         const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
+        // FIXME: check for metadata update once the builder can do it
         should(updatedDoc).have.property('metadata')
       })
     })
-  })
 
-  describe('on remote Cozy', () => {
-    const dstPath = path.normalize('dst/note.cozy-note')
-
-    describe('to a free target location', () => {
-      beforeEach('move local note', async () => {
-        await helpers.remote.move(note, dstPath)
-        await helpers.pullAndSyncAll()
-        await helpers.flushLocalAndSyncAll()
-      })
-
-      it('keeps the note metadata', async () => {
-        const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
-        should(updatedDoc).have.property('metadata')
-      })
-    })
-  })
-})
-
-describe('Cozy Note move with update', () => {
-  let dst, note
-  beforeEach('create note', async () => {
-    dst = await builders
-      .remoteDir()
-      .name('dst')
-      .create()
-    note = await builders
-      .remoteNote()
-      .name('note.cozy-note')
-      .data('Initial content')
-      .createdAt(2018, 5, 15, 21, 1, 53)
-      .create()
-    await helpers.pullAndSyncAll()
-  })
-
-  describe('on local filesystem', () => {
-    const srcPath = 'note.cozy-note'
-    const dstPath = path.normalize('dst/note.cozy-note')
-
-    describe('to a free target location', () => {
-      beforeEach('move and update local note', async () => {
-        await helpers.local.syncDir.move(srcPath, dstPath)
-        await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+    describe('on local filesystem', () => {
+      beforeEach('update local note', async () => {
+        await helpers.local.syncDir.outputFile(
+          'note.cozy-note',
+          'updated content'
+        )
         await helpers.flushLocalAndSyncAll()
         await helpers.pullAndSyncAll()
       })
 
-      it('moves the original remote note then rename it with a conflict suffix', async () => {
-        const updatedRemote = await helpers.remote.byIdMaybe(note._id)
+      it('renames the original remote note with a conflict suffix', async () => {
+        const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
         should(updatedRemote)
           .have.property('name')
           .match(/-conflict-/)
         should(updatedRemote).have.properties({
           md5sum: note.md5sum,
-          dir_id: dst._id
+          dir_id: note.dir_id
         })
         should(isNote(updatedRemote)).be.true()
       })
 
-      it('uploads the new content to the Cozy at the target location', async () => {
-        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+      it('uploads the new content to the Cozy', async () => {
+        should(await helpers.remote.readFile('note.cozy-note')).eql(
           'updated content'
         )
       })
@@ -207,185 +103,295 @@ describe('Cozy Note move with update', () => {
         should(updatedDoc).have.property('metadata')
       })
     })
+  })
 
-    describe('overwriting existing note at target location', () => {
+  describe('Cozy Note move', () => {
+    let note
+    beforeEach('create note', async () => {
+      await builders
+        .remoteDir()
+        .name('dst')
+        .create()
+      note = await builders
+        .remoteNote()
+        .name('note.cozy-note')
+        .data('Initial content')
+        .createdAt(2018, 5, 15, 21, 1, 53)
+        .create()
+      await helpers.pullAndSyncAll()
+    })
+
+    describe('on local filesystem', () => {
       const srcPath = 'note.cozy-note'
       const dstPath = path.normalize('dst/note.cozy-note')
 
-      let existing
-      beforeEach('create note at target location', async () => {
-        existing = await builders
-          .remoteNote()
-          .inDir(dst)
-          .name('note.cozy-note')
-          .data('overwritten content')
-          .createdAt(2018, 5, 15, 21, 1, 53)
-          .create()
-        await helpers.pullAndSyncAll()
-        await helpers.flushLocalAndSyncAll()
-      })
-      beforeEach('move and update local note', async () => {
-        await helpers.local.syncDir.move(srcPath, dstPath, { overwrite: true })
-        await helpers.local.syncDir.outputFile(dstPath, 'updated content')
-        await helpers.flushLocalAndSyncAll()
-      })
-
-      it('moves the original remote note then rename it with a conflict suffix', async () => {
-        const updatedRemote = await helpers.remote.byIdMaybe(note._id)
-        should(updatedRemote)
-          .have.property('name')
-          .match(/-conflict-/)
-        should(updatedRemote).have.properties({
-          md5sum: note.md5sum,
-          dir_id: dst._id
+      describe('to a free target location', () => {
+        beforeEach('move local note', async () => {
+          await helpers.local.syncDir.move(srcPath, dstPath)
+          await helpers.flushLocalAndSyncAll()
+          await helpers.pullAndSyncAll()
         })
-        should(isNote(updatedRemote)).be.true()
-      })
 
-      it('uploads the new content to the Cozy at the target location', async () => {
-        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
-          'updated content'
-        )
+        it('keeps the note metadata', async () => {
+          const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
+          should(updatedDoc).have.property('metadata')
+        })
       })
+    })
 
-      it('sends the overwritten note to the trash', async () => {
-        should(await helpers.remote.byIdMaybe(existing._id)).have.properties({
-          md5sum: existing.md5sum,
-          name: existing.name,
-          dir_id: TRASH_DIR_ID,
-          trashed: true
+    describe('on remote Cozy', () => {
+      const dstPath = path.normalize('dst/note.cozy-note')
+
+      describe('to a free target location', () => {
+        beforeEach('move local note', async () => {
+          await helpers.remote.move(note, dstPath)
+          await helpers.pullAndSyncAll()
+          await helpers.flushLocalAndSyncAll()
+        })
+
+        it('keeps the note metadata', async () => {
+          const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
+          should(updatedDoc).have.property('metadata')
         })
       })
     })
   })
-})
 
-describe('Markdown file with Cozy Note mime type update', () => {
-  let note
-  beforeEach('create note', async () => {
-    note = await builders
-      .remoteNote()
-      .name('note.cozy-note')
-      .data('Initial content')
-      .createdAt(2018, 5, 15, 21, 1, 53)
-      .create()
-    await helpers.pullAndSyncAll()
-    await helpers.flushLocalAndSyncAll()
-  })
-  beforeEach('change note into markdown file', async function() {
-    const doc = await this.pouch.byIdMaybe(metadata.id('note.cozy-note'))
-    // remove everything that makes a note a Cozy Note
-    await this.pouch.put({ ...doc, metadata: {} })
+  describe('Cozy Note move with update', () => {
+    let dst, note
+    beforeEach('create note', async () => {
+      dst = await builders
+        .remoteDir()
+        .name('dst')
+        .create()
+      note = await builders
+        .remoteNote()
+        .name('note.cozy-note')
+        .data('Initial content')
+        .createdAt(2018, 5, 15, 21, 1, 53)
+        .create()
+      await helpers.pullAndSyncAll()
+    })
+
+    describe('on local filesystem', () => {
+      const srcPath = 'note.cozy-note'
+      const dstPath = path.normalize('dst/note.cozy-note')
+
+      describe('to a free target location', () => {
+        beforeEach('move and update local note', async () => {
+          await helpers.local.syncDir.move(srcPath, dstPath)
+          await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+          await helpers.flushLocalAndSyncAll()
+          await helpers.pullAndSyncAll()
+        })
+
+        it('moves the original remote note then rename it with a conflict suffix', async () => {
+          const updatedRemote = await helpers.remote.byIdMaybe(note._id)
+          should(updatedRemote)
+            .have.property('name')
+            .match(/-conflict-/)
+          should(updatedRemote).have.properties({
+            md5sum: note.md5sum,
+            dir_id: dst._id
+          })
+          should(isNote(updatedRemote)).be.true()
+        })
+
+        it('uploads the new content to the Cozy at the target location', async () => {
+          should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+            'updated content'
+          )
+        })
+
+        it('keeps the original note metadata', async () => {
+          const updatedDoc = await helpers.pouch.byRemoteIdMaybe(note._id)
+          should(updatedDoc).have.property('metadata')
+        })
+      })
+
+      describe('overwriting existing note at target location', () => {
+        const srcPath = 'note.cozy-note'
+        const dstPath = path.normalize('dst/note.cozy-note')
+
+        let existing
+        beforeEach('create note at target location', async () => {
+          existing = await builders
+            .remoteNote()
+            .inDir(dst)
+            .name('note.cozy-note')
+            .data('overwritten content')
+            .createdAt(2018, 5, 15, 21, 1, 53)
+            .create()
+          await helpers.pullAndSyncAll()
+          await helpers.flushLocalAndSyncAll()
+        })
+        beforeEach('move and update local note', async () => {
+          await helpers.local.syncDir.move(srcPath, dstPath, {
+            overwrite: true
+          })
+          await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+          await helpers.flushLocalAndSyncAll()
+        })
+
+        it('moves the original remote note then rename it with a conflict suffix', async () => {
+          const updatedRemote = await helpers.remote.byIdMaybe(note._id)
+          should(updatedRemote)
+            .have.property('name')
+            .match(/-conflict-/)
+          should(updatedRemote).have.properties({
+            md5sum: note.md5sum,
+            dir_id: dst._id
+          })
+          should(isNote(updatedRemote)).be.true()
+        })
+
+        it('uploads the new content to the Cozy at the target location', async () => {
+          should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+            'updated content'
+          )
+        })
+
+        it('sends the overwritten note to the trash', async () => {
+          should(await helpers.remote.byIdMaybe(existing._id)).have.properties({
+            md5sum: existing.md5sum,
+            name: existing.name,
+            dir_id: TRASH_DIR_ID,
+            trashed: true
+          })
+        })
+      })
+    })
   })
 
-  describe('on local filesystem', () => {
-    beforeEach('update local note', async () => {
-      await helpers.local.syncDir.outputFile(
-        'note.cozy-note',
-        'updated content'
-      )
+  describe('Markdown file with Cozy Note mime type update', () => {
+    let note
+    beforeEach('create note', async () => {
+      note = await builders
+        .remoteNote()
+        .name('note.cozy-note')
+        .data('Initial content')
+        .createdAt(2018, 5, 15, 21, 1, 53)
+        .create()
+      await helpers.pullAndSyncAll()
       await helpers.flushLocalAndSyncAll()
     })
-
-    it('updates the remote file with the new content', async () => {
-      const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
-      should(updatedRemote).have.properties({
-        name: note.name,
-        dir_id: note.dir_id
-      })
-      should(await helpers.remote.readFile('note.cozy-note')).eql(
-        'updated content'
-      )
-      should(isNote(updatedRemote)).be.false()
+    beforeEach('change note into markdown file', async function() {
+      const doc = await this.pouch.byIdMaybe(metadata.id('note.cozy-note'))
+      // remove everything that makes a note a Cozy Note
+      await this.pouch.put({ ...doc, metadata: {} })
     })
-  })
-})
 
-describe('Markdown file with Cozy Note mime type move with update', () => {
-  let dst, note
-  beforeEach('create note', async () => {
-    dst = await builders
-      .remoteDir()
-      .name('dst')
-      .create()
-    note = await builders
-      .remoteNote()
-      .name('note.cozy-note')
-      .data('Initial content')
-      .createdAt(2018, 5, 15, 21, 1, 53)
-      .create()
-    await helpers.pullAndSyncAll()
-  })
-  beforeEach('change note into markdown file', async function() {
-    const doc = await this.pouch.byIdMaybe(metadata.id('note.cozy-note'))
-    // remove everything that makes a note a Cozy Note
-    await this.pouch.put({ ...doc, metadata: {} })
-  })
-
-  describe('on local filesystem', () => {
-    const srcPath = 'note.cozy-note'
-    const dstPath = path.normalize('dst/note.cozy-note')
-
-    describe('to a free target location', () => {
-      beforeEach('move and update local note', async () => {
-        await helpers.local.syncDir.move(srcPath, dstPath)
-        await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+    describe('on local filesystem', () => {
+      beforeEach('update local note', async () => {
+        await helpers.local.syncDir.outputFile(
+          'note.cozy-note',
+          'updated content'
+        )
         await helpers.flushLocalAndSyncAll()
       })
 
-      it('moves and updates the remote file with the new content', async () => {
+      it('updates the remote file with the new content', async () => {
         const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
         should(updatedRemote).have.properties({
           name: note.name,
-          dir_id: dst._id
+          dir_id: note.dir_id
         })
-        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+        should(await helpers.remote.readFile('note.cozy-note')).eql(
           'updated content'
         )
         should(isNote(updatedRemote)).be.false()
       })
     })
+  })
 
-    describe('overwriting existing note at target location', () => {
+  describe('Markdown file with Cozy Note mime type after move', () => {
+    let dst, note
+    beforeEach('create note', async () => {
+      dst = await builders
+        .remoteDir()
+        .name('dst')
+        .create()
+      note = await builders
+        .remoteNote()
+        .name('note.cozy-note')
+        .data('Initial content')
+        .createdAt(2018, 5, 15, 21, 1, 53)
+        .create()
+      await helpers.pullAndSyncAll()
+    })
+    beforeEach('change note into markdown file', async function() {
+      const doc = await this.pouch.byIdMaybe(metadata.id('note.cozy-note'))
+      // remove everything that makes a note a Cozy Note
+      await this.pouch.put({ ...doc, metadata: {} })
+    })
+
+    describe('on local filesystem', () => {
       const srcPath = 'note.cozy-note'
       const dstPath = path.normalize('dst/note.cozy-note')
 
-      let existing
-      beforeEach('create note at target location', async () => {
-        existing = await builders
-          .remoteNote()
-          .inDir(dst)
-          .name('note.cozy-note')
-          .data('overwritten content')
-          .createdAt(2018, 5, 15, 21, 1, 53)
-          .create()
-        await helpers.pullAndSyncAll()
-        await helpers.flushLocalAndSyncAll()
-      })
-      beforeEach('move and update local note', async () => {
-        await helpers.local.syncDir.move(srcPath, dstPath, { overwrite: true })
-        await helpers.local.syncDir.outputFile(dstPath, 'updated content')
-        await helpers.flushLocalAndSyncAll()
-      })
-
-      it('moves and updates the remote file with the new content', async () => {
-        const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
-        should(updatedRemote).have.properties({
-          name: note.name,
-          dir_id: dst._id
+      describe('to a free target location', () => {
+        beforeEach('move and update local note', async () => {
+          await helpers.local.syncDir.move(srcPath, dstPath)
+          await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+          await helpers.flushLocalAndSyncAll()
         })
-        should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
-          'updated content'
-        )
-        should(isNote(updatedRemote)).be.false()
+
+        it('moves and updates the remote file with the new content', async () => {
+          const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
+          should(updatedRemote).have.properties({
+            name: note.name,
+            dir_id: dst._id
+          })
+          should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+            'updated content'
+          )
+          should(isNote(updatedRemote)).be.false()
+        })
       })
 
-      it('sends the overwritten note to the trash', async () => {
-        should(await helpers.remote.byIdMaybe(existing._id)).have.properties({
-          md5sum: existing.md5sum,
-          name: existing.name,
-          dir_id: TRASH_DIR_ID,
-          trashed: true
+      describe('overwriting existing note at target location', () => {
+        const srcPath = 'note.cozy-note'
+        const dstPath = path.normalize('dst/note.cozy-note')
+
+        let existing
+        beforeEach('create note at target location', async () => {
+          existing = await builders
+            .remoteNote()
+            .inDir(dst)
+            .name('note.cozy-note')
+            .data('overwritten content')
+            .createdAt(2018, 5, 15, 21, 1, 53)
+            .create()
+          await helpers.pullAndSyncAll()
+          await helpers.flushLocalAndSyncAll()
+        })
+        beforeEach('move and update local note', async () => {
+          await helpers.local.syncDir.move(srcPath, dstPath, {
+            overwrite: true
+          })
+          await helpers.local.syncDir.outputFile(dstPath, 'updated content')
+          await helpers.flushLocalAndSyncAll()
+        })
+
+        it('moves and updates the remote file with the new content', async () => {
+          const updatedRemote = (await helpers.remote.byIdMaybe(note._id)) || {}
+          should(updatedRemote).have.properties({
+            name: note.name,
+            dir_id: dst._id
+          })
+          should(await helpers.remote.readFile('dst/note.cozy-note')).eql(
+            'updated content'
+          )
+          should(isNote(updatedRemote)).be.false()
+        })
+
+        it('sends the overwritten note to the trash', async () => {
+          should(await helpers.remote.byIdMaybe(existing._id)).have.properties({
+            md5sum: existing.md5sum,
+            name: existing.name,
+            dir_id: TRASH_DIR_ID,
+            trashed: true
+          })
         })
       })
     })

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -47,7 +47,7 @@ module.exports = class BaseMetadataBuilder {
       }
       this.doc = doc
     }
-    this.buildLocal = false // Default docType is folder
+    this.buildLocal = true
   }
 
   fromRemote(remoteDoc /*: RemoteDoc */) /*: this */ {


### PR DESCRIPTION
We build the `local` attribute of `Metadata` for folders like we
already do for files.
This will allow us to make comparisons between a known local state and
a new one and between a local state and a known synchronized or remote
state.

PouchDB records are migrated with known attributes which are present
in the main section of the `Metadata` object.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
