### PR TITLE
core: Refactor remote types

### DIFF
--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -4,6 +4,11 @@
  * @flow
  */
 
+/*::
+export type FILE_TYPE = 'file'
+export type DIR_TYPE = 'directory'
+*/
+
 module.exports = {
   // Doctypes
   FILES_DOCTYPE: 'io.cozy.files',

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -8,10 +8,84 @@ const { uniq } = require('lodash')
 
 const {
   FILE_TYPE,
+  DIR_TYPE,
   ROOT_DIR_ID,
   TRASH_DIR_ID,
   TRASH_DIR_NAME
 } = require('./constants')
+
+/*::
+import type {
+  FILE_TYPE as FILE,
+  DIR_TYPE as DIR
+} from './constants'
+
+export type RemoteFileAttributes = {
+  type: FILE,
+  class: string,
+  executable?: boolean,
+  md5sum: string,
+  mime: string,
+  size: string,
+}
+
+export type RemoteDirAttributes = {
+  type: DIR,
+  path: string,
+
+}
+
+export type RemoteBase = {
+  _id: string,
+  _rev: string,
+  _type: string,
+  _deleted?: true,
+  dir_id: string,
+  name: string,
+  tags: string[],
+  trashed?: true,
+  created_at: string,
+  updated_at: string,
+  cozyMetadata?: Object,
+  metadata?: Object,
+  restore_path?: string,
+}
+export type RemoteFile = RemoteBase & RemoteFileAttributes
+export type RemoteDir = RemoteBase & RemoteDirAttributes
+export type RemoteDoc = RemoteFile|RemoteDir
+
+export type RemoteDeletion = {
+  _id: string,
+  _rev: string,
+  _deleted: true
+}
+
+export type JsonApiAttributes = {
+  class?: string, // file only
+  dir_id: string,
+  executable?: boolean, // file only
+  md5sum?: string, // file only
+  mime?: string, // file only
+  name: string,
+  path?: string, // folder only
+  size?: string, // file only
+  tags: string[],
+  trashed?: true,
+  created_at: string,
+  updated_at: string,
+  cozyMetadata?: Object,
+  metadata?: Object,
+  restore_path?: string,
+}
+
+export type JsonApiDoc = {
+  _id: string,
+  _rev: string,
+  _type: string,
+  _deleted?: true,
+  attributes: JsonApiAttributes & { type: FILE | DIR },
+}
+*/
 
 module.exports = {
   specialId,
@@ -26,38 +100,6 @@ function specialId(id /*: string */) {
   return id === ROOT_DIR_ID || id === TRASH_DIR_ID || id.startsWith('_design/')
 }
 
-// TODO: Define separate types for files and folders
-
-/*::
-export type RemoteDoc = {
-  _id: string,
-  _rev: string,
-  _type: string,
-  class?: string,
-  dir_id: string,
-  executable?: boolean,
-  md5sum?: string,
-  mime?: string,
-  name: string,
-  path: string, // folder and file
-  size?: string,
-  tags: string[],
-  trashed?: true,
-  restore_path?: string,
-  type: string,
-  created_at: string,
-  updated_at: string,
-  cozyMetadata?: Object,
-  metadata?: Object
-}
-
-export type RemoteDeletion = {
-  _id: string,
-  _rev: string,
-  _deleted: true
-}
-*/
-
 function dropSpecialDocs(docs /*: RemoteDoc[] */) /*: RemoteDoc[] */ {
   return docs.filter(doc => !specialId(doc._id))
 }
@@ -71,46 +113,37 @@ function parentDirIds(docs /*: RemoteDoc[] */) {
 }
 
 function inRemoteTrash(doc /*: RemoteDoc */) /*: boolean */ {
-  return doc.trashed || doc.path.startsWith(`/${TRASH_DIR_NAME}/`)
+  return (
+    !!doc.trashed ||
+    (doc.type === DIR_TYPE && doc.path.startsWith(`/${TRASH_DIR_NAME}/`))
+  )
 }
 
-/*::
-export type JsonApiAttributes = {
-  class?: string, // file only
-  dir_id: string,
-  executable?: boolean, // file only
-  md5sum?: string, // file only
-  mime?: string, // file only
-  name: string,
-  path?: string, // folder only
-  size?: string, // file only
-  tags: string[],
-  type: string,
-  updated_at: string,
-  cozyMetadata?: Object,
-  metadata?: Object
-}
-
-export type JsonApiDoc = {
-  _id: string,
-  _rev: string,
-  _type: string,
-  attributes: JsonApiAttributes,
-}
-*/
-
-function jsonApiToRemoteDoc(json /*: JsonApiDoc */) /*: * */ {
-  let remoteDoc /*: RemoteDoc */ = {}
-
-  Object.assign(
-    remoteDoc,
-    {
+function jsonApiToRemoteDoc(json /*: JsonApiDoc */) /*: RemoteDoc */ {
+  if (json.attributes.type === DIR_TYPE) {
+    const remoteDir = ({
+      type: DIR_TYPE,
       _id: json._id,
       _rev: json._rev,
-      _type: json._type
-    },
-    json.attributes
-  )
+      _type: json._type,
+      ...(json.attributes /*: JsonApiAttributes */)
+    } /*: RemoteDir */)
 
-  return remoteDoc
+    if (json._deleted) remoteDir._deleted = true
+
+    return remoteDir
+  } else {
+    const remoteFile = ({
+      type: FILE_TYPE,
+      _id: json._id,
+      _rev: json._rev,
+      _type: json._type,
+      _deleted: json._deleted,
+      ...(json.attributes /*: JsonApiAttributes */)
+    } /*: RemoteFile */)
+
+    if (json._deleted) remoteFile._deleted = true
+
+    return remoteFile
+  }
 }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -21,9 +21,9 @@ import type EventEmitter from 'events'
 import type { Pouch } from '../../pouch'
 import type Prep from '../../prep'
 import type { RemoteCozy } from '../cozy'
-import type { Metadata, RemoteRevisionsByID } from '../../metadata'
+import type { Metadata, MetadataRemoteInfo, RemoteRevisionsByID } from '../../metadata'
 import type { RemoteChange, RemoteFileMove, RemoteDirMove, RemoteDescendantChange } from '../change'
-import type { RemoteDoc, RemoteDeletion } from '../document'
+import type { RemoteDeletion } from '../document'
 */
 
 const log = logger({
@@ -137,7 +137,7 @@ class RemoteWatcher {
    * FIXME: Misleading method name?
    */
   async pullMany(
-    docs /*: Array<RemoteDoc|RemoteDeletion> */
+    docs /*: Array<MetadataRemoteInfo|RemoteDeletion> */
   ) /*: Promise<void> */ {
     const remoteIds = docs.reduce((ids, doc) => ids.add(doc._id), new Set())
     const olds /*: Metadata[] */ = await this.pouch.allByRemoteIds(remoteIds)
@@ -162,7 +162,7 @@ class RemoteWatcher {
   }
 
   async analyse(
-    remoteDocs /*: Array<RemoteDoc|RemoteDeletion> */,
+    remoteDocs /*: Array<MetadataRemoteInfo|RemoteDeletion> */,
     olds /*: Array<Metadata> */
   ) /*: Promise<RemoteChange[]> */ {
     log.trace('Contextualize and analyse changesfeed results...')
@@ -185,7 +185,7 @@ class RemoteWatcher {
   }
 
   identifyAll(
-    remoteDocs /*: Array<RemoteDoc|RemoteDeletion> */,
+    remoteDocs /*: Array<MetadataRemoteInfo|RemoteDeletion> */,
     olds /*: Array<Metadata> */
   ) {
     const changes /*: Array<RemoteChange> */ = []
@@ -201,7 +201,7 @@ class RemoteWatcher {
   }
 
   identifyChange(
-    remoteDoc /*: RemoteDoc|RemoteDeletion */,
+    remoteDoc /*: MetadataRemoteInfo|RemoteDeletion */,
     was /*: ?Metadata */,
     previousChanges /*: Array<RemoteChange> */,
     originalMoves /*: Array<RemoteDirMove|RemoteDescendantChange> */
@@ -270,7 +270,7 @@ class RemoteWatcher {
    * the trash just after, it looks like it appeared directly on the trash.
    */
   identifyExistingDocChange(
-    remoteDoc /*: RemoteDoc */,
+    remoteDoc /*: MetadataRemoteInfo */,
     was /*: ?Metadata */,
     previousChanges /*: Array<RemoteChange> */,
     originalMoves /*: Array<RemoteDirMove|RemoteDescendantChange> */

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -19,7 +19,7 @@ const cozyHelpers = require('../../test/support/helpers/cozy')
 const Builders = require('../../test/support/builders')
 
 /*::
-import type { RemoteDoc } from '../../core/remote/document'
+import type { MetadataRemoteInfo } from '../../core/metadata'
 */
 
 // eslint-disable-next-line no-console,no-unused-vars
@@ -38,8 +38,8 @@ const createInitialTree = async function(
   if (!scenario.init) return
 
   const builders = new Builders({ cozy, pouch })
-  const remoteDocs /*: { [string]: RemoteDoc } */ = {}
-  const remoteDocsToTrash /*: RemoteDoc[] */ = []
+  const remoteDocs /*: { [string]: MetadataRemoteInfo } */ = {}
+  const remoteDocsToTrash /*: MetadataRemoteInfo[] */ = []
 
   debug('[init]')
   for (const initDoc of scenario.init) {

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -15,14 +15,16 @@ const RemoteFileBuilder = require('./remote/file')
 const RemoteNoteBuilder = require('./remote/note')
 const StreamBuilder = require('./stream')
 const AtomEventBuilder = require('./atom_event')
+const { DefaultStatsBuilder, WinStatsBuilder } = require('./stats')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
-import type { Metadata } from '../../../core/metadata'
+import type { Metadata, MetadataRemoteFile, MetadataRemoteDir } from '../../../core/metadata'
 import type { Pouch } from '../../../core/pouch'
 import type { Warning } from '../../../core/remote/warning'
-import type { RemoteDoc } from '../../../core/remote/document'
+import type { RemoteDoc, RemoteFile, RemoteDir } from '../../../core/remote/document'
 import type { AtomEvent } from '../../../core/local/atom/event'
+import type { StatsBuilder } from './stats'
 */
 
 // Test data builders facade.
@@ -54,21 +56,25 @@ module.exports = class Builders {
     return new FileMetadataBuilder(this.pouch, old)
   }
 
-  remoteDir(old /*: ?RemoteDoc */) /*: RemoteDirBuilder */ {
+  remoteDir(old /*: ?RemoteDir|MetadataRemoteDir */) /*: RemoteDirBuilder */ {
     return new RemoteDirBuilder(this.cozy, old)
   }
 
-  remoteFile(old /*: ?RemoteDoc */) /*: RemoteFileBuilder */ {
+  remoteFile(
+    old /*: ?RemoteFile|MetadataRemoteFile */
+  ) /*: RemoteFileBuilder */ {
     return new RemoteFileBuilder(this.cozy, old)
   }
 
-  remoteNote(old /*: ?RemoteDoc */) /*: RemoteNoteBuilder */ {
+  remoteNote(
+    old /*: ?RemoteFile|MetadataRemoteFile */
+  ) /*: RemoteNoteBuilder */ {
     return new RemoteNoteBuilder(this.cozy, old)
   }
 
   buildRemoteTree(
     paths /*: Array<string|[string, number]> */
-  ) /*: { [string]: RemoteDoc } */ {
+  ) /*: { [string]: MetadataRemoteFile|MetadataRemoteDir } */ {
     const remoteDocsByPath = {}
     for (const p of paths) {
       let docPath, shortRev
@@ -144,5 +150,11 @@ module.exports = class Builders {
         .path(`dir-from-batch-${batchNumber}`)
         .build()
     ]
+  }
+
+  stats() /*: StatsBuilder */ {
+    return process.platform === 'win32'
+      ? new WinStatsBuilder()
+      : new DefaultStatsBuilder()
   }
 }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -50,7 +50,7 @@ module.exports = class BaseMetadataBuilder {
     this.buildLocal = true
   }
 
-  fromRemote(remoteDoc /*: RemoteDoc */) /*: this */ {
+  fromRemote(remoteDoc /*: MetadataRemoteInfo */) /*: this */ {
     this.doc = metadata.fromRemoteDoc(remoteDoc)
     metadata.ensureValidPath(this.doc)
     this._assignId()

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -43,6 +43,12 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   }
 
   // Should only be used to build invalid docs. Prefer using `data()`.
+  md5sum(newMd5sum /*: ?string */) /*: this */ {
+    this.doc.md5sum = newMd5sum
+    return this
+  }
+
+  // Should only be used to build invalid docs. Prefer using `data()`.
   size(newSize /*: number */) /*: this */ {
     this.doc.size = newSize
     return this

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -1,27 +1,30 @@
 /* @flow */
 
+const _ = require('lodash')
+
 const RemoteBaseBuilder = require('./base')
 const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
-import type { RemoteDoc } from '../../../../core/remote/document'
+import type { RemoteDir } from '../../../../core/remote/document'
+import type { MetadataRemoteDir } from '../../../../core/metadata'
 */
 
 // Used to generate readable unique dirnames
 var dirNumber = 1
 
-// Build a RemoteDoc representing a remote Cozy directory:
+// Build a MetadataRemoteDir representing a remote Cozy directory:
 //
-//     const dir: RemoteDoc = builders.remoteDir().inDir(...).build()
+//     const dir: MetadataRemoteDir = builders.remoteDir().inDir(...).build()
 //
 // To actually create the corresponding directory on the Cozy, use the async
 // #create() method instead:
 //
-//     const dir: RemoteDoc = await builders.remoteDir().inDir(...).create()
+//     const dir: MetadataRemoteDir = await builders.remoteDir().inDir(...).create()
 //
-module.exports = class RemoteDirBuilder extends RemoteBaseBuilder {
-  constructor(cozy /*: Cozy */, old /*: ?RemoteDoc */) {
+module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <MetadataRemoteDir> */ {
+  constructor(cozy /*: Cozy */, old /*: ?(RemoteDir|MetadataRemoteDir) */) {
     super(cozy, old)
 
     if (!old) {
@@ -30,15 +33,18 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder {
     this.remoteDoc.type = 'directory'
   }
 
-  async create() /*: Promise<RemoteDoc> */ {
+  async create() /*: Promise<MetadataRemoteDir> */ {
     const cozy = this._ensureCozy()
-    return jsonApiToRemoteDoc(
-      await cozy.files.createDirectory({
-        name: this.remoteDoc.name,
-        dirID: this.remoteDoc.dir_id,
-        createdAt: this.remoteDoc.created_at,
-        updatedAt: this.remoteDoc.updated_at
-      })
+
+    return _.clone(
+      jsonApiToRemoteDoc(
+        await cozy.files.createDirectory({
+          name: this.remoteDoc.name,
+          dirID: this.remoteDoc.dir_id,
+          createdAt: this.remoteDoc.created_at,
+          updatedAt: this.remoteDoc.updated_at
+        })
+      )
     )
   }
 }

--- a/test/support/builders/stats.js
+++ b/test/support/builders/stats.js
@@ -142,6 +142,8 @@ const fromStats = (baseStats /*: ?(WinStats | fs.Stats) */) => {
 }
 
 module.exports = {
+  DefaultStatsBuilder,
+  WinStatsBuilder,
   fileIdFromNumber,
   fromStats
 }

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -16,7 +16,7 @@ import type cozy from 'cozy-client-js'
 import type { Pouch } from '../../../core/pouch'
 import type { RemoteOptions } from '../../../core/remote'
 import type { RemoteDoc } from '../../../core/remote/document'
-import type { Metadata } from '../../../core/metadata'
+import type { Metadata, MetadataRemoteInfo } from '../../../core/metadata'
 */
 
 class RemoteTestHelpers {
@@ -48,7 +48,7 @@ class RemoteTestHelpers {
 
   async createTree(
     paths /*: Array<string> */
-  ) /*: Promise<{ [string]: RemoteDoc}> */ {
+  ) /*: Promise<{ [string]: MetadataRemoteInfo}> */ {
     const remoteDocsByPath = {}
     for (const p of paths) {
       const name = path.posix.basename(p)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -2956,7 +2956,6 @@ describe('Merge', function() {
                   {
                     _id: metadata.id(movedSubdirPath),
                     path: movedSubdirPath,
-                    local: { path: movedSubdirPath },
                     sides: increasedSides(subdir.sides, this.side, 1),
                     moveFrom: movedSubdir
                   },
@@ -3053,7 +3052,6 @@ describe('Merge', function() {
                   {
                     _id: metadata.id(movedSubdirPath),
                     path: movedSubdirPath,
-                    local: { path: movedSubdirPath },
                     sides: increasedSides(subdir.sides, this.side, 1),
                     moveFrom: movedSubdir
                   },

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -515,7 +515,7 @@ describe('remote.Remote', function() {
     })
 
     it('creates the dir if it does not exist', async function() {
-      const deletedDir /*: RemoteDoc */ = await builders
+      const deletedDir = await builders
         .remoteDir()
         .name('deleted-dir')
         .inRootDir()
@@ -593,7 +593,7 @@ describe('remote.Remote', function() {
           .name('moved-to')
           .inRootDir()
           .create()
-        const remoteDoc /*: RemoteDoc */ = await builders
+        const remoteDoc = await builders
           .remoteFile()
           .name('cat6.jpg')
           .data('meow')
@@ -710,7 +710,7 @@ describe('remote.Remote', function() {
           .inRootDir()
           .create()
 
-        const remote1 /*: RemoteDoc */ = await builders
+        const remote1 = await builders
           .remoteFile()
           .inDir(newDir)
           .name('cat7.jpg')
@@ -719,7 +719,7 @@ describe('remote.Remote', function() {
           .create()
         existing = metadata.fromRemoteDoc(remote1)
 
-        const remote2 /*: RemoteDoc */ = await builders
+        const remote2 = await builders
           .remoteFile()
           .name('cat6.jpg')
           .data('meow')


### PR DESCRIPTION
For Flow to help us avoid mistakes it is crucial that the types we
use are well defined to represent the reality and not lie to us.

The `RemoteDoc` type was defined with a `path` attribute for both
file and directory remote documents while the remote Cozy actually
does not populate the path for file documents.

This refactoring updates the `MetadataRemoteInfo` type and creates the
2 subtypes `MetadataRemoteFile` and `MetadataRemoteDir` to accurately
represent the remote documents as we store them in PouchDB while
`RemoteDoc` and its 2 subtypes `RemoteFile` and `RemoteDir` represent
the remote documents as we receive them.

With those new types we caught incoherences in the data being used in
some tests (especially the `metadata` module unit tests which were not
covered by Flow).
