### PR TITLE
test/integration/notes: Update time with note

### DIFF
--- a/core/utils/timestamp.js
+++ b/core/utils/timestamp.js
@@ -34,7 +34,7 @@ function build(
 function spread(date /*: string|Date|Timestamp */) /*: number[] */ {
   const timestamp = new Date(date)
   const year = timestamp.getFullYear()
-  const month = timestamp.getMonth()
+  const month = timestamp.getMonth() + 1 // Months start with 0 in javascript
   const day = timestamp.getDate()
   const hours = timestamp.getHours()
   const minutes = timestamp.getMinutes()

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -13,6 +13,7 @@ const pouchHelpers = require('../support/helpers/pouch')
 const { TRASH_DIR_ID } = require('../../core/remote/constants')
 const { isNote } = require('../../core/utils/notes')
 const metadata = require('../../core/metadata')
+const timestamp = require('../../core/utils/timestamp')
 
 describe('Update', () => {
   let builders, helpers
@@ -52,6 +53,7 @@ describe('Update', () => {
         await builders
           .remoteNote(note)
           .data('updated content')
+          .updatedAt(...timestamp.spread(new Date()))
           .update()
         await helpers.pullAndSyncAll()
         await helpers.flushLocalAndSyncAll()


### PR DESCRIPTION
When updating a remote document in tests, we should always set the
`updated_at` attribute to the update time or the local `Metadata`
object will keep the latest update time and we'll see synchronization
issues arise once the local watcher kicks in (i.e. the update time,
which is used to set the local file metadata on the filesystem, hasn't
changed so we won't recompute the checksum of the local file although
its content has changed).

For now the `RemoteBaseBuilder.update()` method is only used once in
the Notes integration tests.

We also fix the `timestamp.spread()` method which was returning a
0-based month number when builders and `timestamp` methods are
expecting a 1-based month when building dates.
