### PR TITLE
test/merge: Check local & remote attributes' value

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -506,9 +506,15 @@ function dissociateRemote(doc /*: Metadata */) {
   if (doc.remote) delete doc.remote
 }
 
+function dissociateLocal(doc /*: Metadata */) {
+  if (doc.sides && doc.sides.local) delete doc.sides.local
+  if (doc.local) delete doc.local
+}
+
 function markAsUnsyncable(doc /*: Metadata */) {
   removeActionHints(doc)
   dissociateRemote(doc)
+  dissociateLocal(doc)
   doc._deleted = true
 }
 

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -47,7 +47,7 @@ const {
   detectPathIncompatibilities,
   detectPathLengthIncompatibility
 } = require('./incompatibilities/platform')
-const { DIR_TYPE, FILE_TYPE, TRASH_DIR_ID } = require('./remote/constants')
+const { DIR_TYPE, FILE_TYPE, TRASH_DIR_NAME } = require('./remote/constants')
 const { SIDE_NAMES, otherSide } = require('./side')
 
 /*::
@@ -167,6 +167,7 @@ switch (platform) {
 }
 
 module.exports = {
+  LOCAL_ATTRIBUTES,
   assignId,
   assignMaxDate,
   assignPlatformIncompatibilities,
@@ -870,17 +871,19 @@ function shouldIgnore(
   })
 }
 
-function updateLocal(doc /*: Metadata */, newLocal /*: ?Object */ = {}) {
+function updateLocal(doc /*: Metadata */, newLocal /*: Object */ = {}) {
   // Boolean attributes not set in doc when false will not override an existing
   // truthy value.
   // This is the case for `executable` and we need to provide a default falsy
   // value to override the `newLocal` executable value in all cases.
+  const defaults =
+    isFile(doc) &&
+    (process.platform === 'win32' ||
+      (doc.executable == null && newLocal.executable == null))
+      ? { executable: false }
+      : {}
   doc.local = _.pick(
-    _.defaults(
-      _.cloneDeep(newLocal),
-      isFile(doc) ? { executable: false } : {},
-      _.cloneDeep(doc)
-    ),
+    _.defaults(defaults, _.cloneDeep(newLocal), _.cloneDeep(doc)),
     LOCAL_ATTRIBUTES
   )
 }
@@ -900,7 +903,7 @@ function updateRemote(
           ? remotePath.substring(1)
           : remotePath
         : newRemote.trashed
-        ? path.posix.join(TRASH_DIR_ID, newRemote.name)
+        ? path.posix.join(TRASH_DIR_NAME, newRemote.name)
         : path.posix.join(...doc.path.split(path.sep))
     },
     _.cloneDeep(doc.remote)

--- a/core/move.js
+++ b/core/move.js
@@ -73,11 +73,9 @@ function convertToDestinationAddition(
   dst /*: Metadata */
 ) {
   // Delete source
-  if (src.moveTo) delete src.moveTo
   metadata.markAsUnsyncable(src)
 
   // Create destination
-  if (dst.moveFrom) delete dst.moveFrom
   metadata.markAsNew(dst)
   metadata.markSide(side, dst)
 }

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -9,6 +9,7 @@ const {
   TRASH_DIR_ID,
   TRASH_DIR_NAME
 } = require('../../../../core/remote/constants')
+const metadata = require('../../../../core/metadata')
 const timestamp = require('../../../../core/utils/timestamp')
 
 const dbBuilders = require('../db')
@@ -31,6 +32,7 @@ module.exports = class RemoteBaseBuilder /*:: <T: MetadataRemoteInfo> */ {
     this.cozy = cozy
     if (old) {
       this.remoteDoc = _.cloneDeep(old)
+      this.shortRev(metadata.extractRevNumber(old) + 1)
     } else {
       const name = 'whatever'
       // $FlowFixMe dates are added in build

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -38,6 +38,13 @@ function dispatchedCalls(obj /*: Stub */) /*: DispatchedCalls */ {
         method !== 'emit' ||
         !['local-start', 'local-end', 'sync-target'].includes(call.args[0])
       ) {
+        // XXX: buildFile & buildDir always add the `remote` attribute even when
+        // it's not defined.
+        // Metadata builders won't add it though and changing the implementation
+        // will mean a lot of tests to update so we simply remove the attribute
+        // if it's undefined to match the builders data.
+        const doc = call.args[1]
+        if (doc && doc.remote == undefined) delete doc.remote
         dispatchedCalls[method].push(call.args)
       }
     }
@@ -620,8 +627,8 @@ describe('core/local/atom/dispatch.loop()', function() {
             .path(newDirectoryPath)
             .updatedAt(updatedAt)
             .ino(1)
-            .noRemote()
             .noTags()
+            .unmerged('local')
             .build()
 
           await dispatch.loop(channel, stepOptions).pop()
@@ -656,8 +663,8 @@ describe('core/local/atom/dispatch.loop()', function() {
           .path(newDirectoryPath)
           .updatedAt(updatedAt)
           .ino(1)
-          .noRemote()
           .noTags()
+          .unmerged('local')
           .build()
 
         await dispatch.loop(channel, stepOptions).pop()


### PR DESCRIPTION
Now that we're maintaining `local` and `remote` metadata separately we
should check that we have the expected value when calling different
Merge methods.

This meant improving the way we build and maintain those attributes in
the data builders as well.
