### PR TITLE
core/merge: Maintain path in local and remote attributes

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -704,6 +704,14 @@ class Merge {
         dst.incompatibilities = incompatibilities
       else delete dst.incompatibilities
 
+      if (side === 'local' && dst.sides.local) {
+        // Update the local attribute of children existing in the local folder
+        metadata.updateLocal(dst)
+      } else if (side === 'remote' && dst.sides.remote) {
+        // Update the remote attribute of children existing in the remote folder
+        metadata.updateRemote(dst, { path: dst.path })
+      }
+
       bulk.push(dst)
 
       if (folder.overwrite) {

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -72,6 +72,7 @@ const CONFLICT_REGEXP = new RegExp(
 )
 
 const LOCAL_ATTRIBUTES = [
+  'path',
   'md5sum',
   'class',
   'docType',
@@ -94,6 +95,7 @@ export type MetadataLocalInfo = {
   executable?: true,
   fileid?: string,
   ino?: number,
+  path: string,
   md5sum?: string,
   mime?: string,
   size?: number,
@@ -823,9 +825,7 @@ function buildFile(
   if (stats.fileid) {
     doc.fileid = stats.fileid
   }
-  updateLocal(doc, {
-    updated_at: mtime.toISOString()
-  })
+  updateLocal(doc)
   return doc
 }
 

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -1560,7 +1560,7 @@ describe('Merge', function() {
           )
         )
 
-        const movedSrc = _.defaults(
+        const movedSrc = _.defaultsDeep(
           {
             moveTo: doc._id,
             _deleted: true
@@ -1945,7 +1945,7 @@ describe('Merge', function() {
 
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.defaults(
+            _.defaultsDeep(
               {
                 sides: increasedSides(banana.sides, this.side, 1),
                 path: BANANA.path,
@@ -2533,9 +2533,10 @@ describe('Merge', function() {
 
         should(sideEffects).deepEqual({
           savedDocs: [
-            _.defaults(
+            _.defaultsDeep(
               {
                 sides: increasedSides(apple.sides, this.side, 1),
+                path: APPLE.path,
                 moveFrom: _.defaults(
                   {
                     moveTo: APPLE._id,
@@ -2543,9 +2544,9 @@ describe('Merge', function() {
                   },
                   apple
                 ),
-                [otherSide(this.side)]: apple[otherSide(this.side)]
+                [this.side]: APPLE[this.side]
               },
-              APPLE
+              _.omit(apple, ['_rev'])
             )
           ],
           resolvedConflicts: []
@@ -2739,12 +2740,13 @@ describe('Merge', function() {
             _.omit(dstDir, ['_rev'])
           ),
           _.omit(movedSrcFile, ['_rev']),
-          _.defaults(
+          _.defaultsDeep(
             {
               _id: dstFile._id,
               path: dstFile.path,
               sides: increasedSides(srcFile.sides, this.side, 1),
-              moveFrom: movedSrcFile
+              moveFrom: movedSrcFile,
+              [this.side]: { path: dstFile[this.side].path }
             },
             _.omit(srcFile, ['_rev'])
           )
@@ -2822,23 +2824,25 @@ describe('Merge', function() {
             _.omit(doc, ['_rev'])
           ),
           _.omit(movedSubfile, ['_rev']),
-          _.defaults(
+          _.defaultsDeep(
             {
               _id: metadata.id(movedPath(subfile)),
               path: movedPath(subfile),
               sides: increasedSides(subfile.sides, this.side, 1),
               moveFrom: movedSubfile,
+              [this.side]: { path: movedPath(subfile) },
               [otherSide(this.side)]: movedSubfile[otherSide(this.side)]
             },
             _.omit(subfile, ['_rev'])
           ),
           _.omit(movedSubdir, ['_rev']),
-          _.defaults(
+          _.defaultsDeep(
             {
               _id: metadata.id(movedPath(subdir)),
               path: movedPath(subdir),
               sides: increasedSides(subdir.sides, this.side, 1),
               moveFrom: movedSubdir,
+              [this.side]: { path: movedPath(subdir) },
               [otherSide(this.side)]: movedSubdir[otherSide(this.side)]
             },
             _.omit(subdir, ['_rev'])
@@ -3124,7 +3128,8 @@ describe('Merge', function() {
                 _id: metadata.id(movedPath(child)),
                 path: movedPath(child),
                 sides: increasedSides(child.sides, this.side, 1),
-                moveFrom: movedChild
+                moveFrom: movedChild,
+                [this.side]: { path: movedPath(child) }
               },
               _.omit(child, ['_rev'])
             )
@@ -3187,7 +3192,7 @@ describe('Merge', function() {
               subdir
             )
             const movedSubfilePath = path.join(movedSubdirPath, 'file-9')
-            const movedSubfile = _.defaults(
+            const movedSubfile = _.defaultsDeep(
               {
                 moveTo: metadata.id(movedSubfilePath),
                 childMove: true,
@@ -3207,22 +3212,24 @@ describe('Merge', function() {
                   _.omit(doc, ['_rev'])
                 ),
                 _.omit(movedSubdir, ['_rev']),
-                _.defaults(
+                _.defaultsDeep(
                   {
                     _id: metadata.id(movedSubdirPath),
                     path: movedSubdirPath,
                     sides: increasedSides(subdir.sides, this.side, 1),
-                    moveFrom: movedSubdir
+                    moveFrom: movedSubdir,
+                    [this.side]: { path: movedSubdirPath }
                   },
                   _.omit(subdir, ['_rev'])
                 ),
                 _.omit(movedSubfile, ['_rev']),
-                _.defaults(
+                _.defaultsDeep(
                   {
                     _id: metadata.id(movedSubfilePath),
                     path: movedSubfilePath,
                     sides: increasedSides(subfile.sides, this.side, 1),
-                    moveFrom: movedSubfile
+                    moveFrom: movedSubfile,
+                    [this.side]: { path: movedSubfilePath }
                   },
                   _.omit(subfile, ['_rev'])
                 )
@@ -3300,22 +3307,24 @@ describe('Merge', function() {
                   _.omit(doc, ['_rev'])
                 ),
                 _.omit(movedSubdir, ['_rev']),
-                _.defaults(
+                _.defaultsDeep(
                   {
                     _id: metadata.id(movedSubdirPath),
                     path: movedSubdirPath,
                     sides: increasedSides(subdir.sides, this.side, 1),
-                    moveFrom: movedSubdir
+                    moveFrom: movedSubdir,
+                    [this.side]: { path: movedSubdirPath }
                   },
                   _.omit(subdir, ['_rev'])
                 ),
                 _.omit(movedSubfile, ['_rev']),
-                _.defaults(
+                _.defaultsDeep(
                   {
                     _id: metadata.id(movedSubfilePath),
                     path: movedSubfilePath,
                     sides: increasedSides(subfile.sides, this.side, 1),
-                    moveFrom: movedSubfile
+                    moveFrom: movedSubfile,
+                    [this.side]: { path: movedSubfilePath }
                   },
                   _.omit(subfile, ['_rev'])
                 )


### PR DESCRIPTION
We want to track the local and remote path of documents separately
since they will differ between the time a move on one side is merged
and the time it is propagated to the other side.

We already stored the remote path in the `remote` attribute of
`Metadata` records but we now store the local path in the `local`
attribute.

They both need to be updated for children of moved directories since
we won't necessarily receive the move events/changes for those
documents at the same moment, leaving us with incoherent paths.
For other changes, we should have up-to-date side attributes computed
from the event/change.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
