### PR TITLE
core/remote: Update folder after linking it

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -130,6 +130,7 @@ class Remote /*:: implements Reader, Writer */ {
       const remotePath = '/' + posix.join(...doc.path.split(sep))
       const dir = await this.remoteCozy.findDirectoryByPath(remotePath)
       metadata.updateRemote(doc, dir)
+      return this.updateFolderAsync(doc)
     }
   }
 

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -217,7 +217,7 @@ describe('remote.Remote', function() {
       )
     })
 
-    it('links any existing folder', async function() {
+    it('links and updates any existing folder', async function() {
       const remoteDir = await builders
         .remoteDir()
         .inRootDir()
@@ -241,7 +241,7 @@ describe('remote.Remote', function() {
         type
       })
       should(timestamp.roundedRemoteDate(folder.attributes.updated_at)).equal(
-        '2017-02-14T15:03:27.000Z' // remoteDir.updated_at
+        doc.updated_at
       )
       should(doc.remote).have.properties({
         _id: remoteDir._id,
@@ -554,7 +554,7 @@ describe('remote.Remote', function() {
       })
     })
 
-    it('links the dir if it has no remote info', async function() {
+    it('links and updates the dir if it has no remote info', async function() {
       const remoteDir = await builders
         .remoteDir()
         .name('foo')
@@ -583,7 +583,7 @@ describe('remote.Remote', function() {
         tags: doc.tags
       })
       should(timestamp.roundedRemoteDate(folder.attributes.updated_at)).equal(
-        '2015-02-02T02:02:02.000Z' // remoteDir.updated_at
+        doc.updated_at
       )
     })
   })


### PR DESCRIPTION
When we try to propagate the creation of a local folder to the remote
Cozy and a folder with the same name in the same parent already
exists, we link the local and remote version together instead.

However, the local version can be slightly different (have another
last update date for example) so we'll now send an update request with
the local version after the remote document has been linked to the
local one.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
