### PR TITLE
core/metadata: Require `executable` file attribute

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -252,6 +252,12 @@ class Merge {
         if (file.local && doc.local == null) {
           doc.local = file.local
         }
+        // If file is updated on Windows, it will never be executable so we keep
+        // the existing value.
+        if (side === 'local' && process.platform === 'win32') {
+          doc.executable = file.executable
+        }
+
         if (metadata.sameFile(file, doc)) {
           if (needsFileidMigration(file, doc.fileid)) {
             return this.migrateFileid(file, doc.fileid)
@@ -320,6 +326,11 @@ class Merge {
       // If file was updated on remote Cozy, doc won't have local attribute
       if (file.local && doc.local == null) {
         doc.local = file.local
+      }
+      // If file is updated on Windows, it will never be executable so we keep
+      // the existing value.
+      if (side === 'local' && process.platform === 'win32') {
+        doc.executable = file.executable
       }
 
       if (
@@ -507,6 +518,12 @@ class Merge {
     } else if (was.sides && was.sides[side]) {
       metadata.assignMaxDate(doc, was)
       move(side, was, doc)
+
+      // If file is moved on Windows, it will never be executable so we keep the
+      // existing value.
+      if (side === 'local' && process.platform === 'win32') {
+        doc.executable = was.executable
+      }
 
       const file /*: ?Metadata */ = await this.pouch.byIdMaybe(doc._id)
       if (file) {

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -197,6 +197,25 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 7,
+    targetSchemaVersion: 8,
+    description: 'Set all files executable attribute',
+    affectedDocs: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.filter(
+        doc => doc.docType === 'file' && doc.executable == null
+      )
+    },
+    run: (docs /*: Metadata[] */) /*: Metadata[] */ => {
+      return docs.map(doc => {
+        doc.executable = false
+        if (doc.local && doc.local.executable == null) {
+          doc.local.executable = false
+        }
+        return doc
+      })
+    }
   }
 ]
 

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -19,6 +19,7 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
     this.doc.docType = 'file'
     this.doc.mime = mimeType
     this.doc.class = mimeType.split('/')[0]
+    this.doc.executable = old ? old.executable : false
 
     if (this.doc.md5sum == null) {
       this.data('')
@@ -55,11 +56,7 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   }
 
   executable(isExecutable /*: boolean */) /*: this */ {
-    if (!isExecutable && this.doc.executable) {
-      delete this.doc.executable
-    } else if (isExecutable) {
-      this.doc.executable = isExecutable
-    }
+    this.doc.executable = isExecutable
     return this
   }
 }


### PR DESCRIPTION
The `executable` attribute of `Metadata` objects is marked as optional
in the type definition. This leads to uncertainty as to whether the
attribute is defined in `Metadata` objects or not and forces us to
check for its presence every time we want to read or set it. Besides,
it allows us to build file `Metadata` objects without it.

Marking the attribute as required and setting it for every file
`Metadata` object will help us ensure our documents are valid and
simplify the use of this attribute.

/!\ Although it is marked as required, it will still be missing in
folder `Metadata` objects. This is made possible by cracks in our
types coverage but should be fixed once we'll have different type
definitions for file and folder metadata.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
