### PR TITLE
core/merge: addFile delegates existing file update

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -626,9 +626,7 @@ const makeComparator = (name, interestingFields) => {
     if (diff && !_.every(diff, canBeIgnoredDiff)) {
       return false
     }
-    // XXX The fileid can be missing in some old documents in pouchdb.
-    // So, we compare them only if it's present on both documents.
-    if (process.platform === 'win32' && one.fileid && two.fileid) {
+    if (process.platform === 'win32') {
       return one.fileid === two.fileid
     }
     return true


### PR DESCRIPTION
We can receive requests to Merge a file creation while the file
`Metadata` already exists in PouchDB (during an initial local scan for
example).
In this situation we transform the creation into an update.

To avoid code duplication and complexity in the `Merge.addFile()`
method, we now delegate the file update to the `Merge.updateFile()`
method.

**Please** make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
