### PR TITLE
core/metadata: Mark `tags` attribute as required

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -239,9 +239,6 @@ class Merge {
 
     metadata.markSide(side, doc)
     metadata.assignMaxDate(doc)
-    if (doc.tags == null) {
-      doc.tags = []
-    }
     await this.ensureParentExistAsync(side, doc)
 
     return this.pouch.put(doc)
@@ -262,9 +259,6 @@ class Merge {
       doc._id = file._id
       doc._rev = file._rev
       doc.moveFrom = file.moveFrom
-      if (doc.tags == null) {
-        doc.tags = file.tags || []
-      }
       if (doc.remote == null) {
         doc.remote = file.remote
       }
@@ -382,9 +376,6 @@ class Merge {
         return this.pouch.put(doc)
       }
     }
-    if (doc.tags == null) {
-      doc.tags = []
-    }
     await this.ensureParentExistAsync(side, doc)
     return this.pouch.put(doc)
   }
@@ -410,9 +401,6 @@ class Merge {
     } else if (folder) {
       doc._id = folder._id
       doc._rev = folder._rev
-      if (doc.tags == null) {
-        doc.tags = folder.tags || []
-      }
       if (doc.remote == null) {
         doc.remote = folder.remote
       }
@@ -449,9 +437,6 @@ class Merge {
       } else {
         return this.pouch.put(doc)
       }
-    }
-    if (doc.tags == null) {
-      doc.tags = []
     }
     await this.ensureParentExistAsync(side, doc)
 

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -136,7 +136,7 @@ export type Metadata = {
   local: MetadataLocalInfo,
   remote: MetadataRemoteDir|MetadataRemoteFile,
   size?: number,
-  tags?: string[],
+  tags: string[],
   sides: MetadataSidesInfo,
   trashed?: true,
   incompatibilities?: *,
@@ -769,6 +769,7 @@ function buildDir(
     docType: 'folder',
     updated_at: stats.mtime.toISOString(),
     ino: stats.ino,
+    tags: [],
     remote
   }
   if (stats.fileid) {
@@ -802,6 +803,7 @@ function buildFile(
     class: className,
     size,
     executable,
+    tags: [],
     remote
   }
   if (stats.fileid) {

--- a/core/move.js
+++ b/core/move.js
@@ -36,11 +36,12 @@ function move(
     f => !pouchdbReserved.concat(actionHints).includes(f)
   )
   for (const field of fields) {
-    if (dst[field] == null) {
+    if (Array.isArray(src[field]) && Array.isArray(dst[field])) {
+      dst[field] = _.uniq(_.cloneDeep(src[field]).concat(dst[field]))
+    } else if (dst[field] == null) {
       dst[field] = _.cloneDeep(src[field])
     }
   }
-  if (dst.tags == null) dst.tags = []
 
   src.moveTo = dst.path
   src._deleted = true

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -216,6 +216,20 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 8,
+    targetSchemaVersion: 9,
+    description: 'Default tags attribute to an empty Array',
+    affectedDocs: (docs /*: SavedMetadata[] */) /*: SavedMetadata[] */ => {
+      return docs.filter(doc => doc.docType != null && !doc.tags)
+    },
+    run: (docs /*: SavedMetadata[] */) /*: SavedMetadata[] */ => {
+      return docs.map(doc => {
+        doc.tags = []
+        return doc
+      })
+    }
   }
 ]
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -266,7 +266,7 @@ module.exports = class BaseMetadataBuilder {
   }
 
   noTags() /*: this */ {
-    delete this.doc.tags
+    this.doc.tags = []
     return this
   }
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -873,7 +873,8 @@ describe('metadata', function() {
         md5sum,
         ino: stats.ino,
         size: 29865,
-        mime: 'image/jpeg'
+        mime: 'image/jpeg',
+        tags: []
       })
       should(doc).have.property('updated_at')
       should(doc).have.property('executable', false)
@@ -896,7 +897,8 @@ describe('metadata', function() {
         md5sum,
         ino: stats.ino,
         size: 29865,
-        mime: NOTE_MIME_TYPE
+        mime: NOTE_MIME_TYPE,
+        tags: []
       })
       should(doc).have.property('updated_at')
       should(doc).have.property('executable', false)
@@ -921,6 +923,21 @@ describe('metadata', function() {
   })
 
   describe('buildDir', () => {
+    it('creates a document for an existing folder', async function() {
+      const stats = await fse.stat(path.join(__dirname, '../fixtures'))
+      const doc = buildDir('fixtures', stats)
+      should(doc).have.properties({
+        path: 'fixtures',
+        docType: 'folder',
+        ino: stats.ino,
+        tags: []
+      })
+      should(doc).have.property('updated_at')
+
+      const remote = builders.remoteDir().build()
+      should(buildDir('fixtures', stats, remote).remote).deepEqual(remote)
+    })
+
     it('sets #updated_at with mtime', () => {
       const path = 'whatever'
       const d1 = new Date('2018-01-18T16:46:18.362Z')

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -34,7 +34,7 @@ describe('move', () => {
       .metafile()
       .path('dst/file')
       .noRemote()
-      .noTags()
+      .tags('courge')
       .build()
     should(dst.metadata).be.undefined()
 
@@ -42,7 +42,7 @@ describe('move', () => {
 
     should(dst).have.properties({
       metadata: src.metadata,
-      tags: src.tags,
+      tags: ['qux', 'courge'],
       remote: src.remote
     })
     // PouchDB reserved attributes are not transfered


### PR DESCRIPTION
The `Metadata` `tags` attribute could either be missing or a list of
string values. It is now marked as required.

The `metadata.buildFile()` and `metadata.buildFolder()` methods will
now always default it to an empty Array since tags come from remote
documents and those are used to build `Metadata` objects from local
data.

The `merge` and `move` methods won't need to default the attribute to
an empty Array anymore and moved documents will inherit the list of
tags from the source document.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
