### PR TITLE
test/builders/metadata: Type doc with $Shape<>

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -32,7 +32,7 @@ const SOME_MEANINGLESS_TIME_OFFSET = 2000 // 2 seconds
 module.exports = class BaseMetadataBuilder {
   /*::
   pouch: ?Pouch
-  doc: Object
+  doc: $Shape<Metadata>
   buildLocal: boolean
   buildRemote: boolean
   _remoteBuilder: ?*
@@ -43,13 +43,12 @@ module.exports = class BaseMetadataBuilder {
     if (old) {
       this.doc = _.cloneDeep(old)
     } else {
-      const doc /*: Object */ = {
+      this.doc = {
         docType: 'folder', // To make flow happy (overridden by subclasses)
         path: 'foo',
         tags: [],
         updated_at: new Date().toISOString()
       }
-      this.doc = doc
     }
     this.buildLocal = true
     this.buildRemote = true
@@ -156,7 +155,7 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  overwrite(existingDoc /*: Metadata */) /*: this */ {
+  overwrite(existingDoc /*: SavedMetadata */) /*: this */ {
     this.doc.overwrite = existingDoc
     return this
   }
@@ -319,7 +318,8 @@ module.exports = class BaseMetadataBuilder {
     if (
       this.doc.local != null &&
       this.doc.sides &&
-      this.doc.sides.local <= this.doc.sides.remote
+      (!this.doc.sides.remote ||
+        (this.doc.sides.local && this.doc.sides.local <= this.doc.sides.remote))
     ) {
       return
     }
@@ -336,7 +336,9 @@ module.exports = class BaseMetadataBuilder {
     if (
       this.doc.remote != null &&
       (!this.doc.sides ||
-        (this.doc.sides && this.doc.sides.remote <= this.doc.sides.local))
+        (!this.doc.sides.local ||
+          (this.doc.sides.remote &&
+            this.doc.sides.remote <= this.doc.sides.local)))
     ) {
       return
     }

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -45,7 +45,11 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
 
   // Should only be used to build invalid docs. Prefer using `data()`.
   md5sum(newMd5sum /*: ?string */) /*: this */ {
-    this.doc.md5sum = newMd5sum
+    if (newMd5sum) {
+      this.doc.md5sum = newMd5sum
+    } else {
+      delete this.doc.md5sum
+    }
     return this
   }
 

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -25,7 +25,7 @@ const { cozy, deleteAll } = require('../../support/helpers/cozy')
 const Builders = require('../../support/builders')
 
 /*::
-import type { Metadata } from '../../../core/metadata'
+import type { Metadata, SavedMetadata } from '../../../core/metadata'
 import type { RemoteDoc, JsonApiDoc } from '../../../core/remote/document'
 */
 const CHAT_MIGNON_MOD_PATH = 'test/fixtures/chat-mignon-mod.jpg'
@@ -314,11 +314,11 @@ describe('remote.Remote', function() {
           .remoteFile()
           .data('foo')
           .create()
-        const old = builders
+        const old = await builders
           .metafile()
           .fromRemote(created)
           .upToDate()
-          .build()
+          .create()
         const doc = builders
           .metafile(old)
           .overwrite(old)
@@ -710,8 +710,8 @@ describe('remote.Remote', function() {
     context('when overwriting an existing file', function() {
       const existingRefs = [{ _id: 'blah', _type: 'io.cozy.photos.albums' }]
 
-      let existing /*: Metadata */
-      let old /*: Metadata */
+      let existing /*: SavedMetadata */
+      let old /*:SavedMetadata */
       let doc /*: Metadata */
       let newDir /*: RemoteDoc */
 
@@ -729,23 +729,23 @@ describe('remote.Remote', function() {
           .data('woof')
           .referencedBy(existingRefs)
           .create()
-        existing = builders
+        existing = await builders
           .metafile()
           .fromRemote(remote1)
           .upToDate()
-          .build()
+          .create()
 
         const remote2 = await builders
           .remoteFile()
           .name('cat6.jpg')
           .data('meow')
           .create()
-        old = builders
+        old = await builders
           .metafile()
           .fromRemote(remote2)
           .moveTo('moved-to/cat7.jpg')
           .changedSide('local')
-          .build()
+          .create()
 
         doc = builders
           .metafile()


### PR DESCRIPTION
The `$Shape<>` special type allows us to check the type of each
attribute of the typed object without providing all the attributes.
By typing the `BaseMetadataBuilder`'s `doc` with `$Shape<Metadata>` we
can partially build it in the constructor and finish in the `build()`
or `create()` method while still making sure that each attribute set
on the object is correctly typed.
Typing it with `Object` was not offering us this security and allowed
us to modify `doc` in ways that were not correct.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
