### PR TITLE
core/merge: Fix conflicting file updates

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -170,6 +170,7 @@ module.exports = {
   removeActionHints,
   removeNoteMetadata,
   dissociateRemote,
+  dissociateLocal,
   markAsNew,
   markAsUnsyncable,
   markAsUpToDate,

--- a/core/sync.js
+++ b/core/sync.js
@@ -464,6 +464,10 @@ class Sync {
             await side.updateFileMetadataAsync(doc)
           }
         } else {
+          // FIXME: with commit afd01767571915922a4f253beb2e53cc6eae4962, this
+          // block is unnecessary.
+          // However, we can't remove it already since some users could still be
+          // in a situation where they need it.
           if (sideName === 'local' && !doc.overwrite) {
             const copy = await this.local.createBackupCopyAsync(doc)
             await this.local.trashAsync(copy)

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -198,7 +198,7 @@ describe('Conflict resolution', () => {
     })
 
     context('remote merged first', () => {
-      it('it trashes a backup copy of local and overwrites the original', async () => {
+      it('creates a local conflict', async () => {
         await helpers.remote.pullChanges()
         await simulateLocalUpdateMerge() // Client restart with wrong update detection
         await helpers.syncAll()
@@ -206,8 +206,8 @@ describe('Conflict resolution', () => {
         await helpers.flushLocalAndSyncAll()
 
         should(await helpers.trees()).deepEqual({
-          remote: ['concurrent-edited'],
-          local: ['/Trash/concurrent-edited.bck', 'concurrent-edited']
+          remote: expectedTree,
+          local: expectedTree
         })
       })
     })


### PR DESCRIPTION
To avoid losing merged but unsynced remote file updates while avoiding
unnecessary conflicts, we introduced an exception in the
`Merge.updateFileAsync()` behavior when merging an "update" from an
initial scan event.

In this case, we would always consider that the file had not been
updated on the local file system to preserve the remote update.
It means that if the file had actually been updated, we would lose the
local update.
To mitigate this problem, we would not mark the update as an
overwriting one, thus telling Sync to trash a copy of the file before
applying the remote update on the local filesystem.

Now that we track the local metadata separately from the remote and
"merged" metadata, we can tell if the file was updated locally or not.
If it wasn't we won't modify the existing PouchDB record with the
unsynced remote update. This update will then be applied on the local
filesystem as an overwriting one, thus without any trashed copy of the
local version.
If it was updated, the local update will be considered as a
conflicting one and we'll treat it as such by dissociating the local
and remote versions and renaming the local file with a conflict
suffix.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
