### PR TITLE
core/merge: Merge attributes in updateFile

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -765,15 +765,18 @@ function buildDir(
   stats /*: Stats */,
   remote /*: ?MetadataRemoteInfo */
 ) /*: Metadata */ {
-  const doc /*: Object */ = {
+  const doc /*: $Shape<Metadata> */ = {
     path: fpath,
     docType: 'folder',
     updated_at: stats.mtime.toISOString(),
     ino: stats.ino,
-    tags: [],
-    remote
+    tags: []
   }
-  if (stats.fileid) {
+  // FIXME: we should probably not set remote at this point
+  if (remote) {
+    doc.remote = remote
+  }
+  if (typeof stats.fileid === 'string') {
     doc.fileid = stats.fileid
   }
   updateLocal(doc)
@@ -794,7 +797,7 @@ function buildFile(
   const updated_at = mtime.toISOString()
   const executable = stats.mode ? (+stats.mode & EXECUTABLE_MASK) !== 0 : false
 
-  const doc /*: Object */ = {
+  const doc /*: $Shape<Metadata> */ = {
     path: filePath,
     docType: 'file',
     md5sum,
@@ -804,10 +807,13 @@ function buildFile(
     class: className,
     size,
     executable,
-    tags: [],
-    remote
+    tags: []
   }
-  if (stats.fileid) {
+  // FIXME: we should probably not set remote at this point
+  if (remote) {
+    doc.remote = remote
+  }
+  if (typeof stats.fileid === 'string') {
     doc.fileid = stats.fileid
   }
   updateLocal(doc)


### PR DESCRIPTION
When we merge a file update in PouchDB, we fetch the existing record
from PouchDB and copy some of its attributes to the new record for the
updated file.
However, we were not copying all relevant attributes and thus losing
some of them (e.g. the `tags` attribute would be overwritten).

To avoid losing data and make this copy more scalable, we're now
building the new record based on the existing one and overwriting
only the relevant attributes.

This process should probably be done in every `Merge` method updating
an existing PouchDB record.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
