### PR TITLE
ci: Use Github Actions instead of Travis

### DIFF
--- a/.github/actions/build-and-publish/action.yaml
+++ b/.github/actions/build-and-publish/action.yaml
@@ -1,0 +1,46 @@
+name: Build and Publish
+author: Erwan Guyader
+description: Builds Cozy Desktop binaries and publish them to the latest Github release draft.
+inputs:
+  gh-token:
+    description: 'The Github token used to attach binaries to releases.'
+    required: true
+  mac-cert:
+    description: 'The code signing certificate encoded in base64.'
+    required: false
+  mac-cert-password:
+    description: 'The code signing certificate password.'
+    required: false
+  apple-id:
+    description: 'The Apple notarization account id.'
+    required: false
+  apple-id-password:
+    description: 'The Apple notarization account password.'
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: "${{ inputs.gh-token }}"
+        CSC_FOR_PULL_REQUEST: true
+        CSC_LINK: "${{ inputs.mac-cert }}"
+        CSC_KEY_PASSWORD: "${{ inputs.mac-cert-password }}"
+        APPLE_ID: "${{ inputs.apple-id }}"
+        APPLE_ID_PASSWORD: "${{ inputs.apple-id-password }}"
+      run: |
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          docker run --rm \
+            $(env | \
+              grep -Eo '^[^\s=]*(NODE_|ELECTRON_|YARN_|NPM_|CI|GITHUB_|CSC_|_TOKEN|_KEY)[^\s=]*' | \
+              sed 's/^/-e /;/^$/d' | \
+              paste -sd ' ' \
+            ) \
+            -v ${PWD}:/project \
+            -v ~/.cache/electron:/root/.cache/electron \
+            -v ~/.cache/electron-builder:/root/.cache/electron-builder \
+            electronuserland/builder:12 \
+            /bin/bash -c "yarn dist:all"
+        else
+          yarn dist:all
+        fi

--- a/.github/actions/setup-couchdb/action.yaml
+++ b/.github/actions/setup-couchdb/action.yaml
@@ -1,0 +1,31 @@
+name: Setup CouchDB
+author: Erwan Guyader
+description: Starts a CouchDB server of the given version on the given port.
+inputs:
+  couchdb-version:
+    description: 'The version of CouchDB to run'
+    required: true
+  couchdb-port:
+    description: 'The port on which to expose the internal CouchDB port'
+    required: false
+    default: 5984
+runs:
+  using: composite
+  steps:
+    - name: Setup podman-machine
+      shell: bash
+      run: |
+        curl -L https://github.com/boot2podman/machine/releases/download/v0.17/podman-machine.darwin-amd64 --output /usr/local/bin/podman-machine
+        chmod +x /usr/local/bin/podman-machine
+        until podman-machine create --virtualbox-boot2podman-url https://github.com/boot2podman/boot2podman-fedora-iso/releases/download/af598af/boot2podman-fedora.iso box
+        do
+          sleep 1
+        done
+
+    - name: Setup CouchDB
+      shell: bash
+      run: |
+        podman-machine ssh box -L ${{ inputs.couchdb-port }}:localhost:5984 -N &
+        podman-machine ssh box -- sudo podman run -d -p 5984:5984 --name couch apache/couchdb:${{ inputs.couchdb-version }}
+        sleep 5
+        curl -X PUT http://localhost:${{ inputs.couchdb-port }}/{_users,_replicator,_global_changes}

--- a/.github/actions/setup-cozy-stack/action.yaml
+++ b/.github/actions/setup-cozy-stack/action.yaml
@@ -1,0 +1,53 @@
+name: Setup cozy-stack
+author: Erwan Guyader
+description: Downloads cozy-stack, starts it and create a test instance.
+inputs:
+  cozy-stack-storage:
+    description: 'The folder location where the remote cozy-stack files will be stored'
+    required: false
+  cozy-passphrase:
+    description: 'The user passphrase of the created Cozy instance'
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Download cozy-stack
+      shell: bash
+      run: go get github.com/cozy/cozy-stack
+
+    - name: Set env variables
+      shell: bash
+      run: |
+        if [[ -z $COZY_STACK_STORAGE ]]; then
+          echo "COZY_STACK_STORAGE=${{ inputs.cozy-stack-storage }}" >> $GITHUB_ENV
+        fi
+        if [[ -z $COZY_PASSPHRASE ]]; then
+          echo "COZY_PASSPHRASE=${{ inputs.cozy-passphrase }}" >> $GITHUB_ENV
+        fi
+
+    - name: Create cozy-stack storage
+      shell: bash
+      run: |
+        mkdir -p $COZY_STACK_STORAGE
+
+        if [ "${{ runner.os }}" == "macOS" ]; then
+          brew cask install osxfuse
+          curl -L https://github.com/osxfuse/sshfs/releases/download/osxfuse-sshfs-2.5.0/sshfs-2.5.0.pkg --output sshfs-2.5.0.pkg
+          sudo installer -pkg ./sshfs-2.5.0.pkg -target /
+          podman-machine ssh box -- mkdir /home/tc/storage
+          podman-machine mount box:/home/tc/storage $COZY_STACK_STORAGE
+        fi
+
+    - name: Create a local instance and an OAuth client
+      shell: bash
+      run: |
+        cozy-stack serve --fs-url "file://$COZY_STACK_STORAGE" --log-level warning >cozy-stack.log 2>&1 &
+        until cozy-stack instances add --dev --passphrase "$COZY_PASSPHRASE" localhost:8080
+        do
+          sleep 1
+        done
+        COZY_CLIENT_ID=$(cozy-stack instances client-oauth localhost:8080 http://localhost/ test github.com/cozy-labs/cozy-desktop)
+        COZY_STACK_TOKEN=$(cozy-stack instances token-oauth localhost:8080 "$COZY_CLIENT_ID" io.cozy.files io.cozy.settings)
+        # Variables are not directly available in next steps; we need to write them into a special file
+        echo "COZY_CLIENT_ID=$COZY_CLIENT_ID" >> $GITHUB_ENV
+        echo "COZY_STACK_TOKEN=$COZY_STACK_TOKEN" >> $GITHUB_ENV

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,0 +1,201 @@
+name: Linux
+
+# To debug a job, add the following step:
+# - name: Debug with tmate
+#   uses: mxschmitt/action-tmate@v3
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/macos.yaml'
+
+env:
+  COZY_DESKTOP_DIR: "${{ github.workspace }}/cozy-desktop"
+  COZY_STACK_STORAGE: "${{ github.workspace }}/storage"
+  COZY_URL: "http://localhost:8080"
+  COZY_PASSPHRASE: "cozy"
+  GO111MODULE: "on"
+  NODE_ENV: "test"
+  COZY_DESKTOP_HEARTBEAT: "1000"
+  DISPLAY: ":99.0"
+  NODE_VERSION: "12.14.1"
+  GO_VERSION: "1.14"
+  COUCHDB_VERSION: "2.3.1"
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    name: Lint & Unit tests
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup CouchDB
+        uses: 'cobot/couchdb-action@11e2c9f532a0eee2516ff80d92990d8081f2792c' # v4
+        with:
+          couchdb version: ${{ env.COUCHDB_VERSION }}
+      - name: Setup cozy-stack
+        uses: ./.github/actions/setup-cozy-stack
+      - name: Setup local env
+        run: |
+          mkdir -p "$COZY_DESKTOP_DIR"
+          echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Start Xvfb
+        run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+      - name: Build elm
+        run: yarn build:elm
+      - name: Lint
+        run: yarn lint
+      - name: Elm tests
+        run: yarn test:elm
+      - name: World tests
+        run: yarn test:world
+      - name: Unit tests
+        run: yarn test:unit
+
+  integration:
+    runs-on: ubuntu-latest
+    name: Integration tests
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup CouchDB
+        uses: 'cobot/couchdb-action@11e2c9f532a0eee2516ff80d92990d8081f2792c' # v4
+        with:
+          couchdb version: ${{ env.COUCHDB_VERSION }}
+      - name: Setup cozy-stack
+        uses: ./.github/actions/setup-cozy-stack
+      - name: Setup local env
+        run: |
+          mkdir -p "$COZY_DESKTOP_DIR"
+          echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Start Xvfb
+        run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+      - name: Integration tests
+        run: yarn test:integration
+
+  scenarios:
+    runs-on: ubuntu-latest
+    name: Scenarios
+    strategy:
+      matrix:
+        stopped_client: ['', 'STOPPED']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup CouchDB
+        uses: 'cobot/couchdb-action@11e2c9f532a0eee2516ff80d92990d8081f2792c' # v4
+        with:
+          couchdb version: ${{ env.COUCHDB_VERSION }}
+      - name: Setup cozy-stack
+        uses: ./.github/actions/setup-cozy-stack
+      - name: Setup local env
+        run: |
+          mkdir -p "$COZY_DESKTOP_DIR"
+          echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Start Xvfb
+        run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+      - name: Scenarios
+        env:
+            STOPPED_CLIENT: ${{ matrix.stopped_client == 'STOPPED' }}
+        run: yarn test:scenarios
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build packages
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Build assets
+        run: yarn build
+      - name: Build packages
+        uses: ./.github/actions/build-and-publish
+        with:
+          gh-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,216 @@
+name: macOS
+
+# To debug a job, add the following step:
+# - name: Debug with tmate
+#   uses: mxschmitt/action-tmate@v3
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/linux.yaml'
+
+env:
+  COZY_DESKTOP_DIR: "${{ github.workspace }}/cozy-desktop"
+  COZY_STACK_STORAGE: "${{ github.workspace }}/storage"
+  COZY_URL: "http://localhost:8080"
+  COZY_PASSPHRASE: "cozy"
+  GO111MODULE: "on"
+  NO_BREAKPOINTS: "1"
+  NODE_ENV: "test"
+  COZY_DESKTOP_HEARTBEAT: "1000"
+  DISPLAY: ":99.0"
+  NODE_VERSION: "12.14.1"
+  GO_VERSION: "1.14"
+  COUCHDB_VERSION: "2.3.1"
+
+jobs:
+  unit:
+    runs-on: macos-latest
+    name: Unit tests
+    strategy:
+      matrix:
+        fs: ['APFS']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup CouchDB
+        uses: ./.github/actions/setup-couchdb
+        with:
+          couchdb-version: ${{ env.COUCHDB_VERSION }}
+      - name: Setup cozy-stack
+        uses: ./.github/actions/setup-cozy-stack
+      - name: Setup local env
+        env:
+            COZY_DESKTOP_FS: ${{ matrix.fs }}
+        run: |
+          hdiutil create -megabytes 50 -fs "$COZY_DESKTOP_FS" -volname cozy-desktop "$COZY_DESKTOP_DIR"
+          hdiutil attach "${COZY_DESKTOP_DIR}.dmg" -mountpoint "$COZY_DESKTOP_DIR"
+          echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Start Xvfb
+        run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+      - name: Unit tests
+        run: yarn test:unit
+
+  integration:
+    runs-on: macos-latest
+    name: Integration tests
+    strategy:
+      matrix:
+        fs: ['APFS']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup CouchDB
+        uses: ./.github/actions/setup-couchdb
+        with:
+          couchdb-version: ${{ env.COUCHDB_VERSION }}
+      - name: Setup cozy-stack
+        uses: ./.github/actions/setup-cozy-stack
+      - name: Setup local env
+        env:
+            COZY_DESKTOP_FS: ${{ matrix.fs }}
+        run: |
+          hdiutil create -megabytes 50 -fs "$COZY_DESKTOP_FS" -volname cozy-desktop "$COZY_DESKTOP_DIR"
+          hdiutil attach "${COZY_DESKTOP_DIR}.dmg" -mountpoint "$COZY_DESKTOP_DIR"
+          echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Start Xvfb
+        run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+      - name: Integration tests
+        run: yarn test:integration
+
+  scenarios:
+    runs-on: macos-latest
+    name: Scenarios
+    strategy:
+      matrix:
+        stopped_client: ['', 'STOPPED']
+        fs: ['APFS', 'HFS+']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup CouchDB
+        uses: ./.github/actions/setup-couchdb
+        with:
+          couchdb-version: ${{ env.COUCHDB_VERSION }}
+      - name: Setup cozy-stack
+        uses: ./.github/actions/setup-cozy-stack
+      - name: Setup local env
+        env:
+            COZY_DESKTOP_FS: ${{ matrix.fs }}
+        run: |
+          hdiutil create -megabytes 100 -fs "$COZY_DESKTOP_FS" -volname cozy-desktop "$COZY_DESKTOP_DIR"
+          hdiutil attach "${COZY_DESKTOP_DIR}.dmg" -mountpoint "$COZY_DESKTOP_DIR"
+          echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Start Xvfb
+        run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+      - name: Scenarios
+        env:
+            STOPPED_CLIENT: ${{ matrix.stopped_client == 'STOPPED' }}
+        run: yarn test:scenarios
+
+  build:
+    runs-on: macos-latest
+    name: Build packages
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Install dependencies
+        if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
+        run: yarn install:all
+      - name: Build assets
+        run: yarn build
+      - name: Build package
+        uses: ./.github/actions/build-and-publish
+        with:
+          gh-token: "${{ secrets.github_token }}"
+          mac-cert: "${{ secrets.mac_cert }}"
+          mac-cert-password: "${{ secrets.mac_cert_password }}"
+          apple-id: "${{ secrets.apple_id }}"
+          apple-id-password: "${{ secrets.apple_id_password }}"

--- a/build/afterSignHook.js
+++ b/build/afterSignHook.js
@@ -31,8 +31,8 @@ module.exports = async function(params) {
     await electron_notarize.notarize({
       appBundleId: appId,
       appPath: appPath,
-      appleId: process.env.appleId,
-      appleIdPassword: process.env.appleIdPassword
+      appleId: process.env.APPLE_ID,
+      appleIdPassword: process.env.APPLE_ID_PASSWORD
     })
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -9,17 +9,6 @@ const pouchHelpers = require('../support/helpers/pouch')
 const TestHelpers = require('../support/helpers')
 
 describe('Case or encoding change', () => {
-  // This test passes on a macOS workstation when using the docker container,
-  // since files are stored on an ext4 FS. But Travis macOS workers lack
-  // virtualization support, which means the cozy-stack will run directly on
-  // macOS with HFS+ and the test will fail (see below).
-  // Maybe we could create an ext4 volume on Travis and put the storage files
-  // there to better match the production environment?
-  if (process.env.TRAVIS && process.platform === 'darwin') {
-    it.skip('is unstable on Travis (macOS)')
-    return
-  }
-
   let cozy, helpers
 
   before(configHelpers.createConfig)

--- a/test/integration/id_conflict.js
+++ b/test/integration/id_conflict.js
@@ -12,15 +12,6 @@ const pouchHelpers = require('../support/helpers/pouch')
 const TestHelpers = require('../support/helpers')
 
 describe('Identity conflict', () => {
-  if (process.env.TRAVIS && process.platform === 'darwin') {
-    it.skip(
-      'cannot work on macOS Travis since the cozy-stack is currently using ' +
-        'APFS instead of EXT4 (but at least it works on AppVeyor)',
-      () => {}
-    )
-    return
-  }
-
   let cozy, helpers
 
   before(configHelpers.createConfig)

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -33,6 +33,8 @@ module.exports = {
 
   cleanConfig() {
     this.timeout && this.timeout(5 * 60 * 1000)
-    return del.sync(this.syncPath, { force: process.env.TRAVIS })
+    return del.sync(this.syncPath, {
+      force: process.env.TRAVIS || process.env.GITHUB_ENV
+    })
   }
 }

--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -7,7 +7,9 @@ module.exports = {
   },
 
   async cleanDatabase() {
-    await this.pouch.db.destroy()
+    if (this.pouch && this.pouch.db) {
+      await this.pouch.db.destroy()
+    }
     this.pouch = null
   },
 

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -46,8 +46,8 @@ describe('App', function() {
     beforeEach(configHelpers.createConfig)
 
     // FIXME
-    if (process.env.TRAVIS) {
-      it('does not work on Travis')
+    if (process.env.TRAVIS || process.env.GITHUB_ENV) {
+      it('works only on AppVeyor since it uses an actual Cozy.')
       return
     }
 

--- a/test/unit/local/chokidar/watcher.js
+++ b/test/unit/local/chokidar/watcher.js
@@ -15,9 +15,6 @@ const { ContextDir } = require('../../../support/helpers/context_dir')
 const { onPlatform, onPlatforms } = require('../../../support/helpers/platform')
 const pouchHelpers = require('../../../support/helpers/pouch')
 
-const { TRAVIS } = process.env
-const { platform } = process
-
 onPlatform('darwin', () => {
   describe('ChokidarWatcher Tests', function() {
     let builders
@@ -316,14 +313,6 @@ onPlatform('darwin', () => {
       }))
 
     describe('when a file is moved', function() {
-      // This integration test is unstable on travis + OSX (too often red).
-      // It's disabled for the moment, but we should find a way to make it
-      // more stable on travis, and enable it again.
-      if (TRAVIS && platform === 'darwin') {
-        it('is unstable on travis')
-        return
-      }
-
       beforeEach('instanciate pouch', pouchHelpers.createDatabase)
       afterEach('clean pouch', pouchHelpers.cleanDatabase)
 
@@ -369,14 +358,6 @@ onPlatform('darwin', () => {
     })
 
     describe('when a directory is moved', function() {
-      // This integration test is unstable on travis + OSX (too often red).
-      // It's disabled for the moment, but we should find a way to make it
-      // more stable on travis, and enable it again.
-      if (TRAVIS && platform === 'darwin') {
-        it('is unstable on travis')
-        return
-      }
-
       beforeEach('instanciate pouch', pouchHelpers.createDatabase)
       afterEach('clean pouch', pouchHelpers.cleanDatabase)
 


### PR DESCRIPTION
Allow testing and building the application on Github Actions instead of Travis CI.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
