### PR TITLE
core/local/chokidar/analysis: Handle wip moves

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -222,9 +222,7 @@ function analyseEvent(
         const moveChange /*: ?LocalFileMove */ = localChange.maybeMoveFile(
           sameInodeChange
         )
-        /* istanbul ignore next */
-        if (moveChange) {
-          // TODO: Pending move
+        if (moveChange && !moveChange.wip) {
           panic(
             { path: e.path, moveChange, event: e },
             'We should not have both move and unlink changes since ' +
@@ -249,8 +247,7 @@ function analyseEvent(
           sameInodeChange
         )
         /* istanbul ignore next */
-        if (moveChange) {
-          // TODO: pending move
+        if (moveChange && !moveChange.wip) {
           panic(
             { path: e.path, moveChange, event: e },
             'We should not have both move and unlinkDir changes since ' +


### PR DESCRIPTION
Since we buffer events on macOS, if a file or a directory is moved
more than once during the buffering time and `fsevents` fires
`unlink` and `add` events for all moves, then we'll end up with
`wip` moves (i.e. because the document is not at the final location
already)that should be completed by future `unlink` and `add`
events.

However, we were only expecting the situation where `fsevents` will
group those events together and fire only the final `unlink` and
`add` events. Besides not handling `wip` moves, we were throwing an
error when encountering them.

Since we have a better grasp on the situation, we simply stop
throwing errors if we find ourselves in a situation where we should
group a `wip` move event with an `unlink` event. We will still throw
an error if the move was complete though as it is unexpected.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
