### PR TITLE
Release v3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,54 @@
 # Cozy Drive for Desktop: Changelog
 
-## 3.24.0-beta.3 - 2020-12-01
+## 3.24.0 - 2020-12-07
+
+Improvements for all users:
+
+- This release lays the ground work for a future synchronization algorithm. We
+  now store the complete remote metadata of each document and the local metadata
+  of both files and directories. This will allow us to make deeper comparisons
+  and take better action in complex situations (e.g. a file modification and
+  renaming on the local filesystem with a parent directory renaming on the
+  Cozy).
+  Another part of this base work is the move to generated PouchDB records ids.
+  Those were previously based on the document's path and this scheme had several
+  limitations (e.g. when a document was moved or renamed, its record id had to
+  change).
+- The move to generated PouchDB ids allows you to synchronize documents whose
+  name start with an underscore (`_`), in the root synchronization folder. Those
+  previously resulted in reserved PouchDB ids and could not be stored thus
+  synchronized.
+- The upload requests rejection protection does not create memory leaks anymore
+  as it will be cleaned up after the requests terminate, whether they're
+  successful or not.
+- When a new directory is linked with an existing directory on the other side
+  (i.e. either the local filesystem or the remote Cozy) with the same name in
+  the same parent directory, we'll update the existing directory's metadata with
+  the new directory's metadata to make sure they're in sync.
+- Now that we track the local metadata of files, we can still detect during the
+  start-up local scan if a the file was updated on the local filesystem even if
+  a remote update was saved in PouchDB but not synced before the client was
+  stopped. With this detection we can decide if a conflict needs to be created
+  or not without losing any data and stop applying the remote update in all
+  cases.
+- We'll now track more closely the local modifications resulting from the
+  application on the filesystem of changes fetched from the remote Cozy. This is
+  important especially for tracking movements and make sure opposite movements
+  won't be wrongly "detected" after a client restart.
+
+Improvements for Windows and Linux users:
+
+- We've made sure the logic dedicated to the initial scan, run after a client
+  start, won't be used after the initial scan is done. This was the source of
+  bugs when applying folder movements fetched from the remote Cozy.
+
+Improvements for Windows users:
+
+- Files marked as executable and downloaded from the Cozy will remain marked as
+  executable on the Cozy and all the devices recognizing this flag (i.e. on
+  Linux or macOS). Since this flag is not recognized on Windows, synchronizing
+  an executable file with a Windows device would previously remove the flag for
+  everybody.
 
 Improvements for macOS users:
 
@@ -12,6 +60,17 @@ See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KN
 
 Happy syncing!
 
+## 3.24.0-beta.3 - 2020-12-01
+
+Improvements for macOS users:
+
+- We're now handling moving the same document multiple times in a short delay
+  and moving a document just downloaded from the Cozy to a path including UTF-8
+  characters on HFS+ filesystems.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
 
 ## 3.24.0-beta.2 - 2020-11-20
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.24.0-beta.3",
+  "version": "3.24.0",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- This release lays the ground work for a future synchronization
  algorithm. We now store the complete remote metadata of each
  document and the local metadata of both files and directories. This
  will allow us to make deeper comparisons and take better action in
  complex situations (e.g. a file modification and renaming on the
  local filesystem with a parent directory renaming on the Cozy).
  Another part of this base work is the move to generated PouchDB
  records ids. Those were previously based on the document's path and
  this scheme had several limitations (e.g. when a document was moved
  or renamed, its record id had to change).
- The move to generated PouchDB ids allows you to synchronize
  documents whose name start with an underscore (`_`), in the root
  synchronization folder. Those previously resulted in reserved
  PouchDB ids and could not be stored thus synchronized.
- The upload requests rejection protection does not create memory
  leaks anymore as it will be cleaned up after the requests terminate,
  whether they're successful or not.
- When a new directory is linked with an existing directory on the
  other side (i.e. either the local filesystem or the remote
  Cozy) with the same name in the same parent directory, we'll update
  the existing directory's metadata with the new directory's metadata
  to make sure they're in sync.
- Now that we track the local metadata of files, we can still detect
  during the start-up local scan if a the file was updated on the
  local filesystem even if a remote update was saved in PouchDB but
  not synced before the client was stopped. With this detection we can
  decide if a conflict needs to be created or not without losing any
  data and stop applying the remote update in all cases.
- We'll now track more closely the local modifications resulting from
  the application on the filesystem of changes fetched from the remote
  Cozy. This is important especially for tracking movements and make
  sure opposite movements won't be wrongly "detected" after a client
  restart.

Improvements for Windows and Linux users:

- We've made sure the logic dedicated to the initial scan, run after a
  client start, won't be used after the initial scan is done. This was
  the source of bugs when applying folder movements fetched from the
  remote Cozy.

Improvements for Windows users:

- Files marked as executable and downloaded from the Cozy will remain
  marked as executable on the Cozy and all the devices recognizing
  this flag (i.e. on Linux or macOS). Since this flag is not
  recognized on Windows, synchronizing an executable file with a
  Windows device would previously remove the flag for everybody.

Improvements for macOS users:

- We're now handling moving the same document multiple times in a
  short delay and moving a document just downloaded from the Cozy to a
  path including UTF-8 characters on HFS+ filesystems.