### PR TITLE
core/pouch: Fix local tree getter

### DIFF
--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -536,9 +536,9 @@ class Pouch {
     )
   }
 
-  tree() {
-    const { rows } = this.db.allDocs()
-    return rows.map(row => row.doc).map(doc => doc.id)
+  async localTree() /*: Promise<string[]> */ {
+    const docs = await this.allDocs()
+    return docs.filter(doc => doc.local).map(doc => doc.local.path)
   }
 }
 

--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -14,11 +14,16 @@ module.exports = {
   },
 
   createParentFolder(pouch) {
-    let doc = {
+    const updated_at = new Date().toISOString()
+    const doc = {
       path: 'my-folder',
       docType: 'folder',
-      updated_at: new Date().toISOString(),
+      updated_at,
       tags: [],
+      local: {
+        path: 'my-folder',
+        updated_at
+      },
       remote: {
         _id: `XXX`,
         _rev: '1-abc'
@@ -32,11 +37,16 @@ module.exports = {
   },
 
   createFolder(pouch, folderPath) {
-    let doc = {
+    const updated_at = new Date().toISOString()
+    const doc = {
       path: folderPath,
       docType: 'folder',
-      updated_at: new Date().toISOString(),
+      updated_at,
       tags: [],
+      local: {
+        path: folderPath,
+        updated_at
+      },
       remote: {
         _id: `123456789-${folderPath}`
       },
@@ -49,12 +59,17 @@ module.exports = {
   },
 
   createFile(pouch, filePath) {
-    let doc = {
+    const updated_at = new Date().toISOString()
+    const doc = {
       path: filePath,
       docType: 'file',
       md5sum: `111111111111111111111111111111111111111${filePath}`,
-      updated_at: new Date().toISOString(),
+      updated_at,
       tags: [],
+      local: {
+        path: filePath,
+        updated_at
+      },
       remote: {
         _id: `1234567890-${filePath}`
       },

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -693,6 +693,46 @@ describe('Pouch', function() {
           })
           .and.not.have.properties(['path', 'tags']) // erased by PouchDB.remove
       }))
+
+    describe('localTree', () => {
+      let builders
+      beforeEach(async function() {
+        builders = new Builders({ pouch: this.pouch })
+      })
+
+      it('returns the local paths of all saved documents', async function() {
+        await should(this.pouch.localTree()).be.fulfilledWith(
+          createdDocs.map(d => d.local.path).sort()
+        )
+      })
+
+      it('does not return the paths of remote only documents', async function() {
+        await builders
+          .metafile()
+          .path('my-folder/remote-file')
+          .noLocal()
+          .create()
+
+        await should(this.pouch.localTree()).be.fulfilledWith(
+          createdDocs.map(d => d.local.path).sort()
+        )
+      })
+
+      it('resturns the paths of local only documents', async function() {
+        const localFile = await builders
+          .metafile()
+          .path('my-folder/remote-file')
+          .noRemote()
+          .create()
+
+        await should(this.pouch.localTree()).be.fulfilledWith(
+          createdDocs
+            .concat(localFile)
+            .map(d => d.local.path)
+            .sort()
+        )
+      })
+    })
   })
 
   describe('Sequence numbers', function() {


### PR DESCRIPTION
When we migrated the `Pouch` class to native Promises, we missed an
asynchronous call in the `tree()` method that needed to be awaited,
preventing the help messages from being sent to support.

Besides, now that the PouchDB records' ids are not based on the
documents' paths anymore, returning them does not give us an idea of
the documents tree.
We've moved to a more precise `localTree()` method that returns the
local path of documents as saved in the `local.path` attribute of the
records since this tree is mostly used to be compared with the remote
tree.