### PR TITLE
deps: Bump Electron to v10.2.0

### DIFF
--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -110,7 +110,8 @@ module.exports = class WindowManager {
     }
     opts.webPreferences = {
       ...opts.webPreferences,
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
     // https://github.com/AppImage/AppImageKit/wiki/Bundling-Electron-apps
     if (process.platform === 'linux') {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "lodash": "^4.17.11",
     "micromatch": "^3.1.0",
     "mime": "^1.3.4",
-    "node-abi": "^2.18.0",
+    "node-abi": "^2.19.3",
     "opn": "5.0.0",
     "pouchdb": "^7.0.0",
     "pouchdb-find": "^7.0.0",
@@ -131,7 +131,7 @@
     "debug-menu": "^0.6.1",
     "del": "^4.0.0",
     "devtron": "^1.4.0",
-    "electron": "^9.0.0",
+    "electron": "^10.0.0",
     "electron-builder": "^22.8.1",
     "electron-mocha": "^8.1.2",
     "electron-notarize": "^0.1.1",
@@ -172,6 +172,6 @@
     "leveldown": "5.0.2",
     "levelup": "4.0.2",
     "nan": "2.14.0",
-    "node-abi": "2.18.0"
+    "node-abi": "2.19.3"
   }
 }

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -123,7 +123,7 @@ describe('RemoteWatcher', function() {
       await this.watcher.start()
       should(this.watcher.resetTimeout).have.been.calledOnce()
       should(this.watcher.running).be.true()
-      should(this.watcher.watchTimeout.hasRef()).be.true()
+      should(this.watcher.watchTimeout._destroyed).be.false()
 
       this.watcher.resetTimeout.restore()
     })
@@ -200,7 +200,7 @@ describe('RemoteWatcher', function() {
       await this.watcher.start()
       this.watcher.stop()
       should(this.watcher.running).be.false()
-      should(this.watcher.watchTimeout.hasRef()).be.false()
+      should(this.watcher.watchTimeout._destroyed).be.true()
     })
 
     it('can be called multiple times', async function() {
@@ -208,7 +208,7 @@ describe('RemoteWatcher', function() {
       this.watcher.stop()
       this.watcher.stop()
       should(this.watcher.running).be.false()
-      should(this.watcher.watchTimeout.hasRef()).be.false()
+      should(this.watcher.watchTimeout._destroyed).be.true()
     })
   })
 
@@ -247,7 +247,7 @@ describe('RemoteWatcher', function() {
       it('schedules another watch timeout', async function() {
         const timeoutID = this.watcher.watchTimeout
         await this.watcher.resetTimeout()
-        should(this.watcher.watchTimeout.hasRef()).be.true()
+        should(this.watcher.watchTimeout._destroyed).be.false()
         should(this.watcher.watchTimeout.ref()).not.eql(timeoutID)
       })
 
@@ -261,7 +261,7 @@ describe('RemoteWatcher', function() {
         it('does not schedule another watch timeout', async function() {
           await this.watcher.resetTimeout()
           should(this.watcher.watch).have.been.calledOnce()
-          should(this.watcher.watchTimeout.hasRef()).be.false()
+          should(this.watcher.watchTimeout._destroyed).be.true()
         })
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^9.0.0:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-9.2.1.tgz#54ef574e1af4ae967b5efa94312f1b6458d44a02"
-  integrity sha512-ZsetaQjXB8+9/EFW1FnfK4ukpkwXCxMEaiKiUZhZ0ZLFlLnFCpe0Bg4vdDf7e4boWGcnlgN1jAJpBw7w0eXuqA==
+electron@^10.0.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-10.2.0.tgz#4b00f0907b28aca4b93661bb53ce9a4f8ad32201"
+  integrity sha512-GBUyq8dwUqXPkCTkoID+eZ5Pm9GFlLUd2eSoGe8UOaHeW68SgCf5t75/uGHraQ1OIz/0qniyH5M4ebWEHGppyQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"
@@ -5356,10 +5356,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@2.18.0, node-abi@^2.18.0, node-abi@^2.7.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
-  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
+node-abi@2.19.3, node-abi@^2.19.3, node-abi@^2.7.0:
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
+  integrity sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
   dependencies:
     semver "^5.4.1"
 


### PR DESCRIPTION
Also bumps node-abi which is required to get the ABI of the new
Electron release and compile dependencies.Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
