### PR TITLE
gui: Fix syncing status display

### DIFF
--- a/core/syncstate.js
+++ b/core/syncstate.js
@@ -35,7 +35,7 @@ export type SyncStatus =
   | 'buffering'
   | 'squashprepmerge'
   | 'offline'
-  | 'sync'
+  | 'syncing'
   | 'uptodate'
   | 'user-action-required'
 */
@@ -126,7 +126,7 @@ module.exports = class SyncState extends EventEmitter {
         : offline
         ? 'offline'
         : syncing
-        ? 'sync'
+        ? 'syncing'
         : buffering
         ? 'buffering'
         : localPrep || remotePrep

--- a/gui/elm/Data/Status.elm
+++ b/gui/elm/Data/Status.elm
@@ -20,7 +20,7 @@ init =
 fromString : String -> Int -> Status
 fromString str remaining =
     case str of
-        "sync" ->
+        "syncing" ->
             Syncing remaining
 
         "buffering" ->

--- a/gui/js/tray.js
+++ b/gui/js/tray.js
@@ -110,7 +110,7 @@ const systrayInfo = (status, label) => {
     case 'user-action-required':
       return ['pause', label]
     case 'syncing':
-      return ['sync', translate('Tray Syncing') + label ? `‟${label}“` : '…']
+      return ['sync', translate('Tray Syncing') + (label ? ` ‟${label}“` : '…')]
     case 'up-to-date':
     case 'online':
       return ['idle', translate('Tray Your cozy is up to date')]

--- a/gui/main.js
+++ b/gui/main.js
@@ -309,6 +309,8 @@ const updateState = (newState, data) => {
         translate('Dashboard Synchronization suspended')
       )
     else tray.setStatus('syncing')
+  } else if (newState === 'syncing' && data && data.filename) {
+    tray.setStatus(newState, data.filename)
   } else {
     tray.setStatus(newState, data)
   }


### PR DESCRIPTION
The syncing status comes from the Sync state and is propagated to the
main GUI window and the systray icon. It can come with data (i.e.
metadata about the file being transferred) from which we want to
derive a label for the systray.

We had 2 issues with this process:
1. the filename was not passed correctly to the `tray` module in
   charge of setting the systray label
2. the method in charge of setting the systray label would not
   correctly concatenate the main part of the label with the given
   filename

We also take the opportunity to harmonize the status name across the
board by using `syncing` instead of `sync` in the Sync state.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
