### PR TITLE
core/merge: Accept trashing of already trashed doc

### DIFF
--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -251,10 +251,14 @@ describe('Trash', () => {
 
         await helpers.remote.pullChanges()
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-          // XXX: Why isn't file deleted? (it works anyway)
+          // dir/subdir and dir/empty-subdir are deleted recursively when
+          // deleting dir/ and then deleted again when we merge their own remote
+          // changes.
           { path: path.normalize('parent/dir/subdir'), deleted: true },
           { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
           { path: path.normalize('parent/dir'), deleted: true },
+          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
+          { path: path.normalize('parent/dir/subdir'), deleted: true },
           { path: path.normalize('parent/dir/subdir/file'), deleted: true }
         ])
 


### PR DESCRIPTION
When we try to merge a doc trashing and that doc was already trashed
or deleted on the other side, we don't do anything as it looks like we
are already in sync.
However, this is ain't quite true. The sides metadata have changed and
since we use a deletion marker now, Sync will try to apply the first
deletion.
If the first deletion was done on the local PC, we'll try to trash a
doc that has since changed on the Cozy and we'll get a 412 error.
Now that we're blocking the Sync on this error, this is quite visible
and annoying (we can still get out of this situation by giving up on
the change).

By simply accepting the merge the second trashing request, we make the
remote revision will be updated when the remote watcher runs and the
synchronization will resume after a retry (either automatic or
manual).

Note: the situation is mostly the same for documents that were erased
from the Cozy (i.e. the Cozy trash was emptied after the documents
were deleted on the Cozy). It differs by the Merge methods called.

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
