### PR TITLE
test/scenarios: Replace env variables with helpers

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -73,9 +73,9 @@ jobs:
       - name: Elm tests
         run: yarn test:elm
       - name: World tests
-        run: yarn test:world
+        run: yarn test:world --forbid-only
       - name: Unit tests
-        run: yarn test:unit
+        run: yarn test:unit --forbid-only
 
   integration:
     runs-on: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
       - name: Start Xvfb
         run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
       - name: Integration tests
-        run: yarn test:integration
+        run: yarn test:integration --forbid-only
 
   scenarios:
     runs-on: ubuntu-latest
@@ -167,7 +167,7 @@ jobs:
       - name: Scenarios
         env:
             STOPPED_CLIENT: ${{ matrix.stopped_client == 'STOPPED' }}
-        run: yarn test:scenarios
+        run: yarn test:scenarios --forbid-only
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Start Xvfb
         run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
       - name: Unit tests
-        run: yarn test:unit
+        run: yarn test:unit --forbid-only
 
   integration:
     runs-on: macos-latest
@@ -121,11 +121,11 @@ jobs:
           echo "NODE_ENV=test" > "${{ github.workspace }}/.env.test"
       - name: Install dependencies
         if: ${{ ! steps.cache-node-modules.outputs.cache-hit }}
-        run: yarn install:all
+        run: yarn install:all --forbid-only
       - name: Start Xvfb
         run: sudo Xvfb :99 -ac -screen 0 1024x768x8 &
       - name: Integration tests
-        run: yarn test:integration
+        run: yarn test:integration --forbid-only
 
   scenarios:
     runs-on: macos-latest
@@ -178,7 +178,7 @@ jobs:
       - name: Scenarios
         env:
             STOPPED_CLIENT: ${{ matrix.stopped_client == 'STOPPED' }}
-        run: yarn test:scenarios
+        run: yarn test:scenarios --forbid-only
 
   build:
     runs-on: macos-latest

--- a/test/scenarios/move_overwriting_dir/trashed_first/scenario.js
+++ b/test/scenarios/move_overwriting_dir/trashed_first/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runWithStoppedClient } = require('../../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '../..' */
 
 module.exports = ({
@@ -36,7 +38,7 @@ module.exports = ({
     // When the overwrite happens while the client is turned off, we won't detect
     // the files' deletion before the folder's movement so we won't trash them
     // by themselves and will thus be trashed as part of the folder hierarchy.
-    trash: process.env.STOPPED_CLIENT
+    trash: runWithStoppedClient()
       ? [
           'dir/',
           'dir/file',

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -18,7 +18,9 @@ const {
   loadFSEventFiles,
   loadAtomCaptures,
   runActions,
-  scenarios
+  scenarios,
+  runWithBreakpoints,
+  runWithStoppedClient
 } = require('../support/helpers/scenarios')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
@@ -27,8 +29,6 @@ const pouchHelpers = require('../support/helpers/pouch')
 const remoteCaptureHelpers = require('../../dev/capture/remote')
 
 const { platform } = process
-
-const stoppedEnvVar = 'STOPPED_CLIENT'
 
 const logger = require('../../core/utils/logger')
 const log = new logger({ component: 'TEST' })
@@ -63,7 +63,7 @@ describe('Test scenarios', function() {
 
     if (scenario.side === 'remote') {
       it.skip(`test/scenarios/${scenario.name}/local/  (skip remote only test)`, () => {})
-    } else if (process.env[stoppedEnvVar] == null) {
+    } else if (!runWithStoppedClient()) {
       for (let atomCapture of loadAtomCaptures(scenario)) {
         const localTestName = `test/scenarios/${scenario.name}/atom/${atomCapture.name}`
         if (config.watcherType() !== 'atom') {
@@ -118,7 +118,7 @@ describe('Test scenarios', function() {
       }
     }
 
-    if (process.env[stoppedEnvVar]) continue
+    if (runWithStoppedClient()) continue
     const remoteTestName = `test/scenarios/${scenario.name}/remote/`
     const remoteTestSkipped = shouldSkipRemote(scenario)
     if (remoteTestSkipped) {
@@ -132,12 +132,12 @@ describe('Test scenarios', function() {
   }
 })
 
-function shouldSkipLocalStopped(scenario, env = process.env) {
+function shouldSkipLocalStopped(scenario) {
   const disabled = disabledScenarioTest(scenario, 'stopped')
   if (disabled) {
     return disabled
-  } else if (env[stoppedEnvVar] == null) {
-    return `${stoppedEnvVar} is not set`
+  } else if (!runWithStoppedClient()) {
+    return `STOPPED_CLIENT is not set`
   }
 }
 
@@ -163,7 +163,7 @@ function injectChokidarBreakpoints(eventsFile) {
     for (let i = 0; i < eventsFile.events.length; i++) breakpoints.push(i)
   }
 
-  if (process.env.NO_BREAKPOINTS) breakpoints = [0]
+  if (!runWithBreakpoints()) breakpoints = [0]
   return breakpoints
 }
 

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -73,6 +73,20 @@ const windowsPathFixer = (filename, event) => {
   }
 }
 
+const isTruthyVar = envVar => {
+  return envVar === '1' || envVar === 'true' || envVar === true
+}
+
+module.exports.runWithBreakpoints = () => {
+  const { NO_BREAKPOINTS } = process.env
+  return !isTruthyVar(NO_BREAKPOINTS)
+}
+
+module.exports.runWithStoppedClient = () => {
+  const { STOPPED_CLIENT } = process.env
+  return isTruthyVar(STOPPED_CLIENT)
+}
+
 // TODO: Refactor to function
 module.exports.scenarios = glob
   .sync(path.join(scenariosDir, '**/scenario.js*'), {})


### PR DESCRIPTION
The value `false` assigned to the `STOPPED_CLIENT` env variable in our
github workflows is read as a string and thus interpreted as a thuthy
value instead of the boolean `false` in the scenarios configuration.

This means our scenarios were always run with a stopped client in our
github workflows!

In an attempt to prevent such issues in the future, we're now using
helpers to read the value of env variables and interpret them. This
way, all boolean variables will be interpreted the same way which
makes it easier to reason about.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
