### PR TITLE
logs: Reduce Sentry's input flow

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -178,16 +178,22 @@ class App {
       log.info(`Device ${registered.deviceName} has been added to ${cozyUrl}`)
       this.saveConfig(cozyUrl, syncPath)
     } catch (err) {
-      log.error('An error occured while registering your device.')
       let parsed /*: Object */ = this.parseCozyUrl(cozyUrl)
       if (err === 'Bad credentials') {
-        log.warn(err)
-        log.warn('Are you sure there are no typo on the passphrase?')
+        log.warn(
+          { err },
+          'The Cozy passphrase used for registration is incorrect'
+        )
       } else if (err.code === 'ENOTFOUND') {
-        log.warn(`The DNS resolution for ${parsed.hostname} failed.`)
-        log.warn('Are you sure the domain is OK?')
+        log.warn(
+          { err },
+          `The DNS resolution for ${parsed.hostname} failed while registering the device.`
+        )
       } else {
-        log.error(err)
+        log.error(
+          { err, sentry: true },
+          'An error occured while registering the device.'
+        )
         if (parsed.protocol === 'http:') {
           log.warn('Did you try with an httpS URL?')
         }
@@ -207,8 +213,10 @@ class App {
       log.info('Current device properly removed from remote cozy.')
       return null
     } catch (err) {
-      log.error('An error occured while unregistering your device.')
-      log.error(err)
+      log.error(
+        { err, sentry: true },
+        'An error occured while unregistering the device.'
+      )
       return err
     }
   }
@@ -269,7 +277,7 @@ class App {
     try {
       pouchdbTree = await this.pouch.localTree()
     } catch (err) {
-      log.error({ err }, 'FAILED TO FETCH LOCAL TREE')
+      log.error({ err, sentry: true }, 'FAILED TO FETCH LOCAL TREE')
     }
 
     const logsSent = Promise.all([
@@ -282,7 +290,7 @@ class App {
           )
         : Promise.resolve()
     ]).catch(err => {
-      log.error({ err }, 'FAILED TO SEND LOGS')
+      log.error({ err, sentry: true }, 'FAILED TO SEND LOGS')
     })
 
     content =
@@ -355,7 +363,7 @@ class App {
         this.config.version = clientInfo.appVersion
       } catch (err) {
         log.error(
-          { err, clientInfo },
+          { err, clientInfo, sentry: true },
           'could not update config version after app update'
         )
         wasUpdated = false
@@ -372,7 +380,7 @@ class App {
         this.remote.update()
       } catch (err) {
         log.error(
-          { err, config: this.config },
+          { err, config: this.config, sentry: true },
           'could not update OAuth client after app update'
         )
       }

--- a/core/config.js
+++ b/core/config.js
@@ -230,7 +230,7 @@ function loadOrDeleteFile(configPath /*: string */) /*: FileConfig */ {
     return JSON.parse(content)
   } catch (e) {
     if (e instanceof SyntaxError) {
-      log.error(`Could not read config file at ${configPath}:`, e)
+      log.error({ err: e }, `Could not read config file at ${configPath}`)
       fse.unlinkSync(configPath)
       return {}
     } else {

--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -47,7 +47,7 @@ function loop(
     const batch = []
     for (const event of events) {
       if (event.kind === 'symlink') {
-        log.error({ event }, 'Symlinks are not supported')
+        log.warn({ event }, 'Symlinks are not supported')
         // TODO display an error in the UI
         continue
       }

--- a/core/local/atom/await_write_finish.js
+++ b/core/local/atom/await_write_finish.js
@@ -263,7 +263,7 @@ async function awaitWriteFinish(channel /*: Channel */, out /*: Channel */) {
 function loop(channel /*: Channel */, opts /*: {} */) /*: Channel */ {
   const out = new Channel()
   awaitWriteFinish(channel, out).catch(err => {
-    log.error({ err })
+    log.warn({ err })
   })
   return out
 }

--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -69,7 +69,7 @@ function step(opts /*: DispatchOptions */) {
       try {
         await dispatchEvent(event, opts)
       } catch (err) {
-        log.error({ err, event })
+        log.warn({ err, event }, 'could not dispatch local event')
       } finally {
         if (process.platform === 'win32') {
           winDetectMove.forget(event, opts.state)

--- a/core/local/atom/incomplete_fixer.js
+++ b/core/local/atom/incomplete_fixer.js
@@ -306,7 +306,7 @@ function step(
             state.incompletes.splice(i, 1)
           }
         } catch (err) {
-          log.error(
+          log.warn(
             { err, event, item },
             'Error while rebuilding incomplete event'
           )

--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -72,7 +72,7 @@ function loop(
 ) /*: Channel */ {
   const out = new Channel()
   initialDiff(channel, out, opts.state).catch(err => {
-    log.error({ err })
+    log.warn({ err })
   })
   return out
 }

--- a/core/local/atom/overwrite.js
+++ b/core/local/atom/overwrite.js
@@ -169,7 +169,7 @@ const loop = (channel /*: Channel */, opts /*: OverwriteOptions */) => {
   const out = new Channel()
 
   _loop(channel, out, opts).catch(err => {
-    log.error({ err })
+    log.warn({ err })
   })
 
   return out

--- a/core/local/atom/producer.js
+++ b/core/local/atom/producer.js
@@ -146,7 +146,10 @@ class Producer {
           log.debug({ event: scanEvent }, 'Ignored via .cozyignore')
         }
       } catch (err) {
-        log.error({ err, path: path.join(relPath, entry) })
+        log.error(
+          { err, path: path.join(relPath, entry) },
+          'could not get doc info'
+        )
       }
     }
     log.trace({ path: relPath, batch: entries }, 'scan')

--- a/core/local/atom/scan_folder.js
+++ b/core/local/atom/scan_folder.js
@@ -37,7 +37,7 @@ function loop(
       }
       if (event.action === 'created' && event.kind === 'directory') {
         opts.scan(event.path).catch(err => {
-          log.error({ err, event }, 'Error on scan')
+          log.warn({ err, event }, 'Error on folder scan')
         })
       }
     }

--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -286,7 +286,7 @@ function loop(
     out.push(batch)
   }
   winDetectMove(channel, output, opts).catch(err => {
-    log.error({ err })
+    log.warn({ err })
   })
   return out
 }

--- a/core/local/atom/win_identical_renaming.js
+++ b/core/local/atom/win_identical_renaming.js
@@ -173,7 +173,7 @@ const loop = (
   const out = new Channel()
 
   _loop(channel, out, opts).catch(err => {
-    log.error({ err })
+    log.warn({ err })
   })
 
   return out

--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -174,7 +174,7 @@ function analyseEvents(
       changesFound.put(result) // A new change was found
     } catch (err) {
       const sentry = err.name === 'InvalidLocalMoveEvent'
-      log.error({ err, path: e.path, sentry })
+      log.error({ err, path: e.path, sentry }, 'Invalid local move event')
       throw err
     }
   }

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -113,7 +113,7 @@ const step = async (
               )
               e2.wip = true
             } else {
-              log.error({ path: e.path, err }, 'Checksum failed')
+              log.error({ path: e.path, err, sentry: true }, 'Checksum failed')
               return null
             }
           }

--- a/core/local/chokidar/send_to_prep.js
+++ b/core/local/chokidar/send_to_prep.js
@@ -44,7 +44,7 @@ const onAddFile = (
   { path: filePath, stats, md5sum } /*: LocalFileAddition */,
   prep /*: Prep */
 ) => {
-  const logError = err => log.error({ err, path: filePath })
+  const logError = err => log.warn({ err, path: filePath })
   const doc = metadata.buildFile(filePath, stats, md5sum)
   log.info({ path: filePath }, 'FileAddition')
   return prep.addFileAsync(SIDE, doc).catch(logError)
@@ -54,7 +54,7 @@ const onMoveFile = async (
   { path: filePath, stats, md5sum, old, overwrite } /*: LocalFileMove */,
   prep /*: Prep */
 ) => {
-  const logError = err => log.error({ err, path: filePath })
+  const logError = err => log.warn({ err, path: filePath })
   const doc = metadata.buildFile(filePath, stats, md5sum, old.remote)
   if (overwrite) doc.overwrite = overwrite
   log.info({ path: filePath, oldpath: old.path }, 'FileMove')
@@ -65,7 +65,7 @@ const onMoveFolder = (
   { path: folderPath, stats, old, overwrite } /*: LocalDirMove */,
   prep /*: Prep */
 ) => {
-  const logError = err => log.error({ err, path: folderPath })
+  const logError = err => log.warn({ err, path: folderPath })
   const doc = metadata.buildDir(folderPath, stats, old.remote)
   // $FlowFixMe we set doc.overwrite to true, it will be replaced by metadata in merge
   if (overwrite) doc.overwrite = overwrite
@@ -82,7 +82,7 @@ const onAddDir = (
   log.info({ path: folderPath }, 'DirAddition')
   return prep
     .putFolderAsync(SIDE, doc)
-    .catch(err => log.error({ err, path: folderPath }))
+    .catch(err => log.warn({ err, path: folderPath }))
 }
 
 /** File deletion detected
@@ -97,7 +97,7 @@ const onUnlinkFile = (
   log.info({ path: filePath }, 'FileDeletion')
   return prep
     .trashFileAsync(SIDE, { path: filePath })
-    .catch(err => log.error({ err, path: filePath }))
+    .catch(err => log.warn({ err, path: filePath }))
 }
 
 /** Folder deletion detected
@@ -112,7 +112,7 @@ const onUnlinkDir = (
   log.info({ path: folderPath }, 'DirDeletion')
   return prep
     .trashFolderAsync(SIDE, { path: folderPath })
-    .catch(err => log.error({ err, path: folderPath }))
+    .catch(err => log.warn({ err, path: folderPath }))
 }
 
 /** File update detected */
@@ -170,7 +170,7 @@ const step = async (
           throw new Error('wrong changes')
       }
     } catch (err) {
-      log.error({ path: c.path, err })
+      log.warn({ path: c.path, err })
       errors.push(err)
     }
   }

--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -96,7 +96,7 @@ class LocalWatcher {
       try {
         await this.onFlush(rawEvents)
       } catch (err) {
-        log.error({ err }, 'onFlushError')
+        log.error({ err, sentry: true }, 'fatal chokidar watcher error')
         this._runningReject && this._runningReject(err)
       }
     })
@@ -177,11 +177,12 @@ class LocalWatcher {
         .on('error', err => {
           if (err.message === 'watch ENOSPC') {
             log.error(
+              { err, sentry: true },
               'Sorry, the kernel is out of inotify watches! ' +
                 'See doc/usage/inotify.md for how to solve this issue.'
             )
           } else {
-            log.error({ err })
+            log.error({ err, sentry: true }, 'could not start chokidar watcher')
           }
         })
 

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -490,7 +490,7 @@ class Local /*:: implements Reader, Writer */ {
     try {
       return await diskUsage.check(this.syncPath)
     } catch (err) {
-      log.error({ err }, 'Could not get local available disk space')
+      log.warn({ err }, 'Could not get local available disk space')
       return { available: 0, total: 0 }
     }
   }

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -118,7 +118,7 @@ class Pouch {
       if (result.type === MIGRATION_RESULT_FAILED) {
         // Error in case of second failure
         const err = new MigrationFailedError(migration, result.errors)
-        log.fatal({ err }, migrationLog(migration, result))
+        log.fatal({ err, sentry: true }, migrationLog(migration, result))
         throw err
       } else {
         log.info(migrationLog(migration, result))
@@ -141,7 +141,7 @@ class Pouch {
     return new Promise(async (resolve, reject) => {
       const uncaughtExceptionHandler = async err => {
         log.error(
-          { err, options },
+          { err, options, sentry: true },
           'uncaughtException in _allDocs. PouchDB db might be corrupt.'
         )
         reject(err)
@@ -228,7 +228,10 @@ class Pouch {
       if (result.error) {
         const err = new PouchError(result)
         const doc = docs[idx]
-        log.error({ path: doc.path, doc }, err)
+        log.error(
+          { err, path: doc.path, doc, sentry: true },
+          'could not save bulk metadata'
+        )
         throw err
       }
     }
@@ -244,7 +247,7 @@ class Pouch {
       const { rows } = await this.db.query(query, params)
       return rows.filter(row => row.doc != null).map(row => row.doc)
     } catch (err) {
-      log.fatal({ err }, `could not run ${query} query`)
+      log.error({ err }, `could not run ${query} query`)
       return []
     }
   }

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -298,7 +298,7 @@ class RemoteCozy {
 
         if (parent.error || parent.doc == null || parent.doc.path == null) {
           log.error(
-            { remoteDoc, parent },
+            { err: parent.error, remoteDoc, parent, sentry: true },
             'Could not compute doc path from parent'
           )
           continue

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -171,7 +171,7 @@ class Remote /*:: implements Reader, Writer */ {
     old /*: ?SavedMetadata */
   ) /*: Promise<void> */ {
     if (old && isNote(old)) {
-      log.error(
+      log.warn(
         { path: doc.path, doc, old },
         'Local note updates should not be propagated'
       )

--- a/core/remote/warning_poller.js
+++ b/core/remote/warning_poller.js
@@ -85,7 +85,7 @@ class RemoteWarningPoller {
         this.events.emit('user-action-required', err)
       }
     } catch (err) {
-      log.error({ err })
+      log.warn({ err }, 'could not fetch remote warnings')
     } finally {
       this.polling = null
       this.scheduleNext(shiftTicks(this.ticks))

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -81,7 +81,7 @@ class RemoteWatcher {
   }
 
   error(err /*: RemoteError */) {
-    log.error({ err }, `Remote watcher error: ${err.message}`)
+    log.warn({ err }, `Remote watcher error: ${err.message}`)
     this.events.emit('RemoteWatcher:error', err)
   }
 
@@ -90,7 +90,7 @@ class RemoteWatcher {
   }
 
   fatal(err /*: Error */) {
-    log.error({ err }, `Remote watcher fatal: ${err.message}`)
+    log.error({ err, sentry: true }, `Remote watcher fatal: ${err.message}`)
     this.events.emit('RemoteWatcher:fatal', err)
     this.stop()
   }

--- a/core/utils/fs.js
+++ b/core/utils/fs.js
@@ -27,7 +27,7 @@ async function hideOnWindows(path /*: string */) /*: Promise<void> */ {
   try {
     await childProcess.execAsync(`attrib +h "${path}"`)
   } catch (err) {
-    log.error(err)
+    log.warn(err)
   }
 }
 

--- a/core/utils/sentry.js
+++ b/core/utils/sentry.js
@@ -102,8 +102,8 @@ const handleBunyanMessage = msg => {
 
   if (!isSentryConfigured) return
 
-  // Send messages explicitly marked for sentry and all errors
-  if (msg.sentry || msg.err) {
+  // Send messages explicitly marked for sentry and all TypeError instances
+  if (msg.sentry || (msg.err && msg.err.name === 'TypeError')) {
     const extra = _.omit(msg, [
       'err',
       'tags',

--- a/gui/js/help.window.js
+++ b/gui/js/help.window.js
@@ -28,7 +28,7 @@ module.exports = class TrayWM extends WindowManager {
             event.sender.send('mail-sent')
           },
           err => {
-            log.error({ err })
+            log.error({ err, sentry: true }, 'failed sending mail to support')
             event.sender.send('mail-sent', {
               message: 'Help An error occured while sending your email'
             })

--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -82,20 +82,21 @@ const openNote = async (
     log.info({ noteURL }, 'computed url')
     shell.openExternal(noteURL)
   } catch (err) {
-    log.error({ err, path: filePath }, 'could not open note')
-
     if (err.name === 'FetchError') {
       if (err.status === 403 || err.status === 404) {
+        log.warn({ err, path: filePath }, 'could not find remote Note')
         throw new CozyDocumentMissingError({
           cozyURL: desktop.config.cozyUrl,
           doc: { name: path.basename(filePath) }
         })
       } else {
+        log.warn({ err, path: filePath }, 'could not reach remote Cozy')
         throw new UnreachableError({
           cozyURL: desktop.config.cozyUrl
         })
       }
     } else {
+      log.error({ err, path: filePath, sentry: true }, 'could not open note')
       throw err
     }
   }


### PR DESCRIPTION
Our Sentry is swarmed by messages that we mostly don't process and
that could hide some very important errors so we're reducing the
number of messages sent.
We'll focus on errors that could come from bugs rather than user
context which requires more information to analyze.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
