### PR TITLE
core/local: Detect ACL lock on open files

### DIFF
--- a/core/local/constants.js
+++ b/core/local/constants.js
@@ -4,5 +4,9 @@
  */
 
 module.exports = {
-  TMP_DIR_NAME: '.system-tmp-cozy-drive'
+  TMP_DIR_NAME: '.system-tmp-cozy-drive',
+
+  // This constant is not made directly available through `fs` but comes from libuv.
+  // See https://github.com/libuv/libuv/blob/30ff5bf2161257921f3a3ce5655804f7cb282aa9/include/uv/win.h#L685
+  UV_FS_O_EXLOCK: 0x10000000
 }

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -376,7 +376,7 @@ class Sync {
       const syncErr = syncErrors.wrapError(err, sideName, change)
       log.warn(
         { err: syncErr, change, path: change.doc.path },
-        `Sync error: ${err.message}`
+        `Sync error: ${syncErr.message}`
       )
       if (manualRun) {
         await this.updateErrors(change, syncErr)
@@ -592,6 +592,10 @@ class Sync {
 
     let checkInterval
     const check = async () => {
+      // Resest the timer for manual calls
+      // $FlowFixMe intervals have a refresh() method starting with Node v10
+      checkInterval.refresh()
+
       this.events.off('user-action-inprogress', check)
       this.events.off('user-action-skipped', skip)
 

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -8,7 +8,10 @@ const sinon = require('sinon')
 const should = require('should')
 
 const { Local } = require('../../../core/local')
-const { TMP_DIR_NAME } = require('../../../core/local/constants')
+const {
+  TMP_DIR_NAME,
+  UV_FS_O_EXLOCK
+} = require('../../../core/local/constants')
 const timestamp = require('../../../core/utils/timestamp')
 
 const Builders = require('../../support/builders')
@@ -752,5 +755,73 @@ describe('Local', function() {
         /metadata/
       )
     })
+  })
+
+  describe('tryOpening', () => {
+    let file, fullpath
+    beforeEach(async function() {
+      file = builders
+        .metafile()
+        .path('file-to-open.doc')
+        .build()
+      fullpath = syncDir.abspath(file.path)
+      await fse.ensureFile(fullpath)
+    })
+
+    if (process.platform === 'win32') {
+      context('on Windows', () => {
+        context('when doc is not opened anywhere', () => {
+          it('returns OK', async function() {
+            await should(this.local.tryOpening(file)).be.fulfilledWith({
+              ok: true
+            })
+          })
+        })
+
+        context('when doc is opened by another process (e.g. Office)', () => {
+          let fd
+          beforeEach(async function() {
+            // Use exclusive sharing mode flag
+            fd = await fse.open(fullpath, fse.constants.O_RDWR | UV_FS_O_EXLOCK)
+          })
+          afterEach(async function() {
+            await fse.close(fd)
+          })
+
+          it('returns NOK', async function() {
+            const { ok, err } = await this.local.tryOpening(file)
+            should(ok).be.false()
+            should(err).match({ message: /EBUSY/ })
+          })
+        })
+      })
+    } else {
+      context('on Linux and macOS', () => {
+        context('when doc is not opened anywhere', () => {
+          it('returns OK', async function() {
+            await should(this.local.tryOpening(file)).be.fulfilledWith({
+              ok: true
+            })
+          })
+        })
+
+        context('when doc is opened by another process (e.g. Office)', () => {
+          let fd
+          beforeEach(async function() {
+            // Use exclusive sharing mode flag
+            fd = await fse.open(fullpath, fse.constants.O_RDWR | UV_FS_O_EXLOCK)
+          })
+          afterEach(async function() {
+            await fse.close(fd)
+          })
+
+          it('returns OK', async function() {
+            await should(this.local.tryOpening(file)).be.fulfilledWith({
+              ok: true
+            })
+          })
+        })
+      })
+    }
   })
 })


### PR DESCRIPTION
It appears that the Node `fs.access()` method does not check
access-control policies on files and folders.
This means that `fs.access()` won't detect when a file is opened in
an editor like Office and is thus locked (and its parent folders as
well).

As a workaround, we can use the `fs.open()` method with a read/write
access flag. If the file is locked, the call will fail with a `EBUSY`
error.
However, this won't detect locked folders and our only option seems to
try applying changes on the folder and manage errors.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
