### PR TITLE
ci: Fix brew cask install usage

### DIFF
--- a/.github/actions/setup-cozy-stack/action.yaml
+++ b/.github/actions/setup-cozy-stack/action.yaml
@@ -31,7 +31,7 @@ runs:
         mkdir -p $COZY_STACK_STORAGE
 
         if [ "${{ runner.os }}" == "macOS" ]; then
-          brew cask install osxfuse
+          brew install --cask osxfuse
           curl -L https://github.com/osxfuse/sshfs/releases/download/osxfuse-sshfs-2.5.0/sshfs-2.5.0.pkg --output sshfs-2.5.0.pkg
           sudo installer -pkg ./sshfs-2.5.0.pkg -target /
           podman-machine ssh box -- mkdir /home/tc/storage


### PR DESCRIPTION
It seems more recent versions of `brew` don't allow installing casks
via the `brew cask install` command anymore but would have us call
`brew install --cask` instead.

It also seems that such version is now used on the `macos-latest`
Github Workflow OS, making our `setup-cozy-stack` action fail.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
