### PR TITLE
Handle promises' errors outside then() calls

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -187,16 +187,15 @@ class RemoteCozy {
       }
       process.once('unhandledRejection', unhandledRejectionHandler)
 
-      fn().then(
-        result => {
+      fn()
+        .then(result => {
           process.off('unhandledRejection', unhandledRejectionHandler)
           resolve(result)
-        },
-        err => {
+        })
+        .catch(err => {
           process.off('unhandledRejection', unhandledRejectionHandler)
           reject(err)
-        }
-      )
+        })
     })
   }
 

--- a/gui/elm/Window/Tray/Dashboard.elm
+++ b/gui/elm/Window/Tray/Dashboard.elm
@@ -206,50 +206,60 @@ viewAction helpers action =
         link =
             UserAction.getLink action
 
-        primaryLabel =
-            UserAction.primaryLabel action
-                |> helpers.t
-                |> text
+        primaryButton =
+            case UserAction.primaryInteraction action of
+                UserAction.Retry label ->
+                    actionButton helpers UserActionInProgress [] label Nothing
 
-        secondaryLabel =
-            UserAction.secondaryLabel action
-                |> Maybe.map helpers.t
-                |> Maybe.map text
+                UserAction.Open label ->
+                    actionButton helpers UserActionInProgress [] label link
 
-        buttons =
-            case secondaryLabel of
-                Just label ->
-                    [ button
-                        [ class "c-btn c-btn--danger-outline"
-                        , onClick UserActionSkipped
-                        ]
-                        [ span [] [ label ] ]
-                    , button
-                        [ class "c-btn"
-                        , onClick UserActionInProgress
-                        ]
-                        [ span [] [ primaryLabel ] ]
-                    ]
+                _ ->
+                    actionButton helpers UserActionInProgress [] "UserAction Ok" Nothing
 
-                Nothing ->
-                    [ button
-                        [ class "c-btn c-btn--ghost"
-                        , onClick UserActionSkipped
-                        ]
-                        [ span [] [ text (helpers.t "UserAction OK") ] ]
-                    , a
-                        [ class "c-btn" --u-flex-auto"
-                        , href (Maybe.withDefault "" link)
-                        , onClick UserActionInProgress
-                        ]
-                        [ span [] [ primaryLabel ] ]
-                    ]
+        secondaryButton =
+            case UserAction.secondaryInteraction action of
+                Just UserAction.GiveUp ->
+                    actionButton helpers UserActionSkipped [ "c-btn--danger-outline" ] "UserAction Give up" Nothing
+
+                Just UserAction.Ok ->
+                    actionButton helpers UserActionSkipped [ "c-btn--ghost" ] "UserAction Ok" Nothing
+
+                _ ->
+                    []
     in
     div [ class "u-p-1 u-bg-paleGrey" ]
         [ header [ class "u-title-h1" ] [ title ]
         , p [ class "u-text" ] content
-        , div [ class "u-flex u-flex-justify-end" ] buttons
+        , div
+            [ class "u-flex u-flex-justify-end" ]
+            (List.append secondaryButton primaryButton)
         ]
+
+
+actionButton : Helpers -> Msg -> List String -> String -> Maybe String -> List (Html Msg)
+actionButton helpers msg classList label link =
+    let
+        classes =
+            String.join " " ([ "c-btn" ] ++ classList)
+    in
+    case link of
+        Just str ->
+            [ a
+                [ class classes
+                , href str
+                , onClick msg
+                ]
+                [ span [] [ text (helpers.t label) ] ]
+            ]
+
+        Nothing ->
+            [ button
+                [ class classes
+                , onClick msg
+                ]
+                [ span [] [ text (helpers.t label) ] ]
+            ]
 
 
 view : Helpers -> Model -> Html Msg

--- a/gui/js/autolaunch.js
+++ b/gui/js/autolaunch.js
@@ -5,6 +5,10 @@
 
 const AutoLaunch = require('auto-launch')
 
+const log = require('../../core/app').logger({
+  component: 'GUI'
+})
+
 const APP_NAME = 'Cozy-Desktop'
 const opts = {
   name: APP_NAME,
@@ -27,16 +31,21 @@ if (process.env.APPIMAGE) {
   autoLauncher.opts.appName = APP_NAME
 
   // Check if there is an autolaunch entry with the app's path.
-  autoLauncher.isEnabled().then(pathAutoLaunchEnabled => {
-    if (pathAutoLaunchEnabled) {
-      // Remove it to avoid having multiple entries.
-      autoLauncher.disable()
+  autoLauncher
+    .isEnabled()
+    .then(pathAutoLaunchEnabled => {
+      if (pathAutoLaunchEnabled) {
+        // Remove it to avoid having multiple entries.
+        autoLauncher.disable()
 
-      // Create an autolaunch entry with the app's name if there was an entry
-      // with the app's path.
-      autoLauncher.enable()
-    }
-  })
+        // Create an autolaunch entry with the app's name if there was an entry
+        // with the app's path.
+        autoLauncher.enable()
+      }
+    })
+    .catch(err =>
+      log.warn({ err }, 'could not check autolaunch or replace old one')
+    )
 }
 
 module.exports.isEnabled = () => autoLauncher.isEnabled()

--- a/gui/js/help.window.js
+++ b/gui/js/help.window.js
@@ -23,17 +23,19 @@ module.exports = class TrayWM extends WindowManager {
     let that = this
     return {
       'send-mail': (event, body) => {
-        that.desktop.sendMailToSupport(body).then(
-          () => {
+        that.desktop
+          .sendMailToSupport(body)
+          .then(() => {
             event.sender.send('mail-sent')
-          },
-          err => {
+          })
+          .catch(err => {
             log.error({ err, sentry: true }, 'failed sending mail to support')
-            event.sender.send('mail-sent', {
-              message: 'Help An error occured while sending your email'
-            })
-          }
-        )
+            if (event.sender) {
+              event.sender.send('mail-sent', {
+                message: 'Help An error occured while sending your email'
+              })
+            }
+          })
       }
     }
   }

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -95,11 +95,14 @@ module.exports = class OnboardingWM extends WindowManager {
   }
 
   create() {
-    return super.create().then(() => {
-      if (this.shouldJumpToSyncPath) {
-        this.send('registration-done')
-      }
-    })
+    return super
+      .create()
+      .then(() => {
+        if (this.shouldJumpToSyncPath) {
+          this.send('registration-done')
+        }
+      })
+      .catch(err => log.warn({ err }, 'could not create Onboarding window'))
   }
 
   onOnboardingDone(handler) {


### PR DESCRIPTION
There 2 ways to provide an error handling function to promises:
1. as the second parameter of the `then()` call
2. as the sole parameter of a call to `catch()`

The second method has the advantage to also catch errors raised within
the call to `then()` so we should prefer it.

In some situations it was easier to use `async` functions and a
`try/catch/finally` construction.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation