### PR TITLE
core/local: Don't retry moving locked docs

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -6,6 +6,7 @@
 
 const async = require('async')
 const autoBind = require('auto-bind')
+const fs = require('fs').promises
 const fse = require('fs-extra')
 const path = require('path')
 const trash = require('trash')
@@ -422,7 +423,7 @@ class Local /*:: implements Reader, Writer */ {
       }
     }
 
-    await fse.rename(oldPath, newPath)
+    await fs.rename(oldPath, newPath)
     await this.updateMetadataAsync(doc)
     metadata.updateLocal(doc)
   }


### PR DESCRIPTION
On Windows, files and folders can be locked by software. These locks
result in `EPERM`, `EBUSY` or `EACCES` errors when trying to modify or
move the documents (and sometimes their parent folders).
For example, Anti-Virus software can block a folder for up to a minute
and for this reason `graceful-fs`, the drop-in replacement for Node's
`fs` module used by our own dependency `fs-extra` adds a retry
mechanism to the `rename` method in case the returned error is `EPERM`
or `EACCES`.
See isaacs/node-graceful-fs@1139b6f/polyfills.js#L83

Now that we're blocking the synchronization on local filesystem
permission errors, this comes at odds with our own retry mechanism and
delays the result of our retries for a full minute during which we
display a "synchronizing" state to the user.
We probably don't need the retry mechanism from `graceful-fs` anymore
so we use the `fs` module directly when making `rename` calls.

If this change proves to be more inconvenient than useful, we can
always revisit this decision.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
