### PR TITLE
core/app: Unregister client even with deleted Cozy

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -205,10 +205,14 @@ class App {
   // the config file
   async removeRemote() {
     try {
-      if (!this.remote) {
-        this.instanciate()
+      if (!this.remote) this.instanciate()
+
+      try {
+        await this.remote.unregister()
+      } catch (err) {
+        if (!err.status || err.status !== 404) throw err
       }
-      await this.remote.unregister()
+
       await this.removeConfig()
       log.info('Current device properly removed from remote cozy.')
       return null

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -488,6 +488,7 @@ class RemoteCozy {
 }
 
 module.exports = {
+  FetchError,
   DirectoryNotFound,
   RemoteCozy
 }


### PR DESCRIPTION
When the user tries to unregister their Desktop client from its remote
Cozy, we attempt to:
1. delete the OAuth client on the remote Cozy
2. and then delete the local client config

If the remote Cozy does not exist anymore because it's either been
deleted on moved to another location (and 30 days have passed since),
we won't be able to delete the OAuth client.
In this situation we still want to delete the local config so the user
can connect its Desktop client to another Cozy (e.g. the new
location).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
