### PR TITLE
core/sync: Retry failed changes that block Sync

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -334,7 +334,6 @@ class App {
       this.ignore,
       this.events
     )
-    this.sync.diskUsage = this.diskUsage
   }
 
   // Start the synchronization

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -12,11 +12,10 @@ const path = require('path')
 const trash = require('trash')
 const stream = require('stream')
 const _ = require('lodash')
-const diskUsage = require('diskusage')
 
 const bluebird = require('bluebird')
 
-const { TMP_DIR_NAME, UV_FS_O_EXLOCK } = require('./constants')
+const { TMP_DIR_NAME } = require('./constants')
 const { NOTE_MIME_TYPE } = require('../remote/constants')
 const stater = require('./stater')
 const metadata = require('../metadata')
@@ -485,69 +484,6 @@ class Local /*:: implements Reader, Writer */ {
     const copy = _.cloneDeep(doc)
     copy.path = backupPath
     return copy
-  }
-
-  async diskUsage() /*: Promise<{ available: number, total: number }> */ {
-    try {
-      return await diskUsage.check(this.syncPath)
-    } catch (err) {
-      log.warn({ err }, 'Could not get local available disk space')
-      return { available: 0, total: 0 }
-    }
-  }
-
-  async tryOpening(
-    { docType, path } /*: { docType: DocType, path: string } */
-  ) /*: Promise<{ ok: boolean, err?: ErrnoError }> */ {
-    try {
-      if (docType === 'file' || docType === 'folder') {
-        // Use exclusive sharing mode so we can detect Windows locks when file is opened in another application.
-        // It does nothing for directories though.
-        const fd = await fse.open(
-          this.abspath(path),
-          fse.constants.O_RDWR | UV_FS_O_EXLOCK
-        )
-        await fse.close(fd)
-        return { ok: true }
-      } else {
-        // Should never happen
-        log.error(
-          { docType, path, sentry: true },
-          'could not open doc with invalid docType'
-        )
-        return { ok: false }
-      }
-    } catch (err) {
-      log.warn({ err, docType, path }, 'Could not open doc')
-      return { ok: false, err }
-    }
-  }
-
-  /* On Windows, this function won't tell us that we can't apply a change on a
-   * folder that is locked by one of its children. Node doesn't check ACLs so we
-   * don't have any built-in ways to detect the lock.
-   * However, it will work for files and could provide us some useful info in
-   * cases where a change can't be applied for another reason than a filesystem
-   * lock.
-   */
-  async canApplyChange(doc /*: SavedMetadata */) /*: Promise<boolean> */ {
-    log.debug(
-      { path: doc.path, oldPath: doc.moveFrom && doc.moveFrom.path },
-      'canApplyChange'
-    )
-    if (doc.moveFrom) {
-      const { ok } = await this.tryOpening(doc.moveFrom)
-      if (!ok) return false
-    } else {
-      const { ok, err } = await this.tryOpening({
-        docType: 'folder',
-        path: path.join(this.tmpPath, path.basename(doc.path))
-      })
-      return ok || (!!err && err.code === 'ENOENT')
-    }
-
-    const { ok, err } = await this.tryOpening(doc)
-    return ok || (!!err && err.code === 'ENOENT')
   }
 }
 

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -371,6 +371,17 @@ class Remote /*:: implements Reader, Writer */ {
     return this.remoteCozy.diskUsage()
   }
 
+  async ping() /*: Promise<boolean> */ {
+    try {
+      // FIXME: find better way to check if Cozy is reachable?
+      await this.diskUsage()
+      return true
+    } catch (err) {
+      log.debug({ err }, 'Could not reach remote Cozy')
+      return false
+    }
+  }
+
   async usesFlatDomains() /*: Promise<boolean> */ {
     let { flatSubdomains } = this.config.capabilities
     if (flatSubdomains == null) {

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -1,13 +1,7 @@
 /* @flow */
 
-const { Promise } = require('bluebird')
-
-const {
-  HEARTBEAT: REMOTE_HEARTBEAT,
-  TOS_UPDATED_WARNING_CODE
-} = require('../remote/constants')
+const { HEARTBEAT: REMOTE_HEARTBEAT } = require('../remote/constants')
 const remoteErrors = require('../remote/errors')
-const logger = require('../utils/logger')
 
 /*::
 import type { SavedMetadata } from '../metadata'
@@ -22,10 +16,6 @@ const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
 const NO_DISK_SPACE_CODE = 'NoDiskSpace'
 const UNKNOWN_SYNC_ERROR_CODE = 'UnknownSyncError'
 
-const log = logger({
-  component: 'Sync'
-})
-
 class SyncError extends Error {
   /*::
   $key: string
@@ -33,12 +23,18 @@ class SyncError extends Error {
 
   code: string
   message: string
+  sideName: SideName
   originalErr: Error
   doc: SavedMetadata
   */
 
   constructor(
-    { code, err, doc } /*: { code?: string, err: Error, doc: SavedMetadata } */
+    {
+      code,
+      sideName,
+      err,
+      doc
+    } /*: { code?: string, sideName: SideName, err: Error, doc: SavedMetadata } */
   ) {
     super(err.message)
 
@@ -55,6 +51,7 @@ class SyncError extends Error {
 
     this.name = 'SyncError'
     this.code = code || this.code || UNKNOWN_SYNC_ERROR_CODE
+    this.sideName = sideName
     this.doc = doc
     this.originalErr = err
 
@@ -70,170 +67,46 @@ class SyncError extends Error {
   }
 }
 
-const checkFn = (
-  err /*: RemoteError|SyncError */,
-  { local, remote } /*: { local: Local, remote: Remote } */
-) /*: [number, () => Promise<boolean>] */ => {
+const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
   if (err instanceof remoteErrors.RemoteError) {
     switch (err.code) {
       case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
-        return [
-          REMOTE_HEARTBEAT,
-          async () => {
-            // We request a manual run as we don't want to completely stop the
-            // synchronization in case the call fails but we discard any errors as
-            // we can't really handle them here.
-            const err = remote.watcher.resetTimeout({
-              manualRun: true
-            })
-            return err == null
-          }
-        ]
+        return REMOTE_HEARTBEAT
 
       case remoteErrors.UNREACHABLE_COZY_CODE:
-        return [
-          10000,
-          async () => {
-            try {
-              await remote.diskUsage()
-              return true
-            } catch (err) {
-              log.debug({ err }, 'Could not fetch remote disk usage')
-              return false
-            }
-          }
-        ]
+        return 10000
 
       case remoteErrors.USER_ACTION_REQUIRED_CODE:
-        return [
-          60000,
-          async () => {
-            try {
-              await Promise.delay(180000) // Wait 3 minutes to give user the time to read the new ToS
-              const warnings /*: Warning[] */ = await remote.remoteCozy.warnings()
-              return (
-                warnings.length === 0 ||
-                warnings.find(
-                  warning => warning.code === TOS_UPDATED_WARNING_CODE
-                ) != null
-              )
-            } catch (err) {
-              log.debug({ err }, 'Could not fetch remote warnings')
-              return false
-            }
-          }
-        ]
+        return 60000
 
       default:
-        // Keep retrying
-        return [REMOTE_HEARTBEAT, async () => true]
+        return REMOTE_HEARTBEAT
     }
   } else if (err instanceof SyncError) {
-    const { doc } = err
     switch (err.code) {
       case MISSING_PERMISSIONS_CODE:
-        return [
-          10000,
-          async () => {
-            try {
-              return await local.canApplyChange(doc)
-            } catch (err) {
-              log.debug({ err }, 'Could not check local permissions')
-              return false
-            }
-          }
-        ]
+        return 10000
 
       case NO_DISK_SPACE_CODE:
-        return [
-          60000, // TODO: change back to 60000
-          async () => {
-            try {
-              const { size = 0 } = doc
-              const { available } = await local.diskUsage()
-              return available >= size
-            } catch (err) {
-              log.debug({ err }, 'Could not fetch local disk usage')
-              return false
-            }
-          }
-        ]
+        return 60000
 
       case remoteErrors.NO_COZY_SPACE_CODE:
-        return [
-          60000,
-          async () => {
-            try {
-              const { size = 0 } = doc
-              const {
-                attributes: { used, quota }
-              } = await remote.diskUsage()
-              if (!quota) return true
-              else return quota - used >= size
-            } catch (err) {
-              log.debug({ err }, 'Could not fetch remote disk usage')
-              return false
-            }
-          }
-        ]
+        return 10000
 
       case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
-        return [
-          REMOTE_HEARTBEAT,
-          async () => {
-            // We request a manual run as we don't want to completely stop the
-            // synchronization in case the call fails but we discard any errors as
-            // we can't really handle them here.
-            const errOrOffline = await remote.watcher.resetTimeout({
-              manualRun: true
-            })
-            if (errOrOffline) {
-              log.debug({ err: errOrOffline }, 'Could not fetch remote changes')
-              return false
-            }
-            return true
-          }
-        ]
+        return REMOTE_HEARTBEAT
 
       case remoteErrors.UNREACHABLE_COZY_CODE:
-        return [
-          10000,
-          async () => {
-            try {
-              await remote.diskUsage()
-              return true
-            } catch (err) {
-              log.debug({ err }, 'Could not fetch remote disk usage')
-              return false
-            }
-          }
-        ]
+        return 10000
 
       case remoteErrors.USER_ACTION_REQUIRED_CODE:
-        return [
-          60000,
-          async () => {
-            try {
-              await Promise.delay(180000) // Wait 3 minutes to give user the time to read the new ToS
-              const warnings /*: Warning[] */ = await remote.remoteCozy.warnings()
-              return (
-                warnings.length === 0 ||
-                warnings.find(
-                  warning => warning.code === TOS_UPDATED_WARNING_CODE
-                ) != null
-              )
-            } catch (err) {
-              log.debug({ err }, 'Could not fetch remote warnings')
-              return false
-            }
-          }
-        ]
+        return 60000
 
       default:
-        return [0, async () => false]
+        return 0
     }
   } else {
-    return [0, async () => false]
+    return 0
   }
 }
 
@@ -251,13 +124,13 @@ const wrapError = (
 ) => {
   if (sideName === 'remote') {
     // The RemoteError code will be reused
-    return new SyncError({ err: remoteErrors.wrapError(err), doc })
+    return new SyncError({ sideName, err: remoteErrors.wrapError(err), doc })
   } else if (err.code && ['EACCES', 'EPERM', 'EBUSY'].includes(err.code)) {
-    return new SyncError({ err, code: MISSING_PERMISSIONS_CODE, doc })
+    return new SyncError({ sideName, err, code: MISSING_PERMISSIONS_CODE, doc })
   } else if (err.code && err.code === 'ENOSPC') {
-    return new SyncError({ err, code: NO_DISK_SPACE_CODE, doc })
+    return new SyncError({ sideName, err, code: NO_DISK_SPACE_CODE, doc })
   } else {
-    return new SyncError({ err, doc })
+    return new SyncError({ sideName, err, doc })
   }
 }
 
@@ -266,6 +139,6 @@ module.exports = {
   NO_DISK_SPACE_CODE,
   UNKNOWN_SYNC_ERROR_CODE,
   SyncError,
-  checkFn,
+  retryDelay,
   wrapError
 }

--- a/gui/elm/Ports.elm
+++ b/gui/elm/Ports.elm
@@ -30,6 +30,7 @@ port module Ports exposing
     , unlinkCozy
     , updateDownloading
     , updateError
+    , userActionDone
     , userActionInProgress
     , userActionSkipped
     )
@@ -130,6 +131,9 @@ port updateDownloading : (Maybe Progress -> msg) -> Sub msg
 
 
 port updateError : (String -> msg) -> Sub msg
+
+
+port userActionDone : EncodedUserAction -> Cmd msg
 
 
 port userActionInProgress : EncodedUserAction -> Cmd msg

--- a/gui/elm/Window/Tray/Dashboard.elm
+++ b/gui/elm/Window/Tray/Dashboard.elm
@@ -66,6 +66,7 @@ type Msg
     | GotUserActions (List UserAction)
     | UserActionSkipped
     | UserActionInProgress
+    | UserActionDone
 
 
 update : Msg -> Model -> ( Model, Cmd msg )
@@ -131,6 +132,18 @@ update msg model =
                             Cmd.none
             in
             ( model, cmd )
+
+        UserActionDone ->
+            let
+                cmd =
+                    case currentUserAction model of
+                        Just action ->
+                            Ports.userActionDone (UserAction.encode action)
+
+                        Nothing ->
+                            Cmd.none
+            in
+            ( model |> removeCurrentAction, cmd )
 
 
 
@@ -209,13 +222,13 @@ viewAction helpers action =
         primaryButton =
             case UserAction.primaryInteraction action of
                 UserAction.Retry label ->
-                    actionButton helpers UserActionInProgress [] label Nothing
+                    actionButton helpers UserActionDone [] label Nothing
 
                 UserAction.Open label ->
                     actionButton helpers UserActionInProgress [] label link
 
                 _ ->
-                    actionButton helpers UserActionInProgress [] "UserAction Ok" Nothing
+                    actionButton helpers UserActionDone [] "UserAction OK" Nothing
 
         secondaryButton =
             case UserAction.secondaryInteraction action of
@@ -223,7 +236,7 @@ viewAction helpers action =
                     actionButton helpers UserActionSkipped [ "c-btn--danger-outline" ] "UserAction Give up" Nothing
 
                 Just UserAction.Ok ->
-                    actionButton helpers UserActionSkipped [ "c-btn--ghost" ] "UserAction Ok" Nothing
+                    actionButton helpers UserActionSkipped [ "c-btn--ghost" ] "UserAction OK" Nothing
 
                 _ ->
                     []

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -189,10 +189,12 @@ module.exports = class TrayWM extends WindowManager {
         this.desktop.sync.forceSync().catch(err => {
           if (err) log.error({ err, sentry: true }, 'Could not run manual sync')
         }),
+      userActionDone: (event, action) => {
+        this.desktop.events.emit('user-action-done', action)
+      },
       userActionInProgress: (event, action) => {
         this.desktop.events.emit('user-action-inprogress', action)
       },
-
       userActionSkipped: (event, action) => {
         this.desktop.events.emit('user-action-skipped', action)
       }

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -135,6 +135,10 @@ elmectron.ports.openFile.subscribe(path => {
   ipcRenderer.send('open-file', path)
 })
 
+elmectron.ports.userActionDone.subscribe(action => {
+  ipcRenderer.send('userActionDone', action)
+})
+
 elmectron.ports.userActionInProgress.subscribe(action => {
   ipcRenderer.send('userActionInProgress', action)
 })

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "cozy-client-js": "^0.17.4",
     "cozy-stack-client": "^14.1.2",
     "deep-diff": "^1.0.2",
-    "diskusage": "^1.1.3",
     "dtrace-provider": "^0.8.8",
     "electron-fetch": "^1.7.1",
     "electron-positioner": "^4.0.0",

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -65,7 +65,6 @@ class TestHelpers {
     this._local = merge.local = local
     this._remote = merge.remote = remote
     this._sync = sync
-    this._sync.diskUsage = this._remote.diskUsage
     this.pouch = pouch
     this.local = localHelpers
     this.remote = remoteHelpers

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -8,10 +8,7 @@ const sinon = require('sinon')
 const should = require('should')
 
 const { Local } = require('../../../core/local')
-const {
-  TMP_DIR_NAME,
-  UV_FS_O_EXLOCK
-} = require('../../../core/local/constants')
+const { TMP_DIR_NAME } = require('../../../core/local/constants')
 const timestamp = require('../../../core/utils/timestamp')
 
 const Builders = require('../../support/builders')
@@ -755,73 +752,5 @@ describe('Local', function() {
         /metadata/
       )
     })
-  })
-
-  describe('tryOpening', () => {
-    let file, fullpath
-    beforeEach(async function() {
-      file = builders
-        .metafile()
-        .path('file-to-open.doc')
-        .build()
-      fullpath = syncDir.abspath(file.path)
-      await fse.ensureFile(fullpath)
-    })
-
-    if (process.platform === 'win32') {
-      context('on Windows', () => {
-        context('when doc is not opened anywhere', () => {
-          it('returns OK', async function() {
-            await should(this.local.tryOpening(file)).be.fulfilledWith({
-              ok: true
-            })
-          })
-        })
-
-        context('when doc is opened by another process (e.g. Office)', () => {
-          let fd
-          beforeEach(async function() {
-            // Use exclusive sharing mode flag
-            fd = await fse.open(fullpath, fse.constants.O_RDWR | UV_FS_O_EXLOCK)
-          })
-          afterEach(async function() {
-            await fse.close(fd)
-          })
-
-          it('returns NOK', async function() {
-            const { ok, err } = await this.local.tryOpening(file)
-            should(ok).be.false()
-            should(err).match({ message: /EBUSY/ })
-          })
-        })
-      })
-    } else {
-      context('on Linux and macOS', () => {
-        context('when doc is not opened anywhere', () => {
-          it('returns OK', async function() {
-            await should(this.local.tryOpening(file)).be.fulfilledWith({
-              ok: true
-            })
-          })
-        })
-
-        context('when doc is opened by another process (e.g. Office)', () => {
-          let fd
-          beforeEach(async function() {
-            // Use exclusive sharing mode flag
-            fd = await fse.open(fullpath, fse.constants.O_RDWR | UV_FS_O_EXLOCK)
-          })
-          afterEach(async function() {
-            await fse.close(fd)
-          })
-
-          it('returns OK', async function() {
-            await should(this.local.tryOpening(file)).be.fulfilledWith({
-              ok: true
-            })
-          })
-        })
-      })
-    }
   })
 })

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -982,6 +982,25 @@ describe('remote.Remote', function() {
       should(dir.remote).deepEqual(movedDir)
     })
   })
+
+  describe('ping', () => {
+    before(function() {
+      sinon.stub(this.remote.remoteCozy, 'diskUsage')
+    })
+    after(function() {
+      this.remote.remoteCozy.diskUsage.restore()
+    })
+
+    it('resolves to true if we can successfuly fetch the remote disk usage', async function() {
+      this.remote.remoteCozy.diskUsage.resolves()
+      await should(this.remote.ping()).be.fulfilledWith(true)
+    })
+
+    it('resolves to false if we cannot successfuly fetch the remote disk usage', async function() {
+      this.remote.remoteCozy.diskUsage.rejects()
+      await should(this.remote.ping()).be.fulfilledWith(false)
+    })
+  })
 })
 
 describe('remote', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,14 +2038,6 @@ dir-glob@^2.0.0:
   dependencies:
     path-type "^3.0.0"
 
-diskusage@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/diskusage/-/diskusage-1.1.3.tgz#680d7dbf1b679168a195c9240eb3552cbd2c067b"
-  integrity sha512-EAyaxl8hy4Ph07kzlzGTfpbZMNAAAHXSZtNEMwdlnSd1noHzvA6HsgKt4fEMSvaEXQYLSphe5rPMxN4WOj0hcQ==
-  dependencies:
-    es6-promise "^4.2.5"
-    nan "^2.14.0"
-
 dmg-builder@22.8.1:
   version "22.8.1"
   resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.8.1.tgz#9b3bcbbc43e5fed232525d61a5567ea4b66085c3"
@@ -2574,7 +2566,7 @@ es6-error@^4.1.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-promise@^4.0.3, es6-promise@^4.2.5:
+es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==


### PR DESCRIPTION
When we failed to synchronize a change, we would block the Sync
process and subsequently check periodically if the change could be
synchronized via dedicated methods (one for each Sync error code).

This has a major flaw though: the dedicated method must always check
for all possible causes of the synchronization failures and ways to
fix them.
For example, a file upload to the remote Cozy could fail if the Cozy
is out of disk space and the situation can be solved in 3 different
ways:
- by removing files on the Cozy
- by increasing the Cozy disk space (by purchasing some)
- by removing files on the local disk, especially the file we're
  trying to Sync

We were not checking for the third solution and thus the user could be
stuck without understanding why if they ever chose it.

To simplify our retry mechanism, we decided to stop using those
dedicated methods and instead go through the whole Sync process again.
This way, any change made on the remote Cozy or the local disk will be
picked up and can influence the synchronization (or not).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
