### PR TITLE
core/remote: Check available space before upload

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -165,12 +165,12 @@ class RemoteCozy {
 
           if (name && dir_id && (await this.isNameTaken({ name, dir_id }))) {
             err = new FetchError(
-              { url: '', status: 409 },
+              { status: 409 },
               'Conflict: name already taken'
             )
           } else if (!(await this.hasEnoughSpace(contentLength))) {
             err = new FetchError(
-              { url: '', status: 413 },
+              { status: 413 },
               'The file is too big and exceeds the disk quota'
             )
           }


### PR DESCRIPTION
Chromium and thus Electron, does not allow manually setting the value
of the `Content-Length` header on streamed or chunked requests for
security reasons (see
electronjs.org/docs/api/client-request#requestsetheadername-value).

This limitation means that the stack cannot know the size of a file
being uploaded until the end of the upload. If the Cozy does not have
enough disk space to fit the file then a 413 status response is sent
back to the client.

If the file is quite large, the client will have to wait for a while
to get this error response and know the request has failed.
Now that we're retrying failed requests when the Cozy is full, the
client will spend yet more time trying to upload a file that won't
fit.

We introduce here a check of the available disk space on the remote
Cozy before attempting to upload a file. If it won't fit, we return an
error right away.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
