### PR TITLE
core/remote: Use most recent modification date

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -17,6 +17,7 @@ const { RemoteCozy, FetchError } = require('./cozy')
 const { RemoteWarningPoller } = require('./warning_poller')
 const { RemoteWatcher } = require('./watcher')
 const errors = require('./errors')
+const timestamp = require('../utils/timestamp')
 
 /*::
 import type EventEmitter from 'events'
@@ -228,7 +229,7 @@ class Remote /*:: implements Reader, Writer */ {
         executable: doc.executable || false,
         contentLength: doc.size,
         contentType: doc.mime,
-        updatedAt: doc.updated_at,
+        updatedAt: mostRecentUpdatedAt(doc),
         ifMatch: old && old.remote ? old.remote._rev : ''
       }
     )
@@ -246,7 +247,7 @@ class Remote /*:: implements Reader, Writer */ {
 
     const attrs = {
       executable: doc.executable || false,
-      updated_at: doc.updated_at
+      updated_at: mostRecentUpdatedAt(doc)
     }
     const opts = {
       ifMatch: doc.remote._rev
@@ -272,7 +273,7 @@ class Remote /*:: implements Reader, Writer */ {
     )
 
     const attrs = {
-      updated_at: doc.updated_at
+      updated_at: mostRecentUpdatedAt(doc)
     }
     const opts = {
       ifMatch: doc.remote._rev
@@ -321,7 +322,7 @@ class Remote /*:: implements Reader, Writer */ {
     const attrs = {
       name: newName,
       dir_id: newDir._id,
-      updated_at: newMetadata.updated_at
+      updated_at: mostRecentUpdatedAt(newMetadata)
     }
     const opts = {
       ifMatch: oldMetadata.remote._rev
@@ -445,6 +446,16 @@ function newDocumentAttributes(
     // greater.
     createdAt: updatedAt,
     updatedAt
+  }
+}
+
+function mostRecentUpdatedAt(doc /*: SavedMetadata */) {
+  if (doc.remote) {
+    return timestamp
+      .maxDate(doc.updated_at, doc.remote.updated_at)
+      .toISOString()
+  } else {
+    return doc.updated_at
   }
 }
 

--- a/core/utils/timestamp.js
+++ b/core/utils/timestamp.js
@@ -68,8 +68,10 @@ function almostSameDate(
   return Math.abs(twoT - oneT) <= 3000
 }
 
-function maxDate(d1 /*: Date */, d2 /*: Date */) /*: Date */ {
-  return d1.getTime() > d2.getTime() ? d1 : d2
+function maxDate(d1 /*: string|Date */, d2 /*: string|Date */) /*: Date */ {
+  const one = new Date(d1)
+  const two = new Date(d2)
+  return one.getTime() > two.getTime() ? one : two
 }
 
 function stringify(t /*: Timestamp */) {

--- a/test/unit/utils/timestamp.js
+++ b/test/unit/utils/timestamp.js
@@ -97,9 +97,18 @@ describe('timestamp', () => {
     const d2 = new Date('2017-05-18T08:03:16.000Z')
 
     it('finds the most recent of two dates', () => {
-      should(maxDate(d1, d2)).equal(d2)
-      should(maxDate(d2, d1)).equal(d2)
-      should(maxDate(d1, d1)).equal(d1)
+      should(maxDate(d1, d2)).deepEqual(d2)
+      should(maxDate(d2, d1)).deepEqual(d2)
+      should(maxDate(d1, d1)).deepEqual(d1)
+    })
+
+    it('returns the most recent date when passed ISO date strings', () => {
+      const str1 = d1.toISOString()
+      const str2 = d2.toISOString()
+
+      should(maxDate(str1, str2)).deepEqual(d2)
+      should(maxDate(str2, str1)).deepEqual(d2)
+      should(maxDate(str1, str1)).deepEqual(d1)
     })
   })
 


### PR DESCRIPTION
When sending a new file to a remote Cozy, it can happen that the stack
saves in CouchDB a creation date more recent than the one provided in
the upload request.

For example. if the uploaded file is:
- a photo with EXIF metadata
- and the creation date in the metadata does not contain a timezone
- and the photo was taken in a timezone ahead of UTC

In this case, the stack will use the EXIF date as creation date and
consider it as a UTC datetime. Therefore, the creation date as saved
on the remote Cozy will be ahead of the creation date on the local
filesystem.

If this photo is then moved on the local filesystem for example, the
stack would refuse the move as the provided modification date (i.e.
the one taken from the filesystem) will be older than the remote one.
This leads to desynchronization between the computer and the Cozy and
thus potential for more problems in the future.

As a simple mitigation, we now always use the most recent modification
date between the local and the remote one when sending actions to the
remote Cozy.
The next step would be to propagate this new date to the local
filesystem.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
