### PR TITLE
core/utils/logger: Log FetchError's status

### DIFF
--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -83,6 +83,7 @@ function errSerializer(err) {
     port,
     syscall,
     code,
+    status,
     originalErr
   } = err
 
@@ -95,6 +96,7 @@ function errSerializer(err) {
   if (port) obj.port = port
   if (syscall) obj.syscall = syscall
   if (code) obj.code = code
+  if (status) obj.status = status
   if (originalErr) obj.originalErr = originalErr
 
   return obj


### PR DESCRIPTION
The standard serializer of Bunyan, our logging library, strips out
most attributes of logged errors which means we can miss some
important information when those include non standard attributes.

For example, the `status` attribute of `FetchError`s are stipped out
so we can't know the returned status of failed requests.
As we've done for other attributes, we add it back to the logged
object.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
