### PR TITLE
gui/js/lastfiles: Persist same path only once

### DIFF
--- a/gui/js/lastfiles.js
+++ b/gui/js/lastfiles.js
@@ -50,13 +50,18 @@ const persist = async () => {
 
 const list = async () => await lastFiles
 const add = async file => {
-  const previousList = await lastFiles
-  previousList.push(file)
-  lastFiles = Promise.resolve(previousList.slice(-250))
+  const previousList = await remove(file)
+  lastFiles = Promise.resolve(previousList.concat(file).slice(-250))
+  return lastFiles
 }
 const remove = async file => {
   const previousList = await lastFiles
   lastFiles = Promise.resolve(previousList.filter(f => f.path !== file.path))
+  return lastFiles
+}
+const reset = () => {
+  lastFiles = Promise.resolve([])
+  return lastFiles
 }
 
 module.exports = {
@@ -64,5 +69,6 @@ module.exports = {
   list,
   add,
   remove,
-  persist
+  persist,
+  reset
 }

--- a/test/unit/gui/lastfiles.js
+++ b/test/unit/gui/lastfiles.js
@@ -1,0 +1,67 @@
+/* @flow */
+/* eslint-env mocha */
+
+const should = require('should')
+const path = require('path')
+
+const lastfiles = require('../../../gui/js/lastfiles')
+
+const buildFile = fpath => ({
+  filename: path.basename(fpath),
+  path: fpath,
+  icon: 'file',
+  size: 0,
+  updated: +new Date()
+})
+
+describe('gui/js/lastfiles', () => {
+  beforeEach('clean lastfiles list', lastfiles.reset)
+
+  describe('add', () => {
+    it('adds the file to the list', async () => {
+      const file = buildFile('Administrative/Taxes/January.pdf')
+      await lastfiles.add(file)
+      await should(lastfiles.list()).be.fulfilledWith([file])
+    })
+
+    it('keeps only 250 files in the list', async () => {
+      let files = []
+      for (let n = 0; n < 250; n++) {
+        const file = buildFile(`Administrative/Taxes/January-${n}.pdf`)
+        files.push(file)
+        await lastfiles.add(file)
+      }
+
+      const file = buildFile(`Administrative/Taxes/January-250.pdf`)
+      await lastfiles.add(file)
+      await should(lastfiles.list()).be.fulfilledWith(
+        files.slice(1).concat(file)
+      )
+    })
+
+    it('removes files with the same path from the lsit', async () => {
+      const file = buildFile(`Administrative/Taxes/January.pdf`)
+      await lastfiles.add(file)
+
+      await lastfiles.add(file)
+      await should(lastfiles.list()).be.fulfilledWith([file])
+    })
+  })
+
+  describe('remove', () => {
+    it('removes all files with file path from the list', async () => {
+      let files = []
+      for (let n = 0; n < 250; n++) {
+        const file = buildFile(`Administrative/Taxes/January-${n}.pdf`)
+        files.push(file)
+        await lastfiles.add(file)
+      }
+
+      const file = buildFile(`Administrative/Taxes/January-139.pdf`)
+      await lastfiles.remove(file)
+      await should(lastfiles.list()).be.fulfilledWith(
+        files.slice(0, 139).concat(files.slice(140))
+      )
+    })
+  })
+})


### PR DESCRIPTION
The list of recently synchronized files is persisted to disk in a JSON
file. We only keep the last 250 files to keep it short.

However, it happens that we would not remove existing occurrences of
the same path when adding a file to the list although we only display
the latest occurrence in the GUI. This means that if we were to
synchronize 250 modifications on the same file. we would only display
this one file in the GUI while the list on disk would be full.

We now make sure only one occurrence is saved on disk.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
