### PR TITLE
core/sync: Restart remote watcher when back online

### DIFF
--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -69,10 +69,9 @@ class SyncError extends Error {
 
 const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
   if (err instanceof remoteErrors.RemoteError) {
+    // The error originates from the Remote Watcher and is not a change
+    // application error.
     switch (err.code) {
-      case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
-        return REMOTE_HEARTBEAT
-
       case remoteErrors.UNREACHABLE_COZY_CODE:
         return 10000
 
@@ -83,6 +82,7 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
         return REMOTE_HEARTBEAT
     }
   } else if (err instanceof SyncError) {
+    // The error originates from Sync and means we failed to apply a change.
     switch (err.code) {
       case MISSING_PERMISSIONS_CODE:
         return 10000
@@ -94,6 +94,7 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
         return 10000
 
       case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
+        // We want to make sure the remote watcher has run before retrying
         return REMOTE_HEARTBEAT
 
       case remoteErrors.UNREACHABLE_COZY_CODE:


### PR DESCRIPTION
When the remote watcher fails to fetch remote changes because the Cozy
is unreachable (i.e. we received a FetchError with a status for which
we don't have a special treatment or that treatment is notifying that
the Cozy is unreachable) we block the synchronization and stop the
remote watcher to prevent further errors.

While we were regularly pinging the remote Cozy to see if it was
reachable again and notifying the GUI with an `online` event in this
case, we were not restarting the remote watcher.
Therefore, we were not fetching remote changes anymore after the Cozy
was made unreachable once.

We now make sure the remote watcher is restarted whenever we unblock
the synchronization.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
