### PR TITLE
core/merge: Trash files modified on the same side

### DIFF
--- a/.jq
+++ b/.jq
@@ -19,6 +19,7 @@ def cleanNote:
   | if isempty(.doc | objects) |not then redactNote(.doc) else . end
   | if isempty(.was | objects) |not then redactNote(.was) else . end
   | if isempty(.remoteDoc | objects) |not then redactNote(.remoteDoc) else . end
+  | if isempty(.note | objects) |not then redactNote(.note) else . end
   | if isempty(.change | objects) | not then .
     | .change |= (. | redactNote(.doc))
     | .change |= (. | redactNote(.was))

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -117,28 +117,32 @@ export type MetadataSidesInfo = {
 
 // The files/dirs metadata, as stored in PouchDB
 export type Metadata = {
+  // Those attributes should not be included in this type
   _id?: string,
   _rev?: string,
   _deleted?: true,
 
-  deleted?: true,
-  md5sum?: string,
-  class?: string,
   docType: DocType,
-  errors?: number,
-  executable: boolean,
+  path: string,
   updated_at: string,
+  local: MetadataLocalInfo,
+  remote: MetadataRemoteDir|MetadataRemoteFile,
+  tags: string[],
+  sides: MetadataSidesInfo,
+
+  // File attributes
+  executable: boolean,
+  md5sum?: string,
+  size?: number,
   mime?: string,
+  class?: string,
+
+  trashed?: true,
+  deleted?: true,
+  errors?: number,
   moveTo?: string, // Destination id
   overwrite?: SavedMetadata,
   childMove?: boolean,
-  path: string,
-  local: MetadataLocalInfo,
-  remote: MetadataRemoteDir|MetadataRemoteFile,
-  size?: number,
-  tags: string[],
-  sides: MetadataSidesInfo,
-  trashed?: true,
   incompatibilities?: *,
   ino?: number,
   fileid?: string,
@@ -186,6 +190,7 @@ module.exports = {
   markSide,
   incSides,
   side,
+  sideInfo,
   target,
   wasSynced,
   buildDir,
@@ -337,8 +342,13 @@ function fromRemoteFile(remoteFile /*: MetadataRemoteFile */) /*: Metadata */ {
   return doc
 }
 
-function isFile(doc /*: Metadata */) /*: bool */ {
-  return doc.docType === 'file'
+function isFile(
+  doc /*: Metadata|MetadataLocalInfo|MetadataRemoteInfo */
+) /*: boolean %checks */ {
+  return (
+    (doc.docType != null && doc.docType === 'file') ||
+    (doc.type !== null && doc.type === 'file')
+  )
 }
 
 function kind(doc /*: Metadata */) /*: EventKind */ {
@@ -740,6 +750,11 @@ function side(
   return (doc.sides || {})[sideName] || 0
 }
 
+function sideInfo(sideName /*: SideName */, doc /*: Metadata */) {
+  if (sideName === 'local') return doc.local
+  else return doc.remote
+}
+
 function detectSingleSide(doc /*: Metadata */) /*: ?SideName */ {
   if (doc.sides) {
     for (const sideName of SIDE_NAMES) {
@@ -879,7 +894,7 @@ function updateRemote(
   doc.remote = _.defaultsDeep(
     _.cloneDeep(newRemote),
     {
-      path: remotePath.startsWith('/') ? remotePath.substring(1) : remotePath
+      path: remotePath.startsWith('/') ? remotePath : '/' + remotePath
     },
     _.cloneDeep(doc.remote)
   )

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -151,10 +151,10 @@ class RemoteCozy {
   // To make sense of the situation, we run checks on the remote Cozy to try
   // and recreate the error that was returned by the remote Cozy and take
   // appropriate action down the Sync process.
-  _withUnhandledRejectionProtection(
+  _withUnhandledRejectionProtection /*:: <T: MetadataRemoteInfo> */(
     options /*: Object */,
-    fn /*: () => Promise<MetadataRemoteInfo> */
-  ) /*: Promise<MetadataRemoteInfo> */ {
+    fn /*: () => Promise<T> */
+  ) /*: Promise<T> */ {
     return new Promise((resolve, reject) => {
       const abortController = new AbortController()
       options.signal = abortController.signal
@@ -209,7 +209,7 @@ class RemoteCozy {
                  createdAt: string,
                  updatedAt: string,
                  executable: boolean|} */
-  ) /*: Promise<MetadataRemoteInfo> */ {
+  ) /*: Promise<MetadataRemoteFile> */ {
     return this._withUnhandledRejectionProtection(options, async () => {
       const file = await this.client.files.create(data, options)
       return this.toRemoteDoc(file)
@@ -221,7 +221,7 @@ class RemoteCozy {
                  dirID?: string,
                  createdAt: string,
                  updatedAt: string|} */
-  ) /*: Promise<MetadataRemoteInfo> */ {
+  ) /*: Promise<MetadataRemoteDir> */ {
     const folder = await this.client.files.createDirectory(options)
     return this.toRemoteDoc(folder)
   }
@@ -235,7 +235,7 @@ class RemoteCozy {
                  updatedAt: string,
                  executable: boolean,
                  ifMatch: string|} */
-  ) /*: Promise<MetadataRemoteInfo> */ {
+  ) /*: Promise<MetadataRemoteFile> */ {
     return this._withUnhandledRejectionProtection(options, async () => {
       const updated = await this.client.files.updateById(id, data, options)
       return this.toRemoteDoc(updated)
@@ -316,7 +316,7 @@ class RemoteCozy {
     return this.toRemoteDoc(await this.client.files.statById(id))
   }
 
-  async findDir(id /*: string */) /*: Promise<RemoteDir> */ {
+  async findDir(id /*: string */) /*: Promise<MetadataRemoteDir> */ {
     const remoteDir = await this.client.files.statById(id)
     const doc = await this.toRemoteDoc(remoteDir)
     if (doc.type !== DIR_TYPE) {
@@ -325,7 +325,7 @@ class RemoteCozy {
     return doc
   }
 
-  async findMaybe(id /*: string */) /*: Promise<?RemoteDoc> */ {
+  async findMaybe(id /*: string */) /*: Promise<?MetadataRemoteInfo> */ {
     try {
       return await this.find(id)
     } catch (err) {
@@ -361,7 +361,7 @@ class RemoteCozy {
 
   async findOrCreateDirectoryByPath(
     path /*: string */
-  ) /*: Promise<MetadataRemoteInfo> */ {
+  ) /*: Promise<MetadataRemoteDir> */ {
     try {
       return await this.findDirectoryByPath(path)
     } catch (err) {
@@ -370,9 +370,7 @@ class RemoteCozy {
 
       const name = posix.basename(path)
       const parentPath = posix.dirname(path)
-      const parentDir /*: RemoteDoc */ = await this.findOrCreateDirectoryByPath(
-        parentPath
-      )
+      const parentDir = await this.findOrCreateDirectoryByPath(parentPath)
       const dirID = parentDir._id
       const createdAt = new Date().toISOString()
 
@@ -402,7 +400,7 @@ class RemoteCozy {
     return resp.body
   }
 
-  async toRemoteDoc(doc /*: JsonApiDoc */) /*: Promise<MetadataRemoteInfo> */ {
+  async toRemoteDoc /*:: <T: JsonApiDoc> */(doc /*: T */) /*: Promise<*> */ {
     const remoteDoc /*: RemoteDoc */ = jsonApiToRemoteDoc(doc)
     if (remoteDoc.type === FILE_TYPE) {
       const parentDir /*: RemoteDir */ = await this.findDir(remoteDoc.dir_id)

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -244,7 +244,7 @@ class RemoteWatcher {
     const oldpath /*: ?string */ = was ? was.path : undefined
     log.debug(
       {
-        path: (remoteDoc /*: $Shape<MetadataRemoteInfo> */).path || oldpath,
+        path: remoteDoc.path || oldpath,
         oldpath,
         remoteDoc,
         was

--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -22,8 +22,7 @@ import { App } from '../../core/app'
 import { Config } from '../../core/config'
 import { Pouch } from '../../core/pouch'
 import { Remote } from '../../core/remote'
-import type { Metadata } from '../../core/metadata'
-import type { RemoteDoc } from '../../core/remote/document'
+import type { Metadata, MetadataRemoteInfo } from '../../core/metadata'
 */
 
 const localDoc = async (
@@ -44,7 +43,7 @@ const localDoc = async (
 const remoteDoc = async (
   localDoc /*: Metadata */,
   { config, remote } /*: { config: Config, remote: Remote } */
-) /*: Promise<RemoteDoc> */ => {
+) /*: Promise<MetadataRemoteInfo> */ => {
   try {
     return await remote.remoteCozy.find(localDoc.remote._id)
   } catch (err) {

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -345,17 +345,28 @@ module.exports = class BaseMetadataBuilder {
 
     if (this._remoteBuilder == null) {
       if (this.doc.docType === 'file') {
-        this._remoteBuilder = (new RemoteFileBuilder() /*: RemoteBaseBuilder<MetadataRemoteFile> */)
+        this._remoteBuilder = new RemoteFileBuilder()
       } else {
-        this._remoteBuilder = (new RemoteDirBuilder() /*: RemoteBaseBuilder<MetadataRemoteDir> */)
+        this._remoteBuilder = new RemoteDirBuilder()
       }
     }
 
-    this.doc.remote = this._remoteBuilder
+    const builder = this._remoteBuilder
       .name(path.basename(this.doc.path))
       .createdAt(...timestamp.spread(this.doc.updated_at))
       .updatedAt(...timestamp.spread(this.doc.updated_at))
-      .build()
+
+    if (this.doc.docType === 'file') {
+      this.doc.remote = builder
+        // $FlowFixMe those methods exist in RemoteFileBuilder
+        .data(this._data)
+        .executable(this.doc.executable)
+        .contentType(this.doc.mime || '')
+        .build()
+    } else {
+      this.doc.remote = builder.build()
+    }
+
     this.doc.remote.path = '/' + path.posix.normalize(this.doc.path)
   }
 }

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -11,6 +11,10 @@ import type { Metadata } from '../../../../core/metadata'
 */
 
 module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
+  /*::
+  _data: string | Buffer
+  */
+
   constructor(pouch /*: ?Pouch */, old /*: ?Metadata */) {
     super(pouch, old)
 
@@ -28,6 +32,7 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   }
 
   data(data /*: string | Buffer */) /*: this */ {
+    this._data = data
     this.doc.size = Buffer.from(data).length
     this.doc.md5sum = crypto
       .createHash('md5')

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -161,7 +161,10 @@ class RemoteTestHelpers {
     }
   }
 
-  async move({ _id, updated_at } /*: RemoteDoc */, newPath /*: string */) {
+  async move(
+    { _id, updated_at } /*: MetadataRemoteInfo|RemoteDoc */,
+    newPath /*: string */
+  ) {
     const [newDirPath, newName] /*: [string, string] */ = dirAndName(newPath)
     const newDir /*: RemoteDoc */ = await this.side.remoteCozy.findDirectoryByPath(
       newDirPath

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -4297,6 +4297,42 @@ describe('Merge', function() {
         })
       })
     })
+
+    context('when found record was not synced', () => {
+      it('marks it for deletion and upadtes sides info', async function() {
+        const was = await builders
+          .metafile()
+          .sides({ [this.side]: 1 })
+          .create()
+        const doc = builders
+          .metafile(was)
+          .trashed()
+          .unmerged(this.side)
+          .build()
+
+        const sideEffects = await mergeSideEffects(this, () =>
+          this.merge.trashFileAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
+        )
+
+        should(sideEffects).deepEqual({
+          savedDocs: [
+            _.defaults(
+              {
+                sides: increasedSides(was.sides, this.side, 1),
+                [this.side]: doc[this.side],
+                deleted: true
+              },
+              _.omit(was, ['_id', '_rev'])
+            )
+          ],
+          resolvedConflicts: []
+        })
+      })
+    })
   })
 
   describe('trashFolderAsync', () => {
@@ -4457,6 +4493,42 @@ describe('Merge', function() {
 
         should(sideEffects).deepEqual({
           savedDocs: [],
+          resolvedConflicts: []
+        })
+      })
+    })
+
+    context('when found record was not synced', () => {
+      it('marks it for deletion and upadtes sides info', async function() {
+        const was = await builders
+          .metadir()
+          .sides({ [this.side]: 1 })
+          .create()
+        const doc = builders
+          .metadir(was)
+          .trashed()
+          .unmerged(this.side)
+          .build()
+
+        const sideEffects = await mergeSideEffects(this, () =>
+          this.merge.trashFolderAsync(
+            this.side,
+            _.cloneDeep(was),
+            _.cloneDeep(doc)
+          )
+        )
+
+        should(sideEffects).deepEqual({
+          savedDocs: [
+            _.defaults(
+              {
+                sides: increasedSides(was.sides, this.side, 1),
+                [this.side]: doc[this.side],
+                deleted: true
+              },
+              _.omit(was, ['_id', '_rev'])
+            )
+          ],
           resolvedConflicts: []
         })
       })

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -30,7 +30,7 @@ const {
   CONFLICT_REGEXP
 } = metadata
 const { Ignore } = require('../../core/ignore')
-const { FILES_DOCTYPE, TRASH_DIR_NAME } = require('../../core/remote/constants')
+const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const stater = require('../../core/local/stater')
 const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
 
@@ -1612,59 +1612,6 @@ describe('metadata', function() {
         updated_at: file.remote.updated_at,
         cozyMetadata: file.remote.cozyMetadata
       })
-    })
-
-    it('builds the remote path if it is missing in the new remote', () => {
-      const trashedRemoteFile /*: RemoteBase */ = {
-        _id: '123abc',
-        _rev: '1-xxx',
-        _type: 'file',
-        dir_id: '456def',
-        name: 'OLD',
-        trashed: true,
-        tags: [],
-        created_at: '1989-11-14T03:30:23.293Z',
-        updated_at: '1989-11-14T03:30:23.293Z'
-      }
-      const trashedFile = builders
-        .metafile()
-        .path('parent/dir/OLD')
-        .updatedAt('1989-11-14T03:30:23.293Z')
-        .sides({ local: 1 })
-        .build()
-
-      metadata.updateRemote(trashedFile, trashedRemoteFile)
-
-      should(trashedFile).have.property('remote')
-      should(trashedFile.remote).have.property(
-        'path',
-        path.posix.join(TRASH_DIR_NAME, 'OLD')
-      )
-
-      const remoteFile /*: RemoteBase */ = {
-        _id: '123abc',
-        _rev: '1-xxx',
-        _type: 'file',
-        dir_id: '456def',
-        name: 'OLD',
-        tags: [],
-        created_at: '1989-11-14T03:30:23.293Z',
-        updated_at: '1989-11-14T03:30:23.293Z'
-      }
-      const file = builders
-        .metafile()
-        .path('parent/OLD')
-        .updatedAt('1989-11-14T03:30:23.293Z')
-        .sides({ local: 1 })
-        .build()
-
-      metadata.updateRemote(file, remoteFile)
-
-      should(file).have.property('remote')
-      should(file.remote).have.property(
-        'path',
-        path.posix.join(...file.path.split(path.sep))
-      )
     })
   })
 })


### PR DESCRIPTION
To make sure a file modified on the local filesystem would not be
trashed by the remote Cozy before the modification could be uploaded,
we were preventing remote trashing if the existing PouchDB record and
the trashed document did not have the same `md5sum` value.

However, if the file was also edited on the remote Cozy before being
trashed and the Desktop client did not fetch the modification before
the trash order, we get different `md5sum` values but still want to
apply the trash order on the local filesystem.

Now that we store both the `local` and `remote` metadata for each
document, we can achieve the desired result by checking whether the
existing document has the same local and remote `md5sum` instead.
We're also making the protection more generic by protecting remote
modifications from local trashing as well.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
