### PR TITLE
core/sync/errors: Set default retry delay to 1 min

### DIFF
--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -104,10 +104,14 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
         return 60000
 
       default:
-        return 0
+        // Arbutrary value to make sure we don't retry too soon and overload the
+        // server with requests.
+        return REMOTE_HEARTBEAT
     }
   } else {
-    return 0
+    // Arbutrary value to make sure we don't retry too soon and overload the
+    // server with requests.
+    return REMOTE_HEARTBEAT
   }
 }
 


### PR DESCRIPTION
The retry delay for blocking Sync errors which are not specifically
processed (a.k.a the default retry delay) was 0 milliseconds.

This very low value meant that the client would make requests to the
remote Cozy every few seconds (there's a little overhead to process a
change) when retrying to synchronize the changes.
This creates an unnecessary burden on the remote Cozy and the
underlying errors would probably not be solved in such a short delay
anyway.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
