### PR TITLE
core/remote: Remove _type attribute from doc types

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -7,7 +7,6 @@ const autoBind = require('auto-bind')
 const OldCozyClient = require('cozy-client-js').Client
 const CozyClient = require('cozy-client').default
 const { FetchError } = require('cozy-stack-client')
-const _ = require('lodash')
 const path = require('path')
 const {
   AbortController
@@ -353,8 +352,7 @@ class RemoteCozy {
 
     if (results.length === 0) throw new DirectoryNotFound(path, this.url)
 
-    // FIXME: cozy-client-js query results have no _type
-    return _.merge({ _type: FILES_DOCTYPE }, results[0])
+    return results[0]
   }
 
   // FIXME: created_at is returned by some methods, but not all of them

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -35,7 +35,6 @@ export type RemoteDirAttributes = {|
 export type RemoteBase = {|
   _id: string,
   _rev: string,
-  _type: string,
   _deleted?: true,
   dir_id: string,
   name: string,
@@ -138,7 +137,6 @@ function jsonApiToRemoteDoc(json /*: JsonApiDoc */) /*: RemoteDoc */ {
       type: DIR_TYPE,
       _id: json._id,
       _rev: json._rev,
-      _type: json._type,
       ...(json.attributes /*: JsonApiDirAttributes */)
     } /*: RemoteDir */)
 
@@ -150,7 +148,6 @@ function jsonApiToRemoteDoc(json /*: JsonApiDoc */) /*: RemoteDoc */ {
       type: FILE_TYPE,
       _id: json._id,
       _rev: json._rev,
-      _type: json._type,
       _deleted: json._deleted,
       ...(json.attributes /*: JsonApiFileAttributes */)
     } /*: RemoteFile */)

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -100,7 +100,6 @@ describe('metadata', function() {
       const remoteDoc /*: MetadataRemoteDir */ = {
         _id: '12',
         _rev: '34',
-        _type: FILES_DOCTYPE,
         dir_id: '56',
         name: 'bar',
         path: '/foo/bar',

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -9,7 +9,6 @@ const stream = require('stream')
 const { FetchError } = require('cozy-client')
 
 const {
-  FILES_DOCTYPE,
   ROOT_DIR_ID,
   TRASH_DIR_ID,
   TRASH_DIR_NAME
@@ -525,7 +524,6 @@ describe('RemoteCozy', function() {
 
       should(trashed).have.properties({
         _id: orig._id,
-        _type: FILES_DOCTYPE,
         class: orig.class,
         dir_id: TRASH_DIR_ID,
         executable: orig.executable,


### PR DESCRIPTION
The `_type` attribute is used by `cozy-stack` to store the doctype of
CouchDB records. In our case, this doctype is always `io.cozy.files`
and since it is not stored in the CouchDB records themselves, the data
we receive from our calls to the remote changes feed for example does
not contain this attribute.

We don't need this attribute and should not expect its presence in
returned remote records via our Flow types nor add it ourselves since
it makes it harder to compare remote data in tests with docs fetched
from our helpers.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
