### PR TITLE
core/remote: Handle Cozy dates with nanoseconds

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -449,11 +449,9 @@ function newDocumentAttributes(
   }
 }
 
-function mostRecentUpdatedAt(doc /*: SavedMetadata */) {
+function mostRecentUpdatedAt(doc /*: SavedMetadata */) /*: string */ {
   if (doc.remote) {
-    return timestamp
-      .maxDate(doc.updated_at, doc.remote.updated_at)
-      .toISOString()
+    return timestamp.maxDate(doc.updated_at, doc.remote.updated_at)
   } else {
     return doc.updated_at
   }

--- a/core/utils/timestamp.js
+++ b/core/utils/timestamp.js
@@ -68,10 +68,10 @@ function almostSameDate(
   return Math.abs(twoT - oneT) <= 3000
 }
 
-function maxDate(d1 /*: string|Date */, d2 /*: string|Date */) /*: Date */ {
-  const one = new Date(d1)
-  const two = new Date(d2)
-  return one.getTime() > two.getTime() ? one : two
+function maxDate(isoDate1 /*: string */, isoDate2 /*: string */) /*: string */ {
+  const one = roundedRemoteDate(isoDate1)
+  const two = roundedRemoteDate(isoDate2)
+  return new Date(one).getTime() > new Date(two).getTime() ? one : two
 }
 
 function stringify(t /*: Timestamp */) {

--- a/test/unit/utils/timestamp.js
+++ b/test/unit/utils/timestamp.js
@@ -1,24 +1,26 @@
+/* @flow */
 /* eslint-env mocha */
 
 const should = require('should')
 const sinon = require('sinon')
 
-const timestamp = require('../../../core/utils/timestamp')
-const { InvalidTimestampError, maxDate, sameDate, almostSameDate } = timestamp
-
-// XXX: Pass strings to javascript's Date constructor everywhere, so the tests
-//      don't depend on the current timezone.
+const {
+  almostSameDate,
+  build,
+  current,
+  fromDate,
+  maxDate,
+  roundedRemoteDate,
+  sameDate,
+  stringify
+} = require('../../../core/utils/timestamp')
 
 describe('timestamp', () => {
-  const nonDate = 123
-  const dateWithMilliseconds = new Date(2016, 1, 2, 3, 4, 5, 6, 789)
-  const validTimestamp = timestamp.build(2016, 1, 2, 3, 4, 5, 6)
-
   describe('build', () => {
     it('builds an UTC Date, with month starting from 1 and second-only precision', () => {
-      const result = timestamp.build(2016, 11, 22, 9, 54, 37)
-      result.should.be.sameTimestamp(new Date('2016-11-22T09:54:37.000Z'))
-      result.getMilliseconds().should.equal(0)
+      const result = build(2016, 11, 22, 9, 54, 37)
+      should(result).be.sameTimestamp(new Date('2016-11-22T09:54:37.000Z'))
+      should(result.getMilliseconds()).equal(0)
     })
   })
 
@@ -27,8 +29,8 @@ describe('timestamp', () => {
       const now = new Date('2016-11-22T09:54:37.123Z')
       const clock = sinon.useFakeTimers(now.getTime())
 
-      const result = timestamp.current()
-      result.should.be.sameTimestamp(new Date('2016-11-22T09:54:37.000Z'))
+      const result = current()
+      should(result).be.sameTimestamp(new Date('2016-11-22T09:54:37.000Z'))
 
       clock.restore()
     })
@@ -37,60 +39,48 @@ describe('timestamp', () => {
   describe('fromDate', () => {
     it('is the same date without the milliseconds precision', () => {
       const date = new Date('2016-11-22T09:54:37.123Z')
-      const result = timestamp.fromDate(date)
+      const result = fromDate(date)
 
-      result.should.be.timestamp(2016, 11, 22, 9, 54, 37)
+      should(result).be.timestamp(2016, 11, 22, 9, 54, 37)
     })
   })
 
   describe('sameDate', () => {
     it('is true when timestamps have same value', () => {
       should.ok(
-        sameDate(
-          timestamp.build(2016, 11, 22, 9, 54, 37),
-          timestamp.build(2016, 11, 22, 9, 54, 37)
-        )
+        sameDate(build(2016, 11, 22, 9, 54, 37), build(2016, 11, 22, 9, 54, 37))
       )
     })
 
     it('is false otherwise', () => {
       should.ok(
         !sameDate(
-          timestamp.build(2016, 11, 22, 9, 54, 37),
-          timestamp.build(2016, 11, 22, 9, 54, 38)
+          build(2016, 11, 22, 9, 54, 37),
+          build(2016, 11, 22, 9, 54, 38)
         )
       )
     })
-
-    it('throws when one or both args are not valid timestamps', () => {
-      should.throws(() => {
-        timestamp.same(validTimestamp, nonDate)
-      }, InvalidTimestampError)
-
-      should.throws(() => {
-        timestamp.same(dateWithMilliseconds, nonDate)
-      }, InvalidTimestampError)
-    })
   })
 
-  describe('almostSameDate', () =>
+  describe('almostSameDate', () => {
     it('returns true if the date are nearly the same', function() {
       let a = '2015-12-01T11:22:56.517Z'
       let b = '2015-12-01T11:22:56.000Z'
       let c = '2015-12-01T11:22:57.000Z'
       let d = '2015-12-01T11:22:59.200Z'
       let e = '2015-12-01T11:22:52.200Z'
-      almostSameDate(a, b).should.be.true()
-      almostSameDate(a, c).should.be.true()
-      almostSameDate(a, d).should.be.true()
-      almostSameDate(a, e).should.be.false()
-      almostSameDate(b, c).should.be.true()
-      almostSameDate(b, d).should.be.true()
-      almostSameDate(b, e).should.be.false()
-      almostSameDate(c, d).should.be.true()
-      almostSameDate(c, e).should.be.false()
-      almostSameDate(d, e).should.be.false()
-    }))
+      should(almostSameDate(a, b)).be.true()
+      should(almostSameDate(a, c)).be.true()
+      should(almostSameDate(a, d)).be.true()
+      should(almostSameDate(a, e)).be.false()
+      should(almostSameDate(b, c)).be.true()
+      should(almostSameDate(b, d)).be.true()
+      should(almostSameDate(b, e)).be.false()
+      should(almostSameDate(c, d)).be.true()
+      should(almostSameDate(c, e)).be.false()
+      should(almostSameDate(d, e)).be.false()
+    })
+  })
 
   describe('maxDate', () => {
     const d1 = new Date('2017-05-18T08:02:36.000Z')
@@ -114,31 +104,27 @@ describe('timestamp', () => {
 
   describe('stringify', () => {
     it('returns a golang-compatible RFC3339 representation', () => {
-      const t = timestamp.build(2017, 2, 16, 8, 59, 18)
-      should.equal(timestamp.stringify(t), '2017-02-16T08:59:18Z')
+      const t = build(2017, 2, 16, 8, 59, 18)
+      should(stringify(t)).equal('2017-02-16T08:59:18Z')
     })
   })
 
   describe('roundedRemoteDate', () => {
     it('adds the milliseconds when they are missing', function() {
       const time = '2015-12-31T23:59:59Z'
-      should(timestamp.roundedRemoteDate(time)).equal(
-        '2015-12-31T23:59:59.000Z'
-      )
+      should(roundedRemoteDate(time)).equal('2015-12-31T23:59:59.000Z')
     })
 
     it('pads the milliseconds with 0s if they have less than 3 digits', function() {
       const a = '2015-12-31T23:59:59.5Z'
       const b = '2015-12-31T23:59:59.54Z'
-      should(timestamp.roundedRemoteDate(a)).equal('2015-12-31T23:59:59.500Z')
-      should(timestamp.roundedRemoteDate(b)).equal('2015-12-31T23:59:59.540Z')
+      should(roundedRemoteDate(a)).equal('2015-12-31T23:59:59.500Z')
+      should(roundedRemoteDate(b)).equal('2015-12-31T23:59:59.540Z')
     })
 
     it('increments the time by 1 millisecond if they have more than 3 digits', function() {
       const time = '2015-12-31T23:59:59.999232345Z'
-      should(timestamp.roundedRemoteDate(time)).equal(
-        '2016-01-01T00:00:00.000Z'
-      )
+      should(roundedRemoteDate(time)).equal('2016-01-01T00:00:00.000Z')
     })
 
     it('handles dates with timezones other than UTC', function() {
@@ -147,10 +133,10 @@ describe('timestamp', () => {
       const b = '2020-04-05T19:50:06.029+02:00'
       const c = '2020-04-05T19:50:06.02+02:00'
       const d = '2020-04-05T19:50:06.229928394+02:00'
-      should(timestamp.roundedRemoteDate(a)).equal('2020-04-05T17:50:06.000Z')
-      should(timestamp.roundedRemoteDate(b)).equal('2020-04-05T17:50:06.029Z')
-      should(timestamp.roundedRemoteDate(c)).equal('2020-04-05T17:50:06.020Z')
-      should(timestamp.roundedRemoteDate(d)).equal('2020-04-05T17:50:06.230Z')
+      should(roundedRemoteDate(a)).equal('2020-04-05T17:50:06.000Z')
+      should(roundedRemoteDate(b)).equal('2020-04-05T17:50:06.029Z')
+      should(roundedRemoteDate(c)).equal('2020-04-05T17:50:06.020Z')
+      should(roundedRemoteDate(d)).equal('2020-04-05T17:50:06.230Z')
     })
   })
 })

--- a/test/unit/utils/timestamp.js
+++ b/test/unit/utils/timestamp.js
@@ -83,8 +83,8 @@ describe('timestamp', () => {
   })
 
   describe('maxDate', () => {
-    const d1 = new Date('2017-05-18T08:02:36.000Z')
-    const d2 = new Date('2017-05-18T08:03:16.000Z')
+    const d1 = new Date('2017-05-18T08:02:36.000Z').toISOString()
+    const d2 = new Date('2017-05-18T08:03:16.000Z').toISOString()
 
     it('finds the most recent of two dates', () => {
       should(maxDate(d1, d2)).deepEqual(d2)
@@ -92,13 +92,11 @@ describe('timestamp', () => {
       should(maxDate(d1, d1)).deepEqual(d1)
     })
 
-    it('returns the most recent date when passed ISO date strings', () => {
-      const str1 = d1.toISOString()
-      const str2 = d2.toISOString()
+    it('increments the most recent date by 1 millisecond if it has more than 3 millisecond digits', function() {
+      const d1 = '2015-12-31T23:59:59.999232345Z'
+      const d2 = '2015-12-31T23:59:59.999Z'
 
-      should(maxDate(str1, str2)).deepEqual(d2)
-      should(maxDate(str2, str1)).deepEqual(d2)
-      should(maxDate(str1, str1)).deepEqual(d1)
+      should(maxDate(d1, d2)).equal('2016-01-01T00:00:00.000Z')
     })
   })
 


### PR DESCRIPTION
When the Cozy stack assigns the creation and last modification dates
on remote records (it can happen when the creation request does not
include any `createdAt` and `updatedAt` attributes for example), the
dates' precision is up to the nanosecond.
When formatted as a string, the nanoseconds digits will be
concatenated to the ISO format milliseconds digits.

When the Desktop client wants to compare two date strings, it feeds
them to the `Date` JavaScript object constructor which does not
understand nanoseconds and truncates the date string after the last
millisecond digit.
This means, the resulting date will be older than the actual date
represented by the original string.

Now, when we send requests to the stack to modify existing remote
documents with local data, we want to make sure we use the most recent
`updated_at` date otherwise the stack will refuse to apply the change.
This means that the method that returns this most recent date needs to
take into account remote dates with nanoseconds and round them up to
the next millisecond to make sure we have a more recent date when the
local date is older.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
