### PR TITLE
core/sync: Create conflict copy on 409 errors

### DIFF
--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -12,13 +12,14 @@ import type { FetchError } from 'cozy-stack-client'
 export type { FetchError }
 */
 
+const CONFLICTING_NAME_CODE = 'ConflictingName'
 const COZY_CLIENT_REVOKED_CODE = 'CozyClientRevoked'
-const USER_ACTION_REQUIRED_CODE = 'UserActionRequired'
 const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
 const NEEDS_REMOTE_MERGE_CODE = 'NeedsRemoteMerge'
 const NO_COZY_SPACE_CODE = 'NoCozySpace'
-const UNREACHABLE_COZY_CODE = 'UnreachableCozy'
 const UNKNOWN_REMOTE_ERROR_CODE = 'UnknownRemoteError'
+const UNREACHABLE_COZY_CODE = 'UnreachableCozy'
+const USER_ACTION_REQUIRED_CODE = 'UserActionRequired'
 
 const COZY_CLIENT_REVOKED_MESSAGE = 'Cozy client has been revoked' // Only necessary for the GUI
 
@@ -162,6 +163,13 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
           message: 'Cozy client is missing permissions (lack disk-usage?)',
           err
         })
+      case 409:
+        return new RemoteError({
+          code: CONFLICTING_NAME_CODE,
+          message:
+            'A document with the same name already exists on the remote Cozy at the same location',
+          err
+        })
       case 412:
         return new RemoteError({
           code: NEEDS_REMOTE_MERGE_CODE,
@@ -194,12 +202,13 @@ module.exports = {
   RemoteError,
   UnreachableError,
   COZY_CLIENT_REVOKED_MESSAGE, // FIXME: should be removed once gui/main does not use it anymore
+  CONFLICTING_NAME_CODE,
   COZY_CLIENT_REVOKED_CODE,
-  USER_ACTION_REQUIRED_CODE,
   MISSING_PERMISSIONS_CODE,
   NEEDS_REMOTE_MERGE_CODE,
   NO_COZY_SPACE_CODE,
-  UNREACHABLE_COZY_CODE,
   UNKNOWN_REMOTE_ERROR_CODE,
+  UNREACHABLE_COZY_CODE,
+  USER_ACTION_REQUIRED_CODE,
   wrapError
 }

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -94,6 +94,7 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
         return 10000
 
       case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
+      case remoteErrors.CONFLICTING_NAME_CODE:
         // We want to make sure the remote watcher has run before retrying
         return REMOTE_HEARTBEAT
 

--- a/core/utils/conflicts.js
+++ b/core/utils/conflicts.js
@@ -1,0 +1,42 @@
+/* @flow */
+
+const path = require('path')
+
+const fsutils = require('./fs')
+
+const DATE_REGEXP = '\\d{4}(?:-\\d{2}){2}T(?:\\d{2}_?){3}\\.\\d{3}Z'
+const SEPARATOR_REGEXP = `(?!.*\\${path.sep}.*)`
+const CONFLICT_REGEXP = new RegExp(
+  `-conflict-${DATE_REGEXP}${SEPARATOR_REGEXP}`
+)
+
+function conflictSuffix() /*: string */ {
+  const date = fsutils.validName(new Date().toISOString())
+  return `-conflict-${date}`
+}
+
+function replacePreviousConflictSuffix(filePath /*: string */) /*: string */ {
+  return filePath.replace(CONFLICT_REGEXP, conflictSuffix())
+}
+
+function addConflictSuffix(filePath /*: string */) /*: string */ {
+  const dirname = path.dirname(filePath)
+  const extname = path.extname(filePath)
+  const filename = path.basename(filePath, extname)
+  const notTooLongFilename = filename.slice(0, 180)
+  return `${path.join(
+    dirname,
+    notTooLongFilename
+  )}${conflictSuffix()}${extname}`
+}
+
+function generateConflictPath(fpath /*: string */) /*: string */ {
+  return CONFLICT_REGEXP.test(fpath)
+    ? replacePreviousConflictSuffix(fpath)
+    : addConflictSuffix(fpath)
+}
+
+module.exports = {
+  CONFLICT_REGEXP,
+  generateConflictPath
+}

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -4,12 +4,18 @@
 const path = require('path')
 const should = require('should')
 
+const metadata = require('../../core/metadata')
 const configHelpers = require('../support/helpers/config')
 const cozyHelpers = require('../support/helpers/cozy')
 const pouchHelpers = require('../support/helpers/pouch')
 const TestHelpers = require('../support/helpers')
 
 const cozy = cozyHelpers.cozy
+
+const logger = require('../../core/utils/logger')
+const log = new logger({
+  component: 'TEST'
+})
 
 describe('Add', () => {
   let helpers, parent
@@ -19,23 +25,44 @@ describe('Add', () => {
   beforeEach(pouchHelpers.createDatabase)
   beforeEach(cozyHelpers.deleteAll)
 
-  afterEach(() => helpers.local.clean())
-  afterEach(pouchHelpers.cleanDatabase)
-  after(configHelpers.cleanConfig)
-
   beforeEach(async function() {
     helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
 
     parent = await cozy.files.createDirectory({ name: 'parent' })
-    await helpers.remote.pullChanges()
-    await helpers.syncAll()
+    await helpers.pullAndSyncAll()
+    await helpers.local.scan()
 
     helpers.spyPouch()
   })
 
+  afterEach(() => helpers.local.clean())
+  afterEach(pouchHelpers.cleanDatabase)
+  after(configHelpers.cleanConfig)
+
   describe('file', () => {
+    const createDoc = async (side, filename, content = 'foo') => {
+      if (side === 'remote') {
+        return await cozy.files.create(content, {
+          name: filename,
+          dirID: parent._id
+        })
+      } else {
+        return await helpers.local.syncDir.outputFile(
+          path.join(parent.attributes.path.slice(1), filename),
+          'foo'
+        )
+      }
+    }
+    const syncSideAddition = async side => {
+      if (side === 'remote') {
+        await helpers.pullAndSyncAll()
+      } else {
+        await helpers.flushLocalAndSyncAll()
+      }
+    }
+
     describe('local', () => {
       const filename = 'Texte.txt'
       context('when file is completely empty', () => {
@@ -70,11 +97,55 @@ describe('Add', () => {
           should(await helpers.remote.readFile(filename)).eql(filecontent)
         })
       })
+
+      context('when file path is already taken on the remote Cozy', () => {
+        it('renames the remote document as conflict', async () => {
+          const remoteFile = await createDoc(
+            'remote',
+            'file.txt',
+            'remote content'
+          )
+          await createDoc('local', 'file.txt', 'local content')
+
+          await syncSideAddition('local')
+          await helpers.pullAndSyncAll()
+
+          should(await helpers.trees()).deepEqual({
+            local: ['parent/', 'parent/file-conflict-...', 'parent/file.txt'],
+            remote: ['parent/', 'parent/file-conflict-...', 'parent/file.txt']
+          })
+          should(await helpers.remote.byIdMaybe(remoteFile._id))
+            .have.property('name')
+            .startWith('file-conflict-')
+        })
+      })
     })
 
     describe('remote', () => {
       it('downloads the new file', async () => {
         await cozy.files.create('foo', { name: 'file', dirID: parent._id })
+        await helpers.remote.pullChanges()
+
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
+          {
+            path: path.normalize('parent/file'),
+            sides: { target: 1, remote: 1 }
+          }
+        ])
+
+        // $FlowFixMe
+        should(await helpers.remote.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/file'
+        ])
+      })
+    })
+
+    describe('on remote Cozy', () => {
+      it('creates the file on the local file system', async () => {
+        await createDoc('remote', 'file')
         await helpers.remote.pullChanges()
 
         should(
@@ -94,39 +165,155 @@ describe('Add', () => {
   })
 
   describe('dir', () => {
-    it('local')
+    const createDoc = async (side, name, parent) => {
+      if (side === 'remote') {
+        return await cozy.files.createDirectory({ name, dirID: parent._id })
+      } else {
+        const dirPath = path.join(parent.attributes.path.slice(1), name)
+        await helpers.local.syncDir.ensureDir(dirPath)
+        return {
+          _id: metadata.id(dirPath),
+          attributes: { path: `/${dirPath}` },
+          _rev: '1'
+        }
+      }
+    }
+    const syncSideAddition = async side => {
+      if (side === 'remote') {
+        await helpers.pullAndSyncAll()
+      } else {
+        await helpers.flushLocalAndSyncAll()
+      }
+    }
 
-    it('remote', async () => {
-      const dir = await cozy.files.createDirectory({
-        name: 'dir',
-        dirID: parent._id
+    describe('on local file system', () => {
+      it('creates the directory and its content on the remote Cozy', async () => {
+        log.debug('TEST START')
+        const dir = await createDoc('local', 'dir', parent)
+        const subdir = await createDoc('local', 'subdir', dir)
+        await createDoc('local', 'empty-subdir', dir)
+
+        await helpers.local.syncDir.outputFile(
+          path.join(subdir.attributes.path, 'file'),
+          'foo'
+        )
+        await helpers.local.scan()
+
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
+          // Adding children modifies the parent folder's metadata on the
+          // filesystem triggering a call to Pouch.put with the local changes.
+          { path: 'parent', sides: { target: 2, local: 2, remote: 2 } },
+          {
+            path: path.normalize('parent/dir'),
+            sides: { target: 1, local: 1 }
+          },
+          {
+            path: path.normalize('parent/dir/empty-subdir'),
+            sides: { target: 1, local: 1 }
+          },
+          {
+            path: path.normalize('parent/dir/subdir'),
+            sides: { target: 1, local: 1 }
+          },
+          {
+            path: path.normalize('parent/dir/subdir/file'),
+            sides: { target: 1, local: 1 }
+          }
+        ])
+
+        await helpers.syncAll()
+
+        should(await helpers.remote.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/dir/',
+          'parent/dir/empty-subdir/',
+          'parent/dir/subdir/',
+          'parent/dir/subdir/file'
+        ])
       })
-      const subdir = await cozy.files.createDirectory({
-        name: 'subdir',
-        dirID: dir._id
+
+      context('if directory already exists on the remote Cozy', () => {
+        it('links the two directories', async () => {
+          log.debug('TEST START')
+          const remoteDir = await createDoc('remote', 'dir', parent)
+          await createDoc('local', 'dir', parent)
+
+          await syncSideAddition('local')
+
+          const updatedDir = metadata.fromRemoteDoc(
+            await helpers.remote.byId(remoteDir._id)
+          )
+          const savedParent = metadata.fromRemoteDoc(
+            await helpers.remote.byId(parent._id)
+          )
+
+          should(await helpers.trees()).deepEqual({
+            local: ['parent/', 'parent/dir/'],
+            remote: ['parent/', 'parent/dir/']
+          })
+          should(helpers.putDocs('path', 'remote', 'sides')).deepEqual([
+            // Adding children modifies the parent folder's metadata on the
+            // filesystem triggering a call to Pouch.put with the local changes.
+            {
+              path: 'parent',
+              remote: savedParent.remote,
+              sides: { target: 2, local: 2, remote: 2 }
+            },
+            {
+              path: path.normalize('parent/dir'),
+              sides: { target: 1, local: 1 }
+            },
+            {
+              path: path.normalize('parent/dir'),
+              remote: updatedDir.remote,
+              sides: { target: 2, local: 2, remote: 2 }
+            }
+          ])
+        })
       })
-      await cozy.files.createDirectory({ name: 'empty-subdir', dirID: dir._id })
-      await cozy.files.create('foo', { name: 'file', dirID: subdir._id })
-      await helpers.remote.pullChanges()
+    })
 
-      /* FIXME: Nondeterministic
-      should(helpers.putDocs('path', '_deleted', 'trashed', 'sides')).deepEqual([
-        {path: 'parent/dir', sides: {remote: 1}},
-        {path: 'parent/dir/empty-subdir', sides: {remote: 1}},
-        {path: 'parent/dir/subdir', sides: {remote: 1}},
-        {path: 'parent/dir/subdir/file', sides: {remote: 1}}
-      ])
-      */
+    describe('on remote Cozy', () => {
+      it('creates the directory and its content on the local file system', async () => {
+        const dir = await createDoc('remote', 'dir', parent)
+        const subdir = await createDoc('remote', 'subdir', dir)
+        await createDoc('remote', 'empty-subdir', dir)
+        await cozy.files.create('foo', { name: 'file', dirID: subdir._id })
+        await helpers.remote.pullChanges()
 
-      await helpers.syncAll()
+        should(
+          helpers.putDocs('path', '_deleted', 'trashed', 'sides')
+        ).deepEqual([
+          {
+            path: path.normalize('parent/dir'),
+            sides: { target: 1, remote: 1 }
+          },
+          {
+            path: path.normalize('parent/dir/empty-subdir'),
+            sides: { target: 1, remote: 1 }
+          },
+          {
+            path: path.normalize('parent/dir/subdir'),
+            sides: { target: 1, remote: 1 }
+          },
+          {
+            path: path.normalize('parent/dir/subdir/file'),
+            sides: { target: 1, remote: 1 }
+          }
+        ])
 
-      should(await helpers.local.tree()).deepEqual([
-        'parent/',
-        'parent/dir/',
-        'parent/dir/empty-subdir/',
-        'parent/dir/subdir/',
-        'parent/dir/subdir/file'
-      ])
+        await helpers.syncAll()
+
+        should(await helpers.local.treeWithoutTrash()).deepEqual([
+          'parent/',
+          'parent/dir/',
+          'parent/dir/empty-subdir/',
+          'parent/dir/subdir/',
+          'parent/dir/subdir/file'
+        ])
+      })
     })
   })
 })

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -65,7 +65,7 @@ describe('Move', () => {
         'local',
         _.merge(
           {
-            path: 'dst/file',
+            path: path.normalize('dst/file'),
             updated_at: '2017-06-19T08:19:26.769Z'
           },
           _.pick(oldFile, ['docType', 'md5sum', 'mime', 'class', 'size'])
@@ -104,7 +104,7 @@ describe('Move', () => {
             'tags'
           ]),
           {
-            path: 'dst/file',
+            path: path.normalize('dst/file'),
             updated_at: '2017-06-19T08:19:26.769Z',
             remote: {
               _id: file._id,
@@ -140,7 +140,7 @@ describe('Move', () => {
         'local',
         _.merge(
           {
-            path: 'dst/file',
+            path: path.normalize('dst/file'),
             updated_at: '2017-06-19T08:19:26.769Z'
           },
           _.pick(oldFile, [
@@ -168,7 +168,7 @@ describe('Move', () => {
         {
           path: path.normalize('dst/file'),
           moveFrom: oldFile,
-          overwrite: { path: 'dst/file' }
+          overwrite: { path: path.normalize('dst/file') }
         }
       ])
 
@@ -195,7 +195,7 @@ describe('Move', () => {
           'local',
           _.merge(
             {
-              path: 'dst/file.tmp',
+              path: path.normalize('dst/file.tmp'),
               updated_at: '2017-06-19T08:19:26.769Z'
             },
             _.pick(oldFile, ['docType', 'md5sum', 'mime', 'class', 'size'])
@@ -241,7 +241,7 @@ describe('Move', () => {
             'local',
             _.merge(
               {
-                path: 'dst/file.tmp',
+                path: path.normalize('dst/file.tmp'),
                 updated_at: '2017-06-19T08:19:26.769Z'
               },
               _.pick(oldFile, ['docType', 'md5sum', 'mime', 'class', 'size'])
@@ -607,7 +607,7 @@ describe('Move', () => {
         { path: path.normalize('parent/src/dir'), _deleted: true },
         {
           path: path.normalize('parent/dst/dir'),
-          overwrite: { path: 'parent/dst/dir' }
+          overwrite: { path: path.normalize('parent/dst/dir') }
         },
         {
           path: path.normalize('parent/src/dir/empty-subdir'),

--- a/test/scenarios/move_replace_then_edit_moved_file/atom/linux.json
+++ b/test/scenarios/move_replace_then_edit_moved_file/atom/linux.json
@@ -1,0 +1,36 @@
+[
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "dst/file",
+      "oldPath": "src/file"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "src/file"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "src/file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst/file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst/file"
+    }
+  ]
+]

--- a/test/scenarios/move_replace_then_edit_moved_file/atom/win32.json
+++ b/test/scenarios/move_replace_then_edit_moved_file/atom/win32.json
@@ -1,0 +1,65 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src\\file"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "src\\file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "src\\file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "src\\file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ]
+]

--- a/test/scenarios/move_replace_then_edit_moved_file/local/darwin.json
+++ b/test/scenarios/move_replace_then_edit_moved_file/local/darwin.json
@@ -1,0 +1,29 @@
+[
+  {
+    "breakpoints": [0]
+  },
+  {
+    "type": "unlink",
+    "path": "src/file"
+  },
+  {
+    "type": "add",
+    "path": "src/file",
+    "stats": {
+      "ino": 4502906,
+      "size": 11,
+      "mtime": "2021-02-11T16:08:24.013Z",
+      "ctime": "2021-02-11T16:08:24.013Z"
+    }
+  },
+  {
+    "type": "add",
+    "path": "dst/file",
+    "stats": {
+      "ino": 3,
+      "size": 15,
+      "mtime": "2021-02-11T16:08:24.520Z",
+      "ctime": "2021-02-11T16:08:24.520Z"
+    }
+  }
+]

--- a/test/scenarios/move_replace_then_edit_moved_file/scenario.js
+++ b/test/scenarios/move_replace_then_edit_moved_file/scenario.js
@@ -4,9 +4,6 @@
 
 module.exports = ({
   useCaptures: false,
-  // XXX: This scenario does not work on the local side yet as it generates name
-  // conflicts on the Cozy.
-  side: 'remote',
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },

--- a/test/scenarios/replace_file_with_file/scenario.js
+++ b/test/scenarios/replace_file_with_file/scenario.js
@@ -3,10 +3,12 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
+  useCaptures: false,
   init: [{ ino: 1, path: 'file', content: 'initial content' }],
   actions: [
     { type: 'delete', path: 'file' },
-    { type: 'create_file', path: 'file', content: 'new content' }
+    { type: 'create_file', path: 'file', content: 'new content' },
+    { type: 'wait', ms: 1500 }
   ],
   expected: {
     tree: ['file'],

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -191,6 +191,16 @@ async function runLocalAtom(scenario, atomCapture, helpers) {
   if (scenario.useCaptures) {
     await helpers.local.simulateAtomEvents(atomCapture.batches)
   } else {
+    // Wait for all local events to be flushed or a 10s time limit in case no
+    // events are fired.
+    await Promise.race([
+      new Promise(resolve => {
+        helpers.local.side.events.on('local-end', resolve)
+      }),
+      new Promise(resolve => {
+        setTimeout(resolve, 10000)
+      })
+    ])
     await helpers.local.side.watcher.stop()
   }
 

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 const autoBind = require('auto-bind')
+const path = require('path')
 const _ = require('lodash')
 const { pick } = _
 const sinon = require('sinon')
@@ -204,9 +205,10 @@ class TestHelpers {
   }
 
   async docByPath(relpath /*: string */) /*: Promise<SavedMetadata> */ {
-    const doc = await this.pouch.bySyncedPath(relpath)
+    const syncedPath = path.normalize(relpath)
+    const doc = await this.pouch.bySyncedPath(syncedPath)
     if (doc) return doc
-    else throw new Error(`No doc with path ${JSON.stringify(relpath)}`)
+    else throw new Error(`No doc with path ${JSON.stringify(syncedPath)}`)
   }
 }
 

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -8,7 +8,6 @@ const conflictHelpers = require('./conflict')
 const cozyHelpers = require('./cozy')
 
 const { Remote, dirAndName } = require('../../../core/remote')
-const { jsonApiToRemoteDoc } = require('../../../core/remote/document')
 const { TRASH_DIR_NAME } = require('../../../core/remote/constants')
 
 /*::
@@ -153,9 +152,14 @@ class RemoteTestHelpers {
     return resp.text()
   }
 
-  async byIdMaybe(id /*: string */) {
+  async byId(id /*: string */) /*: Promise<MetadataRemoteInfo> */ {
+    const remoteDoc = await this.cozy.files.statById(id)
+    return await this.side.remoteCozy.toRemoteDoc(remoteDoc)
+  }
+
+  async byIdMaybe(id /*: string */) /*: Promise<?MetadataRemoteInfo> */ {
     try {
-      return jsonApiToRemoteDoc(await this.cozy.files.statById(id))
+      return await this.byId(id)
     } catch (err) {
       return null
     }

--- a/test/unit/helpers_merge.js
+++ b/test/unit/helpers_merge.js
@@ -4,7 +4,7 @@ const path = require('path')
 const should = require('should')
 const sinon = require('sinon')
 
-const metadata = require('../../core/metadata')
+const conflicts = require('../../core/utils/conflicts')
 const { Merge, MergeMissingParentError } = require('../../core/merge')
 
 const configHelpers = require('../support/helpers/config')
@@ -128,7 +128,7 @@ describe('Merge Helpers', function() {
       const dstPath = spy.args[0][0].path
       should(dstPath)
         .match(/foo(\/|\\)bar/)
-        .and.match(metadata.CONFLICT_REGEXP)
+        .and.match(conflicts.CONFLICT_REGEXP)
       const srcPath = spy.args[0][1].path
       should(srcPath).equal(doc.path)
     })
@@ -145,7 +145,7 @@ describe('Merge Helpers', function() {
       const dstPath = spy.args[0][0].path
       should(dstPath)
         .match(/foo(\/|\\)bar/)
-        .and.match(metadata.CONFLICT_REGEXP)
+        .and.match(conflicts.CONFLICT_REGEXP)
       should(path.extname(dstPath)).equal('.jpg')
     })
 
@@ -161,7 +161,7 @@ describe('Merge Helpers', function() {
       const dstPath = spy.args[0][0].path
       should(dstPath)
         .match(/foo(\/|\\)baz/)
-        .and.match(metadata.CONFLICT_REGEXP)
+        .and.match(conflicts.CONFLICT_REGEXP)
     })
   })
 })

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -1027,15 +1027,18 @@ describe('remote.Remote', function() {
           .metafile()
           .fromRemote(remote2)
           .moveTo('moved-to/cat7.jpg')
-          .changedSide('local')
+          .upToDate()
           .create()
 
+        // For whatever reason, the creation date of `remote2` is ahead of new Date() !!!
+        const updatedAt = new Date(new Date().getTime() + 1000).toISOString()
         doc = builders
           .metafile()
           .moveFrom(old)
           .path('moved-to/cat7.jpg')
           .overwrite(existing)
-          .updatedAt(new Date())
+          .updatedAt(updatedAt)
+          .changedSide('local')
           .build()
       })
 

--- a/test/unit/utils/conflicts.js
+++ b/test/unit/utils/conflicts.js
@@ -1,0 +1,125 @@
+/* @flow */
+/* eslint-env mocha */
+
+const should = require('should')
+const path = require('path')
+
+const {
+  CONFLICT_REGEXP,
+  generateConflictPath
+} = require('../../../core/utils/conflicts')
+
+describe('Conflicts.generateConflictPath()', () => {
+  const runSharedExamples = (
+    {
+      base,
+      ext = '',
+      ancestors = '',
+      conflict = ''
+    } /*: { base: string, ext?: string, ancestors?: string, conflict?: string } */
+  ) => {
+    const filepath = ancestors + base + conflict + ext
+
+    it('returns a path with a conflict suffix', () => {
+      const conflictPath = generateConflictPath(filepath)
+      should(conflictPath)
+        .be.a.String()
+        .and.match(CONFLICT_REGEXP)
+    })
+
+    it('returns a path within the same parent', () => {
+      const conflictPath = generateConflictPath(filepath)
+      should(conflictPath)
+        .be.a.String()
+        .and.startWith(ancestors)
+
+      if (ancestors !== '')
+        should(conflictPath).not.containEql(ancestors + ancestors)
+    })
+
+    it('returns a path with the same extension', () => {
+      const conflictPath = generateConflictPath(filepath)
+      should(conflictPath)
+        .be.a.String()
+        .and.endWith(ext)
+    })
+
+    it('returns a path with up to the first 180 characters of the original path', () => {
+      const conflictPath = generateConflictPath(filepath)
+      const conflictStart = path.basename(conflictPath).search(CONFLICT_REGEXP)
+      should(conflictStart).be.lessThanOrEqual(180)
+      should(filepath).startWith(conflictPath.slice(0, conflictStart))
+    })
+
+    it('does not modify the original path', () => {
+      const originalPath = filepath
+      generateConflictPath(filepath)
+      should(filepath).equal(originalPath)
+    })
+  }
+
+  context('with no file extension', () => {
+    runSharedExamples({ base: 'docname' })
+  })
+
+  context('with complex extension `.tar.gz`', () => {
+    it('should but does not keep complete extension', () => {
+      // FIXME: must be docname-conflict-<ISODATE>.tar.gz instead of
+      // `docname.tar-conflict-<ISODATE>.gz`.
+      const conflictPath = generateConflictPath('docname.tar.gz')
+      should(path.extname(conflictPath)).equal('.gz')
+    })
+  })
+
+  context('with no previous conflicts', () => {
+    runSharedExamples({ base: 'docname', ext: '.pdf' })
+  })
+
+  context('with previous file conflict', () => {
+    runSharedExamples({
+      base: 'docname',
+      conflict: '-conflict-1970-01-01T13_37_00.666Z',
+      ext: '.pdf'
+    })
+
+    context('with no file extension', () => {
+      runSharedExamples({
+        base: 'docname',
+        conflict: '-conflict-1970-01-01T13_37_00.666Z'
+      })
+    })
+  })
+
+  context('with parents', () => {
+    runSharedExamples({
+      ancestors: path.normalize('parent/dir/'),
+      base: 'docname',
+      ext: '.pdf'
+    })
+  })
+
+  context('with previous parent conflict', () => {
+    const ancestors = path.normalize(
+      'parent/dir-conflict-1970-01-01T13_37_00.666Z/'
+    )
+    const base = 'docname'
+    const ext = '.pdf'
+
+    runSharedExamples({ ancestors, base, ext })
+
+    it('should not replace the conflict suffix of a parent', () => {
+      const conflictPath = generateConflictPath(`${ancestors}${base}${ext}`)
+      should(conflictPath)
+        .startWith(`${ancestors}${base}-conflict-`)
+        .and.endWith(ext)
+    })
+  })
+
+  context('with long file name', () => {
+    runSharedExamples({
+      base:
+        'Lorem ipsum dolor sit amet consectetur adipiscing elit Nam a velit at dolor euismod tincidunt sit amet id ante Cras vehicula lectus purus In lobortis risus lectus vitae rhoncus quam porta nullam',
+      ext: '.pdf'
+    })
+  })
+})


### PR DESCRIPTION
When the stacks responds to a Sync request with a 409 status error, it
means the change we're trying to push is conflicting with an existing
document.
This can happen when we try to push a new document or move an existing
one to a location where another document with the same name exists.
Those conflicts should be managed at the Merge level but there are
situations where the conflict is only detected when trying to apply
the local change on the remote Cozy:
1. we have another change to apply that will free the give name by
   moving the document or renaming it
2. we have not yet merged the remote change that took the name and
   would have generated a conflict copy
3. we have not merged the remote change that took the name and never
   will because we abandoned that change in the past

We can solve `1.` by marking our local change with an increased error
counter so it can be retried later, after we've applied the other
changes that would free the conflicting name.

We can solve `2.` by blocking the Sync process until we've fetched
and merged the new remote changes, thus generating a conflict
copy at the Merge level.

We can only solve `3.` by detecting that we've tried the solutions to
`1.` and `2.`, still can't apply the given change and thus generate a
remote conflict at the Sync level instead of doing it at the Merge
level.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
