### PR TITLE
core/utils: Ensure correct paths on all platforms

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -40,6 +40,7 @@ const path = require('path')
 const logger = require('./utils/logger')
 const timestamp = require('./utils/timestamp')
 const fsutils = require('./utils/fs')
+const pathUtils = require('./utils/path')
 
 const {
   detectPathIncompatibilities,
@@ -282,7 +283,7 @@ function fromRemoteDoc(remoteDoc /*: MetadataRemoteInfo */) /*: Metadata */ {
 function fromRemoteDir(remoteDir /*: MetadataRemoteDir */) /*: Metadata */ {
   const doc /*: Object */ = {
     docType: localDocType(remoteDir.type),
-    path: remoteDir.path.substring(1),
+    path: pathUtils.remoteToLocal(remoteDir.path),
     created_at: timestamp.roundedRemoteDate(remoteDir.created_at),
     updated_at: timestamp.roundedRemoteDate(remoteDir.updated_at)
   }
@@ -312,7 +313,7 @@ function fromRemoteDir(remoteDir /*: MetadataRemoteDir */) /*: Metadata */ {
 function fromRemoteFile(remoteFile /*: MetadataRemoteFile */) /*: Metadata */ {
   const doc /*: Object */ = {
     docType: localDocType(remoteFile.type),
-    path: remoteFile.path.substring(1),
+    path: pathUtils.remoteToLocal(remoteFile.path),
     size: parseInt(remoteFile.size, 10),
     executable: !!remoteFile.executable,
     created_at: timestamp.roundedRemoteDate(remoteFile.created_at),
@@ -564,6 +565,7 @@ function assignMaxDate(doc /*: Metadata */, was /*: ?Metadata */) {
   }
 }
 
+// TODO: move to core/utils/path and improve to compare local and remote paths safely
 function samePath(
   one /*: string|{path:string} */,
   two /*: string|{path:string} */
@@ -578,6 +580,7 @@ function samePath(
   }
 }
 
+// TODO: move to core/utils/path and improve to compare local and remote paths safely
 function areParentChildPaths(
   parent /*: string|{path:string} */,
   child /*: string|{path:string} */
@@ -592,6 +595,7 @@ function areParentChildPaths(
   }
 }
 
+// TODO: move to core/utils/path and improve to work with local and remote paths safely
 function newChildPath(
   oldChildPath /*: string */,
   oldParentPath /*: string */,
@@ -889,13 +893,11 @@ function updateRemote(
   doc /*: Metadata */,
   newRemote /*: {| path: string |}|MetadataRemoteInfo */
 ) {
-  const remotePath = newRemote.path
-
   doc.remote = _.defaultsDeep(
-    _.cloneDeep(newRemote),
     {
-      path: remotePath.startsWith('/') ? remotePath : '/' + remotePath
+      path: pathUtils.localToRemote(newRemote.path) // Works also if newRmote.path is formated as a remote path
     },
+    _.cloneDeep(newRemote),
     _.cloneDeep(doc.remote)
   )
 }

--- a/core/utils/path.js
+++ b/core/utils/path.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+const path = require('path')
+
+const localToRemote = (p /*: string */) /*: string */ =>
+  path.posix.join(path.posix.sep, ...p.split(path.sep))
+
+const remoteToLocal = (p /*: string */) /*: string */ =>
+  p.startsWith(path.posix.sep)
+    ? path.normalize(p.substring(1))
+    : path.normalize(p)
+
+module.exports = {
+  localToRemote,
+  remoteToLocal
+}

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -5,6 +5,7 @@ const path = require('path')
 
 const metadata = require('../../../../core/metadata')
 const timestamp = require('../../../../core/utils/timestamp')
+const pathUtils = require('../../../../core/utils/path')
 
 const RemoteFileBuilder = require('../remote/file')
 const RemoteDirBuilder = require('../remote/dir')
@@ -62,7 +63,7 @@ module.exports = class BaseMetadataBuilder {
   }
 
   moveTo(docpath /*: string */) /*: this */ {
-    this.doc.moveTo = docpath
+    this.doc.moveTo = path.normalize(docpath)
     this.doc._deleted = true
     return this
   }
@@ -367,6 +368,6 @@ module.exports = class BaseMetadataBuilder {
       this.doc.remote = builder.build()
     }
 
-    this.doc.remote.path = '/' + path.posix.normalize(this.doc.path)
+    this.doc.remote.path = pathUtils.localToRemote(this.doc.path)
   }
 }

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -52,7 +52,10 @@ module.exports = class RemoteBaseBuilder /*:: <T: MetadataRemoteInfo> */ {
 
   inDir(dir /*: {_id: string, path: string} */) /*: this */ {
     this.remoteDoc.dir_id = dir._id
-    this.remoteDoc.path = posix.join(dir.path, this.remoteDoc.name)
+    this.remoteDoc.path = posix.join(
+      posix.normalize(dir.path),
+      this.remoteDoc.name
+    )
     return this
   }
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -33,6 +33,7 @@ const { Ignore } = require('../../core/ignore')
 const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const stater = require('../../core/local/stater')
 const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
+const pathUtils = require('../../core/utils/path')
 
 /*::
 import type { Metadata, MetadataRemoteFile, MetadataRemoteDir } from '../../core/metadata'
@@ -77,7 +78,7 @@ describe('metadata', function() {
         updated_at: '2017-09-08T07:06:05.000Z',
         mime: 'test/html',
         name: 'bar',
-        path: 'foo/bar',
+        path: pathUtils.remoteToLocal('foo/bar'),
         dir_id: '56',
         remote: remoteDoc,
         size: 78,
@@ -115,7 +116,7 @@ describe('metadata', function() {
         docType: 'folder',
         created_at: '2017-09-07T07:06:05.000Z',
         updated_at: '2017-09-08T07:06:05.000Z',
-        path: 'foo/bar',
+        path: pathUtils.remoteToLocal('foo/bar'),
         name: 'bar',
         dir_id: '56',
         remote: remoteDoc,

--- a/test/unit/utils/path.js
+++ b/test/unit/utils/path.js
@@ -1,0 +1,58 @@
+/* @flow */
+/* eslint-env mocha */
+
+const path = require('path')
+const should = require('should')
+
+const { localToRemote, remoteToLocal } = require('../../../core/utils/path')
+
+describe('utils/path', () => {
+  describe('localToRemote', () => {
+    it('converts local paths into their remote equivalent', () => {
+      // We use path.normalize to get local paths on all platforms
+      const localRootPath = path.normalize('')
+      const localDirPath = path.normalize('dir')
+      const localFilePath = path.normalize('dir/subdir/file')
+
+      should(localToRemote(localRootPath)).equal('/')
+      should(localToRemote(localDirPath)).equal('/dir')
+      should(localToRemote(localFilePath)).equal('/dir/subdir/file')
+    })
+
+    it('keeps remote paths untouched', () => {
+      const remoteRootPath = '/'
+      const remoteDirPath = '/dir'
+      const remoteFilePath = '/dir/subdir/file'
+
+      should(localToRemote(remoteRootPath)).equal(remoteRootPath)
+      should(localToRemote(remoteDirPath)).equal(remoteDirPath)
+      should(localToRemote(remoteFilePath)).equal(remoteFilePath)
+    })
+  })
+
+  describe('remoteToLocal', () => {
+    it('converts remote paths into their local equivalent', () => {
+      const remoteRootPath = '/'
+      const remoteDirPath = '/dir'
+      const remoteFilePath = '/dir/subdir/file'
+
+      // We use path.normalize to get local paths on all platforms
+      should(remoteToLocal(remoteRootPath)).equal(path.normalize(''))
+      should(remoteToLocal(remoteDirPath)).equal(path.normalize('dir'))
+      should(remoteToLocal(remoteFilePath)).equal(
+        path.normalize('dir/subdir/file')
+      )
+    })
+
+    it('keeps local paths untouched', () => {
+      // We use path.normalize to get local paths on all platforms
+      const localRootPath = path.normalize('')
+      const localDirPath = path.normalize('dir')
+      const localFilePath = path.normalize('dir/subdir/file')
+
+      should(remoteToLocal(localRootPath)).equal(localRootPath)
+      should(remoteToLocal(localDirPath)).equal(localDirPath)
+      should(remoteToLocal(localFilePath)).equal(localFilePath)
+    })
+  })
+})


### PR DESCRIPTION
We do convert remote paths to their local counterpart and vice versa
when creating Metadata objects from remote documents for example or
when building test data from our builders.

Those paths don't have the same format:
- remote paths use a POSIX format and have a leading `/`
- local paths don't have the leading `/`
- Windows paths use a `\` as separator instead of the POSIX `/`

The Node's `path.normalize()` helper is not sufficient to convert one
format to the other when dealing with Windows paths so we introduce
our own helpers which can deal with paths on every platform we
support.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
