### PR TITLE
test/builders/metadata: Keep up-to-date sides

### DIFF
--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -700,6 +700,7 @@ describe('Move', () => {
           const doc = builders
             .metadir(oldFolder)
             .path('parent/dst/dir')
+            .unmerged('local')
             .build()
 
           await prep.moveFolderAsync('local', doc, oldFolder)
@@ -716,6 +717,7 @@ describe('Move', () => {
           const doc = builders
             .metadir(oldFolder)
             .path('.system-tmp-cozy-drive/dir')
+            .unmerged('local')
             .build()
 
           await prep.moveFolderAsync('local', doc, oldFolder)

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -24,7 +24,7 @@ var dirNumber = 1
 //     const dir: MetadataRemoteDir = await builders.remoteDir().inDir(...).create()
 //
 module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <MetadataRemoteDir> */ {
-  constructor(cozy /*: Cozy */, old /*: ?(RemoteDir|MetadataRemoteDir) */) {
+  constructor(cozy /*: ?Cozy */, old /*: ?(RemoteDir|MetadataRemoteDir) */) {
     super(cozy, old)
 
     if (!old) {

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -49,7 +49,7 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
   _data: string | stream.Readable | Buffer
   */
 
-  constructor(cozy /*: Cozy */, old /*: ?(RemoteFile|MetadataRemoteFile) */) {
+  constructor(cozy /*: ?Cozy */, old /*: ?(RemoteFile|MetadataRemoteFile) */) {
     super(cozy, old)
 
     if (!old) {

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -574,6 +574,7 @@ describe('core/local/atom/dispatch.loop()', function() {
           .path(filePath)
           .moveTo(newFilePath)
           .ino(1)
+          .upToDate()
           .create()
 
         const dst = await builders
@@ -581,6 +582,7 @@ describe('core/local/atom/dispatch.loop()', function() {
           .moveFrom(src)
           .path(newFilePath)
           .updatedAt(updatedAt)
+          .upToDate()
           .create()
         // Simulate Sync removing the moveFrom attribute after propagating the
         // remote move.
@@ -807,6 +809,7 @@ describe('core/local/atom/dispatch.loop()', function() {
           .path(directoryPath)
           .moveTo(newDirectoryPath)
           .ino(1)
+          .upToDate()
           .create()
 
         const dst = await builders
@@ -814,6 +817,7 @@ describe('core/local/atom/dispatch.loop()', function() {
           .moveFrom(src)
           .path(newDirectoryPath)
           .updatedAt(updatedAt)
+          .upToDate()
           .create()
         // Simulate Sync removing the moveFrom attribute after propagating the
         // remote move.


### PR DESCRIPTION
Our Metadata builders allow us to generate accurate Metadata objects
from scratch or built either from a remote document or another
Metadata object or even both.
However, to accommodate for a lot of different test contexts, the logic
for ensuring we have valid `local` and `remote` attributes is quite
complex and we missed a spot for built Metadata objects marked as
up-to-date (i.e. their `sides` attribute's `local` and `remote` values
are both equal to the `target` value which means the represented
document is synced).

To cover this case, we introduce 2 functions that will help us
determine if the `local` and `remote` attributes need to be updated or
should remain untouched.
These methods are meant to be modified in case new attributes should
be considered to make the decision.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
