### PR TITLE
core/metadata: Round updated remote date times

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -897,6 +897,16 @@ function updateRemote(
     {
       path: pathUtils.localToRemote(newRemote.path) // Works also if newRmote.path is formated as a remote path
     },
+    newRemote.created_at != null
+      ? {
+          created_at: timestamp.roundedRemoteDate(newRemote.created_at)
+        }
+      : {},
+    newRemote.updated_at != null
+      ? {
+          updated_at: timestamp.roundedRemoteDate(newRemote.updated_at)
+        }
+      : {},
     _.cloneDeep(newRemote),
     _.cloneDeep(doc.remote)
   )

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -34,6 +34,7 @@ const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const stater = require('../../core/local/stater')
 const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
 const pathUtils = require('../../core/utils/path')
+const timestamp = require('../../core/utils/timestamp')
 
 /*::
 import type { Metadata, MetadataRemoteFile, MetadataRemoteDir } from '../../core/metadata'
@@ -80,7 +81,11 @@ describe('metadata', function() {
         name: 'bar',
         path: pathUtils.remoteToLocal('foo/bar'),
         dir_id: '56',
-        remote: remoteDoc,
+        remote: {
+          ...remoteDoc,
+          created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
+          updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
+        },
         size: 78,
         tags: ['foo'],
         executable: false,
@@ -119,7 +124,11 @@ describe('metadata', function() {
         path: pathUtils.remoteToLocal('foo/bar'),
         name: 'bar',
         dir_id: '56',
-        remote: remoteDoc,
+        remote: {
+          ...remoteDoc,
+          created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
+          updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
+        },
         tags: ['foo']
       })
     })

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -871,10 +871,12 @@ describe('remote.Remote', function() {
             _id: old.remote._id,
             _rev: doc.remote._rev
           })
-          should(movedFile.attributes).have.properties({
-            name: 'My Cat.jpg',
-            updated_at: doc.remote.updated_at // The `remote` attribute of the PouchDB record is updated
-          })
+          should(movedFile.attributes).have.property('name', 'My Cat.jpg')
+          // The `remote` attribute of the PouchDB record is updated
+          should(doc.remote).have.property(
+            'updated_at',
+            timestamp.roundedRemoteDate(movedFile.attributes.updated_at)
+          )
         })
       }
     )
@@ -968,9 +970,13 @@ describe('remote.Remote', function() {
       it('updates the remote attribute', async function() {
         await this.remote.moveAsync(doc, old)
 
-        should(doc.remote).deepEqual(
-          await this.remote.remoteCozy.find(doc.remote._id)
-        )
+        const udpatedFile = await this.remote.remoteCozy.find(doc.remote._id)
+
+        should(doc.remote).deepEqual({
+          ...udpatedFile,
+          created_at: timestamp.roundedRemoteDate(udpatedFile.created_at),
+          updated_at: timestamp.roundedRemoteDate(udpatedFile.updated_at)
+        })
       })
     })
   })
@@ -1147,11 +1153,19 @@ describe('remote.Remote', function() {
 
       const movedFile = await this.remote.remoteCozy.find(remoteFile._id)
       await this.remote.assignNewRemote(file)
-      should(file.remote).deepEqual(movedFile)
+      should(file.remote).deepEqual({
+        ...movedFile,
+        created_at: timestamp.roundedRemoteDate(movedFile.created_at),
+        updated_at: timestamp.roundedRemoteDate(movedFile.updated_at)
+      })
 
       const movedDir = await this.remote.remoteCozy.find(remoteDir._id)
       await this.remote.assignNewRemote(dir)
-      should(dir.remote).deepEqual(movedDir)
+      should(dir.remote).deepEqual({
+        ...movedDir,
+        created_at: timestamp.roundedRemoteDate(movedDir.created_at),
+        updated_at: timestamp.roundedRemoteDate(movedDir.updated_at)
+      })
     })
   })
 


### PR DESCRIPTION
When a creation or modification date is generated by the remote Cozy,
it has a nanosecond precision, formatted as extra millisecond digits.

When those dates are converted by the Desktop client (for comparison
pruposes) via the `Date` contructor, those extra digits are simply
dropped. The resulting date is thus older than the original one.

This can prevent future requests to the Cozy to complete so we
introduced a method to round those dates up to the next millisecond
instead.
However, we used it only during the creation of documents on the
remote Cozy and forgot to use it when dealing with updated remote
documents.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
