### PR TITLE
core/local/atom: Fetch deleted local inode ASAP

### DIFF
--- a/core/local/atom/await_write_finish.js
+++ b/core/local/atom/await_write_finish.js
@@ -74,7 +74,9 @@ function countFileWriteEvents(events /*: AtomEvent[] */) /*: number */ {
 }
 
 function ino(event /*: AtomEvent */) {
-  return event.stats && (event.stats.fileid || event.stats.ino)
+  return (
+    (event.stats && (event.stats.fileid || event.stats.ino)) || event.deletedIno
+  )
 }
 
 function aggregateBatch(events) {

--- a/core/local/atom/event.js
+++ b/core/local/atom/event.js
@@ -27,6 +27,7 @@ export type AtomEvent = {
   oldPath?: string,
   _id?: string,
   stats?: Stats,
+  deletedIno?: number|string,
   md5sum?: string,
   incomplete?: bool,
   noIgnore?: bool,

--- a/core/local/atom/initial_diff.js
+++ b/core/local/atom/initial_diff.js
@@ -189,7 +189,8 @@ async function initialDiff(
               action: 'deleted',
               kind: kind(was),
               [STEP_NAME]: { inodeReuse: event },
-              path: was.path
+              path: was.path,
+              deletedIno: was.fileid || was.ino
             })
           }
         } else if (foundUntouchedFile(event, was)) {
@@ -223,7 +224,8 @@ async function initialDiff(
           const deletedEvent /*: AtomEvent */ = {
             action: 'deleted',
             kind: kind(doc),
-            path: doc.path
+            path: doc.path,
+            deletedIno: doc.fileid || doc.ino
           }
           fixPathsAfterParentMove(renamedEvents, deletedEvent)
           _.set(

--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -127,8 +127,14 @@ async function findDeletedInoRecentlyRenamed(
   }
 }
 
-async function findDeletedIno(event, pouch, unmergedRenamedEvents) {
+async function findDeletedIno(
+  event,
+  pouch,
+  unmergedRenamedEvents
+) /*: { deletedIno?: number|string, oldPaths?: string[] } */ {
   if (event.action !== 'deleted') return {}
+  if (event.deletedIno != null) return { deletedIno: event.deletedIno }
+
   // OPTIMIZE: Make .previousPaths() include event.path so we don't need a lock
   const release = await pouch.lock('winDetectMove')
   try {

--- a/test/support/builders/atom_event.js
+++ b/test/support/builders/atom_event.js
@@ -101,6 +101,18 @@ module.exports = class AtomEventBuilder {
     return this
   }
 
+  deletedIno(ino /*: number */) /*: this */ {
+    if (this._event.action === 'deleted') {
+      this._event.deletedIno = statsBuilder.platformIno(ino)
+    }
+    return this
+  }
+
+  size(newSize /*: number */) /*: this */ {
+    this._ensureStatsBuilder().size(newSize)
+    return this
+  }
+
   mtime(newMtime /*: Date */) /*: this */ {
     this._ensureStatsBuilder().mtime(newMtime)
     return this

--- a/test/support/builders/stats.js
+++ b/test/support/builders/stats.js
@@ -12,6 +12,7 @@ import type { EventKind } from '../../../core/local/atom/event'
 
 export interface StatsBuilder {
   ino (number): StatsBuilder,
+  size (number): StatsBuilder,
   kind (EventKind): StatsBuilder,
   mtime (Date) : StatsBuilder,
   ctime (Date) : StatsBuilder,
@@ -53,6 +54,11 @@ class DefaultStatsBuilder {
 
   ino(newIno /*: number */) /*: this */ {
     this.stats.ino = newIno
+    return this
+  }
+
+  size(newSize /*: number */) /*: this */ {
+    this.stats.size = newSize
     return this
   }
 
@@ -111,6 +117,11 @@ class WinStatsBuilder {
     return this
   }
 
+  size(newSize /*: number */) /*: this */ {
+    this.winStats.size = newSize
+    return this
+  }
+
   kind(newKind /*: EventKind */) /*: this */ {
     this.winStats.directory = newKind === 'directory'
     this.winStats.symbolicLink = newKind === 'symlink'
@@ -141,9 +152,17 @@ const fromStats = (baseStats /*: ?(WinStats | fs.Stats) */) => {
   return forPlatform()
 }
 
+const platformIno = (
+  ino /*: number */,
+  platform /*: string */ = process.platform
+) /*: number|string */ => {
+  return platform === 'win32' ? fileIdFromNumber(ino) : ino
+}
+
 module.exports = {
   DefaultStatsBuilder,
   WinStatsBuilder,
   fileIdFromNumber,
-  fromStats
+  fromStats,
+  platformIno
 }

--- a/test/unit/local/atom/add_infos.js
+++ b/test/unit/local/atom/add_infos.js
@@ -102,14 +102,19 @@ describe('core/local/atom/add_infos.loop()', () => {
 
   context('when deleted event kind is unknown', () => {
     context('and document exists in Pouch', () => {
+      let file, dir
       beforeEach('populate Pouch with documents', async function() {
-        await builders
+        file = await builders
           .metafile()
           .path('file')
+          .ino(1)
+          .upToDate()
           .create()
-        await builders
+        dir = await builders
           .metadir()
           .path('dir')
+          .ino(2)
+          .upToDate()
           .create()
       })
 
@@ -135,13 +140,15 @@ describe('core/local/atom/add_infos.loop()', () => {
             action: 'deleted',
             kind: 'file',
             path: 'file',
-            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' }
+            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' },
+            deletedIno: file.fileid || file.ino
           },
           {
             action: 'deleted',
             kind: 'directory',
             path: 'dir',
-            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' }
+            [addInfos.STEP_NAME]: { kindConvertedFrom: 'unknown' },
+            deletedIno: dir.fileid || dir.ino
           }
         ])
       })

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -137,14 +137,31 @@ describe('core/local/atom/dispatch.loop()', function() {
     let changeEvents
     beforeEach(() => {
       changeEvents = [
-        builders.event().build(),
-        builders.event().build(),
+        builders
+          .event()
+          .action('created')
+          .kind('file')
+          .build(),
+        builders
+          .event()
+          .action('created')
+          .kind('file')
+          .build(),
         builders
           .event()
           .action('ignored')
+          .kind('file')
           .build(), // No events for this one
-        builders.event().build(),
-        builders.event().build()
+        builders
+          .event()
+          .action('created')
+          .kind('file')
+          .build(),
+        builders
+          .event()
+          .action('created')
+          .kind('file')
+          .build()
       ]
       channel.push(changeEvents)
     })
@@ -152,14 +169,26 @@ describe('core/local/atom/dispatch.loop()', function() {
     it('emits sync-target events via the emitter', async function() {
       await dispatch.loop(channel, stepOptions).pop()
 
-      should(dispatchedCalls(events)).not.containDeep({
-        emit: [
-          ['sync-target'],
-          ['sync-target'],
-          ['sync-target'],
-          ['sync-target']
-        ]
-      })
+      // Make sure we emit exactly 4 sync-target events, one for each
+      // non-ignored event.
+      should(dispatchedCalls(events))
+        .containDeep({
+          emit: [
+            ['sync-target'],
+            ['sync-target'],
+            ['sync-target'],
+            ['sync-target']
+          ]
+        })
+        .and.not.containDeep({
+          emit: [
+            ['sync-target'],
+            ['sync-target'],
+            ['sync-target'],
+            ['sync-target'],
+            ['sync-target']
+          ]
+        })
     })
   })
 

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -515,7 +515,8 @@ describe('core/local/atom/initial_diff', () => {
             )
           },
           kind: 'directory',
-          path: foo.path
+          path: foo.path,
+          deletedIno: foo.fileid || foo.ino
         },
         {
           action: 'deleted',
@@ -526,7 +527,8 @@ describe('core/local/atom/initial_diff', () => {
             )
           },
           kind: 'file',
-          path: bar.path
+          path: bar.path,
+          deletedIno: bar.fileid || bar.ino
         },
         initialScanDone
       ])
@@ -827,6 +829,7 @@ describe('core/local/atom/initial_diff', () => {
         .pop()
 
       const deletedPath = path.normalize('parent-2/foo-2/bar')
+      const deletedIno = missingDoc.fileid || missingDoc.ino
 
       should(events).deepEqual([
         {
@@ -861,7 +864,8 @@ describe('core/local/atom/initial_diff', () => {
               oldPath: path.normalize('parent-2/foo'),
               path: foo2Scan.path
             }
-          }
+          },
+          deletedIno
         },
         initialScanDone
       ])


### PR DESCRIPTION
When `@atom/watcher` sends us a `deleted` event, it does not contain
the inode (or fileid) of the deleted document. Besides, we cannot get
it from the filesystem as it does not exist anymore.

Until now we were fetching the supposedly deleted inode from PouchDB
(via the document's path) only when needed. However, in some
situations like the application of a remote move on the local
filesystem on Windows (on Windows we detect moves by grouping
`deleted` and `created` events), it might be too late to get the
inode of the moved document from PouchDB (i.e. it has been erased
already by Sync after the change application has completed).

To mitigate this situation we now fetch the inode of locally deleted
documents as soon as we get the event in case it would be modified or
moved in PouchDB before we actually need it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
