### PR TITLE
core/local/atom: Fetch from PouchDB via local path

### DIFF
--- a/core/local/atom/add_infos.js
+++ b/core/local/atom/add_infos.js
@@ -66,7 +66,7 @@ function loop(
           } else if (needsPouchRecord(event)) {
             // Even if the doc is deleted, we probably have a better chance to
             // get the right kind by using its own.
-            const doc /*: ?Metadata */ = await opts.pouch.bySyncedPath(
+            const doc /*: ?Metadata */ = await opts.pouch.byLocalPath(
               event.path
             )
 
@@ -78,7 +78,7 @@ function loop(
             }
             // We save the deleted inode for use in other steps
             if (event.action === 'deleted' && doc) {
-              event.deletedIno = doc.fileid || doc.ino
+              event.deletedIno = doc.local.fileid || doc.local.ino
             }
           }
         }

--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -153,7 +153,7 @@ actions = {
   },
 
   renamedfile: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.bySyncedPath(event.oldPath)
+    const was /*: ?Metadata */ = await pouch.byLocalPath(event.oldPath)
     // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       if (await docWasAlreadyMoved(event.oldPath, event.path, pouch)) {
@@ -177,7 +177,7 @@ actions = {
 
     const doc = buildFile(event.path, event.stats, event.md5sum)
     if (event.overwrite) {
-      const existing = await pouch.bySyncedPath(event.path)
+      const existing = await pouch.byLocalPath(event.path)
       doc.overwrite = existing
     }
 
@@ -185,7 +185,7 @@ actions = {
   },
 
   renameddirectory: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.bySyncedPath(event.oldPath)
+    const was /*: ?Metadata */ = await pouch.byLocalPath(event.oldPath)
     // If was is marked for deletion, we'll transform it into a move.
     if (!was) {
       if (await docWasAlreadyMoved(event.oldPath, event.path, pouch)) {
@@ -213,7 +213,7 @@ actions = {
 
     const doc = buildDir(event.path, event.stats)
     if (event.overwrite) {
-      const existing = await pouch.bySyncedPath(event.path)
+      const existing = await pouch.byLocalPath(event.path)
       doc.overwrite = existing
     }
 
@@ -221,7 +221,7 @@ actions = {
   },
 
   deletedfile: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.bySyncedPath(event.path)
+    const was /*: ?Metadata */ = await pouch.byLocalPath(event.path)
     if (!was || was.deleted) {
       log.debug({ event }, 'Assuming file already removed')
       // The file was already marked as deleted in pouchdb
@@ -233,7 +233,7 @@ actions = {
   },
 
   deleteddirectory: async (event, { pouch, prep }) => {
-    const was /*: ?Metadata */ = await pouch.bySyncedPath(event.path)
+    const was /*: ?Metadata */ = await pouch.byLocalPath(event.path)
     if (!was || was.deleted) {
       log.debug({ event }, 'Assuming dir already removed')
       // The dir was already marked as deleted in pouchdb
@@ -259,7 +259,7 @@ async function docWasAlreadyMoved(
   pouch /*: Pouch */
 ) /*: Promise<boolean> */ {
   try {
-    const existing = await pouch.bySyncedPath(dst)
+    const existing = await pouch.byLocalPath(dst)
     if (!existing) return false
 
     const previous = await pouch.getPreviousRev(existing._id, 1)

--- a/core/local/atom/incomplete_fixer.js
+++ b/core/local/atom/incomplete_fixer.js
@@ -268,7 +268,7 @@ function step(
           // (e.g. a temporary document now renamed), we'll want to make sure the old
           // document is removed to avoid having 2 documents with the same inode.
           // We can do this by keeping the completing renamed event.
-          const incompleteForExistingDoc /*: ?Metadata */ = await opts.pouch.bySyncedPath(
+          const incompleteForExistingDoc /*: ?Metadata */ = await opts.pouch.byLocalPath(
             item.event.path
           )
           if (

--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -106,9 +106,9 @@ async function findDeletedInoByPath(
   dpath,
   pouch
 ) /*: Promise<?{ deletedIno: ?number|string }> */ {
-  const doc /*: ?Metadata */ = await pouch.bySyncedPath(dpath)
-  if (doc && !doc.deleted) {
-    return { deletedIno: doc.fileid || doc.ino }
+  const doc /*: ?Metadata */ = await pouch.byLocalPath(dpath)
+  if (doc) {
+    return { deletedIno: doc.local.fileid || doc.local.ino }
   }
 }
 
@@ -117,10 +117,10 @@ async function findDeletedInoRecentlyRenamed(
   pouch
 ) /*: Promise<?{ deletedIno: ?number|string, oldPaths: string[] }> */ {
   for (const [index, previousPath] of previousPaths.entries()) {
-    const doc /*: ?Metadata */ = await pouch.bySyncedPath(previousPath)
-    if (doc && !doc.deleted) {
+    const doc /*: ?Metadata */ = await pouch.byLocalPath(previousPath)
+    if (doc) {
       return {
-        deletedIno: doc.fileid || doc.ino,
+        deletedIno: doc.local.fileid || doc.local.ino,
         oldPaths: previousPaths.slice(index)
       }
     }

--- a/core/local/atom/win_identical_renaming.js
+++ b/core/local/atom/win_identical_renaming.js
@@ -30,7 +30,7 @@ type WinIdenticalRenamingState = {
 }
 
 type PouchFunctions = {
-  bySyncedPath: (string) => Promise<?Metadata>
+  byLocalPath: (string) => Promise<?Metadata>
 }
 
 type WinIdenticalRenamingOptions = {
@@ -88,9 +88,9 @@ const indexDeletedEvent = (event, state) => {
 }
 
 /** Possibly fix oldPath when event is identical renamed. */
-const fixIdenticalRenamed = async (event, { bySyncedPath }) => {
+const fixIdenticalRenamed = async (event, { byLocalPath }) => {
   if (event.path === event.oldPath) {
-    const doc /*: ?Metadata */ = await bySyncedPath(event.path)
+    const doc /*: ?Metadata */ = await byLocalPath(event.path)
 
     if (doc && !doc.deleted && doc.path !== event.oldPath) {
       _.set(event, [STEP_NAME, 'oldPathBeforeFix'], event.oldPath)

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -210,6 +210,15 @@ class Pouch {
     return this.put(_.defaults({ _deleted: true }, doc))
   }
 
+  // This method lets us completely erase a document from PouchDB while removing
+  // all attributes that could get picked up by Sync the next time the document
+  // shows up in the changesfeed (erasing documents generates changes) and thus
+  // result in an attempt to take action.
+  // This method also does not care about invariants like `remove()` does.
+  eraseDocument({ _id, _rev } /*: SavedMetadata */) {
+    return this.db.put({ _id, _rev, _deleted: true })
+  }
+
   // WARNING: bulkDocs is not a transaction, some updates can be applied while
   // others do not.
   // Make sure lock is acquired before using it to avoid conflict.
@@ -631,7 +640,7 @@ class Pouch {
   }
 }
 
-const byPathKey = fpath => {
+const byPathKey = (fpath /*: string */) /*: [string, string] */ => {
   const normalized = metadata.id(fpath)
   const parts = normalized.split(path.sep)
   const name = parts.pop()
@@ -646,4 +655,4 @@ const sortByPath = (docA, docB) => {
   return 0
 }
 
-module.exports = { Pouch }
+module.exports = { Pouch, byPathKey }

--- a/core/prep.js
+++ b/core/prep.js
@@ -180,14 +180,11 @@ class Prep {
   // TODO add comments + tests
   async trashFileAsync(
     side /*: SideName */,
-    was /*: {path: string} */,
+    was /*: SavedMetadata|{path: string} */,
     doc /*: ?Metadata */
   ) {
     log.debug({ path: doc && doc.path, oldpath: was.path }, 'trashFileAsync')
     metadata.ensureValidPath(was)
-    const trashed = {
-      path: was.path
-    }
 
     if (!doc) {
       doc = clone(was)
@@ -199,20 +196,17 @@ class Prep {
     doc.docType = 'file'
 
     // TODO metadata.shouldIgnore
-    return this.merge.trashFileAsync(side, trashed, doc)
+    return this.merge.trashFileAsync(side, was, doc)
   }
 
   // TODO add comments + tests
   async trashFolderAsync(
     side /*: SideName */,
-    was /*: {path: string} */,
+    was /*: SavedMetadata|{path: string} */,
     doc /*: ?Metadata */
   ) {
     log.debug({ path: doc && doc.path, oldpath: was.path }, 'trashFolderAsync')
     metadata.ensureValidPath(was)
-    const trashed = {
-      path: was.path
-    }
 
     if (!doc) {
       doc = clone(was)
@@ -224,7 +218,7 @@ class Prep {
     doc.docType = 'folder'
 
     // TODO metadata.shouldIgnore
-    return this.merge.trashFolderAsync(side, trashed, doc)
+    return this.merge.trashFolderAsync(side, was, doc)
   }
 
   // Expectations:

--- a/gui/notes/index.js
+++ b/gui/notes/index.js
@@ -30,7 +30,7 @@ const localDoc = async (
   { config, pouch } /*: { config: Config, pouch: Pouch } */
 ) /*: Promise<Metadata> */ => {
   const relPath = path.relative(config.syncPath, filePath)
-  const doc = await pouch.bySyncedPath(relPath)
+  const doc = await pouch.byLocalPath(relPath)
   if (!doc || doc.deleted) {
     throw new CozyDocumentMissingError({
       cozyURL: config.cozyUrl,

--- a/test/integration/sync_state.js
+++ b/test/integration/sync_state.js
@@ -39,9 +39,9 @@ describe('Sync state', () => {
       ['sync-start'],
       // FIXME: 3 attempts to download a missing file
       // FIXME: in debug.log with DEBUG=1: Sync: Seq was already synced! (seq=0)
-      ['sync-current', 4], // XXX: update seq includes design docs creation
-      ['sync-current', 5],
+      ['sync-current', 5], // XXX: update seq includes design docs creation
       ['sync-current', 6],
+      ['sync-current', 7],
       ['sync-end']
     ])
   })

--- a/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
+++ b/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runWithStoppedClient } = require('../../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '../..' */
 
 module.exports = ({
@@ -44,7 +46,24 @@ module.exports = ({
       'dst/dir/subdir/subsub/',
       'src/'
     ],
-    trash: ['deletedFile', 'file', 'file (__cozy__: ...)'],
+    trash:
+      process.platform !== 'darwin' && runWithStoppedClient()
+        ? [
+            // Since we're merging here, the destination directories are kept while
+            // the source ones are trashed as initialDiff won't find them.
+            // On macOS, the local events are sorted so the children will be
+            // trashed first and the then empty parent directories will be
+            // completely erased from the Cozy.
+            // On Linux and Windows, events will be processed in path order so
+            // the parents will be trashed first. Since they're not empty at
+            // that point they will remain in the remote trash.
+            'dir/',
+            'dir/deletedFile',
+            'dir/subdir/',
+            'file',
+            'file (__cozy__: ...)'
+          ]
+        : ['deletedFile', 'file', 'file (__cozy__: ...)'],
     contents: {
       'dst/dir/deletedFile': 'should be kept',
       'dst/dir/file': 'overwriter',

--- a/test/scenarios/move_replace_then_edit_moved_file/remote/changes.json
+++ b/test/scenarios/move_replace_then_edit_moved_file/remote/changes.json
@@ -1,0 +1,86 @@
+[
+  {
+    "_id": "cbb3a5ef2ccde3b8fc6e07b82d372323",
+    "_rev": "1-d4344377ef319989a7726156bf388664",
+    "class": "text",
+    "cozyMetadata": {
+      "createdAt": "2021-02-11T16:18:59.140067866Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-02-11T16:18:59.140067866Z",
+      "updatedByApps": [
+        {
+          "date": "2021-02-11T16:18:59.140067866Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-02-11T16:18:59.140067866Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "b6e003719af69912d43deb6e85e0fe28",
+          "kind": "",
+          "name": "test-4"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-02-11T16:18:59.084Z",
+    "dir_id": "cbb3a5ef2ccde3b8fc6e07b82d371d57",
+    "executable": false,
+    "md5sum": "lsFcK7KSEZO/KQ34zYXiug==",
+    "mime": "text/plain",
+    "name": "file",
+    "size": "11",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2021-02-11T16:18:59.084Z",
+    "path": "/src/file"
+  },
+  {
+    "_id": "cbb3a5ef2ccde3b8fc6e07b82d371e2d",
+    "_rev": "3-398527bac1cd2b45e8566bca49754f7f",
+    "class": "text",
+    "cozyMetadata": {
+      "createdAt": "2021-02-11T16:18:56.967059352Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-02-11T16:18:59.722622052Z",
+      "updatedByApps": [
+        {
+          "date": "2021-02-11T16:18:59.722622052Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-02-11T16:18:56.967059352Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "b6e003719af69912d43deb6e85e0fe28",
+          "kind": "",
+          "name": "test-4"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-02-11T17:18:56Z",
+    "dir_id": "cbb3a5ef2ccde3b8fc6e07b82d37191e",
+    "executable": false,
+    "md5sum": "peMo42/hVYOSS7d/xT4A9Q==",
+    "mime": "text/plain",
+    "name": "file",
+    "size": "15",
+    "tags": [],
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2021-02-11T16:18:59.665Z",
+    "path": "/dst/file"
+  }
+]

--- a/test/scenarios/move_replace_then_edit_moved_file/scenario.js
+++ b/test/scenarios/move_replace_then_edit_moved_file/scenario.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  useCaptures: false,
+  // XXX: This scenario does not work on the local side yet as it generates name
+  // conflicts on the Cozy.
+  side: 'remote',
+  init: [
+    { ino: 1, path: 'dst/' },
+    { ino: 2, path: 'src/' },
+    { ino: 3, path: 'src/file', content: 'initial content' }
+  ],
+  actions: [
+    { type: 'mv', src: 'src/file', dst: 'dst/file' },
+    { type: 'wait', ms: 500 },
+    { type: 'create_file', path: 'src/file', content: 'new content' },
+    { type: 'wait', ms: 500 },
+    { type: 'update_file', path: 'dst/file', content: 'updated content' },
+    { type: 'wait', ms: 1500 }
+  ],
+  expected: {
+    tree: ['dst/', 'dst/file', 'src/', 'src/file'],
+    trash: [],
+    contents: {
+      'dst/file': 'updated content',
+      'src/file': 'new content'
+    }
+  }
+} /*: Scenario */)

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -510,25 +510,25 @@ describe('core/local/atom/initial_diff', () => {
           action: 'deleted',
           initialDiff: {
             notFound: _.defaults(
-              { kind: kind(foo) },
-              _.pick(foo, ['path', 'md5sum', 'updated_at'])
+              { kind: kind(bar), path: bar.local.path },
+              _.pick(bar, ['md5sum', 'updated_at'])
             )
           },
-          kind: 'directory',
-          path: foo.path,
-          deletedIno: foo.fileid || foo.ino
+          kind: 'file',
+          path: bar.local.path,
+          deletedIno: bar.local.fileid || bar.local.ino
         },
         {
           action: 'deleted',
           initialDiff: {
             notFound: _.defaults(
-              { kind: kind(bar) },
-              _.pick(bar, ['path', 'md5sum', 'updated_at'])
+              { kind: kind(foo), path: foo.local.path },
+              _.pick(foo, ['md5sum', 'updated_at'])
             )
           },
-          kind: 'file',
-          path: bar.path,
-          deletedIno: bar.fileid || bar.ino
+          kind: 'directory',
+          path: foo.local.path,
+          deletedIno: foo.local.fileid || foo.local.ino
         },
         initialScanDone
       ])
@@ -829,7 +829,7 @@ describe('core/local/atom/initial_diff', () => {
         .pop()
 
       const deletedPath = path.normalize('parent-2/foo-2/bar')
-      const deletedIno = missingDoc.fileid || missingDoc.ino
+      const deletedIno = missingDoc.local.fileid || missingDoc.local.ino
 
       should(events).deepEqual([
         {

--- a/test/unit/local/atom/overwrite.js
+++ b/test/unit/local/atom/overwrite.js
@@ -6,7 +6,6 @@ const should = require('should')
 
 const Channel = require('../../../../core/local/atom/channel')
 const overwrite = require('../../../../core/local/atom/overwrite')
-const metadata = require('../../../../core/metadata')
 
 const Builders = require('../../../support/builders')
 
@@ -23,28 +22,8 @@ describe('core/local/atom/overwrite', () => {
 
     beforeEach(() => {
       builders = new Builders()
-      const docs = {
-        'SRC/FILE': builders
-          .metafile()
-          .path('src/file')
-          .ino(1)
-          .build(),
-        'SRC/DIR': builders
-          .metadir()
-          .path('src/dir')
-          .ino(2)
-          .build(),
-        'DST/FILE': builders
-          .metafile()
-          .path('dst/file')
-          .ino(3)
-          .build()
-      }
       inputChannel = new Channel()
       outputChannel = overwrite.loop(inputChannel, {
-        pouch: {
-          bySyncedPath: async path => _.cloneDeep(docs[metadata.id(path)])
-        },
         state: overwrite.initialState()
       })
     })

--- a/test/unit/local/atom/win_identical_renaming.js
+++ b/test/unit/local/atom/win_identical_renaming.js
@@ -37,7 +37,7 @@ if (process.platform === 'win32') {
         inputChannel = new Channel()
         outputChannel = winIdenticalRenaming.loop(inputChannel, {
           pouch: {
-            bySyncedPath: async path => _.cloneDeep(docs[metadata.id(path)])
+            byLocalPath: async path => _.cloneDeep(docs[metadata.id(path)])
           },
           state: winIdenticalRenaming.initialState()
         })

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -4211,40 +4211,73 @@ describe('Merge', function() {
     })
 
     context('when a record marked for deletion is found in Pouch', () => {
-      it('keeps the deletion marker and updates sides info', async function() {
-        const was = await builders
-          .metafile()
-          .deleted()
-          .changedSide(otherSide(this.side))
-          .create()
-        const doc = builders
-          .metafile(was)
-          .trashed()
-          .unmerged(this.side)
-          .build()
+      context('and the record was modified on the other side', () => {
+        it('completely erases the document from PouchDB', async function() {
+          const was = await builders
+            .metafile()
+            .deleted()
+            .changedSide(otherSide(this.side))
+            .create()
+          const doc = builders
+            .metafile(was)
+            .trashed()
+            .unmerged(this.side)
+            .build()
 
-        const sideEffects = await mergeSideEffects(this, () =>
-          this.merge.trashFileAsync(
-            this.side,
-            _.cloneDeep(was),
-            _.cloneDeep(doc)
-          )
-        )
-
-        should(sideEffects).deepEqual({
-          savedDocs: [
-            _.defaults(
-              {
-                // We increase the side by 2 since the other side was increased
-                // when `was` was marked for deletion
-                sides: increasedSides(was.sides, this.side, 2),
-                [this.side]: doc[this.side],
-                deleted: true
-              },
-              _.omit(was, ['_id', '_rev'])
+          const sideEffects = await mergeSideEffects(this, () =>
+            this.merge.trashFileAsync(
+              this.side,
+              _.cloneDeep(was),
+              _.cloneDeep(doc)
             )
-          ],
-          resolvedConflicts: []
+          )
+
+          should(sideEffects).deepEqual({
+            savedDocs: [
+              {
+                // _id and _rev are removed from sideEffects
+                _deleted: true
+              }
+            ],
+            resolvedConflicts: []
+          })
+        })
+      })
+
+      context('and the record was modified on the same side', () => {
+        it('keeps the deletion marker and updates sides info', async function() {
+          const was = await builders
+            .metafile()
+            .deleted()
+            .changedSide(this.side)
+            .create()
+          const doc = builders
+            .metafile(was)
+            .trashed()
+            .unmerged(this.side)
+            .build()
+
+          const sideEffects = await mergeSideEffects(this, () =>
+            this.merge.trashFileAsync(
+              this.side,
+              _.cloneDeep(was),
+              _.cloneDeep(doc)
+            )
+          )
+
+          should(sideEffects).deepEqual({
+            savedDocs: [
+              _.defaults(
+                {
+                  sides: increasedSides(was.sides, this.side, 1),
+                  [this.side]: doc[this.side],
+                  deleted: true
+                },
+                _.omit(was, ['_id', '_rev'])
+              )
+            ],
+            resolvedConflicts: []
+          })
         })
       })
     })
@@ -4411,40 +4444,73 @@ describe('Merge', function() {
     })
 
     context('when a record marked for deletion is found in Pouch', () => {
-      it('keeps the deletion marker and updates sides info', async function() {
-        const was = await builders
-          .metadir()
-          .deleted()
-          .changedSide(otherSide(this.side))
-          .create()
-        const doc = builders
-          .metadir(was)
-          .trashed()
-          .unmerged(this.side)
-          .build()
+      context('and the record was modified on the other side', () => {
+        it('completely erases the record from PouchDB', async function() {
+          const was = await builders
+            .metadir()
+            .deleted()
+            .changedSide(otherSide(this.side))
+            .create()
+          const doc = builders
+            .metadir(was)
+            .trashed()
+            .unmerged(this.side)
+            .build()
 
-        const sideEffects = await mergeSideEffects(this, () =>
-          this.merge.trashFolderAsync(
-            this.side,
-            _.cloneDeep(was),
-            _.cloneDeep(doc)
-          )
-        )
-
-        should(sideEffects).deepEqual({
-          savedDocs: [
-            _.defaults(
-              {
-                // We increase the side by 2 since the other side was increased
-                // when `was` was marked for deletion
-                sides: increasedSides(was.sides, this.side, 2),
-                [this.side]: doc[this.side],
-                deleted: true
-              },
-              _.omit(was, ['_id', '_rev'])
+          const sideEffects = await mergeSideEffects(this, () =>
+            this.merge.trashFolderAsync(
+              this.side,
+              _.cloneDeep(was),
+              _.cloneDeep(doc)
             )
-          ],
-          resolvedConflicts: []
+          )
+
+          should(sideEffects).deepEqual({
+            savedDocs: [
+              {
+                // _id and _rev are removed from sideEffects
+                _deleted: true
+              }
+            ],
+            resolvedConflicts: []
+          })
+        })
+      })
+
+      context('and the record was modified on the same side', () => {
+        it('keeps the deletion marker and updates sides info', async function() {
+          const was = await builders
+            .metadir()
+            .deleted()
+            .changedSide(this.side)
+            .create()
+          const doc = builders
+            .metadir(was)
+            .trashed()
+            .unmerged(this.side)
+            .build()
+
+          const sideEffects = await mergeSideEffects(this, () =>
+            this.merge.trashFolderAsync(
+              this.side,
+              _.cloneDeep(was),
+              _.cloneDeep(doc)
+            )
+          )
+
+          should(sideEffects).deepEqual({
+            savedDocs: [
+              _.defaults(
+                {
+                  sides: increasedSides(was.sides, this.side, 1),
+                  [this.side]: doc[this.side],
+                  deleted: true
+                },
+                _.omit(was, ['_id', '_rev'])
+              )
+            ],
+            resolvedConflicts: []
+          })
         })
       })
     })

--- a/test/unit/prep.js
+++ b/test/unit/prep.js
@@ -353,22 +353,7 @@ describe('Prep', function() {
   })
 
   describe('trashFileAsync', () => {
-    it('merges the metadata with an _id and a docType', async function() {
-      const doc = {
-        path: 'file-to-be-trashed',
-        md5sum: 'rcg7GeeTSRscbqD9i0bNnw=='
-      }
-      await this.prep.trashFileAsync(this.side, doc, doc)
-
-      should(this.merge.trashFileAsync).be.calledOnce()
-      should(this.merge.trashFileAsync).be.calledWith(
-        this.side,
-        { path: doc.path },
-        { ...doc, trashed: true, docType: 'file' }
-      )
-    })
-
-    it('throws when path is invalid', async function() {
+    it('throws when the trashed path is invalid', async function() {
       const doc = { path: '/' }
 
       return this.prep
@@ -385,16 +370,12 @@ describe('Prep', function() {
       await this.prep.trashFileAsync(this.side, was)
 
       should(this.merge.trashFileAsync).be.calledOnce()
-      should(this.merge.trashFileAsync).be.calledWith(
-        this.side,
-        { path: was.path },
-        {
-          ...was,
-          path: path.join(TRASH_DIR_NAME, was.path),
-          trashed: true,
-          docType: 'file'
-        }
-      )
+      should(this.merge.trashFileAsync).be.calledWith(this.side, was, {
+        ...was,
+        path: path.join(TRASH_DIR_NAME, was.path),
+        trashed: true,
+        docType: 'file'
+      })
     })
 
     // FIXME
@@ -408,20 +389,7 @@ describe('Prep', function() {
   })
 
   describe('trashFolderAsync', () => {
-    it('merges the metadata with an _id and a docType', async function() {
-      const doc = { path: 'folder-to-be-trashed' }
-
-      await this.prep.trashFolderAsync(this.side, doc, doc)
-
-      should(this.merge.trashFolderAsync).be.calledOnce()
-      should(this.merge.trashFolderAsync).be.calledWith(
-        this.side,
-        { path: doc.path },
-        { ...doc, trashed: true, docType: 'folder' }
-      )
-    })
-
-    it('throws when path is invalid', async function() {
+    it('throws when the trashed path is invalid', async function() {
       const doc = { path: '/' }
 
       return this.prep
@@ -435,16 +403,12 @@ describe('Prep', function() {
       await this.prep.trashFolderAsync(this.side, was)
 
       should(this.merge.trashFolderAsync).be.calledOnce()
-      should(this.merge.trashFolderAsync).be.calledWith(
-        this.side,
-        { path: was.path },
-        {
-          ...was,
-          path: path.join(TRASH_DIR_NAME, was.path),
-          trashed: true,
-          docType: 'folder'
-        }
-      )
+      should(this.merge.trashFolderAsync).be.calledWith(this.side, was, {
+        ...was,
+        path: path.join(TRASH_DIR_NAME, was.path),
+        trashed: true,
+        docType: 'folder'
+      })
     })
 
     // FIXME


### PR DESCRIPTION
In a number of the local Atom watcher, we try to fetch the PouchDB
record associated with the events we're processing. We use for that
the events' paths as the record key.

However, the record itself has 3 different path values:
- a local path
- a remote path
- a "main" path, modified by Merge each time it's changed either
  locally or remotely (i.e. the document was renamed or moved)

This means that fetching the record from the local watcher via its
main path can return unexpected results (the wrong record, more than
one records or no records at all) if the document was moved or renamed
remotely and this information was merged but not fully applied.
We're usually in this situation when we're actually applying the
remote path change to the local filesystem and processing the events
fired by this application.

In some cases, it is crucial that those events are processed correctly
to not detect and propagate to the remote Cozy changes that were not
done by the user (e.g. when a file was moved then replaced or edited
on the remote Cozy, we could end up trashing the new doc on the Cozy).

By matching the local events' paths with the local path or PouchDB
records, we make sure the appropriate record is returned in these
situations if fetched before it is updated by Sync after the remote
change was successfully applied on the filesystem. This shouldn't be a
problem as the steps needing this kind of information come first (e.g.
`add_infos` which needs the record to find the inode of `deleted`
events).
We use the same request across the other steps to make sure we stay
coherent.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
