### PR TITLE
core/remote: Don't sanitize doc names in requests

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -210,7 +210,10 @@ class RemoteCozy {
                  executable: boolean|} */
   ) /*: Promise<MetadataRemoteFile> */ {
     return this._withUnhandledRejectionProtection(options, async () => {
-      const file = await this.client.files.create(data, options)
+      const file = await this.client.files.create(data, {
+        ...options,
+        noSanitize: true
+      })
       return this.toRemoteDoc(file)
     })
   }
@@ -221,7 +224,10 @@ class RemoteCozy {
                  createdAt: string,
                  updatedAt: string|} */
   ) /*: Promise<MetadataRemoteDir> */ {
-    const folder = await this.client.files.createDirectory(options)
+    const folder = await this.client.files.createDirectory({
+      ...options,
+      noSanitize: true
+    })
     return this.toRemoteDoc(folder)
   }
 
@@ -236,7 +242,10 @@ class RemoteCozy {
                  ifMatch: string|} */
   ) /*: Promise<MetadataRemoteFile> */ {
     return this._withUnhandledRejectionProtection(options, async () => {
-      const updated = await this.client.files.updateById(id, data, options)
+      const updated = await this.client.files.updateById(id, data, {
+        ...options,
+        noSanitize: true
+      })
       return this.toRemoteDoc(updated)
     })
   }
@@ -249,11 +258,10 @@ class RemoteCozy {
                updated_at: string|} */,
     options /*: {|ifMatch: string|} */
   ) /*: Promise<MetadataRemoteInfo> */ {
-    const updated = await this.client.files.updateAttributesById(
-      id,
-      attrs,
-      options
-    )
+    const updated = await this.client.files.updateAttributesById(id, attrs, {
+      ...options,
+      noSanitize: true
+    })
     return this.toRemoteDoc(updated)
   }
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "chai-like": "^1.1.1",
     "chokidar": "^3.5.0",
     "cozy-client": "^14.6.0",
-    "cozy-client-js": "^0.17.4",
+    "cozy-client-js": "^0.18.0",
     "cozy-stack-client": "^14.1.2",
     "deep-diff": "^1.0.2",
     "dtrace-provider": "^0.8.8",

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -42,7 +42,8 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
           name: this.remoteDoc.name,
           dirID: this.remoteDoc.dir_id,
           createdAt: this.remoteDoc.created_at,
-          updatedAt: this.remoteDoc.updated_at
+          updatedAt: this.remoteDoc.updated_at,
+          noSanitize: true
         })
       )
     )

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -110,7 +110,8 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
           executable: this.remoteDoc.executable,
           createdAt: this.remoteDoc.created_at,
           updatedAt: this.remoteDoc.updated_at || this.remoteDoc.created_at,
-          name: this.remoteDoc.name
+          name: this.remoteDoc.name,
+          noSanitize: true
         })
       )
     )
@@ -144,7 +145,8 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
           dirID: this.remoteDoc.dir_id,
           executable: this.remoteDoc.executable,
           updatedAt: this.remoteDoc.updated_at,
-          name: this.remoteDoc.name
+          name: this.remoteDoc.name,
+          noSanitize: true
         })
       )
     )

--- a/test/support/builders/remote/note.js
+++ b/test/support/builders/remote/note.js
@@ -131,7 +131,8 @@ module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder /*:: <Metadat
       metadata: this.remoteDoc.metadata,
       contentType: this.remoteDoc.mime,
       createdAt: this.remoteDoc.created_at,
-      updatedAt: this.remoteDoc.updated_at || this.remoteDoc.created_at
+      updatedAt: this.remoteDoc.updated_at || this.remoteDoc.created_at,
+      noSanitize: true
     })
     const remoteFile /*: RemoteFile */ = _.clone(jsonApiToRemoteDoc(data))
     remoteFile._rev = data.meta.rev
@@ -159,7 +160,8 @@ module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder /*:: <Metadat
         await cozy.files.updateById(this.remoteDoc._id, this._data, {
           dirID: this.remoteDoc.dir_id,
           updatedAt: this.remoteDoc.updated_at,
-          name: this.remoteDoc.name
+          name: this.remoteDoc.name,
+          noSanitize: true
         })
       )
     )

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -72,6 +72,32 @@ describe('RemoteCozy', function() {
   })
 
   describe('createFile', () => {
+    context('when the name starts or ends with a space', () => {
+      it('creates the file with the given name', async () => {
+        should(
+          await remoteCozy.createFile(
+            builders
+              .stream()
+              .push('')
+              .build(),
+            {
+              name: ' foo ',
+              dirID: ROOT_DIR_ID,
+              contentType: 'text/plain',
+              contentLength: 0,
+              checksum: '1B2M2Y8AsgTpgAmY7PhCfg==', // md5sum of an empty file
+              executable: false,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString()
+            }
+          )
+        ).have.properties({
+          type: 'file',
+          name: ' foo '
+        })
+      })
+    })
+
     context(
       'when the request fails with an unhandled promise rejection',
       () => {
@@ -146,7 +172,58 @@ describe('RemoteCozy', function() {
     )
   })
 
+  describe('createDirectory', () => {
+    context('when the name starts or ends with a space', () => {
+      it('creates the directory with the given name', async () => {
+        should(
+          await remoteCozy.createDirectory({
+            name: ' foo ',
+            dirID: ROOT_DIR_ID,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          })
+        ).have.properties({
+          type: 'directory',
+          name: ' foo '
+        })
+      })
+    })
+  })
+
   describe('updateFileById', () => {
+    context('when the name starts or ends with a space', () => {
+      it('updates the file with the given name', async () => {
+        const remoteFile = await builders
+          .remoteFile()
+          .inRootDir()
+          .name(' foo ')
+          .data('initial content')
+          .create()
+
+        should(
+          await remoteCozy.updateFileById(
+            remoteFile._id,
+            builders
+              .stream()
+              .push('')
+              .build(),
+            {
+              contentType: 'text/plain',
+              contentLength: 0,
+              checksum: '1B2M2Y8AsgTpgAmY7PhCfg==', // md5sum of an empty file
+              executable: false,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString()
+            }
+          )
+        ).have.properties({
+          type: 'file',
+          name: ' foo ',
+          md5sum: '1B2M2Y8AsgTpgAmY7PhCfg=='
+        })
+      })
+    })
+
     context(
       'when the request fails with an unhandled promise rejection',
       () => {
@@ -204,6 +281,29 @@ describe('RemoteCozy', function() {
         })
       }
     )
+  })
+
+  describe('updateAttributesById', () => {
+    context('when the name starts or ends with a space', () => {
+      it('updates the file with the given name', async () => {
+        const remoteFile = await builders
+          .remoteFile()
+          .inRootDir()
+          .name(' foo')
+          .data('initial content')
+          .create()
+
+        should(
+          await remoteCozy.updateAttributesById(remoteFile._id, {
+            name: 'bar ',
+            updatedAt: new Date().toISOString()
+          })
+        ).have.properties({
+          type: 'file',
+          name: 'bar '
+        })
+      })
+    })
   })
 
   describe('changes', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,19 +1615,19 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
   integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-js@^3.6.5:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.0.tgz#790b1bb11553a2272b36e2625c7179db345492f8"
+  integrity sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cozy-client-js@^0.17.4:
-  version "0.17.4"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.17.4.tgz#58b2b112da2486299c118d5a11480f763b0ce347"
-  integrity sha512-Lt6XjlES6PipWBZd/5pT6qnvuGtH5bfJ6OpmTok3ooJb8vmPQdh/V//9JaV2ajAtbEpsnfO8K3kZSHfmQRehLA==
+cozy-client-js@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.18.0.tgz#68e40f6206bc51ef1a60eb91637136b3337292a4"
+  integrity sha512-PXkyBLACDGvN6GnVsy+GLMKT4CQhafP0JaBHY9dSV25g0316hMGKwgzkKl2PTWuAO6Sc/7tPxi+kk2HD9YmJ7g==
   dependencies:
     core-js "^3.6.5"
     cross-fetch "^3.0.6"


### PR DESCRIPTION
By default `cozy-client-js` will sanitize the names of documents (i.e.
trim them) when sending requests to the remote Cozy.
This is a problem for the Desktop client as we won't update local
names if their remote counterparts were sanitized and we can end up
with missing parent documents or other similar errors.

Since v0.18.0, `cozy-client-js` has a `noSanitize` option for all
requests that would sanitize names by default. If this option is
passed and set to `true`, `cozy-client-js` will refrain from
sanitizing.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
