### PR TITLE
core/remote: Send file size via query-string

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -14,10 +14,9 @@ const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
 const conflicts = require('../utils/conflicts')
 const metadata = require('../metadata')
-const { RemoteCozy, FetchError } = require('./cozy')
+const { RemoteCozy } = require('./cozy')
 const { RemoteWarningPoller } = require('./warning_poller')
 const { RemoteWatcher } = require('./watcher')
-const errors = require('./errors')
 const timestamp = require('../utils/timestamp')
 
 /*::
@@ -157,17 +156,6 @@ class Remote /*:: implements Reader, Writer */ {
     // FIXME: stop creating parent folder and manage missing parent error
     const dir = await this.remoteCozy.findOrCreateDirectoryByPath(dirPath)
 
-    if (!(await this.hasEnoughSpace(doc))) {
-      throw new errors.RemoteError({
-        code: errors.NO_COZY_SPACE_CODE,
-        message: 'Not enough space available on remote Cozy',
-        err: new FetchError(
-          { status: 413 },
-          'The file is too big and exceeds the disk quota'
-        )
-      })
-    }
-
     const created = await this.remoteCozy.createFile(stream, {
       ...newDocumentAttributes(name, dir._id, doc.updated_at),
       checksum: doc.md5sum,
@@ -205,17 +193,6 @@ class Remote /*:: implements Reader, Writer */ {
         return doc
       }
       throw err
-    }
-
-    if (!(await this.hasEnoughSpace(doc))) {
-      throw new errors.RemoteError({
-        code: errors.NO_COZY_SPACE_CODE,
-        message: 'Not enough space available on remote Cozy',
-        err: new FetchError(
-          { status: 413 },
-          'The file is too big and exceeds the disk quota'
-        )
-      })
     }
 
     // Object.assign gives us the opportunity to enforce required options with

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "chai-like": "^1.1.1",
     "chokidar": "^3.5.0",
     "cozy-client": "^14.6.0",
-    "cozy-client-js": "^0.18.0",
+    "cozy-client-js": "^0.19.0",
     "cozy-stack-client": "^14.1.2",
     "deep-diff": "^1.0.2",
     "dtrace-provider": "^0.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,10 +1624,10 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cozy-client-js@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.18.0.tgz#68e40f6206bc51ef1a60eb91637136b3337292a4"
-  integrity sha512-PXkyBLACDGvN6GnVsy+GLMKT4CQhafP0JaBHY9dSV25g0316hMGKwgzkKl2PTWuAO6Sc/7tPxi+kk2HD9YmJ7g==
+cozy-client-js@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.19.0.tgz#ccfb0572d6c6f3aa7c187978c23dd89f04caf796"
+  integrity sha512-3EPLxLu7mg/GSmAHauW7rfdVMynCQb9Yj1vHvDO1Rpda/CV0xN04HRH1eq+3HhZiIx1g1L76zSh0jN1shgCknQ==
   dependencies:
     core-js "^3.6.5"
     cross-fetch "^3.0.6"


### PR DESCRIPTION
Since Electron prevents us from setting the `Content-Length` header
when uploading a file as a chunked request, the stack cannot respond
with an error right away when the file is either larger than the max
file size or the available space on the Cozy.
This means we have to wait until the end of the request to get that
response back thus wasting time and resources.

As a workaround, we were checking if the Cozy had enough space before
making the request but this has 2 major flaws:
- we make an extra request to the server each time we try to upload a
  file (or retry)
- the available space can change between the time we make this request
  and the upload one

However, the stack can now read the file size from the `Size`
query-string parameter as well as the `Content-Length` header and
`cozy-client-js` v0.19.0 is now sending this parameter with upload
requests.
Simply upgrading `cozy-client-js` gives us back the early checks we
used to have prior to Electron v7 and we can remove the extra request
to check the available disk space.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
