### PR TITLE
core/sync: Handle 4xx remote errors

### DIFF
--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -17,6 +17,7 @@ export type { FetchError }
 const CONFLICTING_NAME_CODE = 'ConflictingName'
 const COZY_CLIENT_REVOKED_CODE = 'CozyClientRevoked'
 const INVALID_METADATA_CODE = 'InvalidMetadata'
+const MISSING_DOCUMENT_CODE = 'MissingDocument'
 const MISSING_PARENT_CODE = 'MissingParent'
 const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
 const NEEDS_REMOTE_MERGE_CODE = 'NeedsRemoteMerge'
@@ -167,6 +168,12 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
           message: 'Cozy client is missing permissions (lack disk-usage?)',
           err
         })
+      case 404:
+        return new RemoteError({
+          code: MISSING_DOCUMENT_CODE,
+          message: 'The updated document is missing on the remote Cozy',
+          err
+        })
       case 409:
         return new RemoteError({
           code: CONFLICTING_NAME_CODE,
@@ -221,6 +228,7 @@ module.exports = {
   CONFLICTING_NAME_CODE,
   COZY_CLIENT_REVOKED_CODE,
   INVALID_METADATA_CODE,
+  MISSING_DOCUMENT_CODE,
   MISSING_PARENT_CODE,
   MISSING_PERMISSIONS_CODE,
   NEEDS_REMOTE_MERGE_CODE,

--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -17,6 +17,7 @@ export type { FetchError }
 const CONFLICTING_NAME_CODE = 'ConflictingName'
 const COZY_CLIENT_REVOKED_CODE = 'CozyClientRevoked'
 const INVALID_METADATA_CODE = 'InvalidMetadata'
+const INVALID_NAME_CODE = 'InvalidName'
 const MISSING_DOCUMENT_CODE = 'MissingDocument'
 const MISSING_PARENT_CODE = 'MissingParent'
 const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
@@ -204,11 +205,20 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
           err
         })
       case 422:
-        return new RemoteError({
-          code: INVALID_METADATA_CODE,
-          message: 'The local metadata for the document is corrupted',
-          err
-        })
+        if (sourceParameter(err) === 'name') {
+          return new RemoteError({
+            code: INVALID_NAME_CODE,
+            message:
+              'The name of the document contains characters forbidden by the remote Cozy',
+            err
+          })
+        } else {
+          return new RemoteError({
+            code: INVALID_METADATA_CODE,
+            message: 'The local metadata for the document is corrupted',
+            err
+          })
+        }
       default:
         // TODO: Merge with UnreachableError?!
         return new RemoteError({
@@ -245,6 +255,7 @@ module.exports = {
   CONFLICTING_NAME_CODE,
   COZY_CLIENT_REVOKED_CODE,
   INVALID_METADATA_CODE,
+  INVALID_NAME_CODE,
   MISSING_DOCUMENT_CODE,
   MISSING_PARENT_CODE,
   MISSING_PERMISSIONS_CODE,

--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -3,6 +3,8 @@
  * @flow
  */
 
+const { DirectoryNotFound } = require('./cozy')
+
 /*::
 import type { RemoteChange } from './change'
 import type { MetadataChange } from '../sync'
@@ -15,6 +17,7 @@ export type { FetchError }
 const CONFLICTING_NAME_CODE = 'ConflictingName'
 const COZY_CLIENT_REVOKED_CODE = 'CozyClientRevoked'
 const INVALID_METADATA_CODE = 'InvalidMetadata'
+const MISSING_PARENT_CODE = 'MissingParent'
 const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
 const NEEDS_REMOTE_MERGE_CODE = 'NeedsRemoteMerge'
 const NO_COZY_SPACE_CODE = 'NoCozySpace'
@@ -197,6 +200,12 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
           err
         })
     }
+  } else if (err instanceof DirectoryNotFound) {
+    return new RemoteError({
+      code: MISSING_PARENT_CODE,
+      message: '',
+      err
+    })
   } else if (err instanceof RemoteError) {
     return err
   } else {
@@ -212,6 +221,7 @@ module.exports = {
   CONFLICTING_NAME_CODE,
   COZY_CLIENT_REVOKED_CODE,
   INVALID_METADATA_CODE,
+  MISSING_PARENT_CODE,
   MISSING_PERMISSIONS_CODE,
   NEEDS_REMOTE_MERGE_CODE,
   NO_COZY_SPACE_CODE,

--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -16,6 +16,7 @@ export type { FetchError }
 
 const CONFLICTING_NAME_CODE = 'ConflictingName'
 const COZY_CLIENT_REVOKED_CODE = 'CozyClientRevoked'
+const INVALID_FOLDER_MOVE_CODE = 'InvalidFolderMove'
 const INVALID_METADATA_CODE = 'InvalidMetadata'
 const INVALID_NAME_CODE = 'InvalidName'
 const MISSING_DOCUMENT_CODE = 'MissingDocument'
@@ -191,6 +192,14 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
             message: 'The known remote document revision is outdated',
             err
           })
+        } else if (sourceParameter(err) === 'dir-id') {
+          // The directory is asked to move to one of its sub-directories
+          return new RemoteError({
+            code: INVALID_FOLDER_MOVE_CODE,
+            message:
+              'The folder would be moved wihtin one of its sub-folders on the remote Cozy',
+            err
+          })
         } else {
           // Invalid hash or content length error
           return new RemoteError({
@@ -262,6 +271,7 @@ module.exports = {
   COZY_CLIENT_REVOKED_MESSAGE, // FIXME: should be removed once gui/main does not use it anymore
   CONFLICTING_NAME_CODE,
   COZY_CLIENT_REVOKED_CODE,
+  INVALID_FOLDER_MOVE_CODE,
   INVALID_METADATA_CODE,
   INVALID_NAME_CODE,
   MISSING_DOCUMENT_CODE,

--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -23,6 +23,7 @@ const MISSING_PARENT_CODE = 'MissingParent'
 const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
 const NEEDS_REMOTE_MERGE_CODE = 'NeedsRemoteMerge'
 const NO_COZY_SPACE_CODE = 'NoCozySpace'
+const PATH_TOO_DEEP_CODE = 'PathTooDeep'
 const UNKNOWN_REMOTE_ERROR_CODE = 'UnknownRemoteError'
 const UNREACHABLE_COZY_CODE = 'UnreachableCozy'
 const USER_ACTION_REQUIRED_CODE = 'UserActionRequired'
@@ -212,6 +213,13 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
               'The name of the document contains characters forbidden by the remote Cozy',
             err
           })
+        } else if (sourceParameter(err) === 'path') {
+          return new RemoteError({
+            code: PATH_TOO_DEEP_CODE,
+            message:
+              'The path of the document has too many levels for the remote Cozy',
+            err
+          })
         } else {
           return new RemoteError({
             code: INVALID_METADATA_CODE,
@@ -261,6 +269,7 @@ module.exports = {
   MISSING_PERMISSIONS_CODE,
   NEEDS_REMOTE_MERGE_CODE,
   NO_COZY_SPACE_CODE,
+  PATH_TOO_DEEP_CODE,
   UNKNOWN_REMOTE_ERROR_CODE,
   UNREACHABLE_COZY_CODE,
   USER_ACTION_REQUIRED_CODE,

--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -14,6 +14,7 @@ export type { FetchError }
 
 const CONFLICTING_NAME_CODE = 'ConflictingName'
 const COZY_CLIENT_REVOKED_CODE = 'CozyClientRevoked'
+const INVALID_METADATA_CODE = 'InvalidMetadata'
 const MISSING_PERMISSIONS_CODE = 'MissingPermissions'
 const NEEDS_REMOTE_MERGE_CODE = 'NeedsRemoteMerge'
 const NO_COZY_SPACE_CODE = 'NoCozySpace'
@@ -182,6 +183,12 @@ const wrapError = (err /*: FetchError |  Error */) /*: RemoteError */ => {
           message: 'Not enough space available on remote Cozy',
           err
         })
+      case 422:
+        return new RemoteError({
+          code: INVALID_METADATA_CODE,
+          message: 'The local metadata for the document is corrupted',
+          err
+        })
       default:
         // TODO: Merge with UnreachableError?!
         return new RemoteError({
@@ -204,6 +211,7 @@ module.exports = {
   COZY_CLIENT_REVOKED_MESSAGE, // FIXME: should be removed once gui/main does not use it anymore
   CONFLICTING_NAME_CODE,
   COZY_CLIENT_REVOKED_CODE,
+  INVALID_METADATA_CODE,
   MISSING_PERMISSIONS_CODE,
   NEEDS_REMOTE_MERGE_CODE,
   NO_COZY_SPACE_CODE,

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -125,8 +125,11 @@ const wrapError = (
   sideName /*: SideName */,
   { doc } /*: { doc: SavedMetadata } */ = {}
 ) => {
-  if (sideName === 'remote') {
-    // The RemoteError code will be reused
+  if (sideName === 'remote' || err.name === 'FetchError') {
+    // FetchErrors can be raised from the LocalWriter when failing to download a
+    // file for example. In this case the sideName will be "local" but the error
+    // name will still be "FetchError".
+    // If err is a RemoteError, its code will be reused.
     return new SyncError({ sideName, err: remoteErrors.wrapError(err), doc })
   } else if (err.code && ['EACCES', 'EPERM', 'EBUSY'].includes(err.code)) {
     return new SyncError({ sideName, err, code: MISSING_PERMISSIONS_CODE, doc })

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -93,11 +93,6 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
       case remoteErrors.NO_COZY_SPACE_CODE:
         return 10000
 
-      case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
-      case remoteErrors.CONFLICTING_NAME_CODE:
-        // We want to make sure the remote watcher has run before retrying
-        return REMOTE_HEARTBEAT
-
       case remoteErrors.UNREACHABLE_COZY_CODE:
         return 10000
 
@@ -107,6 +102,8 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
       default:
         // Arbutrary value to make sure we don't retry too soon and overload the
         // server with requests.
+        // This also gives us the opportunity to merge new remote changes and
+        // fix errors.
         return REMOTE_HEARTBEAT
     }
   } else {

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -366,6 +366,7 @@ class Sync {
       const syncErr = syncErrors.wrapError(err, sideName, change)
       if (
         [
+          remoteErrors.INVALID_FOLDER_MOVE_CODE,
           remoteErrors.INVALID_METADATA_CODE,
           remoteErrors.MISSING_DOCUMENT_CODE
         ].includes(syncErr.code)
@@ -383,6 +384,7 @@ class Sync {
       switch (syncErr.code) {
         case syncErrors.MISSING_PERMISSIONS_CODE:
         case syncErrors.NO_DISK_SPACE_CODE:
+        case remoteErrors.INVALID_FOLDER_MOVE_CODE:
         case remoteErrors.INVALID_METADATA_CODE:
         case remoteErrors.INVALID_NAME_CODE:
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
@@ -802,6 +804,7 @@ class Sync {
       case remoteErrors.UNKNOWN_REMOTE_ERROR_CODE:
         break
       case remoteErrors.CONFLICTING_NAME_CODE:
+      case remoteErrors.INVALID_FOLDER_MOVE_CODE:
       case remoteErrors.MISSING_DOCUMENT_CODE:
       case remoteErrors.MISSING_PARENT_CODE:
         // Hide the conflict from the user as we can solve it by ourselves

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -387,6 +387,7 @@ class Sync {
         case remoteErrors.INVALID_NAME_CODE:
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
         case remoteErrors.NO_COZY_SPACE_CODE:
+        case remoteErrors.PATH_TOO_DEEP_CODE:
         case remoteErrors.UNREACHABLE_COZY_CODE:
         case remoteErrors.USER_ACTION_REQUIRED_CODE:
           // We will keep retrying to apply the change until it's fixed or the

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -368,7 +368,8 @@ class Sync {
         [
           remoteErrors.INVALID_FOLDER_MOVE_CODE,
           remoteErrors.INVALID_METADATA_CODE,
-          remoteErrors.MISSING_DOCUMENT_CODE
+          remoteErrors.MISSING_DOCUMENT_CODE,
+          remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE
         ].includes(syncErr.code)
       ) {
         log.error(
@@ -390,6 +391,7 @@ class Sync {
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
         case remoteErrors.NO_COZY_SPACE_CODE:
         case remoteErrors.PATH_TOO_DEEP_CODE:
+        case remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE:
         case remoteErrors.UNREACHABLE_COZY_CODE:
         case remoteErrors.USER_ACTION_REQUIRED_CODE:
           // We will keep retrying to apply the change until it's fixed or the

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -364,17 +364,25 @@ class Sync {
       // `apply()` and some expect `updateErrors` to be called (e.g. when
       // applying a move with a failing content change).
       const syncErr = syncErrors.wrapError(err, sideName, change)
-      log.warn(
-        { err: syncErr, change, path: change.doc.path },
-        `Sync error: ${syncErr.message}`
-      )
+      if (syncErr.code === remoteErrors.INVALID_METADATA_CODE) {
+        log.error(
+          { err: syncErr, change, path, sentry: true },
+          `Sync error: ${syncErr.message}`
+        )
+      } else {
+        log.warn(
+          { err: syncErr, change, path },
+          `Sync error: ${syncErr.message}`
+        )
+      }
       switch (syncErr.code) {
         case syncErrors.MISSING_PERMISSIONS_CODE:
         case syncErrors.NO_DISK_SPACE_CODE:
-        case remoteErrors.NO_COZY_SPACE_CODE:
+        case remoteErrors.INVALID_METADATA_CODE:
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
-        case remoteErrors.USER_ACTION_REQUIRED_CODE:
+        case remoteErrors.NO_COZY_SPACE_CODE:
         case remoteErrors.UNREACHABLE_COZY_CODE:
+        case remoteErrors.USER_ACTION_REQUIRED_CODE:
           // We will keep retrying to apply the change until it's fixed or the
           // user contacts our support.
           // We increment the record's errors counter to keep track of the

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -384,6 +384,7 @@ class Sync {
         case syncErrors.MISSING_PERMISSIONS_CODE:
         case syncErrors.NO_DISK_SPACE_CODE:
         case remoteErrors.INVALID_METADATA_CODE:
+        case remoteErrors.INVALID_NAME_CODE:
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
         case remoteErrors.NO_COZY_SPACE_CODE:
         case remoteErrors.UNREACHABLE_COZY_CODE:

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -369,7 +369,8 @@ class Sync {
           remoteErrors.INVALID_FOLDER_MOVE_CODE,
           remoteErrors.INVALID_METADATA_CODE,
           remoteErrors.MISSING_DOCUMENT_CODE,
-          remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE
+          remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE,
+          remoteErrors.UNKNOWN_REMOTE_ERROR_CODE
         ].includes(syncErr.code)
       ) {
         log.error(
@@ -392,6 +393,7 @@ class Sync {
         case remoteErrors.NO_COZY_SPACE_CODE:
         case remoteErrors.PATH_TOO_DEEP_CODE:
         case remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE:
+        case remoteErrors.UNKNOWN_REMOTE_ERROR_CODE:
         case remoteErrors.UNREACHABLE_COZY_CODE:
         case remoteErrors.USER_ACTION_REQUIRED_CODE:
           // We will keep retrying to apply the change until it's fixed or the
@@ -803,13 +805,11 @@ class Sync {
       case remoteErrors.UNREACHABLE_COZY_CODE:
         this.events.emit('offline')
         break
-      case remoteErrors.UNKNOWN_REMOTE_ERROR_CODE:
-        break
       case remoteErrors.CONFLICTING_NAME_CODE:
       case remoteErrors.INVALID_FOLDER_MOVE_CODE:
       case remoteErrors.MISSING_DOCUMENT_CODE:
       case remoteErrors.MISSING_PARENT_CODE:
-        // Hide the conflict from the user as we can solve it by ourselves
+        // Hide the error from the user as we should be able to solve it
         break
       default:
         this.events.emit(

--- a/gui/elm/Data/UserAction.elm
+++ b/gui/elm/Data/UserAction.elm
@@ -299,6 +299,17 @@ view code =
             , label = Nothing
             }
 
+        "PathTooDeep" ->
+            { title = "Error Document path with too many levels"
+            , details =
+                [ "Error The {0} `{1}`'s path has too many levels (i.e. parent folders) for your Cozy."
+                , "Error Try removing some parent levels or moving it to antoher folder."
+                ]
+            , primaryInteraction = Retry "UserAction Retry"
+            , secondaryInteraction = Nothing
+            , label = Nothing
+            }
+
         "UserActionRequired" ->
             { title = "CGUUpdated The ToS have been updated"
             , details =

--- a/gui/elm/Data/UserAction.elm
+++ b/gui/elm/Data/UserAction.elm
@@ -310,6 +310,17 @@ view code =
             , label = Nothing
             }
 
+        "UnknownRemoteError" ->
+            { title = "Error Unhandled synchronization error"
+            , details =
+                [ "Error We encountered an unhandled error while trying to synchronise the {0} `{1}`."
+                , "Error Please contact our support to get help."
+                ]
+            , primaryInteraction = Retry "UserAction Retry"
+            , secondaryInteraction = Nothing
+            , label = Nothing
+            }
+
         "UserActionRequired" ->
             { title = "CGUUpdated The ToS have been updated"
             , details =

--- a/gui/elm/Data/UserAction.elm
+++ b/gui/elm/Data/UserAction.elm
@@ -244,6 +244,17 @@ view code =
             , label = Nothing
             }
 
+        "InvalidName" ->
+            { title = "Error Invalid document name"
+            , details =
+                [ "Error The {0} `{1}`'s name contains characters forbidden by your Cozy."
+                , "Error Try renaming it without using the following characters: / \u{0000} \n \u{000D}."
+                ]
+            , primaryInteraction = Retry "UserAction Retry"
+            , secondaryInteraction = Nothing
+            , label = Nothing
+            }
+
         "MissingPermissions" ->
             { title = "Error Access denied temporarily"
             , details =

--- a/gui/elm/Data/UserAction.elm
+++ b/gui/elm/Data/UserAction.elm
@@ -233,6 +233,17 @@ type alias UserActionView =
 view : String -> UserActionView
 view code =
     case code of
+        "InvalidMetadata" ->
+            { title = "Error Invalid document metadata"
+            , details =
+                [ "Error The {0} `{1}`'s metadata cannot be accepted by your Cozy."
+                , "Error This message persists if the local metadata of your document is corrupted. In this case try to move it out of the Cozy Drive folder and back again or contact support for help on the procedure."
+                ]
+            , primaryInteraction = Retry "UserAction Retry"
+            , secondaryInteraction = Nothing
+            , label = Nothing
+            }
+
         "MissingPermissions" ->
             { title = "Error Access denied temporarily"
             , details =

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -675,25 +675,6 @@ describe('Sync', function() {
       should(actual.sides).deepEqual({ target: 5, local: 2, remote: 5 })
       should(metadata.isUpToDate('remote', actual)).be.true()
     })
-
-    it('stops retrying after 3 errors', async function() {
-      const doc = await builders
-        .metadata()
-        .path('third/failure')
-        .errors(3)
-        .sides({ remote: 4 })
-        .create()
-
-      await this.sync.updateErrors(
-        { doc },
-        localSyncError('simulated error', doc)
-      )
-
-      const actual = await this.pouch.bySyncedPath(doc.path)
-      should(actual.errors).equal(3)
-      should(actual._rev).equal(doc._rev)
-      should(metadata.isUpToDate('remote', actual)).be.true()
-    })
   })
 
   for (const syncSide of ['local', 'remote']) {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -410,9 +410,16 @@ describe('Sync', function() {
           this.sync.blockSyncFor.restore()
         })
 
-        it('keeps sides unchanged', async function() {
-          const synced = await this.pouch.bySyncedPath(file.path)
-          should(synced.sides).deepEqual(merged.sides)
+        it('keeps the out-of-date side', async function() {
+          const outOfDateSide = metadata.outOfDateSide(merged)
+          const synced = await this.pouch.bySyncedPath(merged.path)
+          should(metadata.outOfDateSide(synced)).equal(outOfDateSide)
+        })
+
+        it('increases the record errors counter', async function() {
+          const errors = merged.errors || 0
+          const synced = await this.pouch.bySyncedPath(merged.path)
+          should(synced.errors).equal(errors + 1)
         })
 
         it('does not skip the change by saving seq', async function() {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -833,7 +833,7 @@ describe('Sync', function() {
       beforeEach(function() {
         this.sync.blockSyncFor({
           err: remoteErrors.wrapError(
-            new FetchError({ status: 404 }, 'UnreachableCozy test error')
+            new FetchError({ status: 500 }, 'UnreachableCozy test error')
           )
         })
       })


### PR DESCRIPTION
We specifically handle 4xx remote errors (i.e. Fetch errors with a 
status code between 400 and 499) so that they won't show up as an 
unreachable Cozy to the user.

When we can, we provide new errors messages to help the user figure out
how to fix the issue and resume the synchronization.

Some errors will be sent to Sentry so we can try to solve them before
too many users encounter them.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation