### PR TITLE
core/remote/watcher: Deleted file move is move

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -333,7 +333,6 @@ class RemoteWatcher {
 
     if (
       was &&
-      was.remote &&
       metadata.extractRevNumber(was.remote) >=
         metadata.extractRevNumber(doc.remote)
     ) {
@@ -380,10 +379,9 @@ class RemoteWatcher {
       return remoteChange.trashed(doc, was)
     }
 
-    if (!was || was.deleted) {
+    if (!was || inRemoteTrash(was.remote)) {
       return remoteChange.added(doc)
-    }
-    if (metadata.samePath(was, doc)) {
+    } else if (metadata.samePath(was, doc)) {
       if (
         doc.docType === 'file' &&
         doc.md5sum === was.md5sum &&

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -2398,6 +2398,35 @@ describe('RemoteWatcher', function() {
       })
     })
 
+    describe('file moved while deleted on local filesystem', () => {
+      it('returns a FileMove', function() {
+        const origFile = builders
+          .remoteFile()
+          .name('foo')
+          .build()
+        const trashedFile = builders
+          .metafile()
+          .fromRemote(origFile)
+          .deleted()
+          .changedSide('local')
+          .build()
+        const movedFile = builders
+          .remoteFile(origFile)
+          .name('bar')
+          .build()
+
+        const doc = metadata.fromRemoteDoc(movedFile)
+
+        should(
+          this.watcher.identifyChange(movedFile, trashedFile, [], [])
+        ).have.properties({
+          sideName: 'remote',
+          type: 'FileMove',
+          doc
+        })
+      })
+    })
+
     describe('added file', () => {
       let addedRemoteFile
 


### PR DESCRIPTION
In a effort to consolidate the `trashed` and `deleted` attribute usage
we replaced a condition in the remote watcher based on the `trashed`
attribute to use the `deleted` attribute.
This condition was meant to treat "new" remote records for documents
previously trashed as additions.
While we still want this behavior, the usage of the `deleted`
attribute goes against another desired behavior which is to cancel the
local deletion of documents which were moved on the remote Cozy.

To accommodate both we go back to using the `trashed` attribute via a
call to the `inRemoteTrash()` helper which carries more meaning than
  the `trashed` attribute alone.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
