### PR TITLE
core: Sync `sides` attribute with side attributes

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -197,7 +197,7 @@ class Merge {
     }
 
     // We create it at the destination location as a normal local file
-    metadata.markAsNew(doc)
+    metadata.markAsUnmerged(doc)
     metadata.dissociateRemote(doc)
     metadata.removeNoteMetadata(doc)
     return this.addFileAsync('local', doc)
@@ -441,8 +441,9 @@ class Merge {
 
     if (!metadata.wasSynced(was) || was.deleted) {
       metadata.markAsUnsyncable(was)
-      metadata.markAsNew(doc)
       await this.pouch.put(was)
+
+      metadata.markAsUnmerged(doc)
       return this.addFileAsync(side, doc)
     } else if (was.sides && was.sides[side]) {
       metadata.assignMaxDate(doc, was)
@@ -537,8 +538,9 @@ class Merge {
 
     if (!metadata.wasSynced(was)) {
       metadata.markAsUnsyncable(was)
-      metadata.markAsNew(doc)
       await this.pouch.put(was)
+
+      metadata.markAsUnmerged(doc)
       return this.putFolderAsync(side, doc)
     }
 

--- a/core/merge.js
+++ b/core/merge.js
@@ -199,6 +199,7 @@ class Merge {
     // We create it at the destination location as a normal local file
     metadata.markAsUnmerged(doc)
     metadata.dissociateRemote(doc)
+    metadata.markSide('local', doc)
     metadata.removeNoteMetadata(doc)
     return this.addFileAsync('local', doc)
   }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -514,11 +514,19 @@ function markAsUnsyncable(doc /*: SavedMetadata */) {
   doc._deleted = true
 }
 
-function markAsUnmerged(doc /*: Metadata|SavedMetadata */) {
+function markAsUnmerged(
+  doc /*: Metadata|SavedMetadata */,
+  sideName /*: SideName */
+) {
   removeActionHints(doc)
   if (doc._id) delete doc._id
   if (doc._rev) delete doc._rev
   if (doc._deleted) delete doc._deleted
+  if (sideName === 'local') {
+    dissociateRemote(doc)
+  } else {
+    dissociateLocal(doc)
+  }
 }
 
 function markAsUpToDate /*:: <T: Metadata|SavedMetadata> */(doc /*: T */) {

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -170,7 +170,7 @@ module.exports = {
   removeNoteMetadata,
   dissociateRemote,
   dissociateLocal,
-  markAsNew,
+  markAsUnmerged,
   markAsUnsyncable,
   markAsUpToDate,
   samePath,
@@ -516,7 +516,7 @@ function markAsUnsyncable(doc /*: SavedMetadata */) {
   doc._deleted = true
 }
 
-function markAsNew(doc /*: Metadata|SavedMetadata */) {
+function markAsUnmerged(doc /*: Metadata|SavedMetadata */) {
   removeActionHints(doc)
   if (doc._id) delete doc._id
   if (doc._rev) delete doc._rev

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -381,6 +381,9 @@ function ensureValidPath(doc /*: {path: string} */) {
 }
 
 function invariants /*:: <T: Metadata|SavedMetadata> */(doc /*: T */) {
+  // If the record is meant to be erased we don't care about invariants
+  if (doc._deleted && !doc.moveTo) return doc
+
   let err
   if (!doc.sides) {
     err = new Error(`Metadata has no sides`)
@@ -480,12 +483,7 @@ function isAtLeastUpToDate(sideName /*: SideName */, doc /*: Metadata */) {
 }
 
 function removeActionHints(doc /*: Metadata */) {
-  if (doc.sides) {
-    // We remove parts of sides individually because of the invariant on sides
-    if (doc.sides.local) delete doc.sides.local
-    if (doc.sides.remote) delete doc.sides.remote
-    if (doc.sides.target) delete doc.sides.target
-  }
+  if (doc.sides) delete doc.sides
   if (doc.moveFrom) delete doc.moveFrom
   if (doc.moveTo) delete doc.moveTo
 }

--- a/core/move.js
+++ b/core/move.js
@@ -84,6 +84,6 @@ function convertToDestinationAddition(
   metadata.markAsUnsyncable(src)
 
   // Create destination
-  metadata.markAsUnmerged(dst)
+  metadata.markAsUnmerged(dst, side)
   metadata.markSide(side, dst)
 }

--- a/core/move.js
+++ b/core/move.js
@@ -84,6 +84,6 @@ function convertToDestinationAddition(
   metadata.markAsUnsyncable(src)
 
   // Create destination
-  metadata.markAsNew(dst)
+  metadata.markAsUnmerged(dst)
   metadata.markSide(side, dst)
 }

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -174,8 +174,11 @@ class Pouch {
         row =>
           !row.key.startsWith('_') && // Filter out design docs
           !row.doc.deleted && // Filter out docs already marked for deletion
+          // Keep only docs that have existed locally
           row.doc.sides &&
-          row.doc.sides.local // Keep only docs that have existed locally
+          row.doc.sides.local &&
+          // Make sure the returned docs do have a local attribute
+          row.doc.local
       )
       .map(row => row.doc)
       .sort(sortByPath)
@@ -651,10 +654,10 @@ const byPathKey = (fpath /*: string */) /*: [string, string] */ => {
   return [parentPath, name]
 }
 
-const sortByPath = (docA, docB) => {
+const sortByPath = (docA /*: SavedMetadata */, docB /*: SavedMetadata */) => {
   if (docA.path < docB.path) return -1
   if (docA.path > docB.path) return 1
   return 0
 }
 
-module.exports = { Pouch, byPathKey }
+module.exports = { Pouch, byPathKey, sortByPath }

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -185,9 +185,8 @@ class Pouch {
     doc /*: T */
   ) /*: Promise<SavedMetadata> */ {
     metadata.invariants(doc)
-    const { local, remote } = doc.sides
     log.debug(
-      { path: doc.path, local, remote, _deleted: doc._deleted, doc },
+      { path: doc.path, _deleted: doc._deleted, doc },
       'Saving metadata...'
     )
     if (!doc._id) {

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -230,6 +230,37 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 9,
+    targetSchemaVersion: 10,
+    description: 'Cleanup corrupted record sides',
+    affectedDocs: (docs /*: SavedMetadata[] */) /*: SavedMetadata[] */ => {
+      return docs.filter(
+        doc =>
+          doc.sides &&
+          ((doc.sides.local && !doc.local) || (doc.sides.remote && !doc.remote))
+      )
+    },
+    run: (docs /*: SavedMetadata[] */) /*: SavedMetadata[] */ => {
+      return docs.map(doc => {
+        if (doc.sides.local && !doc.local) {
+          // Remove local side when no local attribute exists
+          delete doc.sides.local
+        }
+        if (doc.sides.remote && !doc.remote) {
+          // Remove remote side when no remote attribute exists
+          delete doc.sides.remote
+        }
+        if (!doc.sides.local && !doc.sides.remote) {
+          // Erase record is no sides are remaining
+          doc._deleted = true
+        }
+        // Remove errors, in case this would result in a new Sync attempt
+        delete doc.errors
+        return doc
+      })
+    }
   }
 ]
 

--- a/test/property/runner.js
+++ b/test/property/runner.js
@@ -34,6 +34,7 @@ async function step(state /*: Object */, op /*: Object */) {
         dbPath: { name: state.name, adapter: 'memory' },
         syncPath: state.dir.root
       }
+      // $FlowFixMe expects a Config object here
       state.pouchdb = new Pouch(state.config)
       await state.pouchdb.addAllViews()
     // break omitted intentionally

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -1493,10 +1493,9 @@ describe('Merge', function() {
         savedDocs: [
           _.defaults(
             {
-              _deleted: true,
-              sides: {}
+              _deleted: true
             },
-            _.omit(synced, ['_id', '_rev', 'local', 'remote'])
+            _.omit(synced, ['_id', '_rev', 'sides', 'local', 'remote'])
           ),
           _.defaults(
             {
@@ -2150,10 +2149,9 @@ describe('Merge', function() {
 
       const unsyncedFile = _.defaults(
         {
-          sides: {},
           _deleted: true
         },
-        _.omit(was, ['_id', '_rev', 'local', 'remote'])
+        _.omit(was, ['_id', '_rev', 'sides', 'local', 'remote'])
       )
       const fileAddition = _.defaults(
         {
@@ -2195,10 +2193,9 @@ describe('Merge', function() {
 
       const unsyncedFile = _.defaults(
         {
-          sides: {},
           _deleted: true
         },
-        _.omit(was, ['_id', '_rev', 'local', 'remote'])
+        _.omit(was, ['_id', '_rev', 'sides', 'local', 'remote'])
       )
       const fileAddition = _.defaults(
         {
@@ -2653,10 +2650,9 @@ describe('Merge', function() {
 
       const unsyncedFolder = _.defaults(
         {
-          sides: {},
           _deleted: true
         },
-        _.omit(was, ['_id', '_rev', 'fileid', 'local', 'remote'])
+        _.omit(was, ['_id', '_rev', 'fileid', 'sides', 'local', 'remote'])
       )
       const folderAddition = _.defaults(
         {
@@ -2697,10 +2693,9 @@ describe('Merge', function() {
 
       const unsyncedFolder = _.defaults(
         {
-          sides: {},
           _deleted: true
         },
-        _.omit(was, ['_id', '_rev', 'fileid', 'local', 'remote'])
+        _.omit(was, ['_id', '_rev', 'fileid', 'sides', 'local', 'remote'])
       )
       const folderAddition = _.defaults(
         {
@@ -3336,10 +3331,9 @@ describe('Merge', function() {
             ),
             _.defaults(
               {
-                sides: {},
                 _deleted: true
               },
-              _.omit(unsyncedFile, ['_id', '_rev', 'remote'])
+              _.omit(unsyncedFile, ['_id', '_rev', 'sides', 'remote'])
             ),
             _.defaults(
               {
@@ -3412,10 +3406,9 @@ describe('Merge', function() {
             ),
             _.defaults(
               {
-                sides: {},
                 _deleted: true
               },
-              _.omit(unsyncedFile, ['_id', '_rev', 'local'])
+              _.omit(unsyncedFile, ['_id', '_rev', 'sides', 'local'])
             ),
             _.defaults(
               {


### PR DESCRIPTION
The historical `sides.local` and `sides.remote` attributes are hints
used in conjunction with `sides.target` to tell the synchronization
process on which side changes should be applied.
But we now also have `local` and `remote` attributes which store the
document's metadata on the given side (i.e. the local filesystem or
the remote Cozy).

Each side attribute (i.e. `local` or `remote`) should only exist on a
record if there is a matching `sides.remote` attribute and vice versa.

We take measures to make sure this is true in the future and that
existing records are cleaned up.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
