### PR TITLE
WIP: Clear all caches when OS resumes from sleep

### DIFF
--- a/core/local/chokidar/initial_scan.js
+++ b/core/local/chokidar/initial_scan.js
@@ -7,7 +7,7 @@
 const chokidarEvent = require('./event')
 const logger = require('../../utils/logger')
 const metadata = require('../../metadata')
-const { SYNC_DIR_EMPTY_MESSAGE } = require('../../')
+const { SYNC_DIR_EMPTY_MESSAGE } = require('../errors')
 
 const log = logger({
   component: 'chokidar/initial_scan'

--- a/core/local/errors.js
+++ b/core/local/errors.js
@@ -1,0 +1,12 @@
+/**
+ * @module core/local/errors
+ * @flow
+ */
+
+const SYNC_DIR_EMPTY_MESSAGE = 'Syncdir is empty'
+const SYNC_DIR_UNLINKED_MESSAGE = 'Syncdir has been unlinked'
+
+module.exports = {
+  SYNC_DIR_EMPTY_MESSAGE,
+  SYNC_DIR_UNLINKED_MESSAGE
+}

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -55,9 +55,6 @@ export type LocalOptions = {
 }
 */
 
-const SYNC_DIR_EMPTY_MESSAGE = 'Syncdir is empty'
-const SYNC_DIR_UNLINKED_MESSAGE = 'Syncdir has been unlinked'
-
 /** `Local` is the class that interfaces cozy-desktop with the local filesystem.
  *
  * It uses a watcher, based on chokidar, to listen for file and folder changes.
@@ -488,7 +485,5 @@ class Local /*:: implements Reader, Writer */ {
 }
 
 module.exports = {
-  SYNC_DIR_EMPTY_MESSAGE,
-  SYNC_DIR_UNLINKED_MESSAGE,
   Local
 }

--- a/core/local/sync_dir.js
+++ b/core/local/sync_dir.js
@@ -6,7 +6,7 @@
 
 const fs = require('fs')
 
-const { SYNC_DIR_UNLINKED_MESSAGE } = require('./')
+const { SYNC_DIR_UNLINKED_MESSAGE } = require('./errors')
 
 /*::
 import type EventEmitter from 'events'

--- a/gui/js/updater.window.js
+++ b/gui/js/updater.window.js
@@ -85,7 +85,7 @@ module.exports = class UpdaterWM extends WindowManager {
         this.skipUpdate('assuming development environment')
       } else {
         await Promise.delay(UPDATE_RETRY_DELAY)
-        autoUpdater.checkForUpdates()
+        await autoUpdater.checkForUpdates()
       }
     })
     autoUpdater.on('download-progress', progressObj => {
@@ -122,12 +122,19 @@ module.exports = class UpdaterWM extends WindowManager {
     }
   }
 
-  checkForUpdates() {
+  async checkForUpdates() {
     this.skipped = false
     this.timeout = setTimeout(() => {
       this.skipUpdate(`check is taking more than ${UPDATE_CHECK_TIMEOUT} ms`)
     }, UPDATE_CHECK_TIMEOUT)
-    autoUpdater.checkForUpdates()
+
+    try {
+      await autoUpdater.checkForUpdates()
+    } catch (err) {
+      // Dealing with the error itself is alreay done via the listener on the
+      // `error` event.
+      log.error({ err })
+    }
   }
 
   skipUpdate(reason) {

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -111,6 +111,7 @@ module.exports = class WindowManager {
     opts.webPreferences = {
       ...opts.webPreferences,
       nodeIntegration: true,
+      contextIsolation: false,
       enableRemoteModule: true
     }
     // https://github.com/AppImage/AppImageKit/wiki/Bundling-Electron-apps

--- a/gui/main.js
+++ b/gui/main.js
@@ -594,11 +594,9 @@ app.on('ready', async () => {
     }, 1000)
   }
 
-  const { session } = require('electron')
-
   const hostID = (dumbhash(os.hostname()) % 4096).toString(16)
   let userAgent = `Cozy-Desktop-${process.platform}-${pkg.version}-${hostID}`
-  await proxy.setup(app, proxy.config(), session, userAgent)
+  await proxy.setup(app, proxy.config(), userAgent)
   log.info('Loading CLI...')
   i18n.init(app)
   try {

--- a/gui/main.js
+++ b/gui/main.js
@@ -14,7 +14,7 @@ const { COZY_CLIENT_REVOKED_MESSAGE } = require('../core/remote/errors')
 const {
   SYNC_DIR_EMPTY_MESSAGE,
   SYNC_DIR_UNLINKED_MESSAGE
-} = require('../core/local')
+} = require('../core/local/errors')
 const migrations = require('../core/pouch/migrations')
 const config = require('../core/config')
 const winRegistry = require('../core/utils/win_registry')

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "debug-menu": "^0.6.1",
     "del": "^4.0.0",
     "devtron": "^1.4.0",
-    "electron": "^11.0.0",
+    "electron": "^12.0.0",
     "electron-builder": "^22.8.1",
     "electron-mocha": "^8.1.2",
     "electron-notarize": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "lodash": "^4.17.11",
     "micromatch": "^3.1.0",
     "mime": "^1.3.4",
-    "node-abi": "^2.19.3",
+    "node-abi": "^2.21.0",
     "opn": "5.0.0",
     "pouchdb": "^7.2.2",
     "pouchdb-find": "^7.2.2",
@@ -168,6 +168,6 @@
   "resolutions": {
     "dtrace-provider": "0.8.8",
     "nan": "2.14.0",
-    "node-abi": "2.19.3"
+    "node-abi": "2.21.0"
   }
 }

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -4,17 +4,17 @@
 require('../../../core/globals')
 
 // Setup proxy so that all test requests will go through `electron-fetch`
-const { app, session } = require('electron')
+const { app } = require('electron')
 const proxy = require('../../../gui/js/proxy')
 
 let originalNet
 const setupGlobalProxy = async () => {
   await app.whenReady()
-  originalNet = await proxy.setup(app, {}, session, '')
+  originalNet = await proxy.setup(app, {}, '')
 }
 const resetGlobalProxy = async () => {
   if (originalNet && (await originalNet)) {
-    await proxy.reset(app, session, originalNet)
+    await proxy.reset(app, originalNet)
     originalNet = null
   }
 }

--- a/test/support/hooks/logging.js
+++ b/test/support/hooks/logging.js
@@ -29,6 +29,6 @@ beforeEach(function() {
 afterEach(function() {
   for (const err of errors) {
     // eslint-disable-next-line no-console
-    console.error(err)
+    console.log(err)
   }
 })

--- a/test/unit/gui/proxy.js
+++ b/test/unit/gui/proxy.js
@@ -100,7 +100,7 @@ describe('gui/js/proxy', function() {
     })
 
     const proxySetupHook = config => async () => {
-      proxySideEffects = await proxy.setup(app, config, session, userAgent)
+      proxySideEffects = await proxy.setup(app, config, userAgent)
     }
     const revertProxySideEffects = async () => {
       await proxy.reset(app, session, proxySideEffects)

--- a/test/unit/gui/updater.window.js
+++ b/test/unit/gui/updater.window.js
@@ -4,9 +4,13 @@ const UpdaterWM = require('../../../gui/js/updater.window')
 
 describe('updater.window', () => {
   describe('checkForUpdates', () => {
-    it('resets the skipped property', () => {
+    it('resets the skipped property', async () => {
       const updater = new UpdaterWM()
       updater.skipped = true
+      // We're not await here otherwise the error raised in test and dev
+      // environments (i.e. missing update config file) would lead the
+      // `UpdateWN` to call `skipUpdate()` and thus set `skipped` back to
+      // `true`.
       updater.checkForUpdates()
       should(updater.skipped).be.false()
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5431,10 +5431,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@2.19.3, node-abi@^2.19.3, node-abi@^2.7.0:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
-  integrity sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
+node-abi@2.21.0, node-abi@^2.21.0, node-abi@^2.7.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.21.0.tgz#c2dc9ebad6f4f53d6ea9b531e7b8faad81041d48"
+  integrity sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==
   dependencies:
     semver "^5.4.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,10 +405,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.1.tgz#1fd7b821f798b7fa29f667a1be8f3442bb8922a3"
   integrity sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A==
 
-"@types/node@^12.0.12":
-  version "12.12.54"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.54.tgz#a4b58d8df3a4677b6c08bfbc94b7ad7a7a5f82d1"
-  integrity sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==
+"@types/node@^14.6.2":
+  version "14.14.33"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
+  integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -2346,13 +2346,13 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^11.0.0:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.1.1.tgz#188f036f8282798398dca9513e9bb3b10213e3aa"
-  integrity sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==
+electron@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-12.0.0.tgz#b3b1d88cc64622e59c637521da5a6b6ab4df4eb5"
+  integrity sha512-p6oxZ4LG82hopPGAsIMOjyoL49fr6cexyFNH0kADA9Yf+mJ72DN7bjvBG+6V7r6QKhwYgsSsW8RpxBeVOUbxVQ==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
+    "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
 elm-format@elm0.19.1:


### PR DESCRIPTION
  Attempt to avoid or clear network errors on requests sent after the OS
  resumes from sleep.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
