### PR TITLE
core/merge: Stop creating local parent records

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -8,7 +8,6 @@ const Promise = require('bluebird')
 const _ = require('lodash')
 
 const metadata = require('../../metadata')
-const { MergeMissingParentError } = require('../../merge')
 const remoteChange = require('../change')
 const { HEARTBEAT } = require('../constants')
 const remoteErrors = require('../errors')
@@ -181,17 +180,7 @@ class RemoteWatcher {
 
     log.trace('Apply changes...')
     const errors = await this.applyAll(changes)
-
-    for (const { err, change } of errors) {
-      if (err instanceof MergeMissingParentError) {
-        log.warn(
-          { err, change, path: change && change.doc.path },
-          'swallowing missing parent metadata error'
-        )
-        continue
-      }
-      throw err
-    }
+    if (errors.length) throw errors[0].err
 
     log.trace('Done with pull.')
   }

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -18,7 +18,6 @@ const cozyHelpers = require('../../support/helpers/cozy')
 const Builders = require('../../support/builders')
 
 const metadata = require('../../../core/metadata')
-const { MergeMissingParentError } = require('../../../core/merge')
 const Prep = require('../../../core/prep')
 const { RemoteCozy } = require('../../../core/remote/cozy')
 const remoteErrors = require('../../../core/remote/errors')
@@ -457,30 +456,6 @@ describe('RemoteWatcher', function() {
         should(await this.watcher.watch()).match({
           code: remoteErrors.UNKNOWN_REMOTE_ERROR_CODE
         })
-      })
-    })
-
-    context('on MergeMissingParentError', () => {
-      let missingParentError
-      beforeEach(function() {
-        missingParentError = {
-          err: new MergeMissingParentError(builders.metadata().build())
-        }
-      })
-
-      beforeEach(function() {
-        this.watcher.pullMany.returns([missingParentError])
-      })
-
-      it('does not reject any errors', async function() {
-        await should(this.watcher.watch()).be.fulfilled()
-      })
-
-      it('updates the last update sequence in local db', async function() {
-        await this.watcher.watch()
-        this.pouch.setRemoteSeq.should.be
-          .calledOnce()
-          .and.be.calledWithExactly(lastRemoteSeq)
       })
     })
   })


### PR DESCRIPTION
When merging a local change, we were checking if its parent folder
record existed in PouchDB. To make sure the whole hierarchy was
present in the database, we would create any missing parent folder
record with only a few attributes: their path and update date.

However, this generates records missing most attributes that we rely
on more and more (i.e. inode, local and remote attributes…) and should
not be necessary as a document cannot exist on the local filesystem
without its parent folder and so we should receive an event leading us
to merge that parent folder record at some point.

This is why we'll be more optimistic and rely on an eventual
consistency regarding the parent hierarchy of any given record in
PouchDB.
Besides, we were not creating those parent records for remote
documents anymore.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
