### PR TITLE
core/sync: Handle missing doc remote move retries

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -318,11 +318,22 @@ class Remote /*:: implements Reader, Writer */ {
     metadata.updateRemote(newMetadata, newRemoteDoc)
 
     if (overwrite && isOverwritingTarget) {
-      const referencedBy = await this.remoteCozy.getReferencedBy(
-        overwrite.remote._id
-      )
-      await this.remoteCozy.addReferencedBy(remoteId, referencedBy)
-      await this.assignNewRemote(newMetadata)
+      try {
+        const referencedBy = await this.remoteCozy.getReferencedBy(
+          overwrite.remote._id
+        )
+        await this.remoteCozy.addReferencedBy(remoteId, referencedBy)
+        await this.assignNewRemote(newMetadata)
+      } catch (err) {
+        if (err.status === 404) {
+          log.warn(
+            { path },
+            `Cannot fetch references of missing ${overwrite.docType}.`
+          )
+          return
+        }
+        throw err
+      }
     }
   }
 

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -446,13 +446,16 @@ class Sync {
             if (change.doc.deleted) {
               await this.skipChange(change, syncErr)
             } else if (sideName === 'remote') {
-              if (change.doc.moveFrom) delete change.doc.moveFrom
+              delete change.doc.moveFrom
+              delete change.doc.overwrite
+              delete change.doc.remote
 
               if (metadata.isFile(change.doc)) {
                 await this.remote.addFileAsync(change.doc)
               } else {
                 await this.remote.addFolderAsync(change.doc)
               }
+              await this.updateRevs(change.doc, 'remote')
             } else {
               await this.pouch.eraseDocument(change.doc)
               if (doc.docType === 'file') {

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -48,4 +48,21 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
       )
     )
   }
+
+  async update() /*: Promise<MetadataRemoteDir> */ {
+    const cozy = this._ensureCozy()
+
+    const json = this.remoteDoc._deleted
+      ? await cozy.files.destroyById(this.remoteDoc._id)
+      : this.remoteDoc.trashed
+      ? await cozy.files.trashById(this.remoteDoc._id, { dontRetry: true })
+      : await cozy.files.updateAttributesById(this.remoteDoc._id, {
+          dir_id: this.remoteDoc.dir_id,
+          name: this.remoteDoc.name,
+          updated_at: this.remoteDoc.updated_at,
+          noSanitize: true
+        })
+
+    return _.clone(jsonApiToRemoteDoc(json))
+  }
 }


### PR DESCRIPTION
After reaching the maximum number of failed synchronization attempts
due to a missing remote document, we take steps to finally get the
current change synchronized and move on.

If the change in question is a move of the document missing on the
remote Cozy, potentially overwriting another document, then we'll try
to synchronize the local document as a new document.

However, this involves removing from the PouchDB record the attributes
used by Sync to detect that the document has been moved. Otherwise, on
the next round of synchronization, Sync will try again to move the
document that no longer exists on the Cozy.

We also remove the overwriting hint as the move action first attempts
to trash the overwritten document and this part should not fail
because the document we're trying to move does not exist anymore.
We won't copy any references from the "overwritten" document to the
newly created one though.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
