### PR TITLE
core/metadata: Enforce `local` invariant

### DIFF
--- a/core/incompatibilities/platform.js
+++ b/core/incompatibilities/platform.js
@@ -10,6 +10,8 @@ const { sep } = path
 const _ = require('lodash')
 
 /*::
+import type { Incompatibility, SavedMetadata } from '../metadata'
+
 type SingleCharString = string
 
 type PlatformRestrictions = {
@@ -327,11 +329,31 @@ const detectPathLengthIncompatibility = (
   }
 }
 
+class IncompatibleDocError extends Error {
+  /*::
+  doc: SavedMetadata
+  incompatibilities: ?Incompatibility[]
+  */
+
+  constructor({ doc } /*: { doc: SavedMetadata } */) {
+    super('Document is incompatible with local platform')
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, IncompatibleDocError)
+    }
+
+    this.name = 'IncompatibleDocError'
+    this.doc = doc
+    this.incompatibilities = this.doc.incompatibilities
+  }
+}
+
 module.exports = {
   win,
   mac,
   linux,
   detectNameIncompatibilities,
   detectPathIncompatibilities,
-  detectPathLengthIncompatibility
+  detectPathLengthIncompatibility,
+  IncompatibleDocError
 }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -389,6 +389,8 @@ function invariants /*:: <T: Metadata|SavedMetadata> */(doc /*: T */) {
     err = new Error(`Metadata has no sides`)
   } else if (doc.sides.remote && !doc.remote) {
     err = new Error(`Metadata has 'sides.remote' but no remote`)
+  } else if (doc.sides.local && !doc.local) {
+    err = new Error(`Metadata has 'sides.local' but no local`)
   } else if (doc.docType === 'file' && doc.md5sum == null) {
     err = new Error(`File metadata has no checksum`)
   }

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -404,7 +404,7 @@ function invariants /*:: <T: Metadata|SavedMetadata> */(doc /*: T */) {
 }
 
 /*::
-export type Incompatibility = PlatformIncompatibility & {docType: string}
+export type Incompatibility = { ...PlatformIncompatibility, docType: string }
 */
 
 /** Identify incompatibilities that will prevent synchronization.

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -9,6 +9,7 @@ const Promise = require('bluebird')
 const { dirname } = require('path')
 const _ = require('lodash')
 
+const { IncompatibleDocError } = require('../incompatibilities/platform')
 const metadata = require('../metadata')
 const { HEARTBEAT: REMOTE_HEARTBEAT } = require('../remote/constants')
 const remoteErrors = require('../remote/errors')
@@ -508,6 +509,9 @@ class Sync {
             }
           }
           break
+        case syncErrors.INCOMPATIBLE_DOC_CODE:
+          await this.skipChange(change, syncErr)
+          break
         default:
           // Don't try more than MAX_SYNC_ATTEMPTS for the same operation
           if (!change.doc.errors || change.doc.errors < MAX_SYNC_ATTEMPTS) {
@@ -556,6 +560,7 @@ class Sync {
           { path: doc.path, incompatibilities: doc.incompatibilities },
           `Not syncing incompatible ${doc.docType}`
         )
+        throw new IncompatibleDocError({ doc })
       }
     } else if (doc.docType !== 'file' && doc.docType !== 'folder') {
       throw new Error(`Unknown docType: ${doc.docType}`)

--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -72,34 +72,25 @@ if (process.env.TESTDEBUG) {
 }
 
 function errSerializer(err) {
-  const obj = bunyan.stdSerializers.err(err)
-  const {
-    type,
-    reason,
-    address,
-    dest,
-    info,
-    path,
-    port,
-    syscall,
-    code,
-    status,
-    originalErr,
-    errors
-  } = err
-
-  if (type) obj.type = type
-  if (reason) obj.reason = reason
-  if (address) obj.address = err.address
-  if (dest) obj.dest = err.dest
-  if (info) obj.info = info
-  if (path) obj.path = path
-  if (port) obj.port = port
-  if (syscall) obj.syscall = syscall
-  if (code) obj.code = code
-  if (status) obj.status = status
-  if (originalErr) obj.originalErr = originalErr
-  if (errors) obj.errors = errors
+  const obj = _.defaults(
+    bunyan.stdSerializers.err(err),
+    _.pick(err, [
+      'type',
+      'reason',
+      'address',
+      'dest',
+      'info',
+      'path',
+      'port',
+      'syscall',
+      'code',
+      'status',
+      'originalErr',
+      'errors',
+      'doc',
+      'incompatibilities'
+    ])
+  )
 
   return obj
 }

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -367,20 +367,22 @@ describe('Conflict resolution', () => {
 
   describe('migrating to Cozy Desktop 3.15', () => {
     it('does not generate conflicts on existing documents with NFD encoded paths', async () => {
-      const nfdPath = 'Partages reçus'.normalize('NFD')
+      const nfdName = 'Partages reçus'.normalize('NFD')
 
-      await helpers.local.syncDir.ensureDir(nfdPath)
-      const stats = await helpers.local.syncDir.stat(nfdPath)
+      await helpers.local.syncDir.ensureDir(nfdName)
+      const stats = await helpers.local.syncDir.stat(nfdName)
+      const remoteDir = await helpers.remote.createDirectory(nfdName)
       const doc = await builders
         .metadir()
-        .path(nfdPath)
+        .fromRemote(remoteDir)
         .stats(stats)
+        .upToDate()
         .create()
       await helpers.prep.putFolderAsync('local', doc)
 
       await fullSyncStartingFrom('local')
 
-      should(await helpers.trees()).deepEqual(bothSides([`${nfdPath}/`]))
+      should(await helpers.trees()).deepEqual(bothSides([`${nfdName}/`]))
     })
 
     it('does not generate conflicts on new documents with NFD encoded paths', async () => {

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -317,8 +317,9 @@ module.exports = class BaseMetadataBuilder {
     }
 
     const doc = this.build()
-    doc.sides = doc.sides || { local: 1 }
-    doc.sides.target = Math.max(doc.sides.local || 0, doc.sides.remote || 0)
+    if (doc.sides) {
+      doc.sides.target = Math.max(doc.sides.local || 0, doc.sides.remote || 0)
+    }
 
     return await pouch.put(doc)
   }

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -8,7 +8,10 @@ const conflictHelpers = require('./conflict')
 const cozyHelpers = require('./cozy')
 
 const { Remote, dirAndName } = require('../../../core/remote')
-const { TRASH_DIR_NAME } = require('../../../core/remote/constants')
+const {
+  ROOT_DIR_ID,
+  TRASH_DIR_NAME
+} = require('../../../core/remote/constants')
 
 /*::
 import type cozy from 'cozy-client-js'
@@ -45,6 +48,35 @@ class RemoteTestHelpers {
     await this.side.watcher.watch()
   }
 
+  async createDirectory(
+    name /*: string */,
+    dirID /*: string */ = ROOT_DIR_ID
+  ) /*: Promise<MetadataRemoteInfo> */ {
+    return this.cozy.files
+      .createDirectory({
+        name,
+        dirID,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      })
+      .then(this.side.remoteCozy.toRemoteDoc)
+  }
+
+  async createFile(
+    name /*: string */,
+    dirID /*: string */ = ROOT_DIR_ID,
+    content /*: string */ = 'whatever'
+  ) /*: Promise<MetadataRemoteInfo> */ {
+    return this.cozy.files
+      .create(content, {
+        name,
+        dirID,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      })
+      .then(this.side.remoteCozy.toRemoteDoc)
+  }
+
   async createTree(
     paths /*: Array<string> */
   ) /*: Promise<{ [string]: MetadataRemoteInfo}> */ {
@@ -60,23 +92,13 @@ class RemoteTestHelpers {
         {}
       )._id
       if (p.endsWith('/')) {
-        remoteDocsByPath[p] = await this.cozy.files
-          .createDirectory({
-            name,
-            dirID,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
-          })
-          .then(this.side.remoteCozy.toRemoteDoc)
+        remoteDocsByPath[p] = await this.createDirectory(name, dirID)
       } else {
-        remoteDocsByPath[p] = await this.cozy.files
-          .create(`Content of file ${p}`, {
-            name,
-            dirID,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
-          })
-          .then(this.side.remoteCozy.toRemoteDoc)
+        remoteDocsByPath[p] = await this.createFile(
+          name,
+          dirID,
+          `Content of file ${p}`
+        )
       }
     }
 

--- a/test/unit/gui/notes/index.js
+++ b/test/unit/gui/notes/index.js
@@ -31,6 +31,7 @@ describe('gui/notes/index', () => {
       const doc = await builders
         .metafile()
         .path(docPath)
+        .upToDate()
         .create()
 
       await should(localDoc(filePath, this)).be.fulfilledWith(doc)
@@ -53,6 +54,7 @@ describe('gui/notes/index', () => {
       await builders
         .metafile()
         .path(docPath)
+        .upToDate()
         .create()
 
       await should(localDoc(filePath, this)).be.rejectedWith(

--- a/test/unit/helpers_merge.js
+++ b/test/unit/helpers_merge.js
@@ -32,7 +32,7 @@ describe('Merge Helpers', function() {
   describe('resolveConflict', function() {
     it('appends -conflict- and the date to the path', async function() {
       const doc = builders
-        .metadata()
+        .metadir()
         .path('foo/bar')
         .build()
       const spy = this.merge.local.moveAsync

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -544,9 +544,10 @@ describe('core/local/atom/dispatch.loop()', function() {
 
         beforeEach(async () => {
           oldDoc = await builders
-            .metadata()
+            .metafile()
             .path(filePath)
             .ino(fileIno)
+            .upToDate()
             .create()
         })
 
@@ -582,9 +583,10 @@ describe('core/local/atom/dispatch.loop()', function() {
       context('but the inodes do not match', () => {
         beforeEach(async () => {
           await builders
-            .metadata()
+            .metafile()
             .path(filePath)
             .ino(fileIno + 1)
+            .upToDate()
             .create()
         })
 
@@ -654,9 +656,10 @@ describe('core/local/atom/dispatch.loop()', function() {
 
       beforeEach(async () => {
         oldDoc = await builders
-          .metadata()
+          .metafile()
           .path(filePath)
           .ino(1)
+          .upToDate()
           .create()
       })
 
@@ -665,9 +668,10 @@ describe('core/local/atom/dispatch.loop()', function() {
 
         beforeEach(async () => {
           existingDoc = await builders
-            .metadata()
+            .metafile()
             .path(newFilePath)
             .ino(2)
+            .upToDate()
             .create()
         })
 
@@ -764,9 +768,10 @@ describe('core/local/atom/dispatch.loop()', function() {
 
         beforeEach(async () => {
           oldDoc = await builders
-            .metadata()
+            .metadir()
             .path(directoryPath)
             .ino(dirIno)
+            .upToDate()
             .create()
         })
 
@@ -791,9 +796,10 @@ describe('core/local/atom/dispatch.loop()', function() {
       context('and the inodes do not match', () => {
         beforeEach(async () => {
           await builders
-            .metadata()
+            .metadir()
             .path(directoryPath)
             .ino(dirIno + 1)
+            .upToDate()
             .create()
         })
 
@@ -882,9 +888,10 @@ describe('core/local/atom/dispatch.loop()', function() {
 
       beforeEach(async () => {
         oldDoc = await builders
-          .metadata()
+          .metafile()
           .path(filePath)
           .ino(1)
+          .upToDate()
           .create()
       })
 
@@ -926,9 +933,10 @@ describe('core/local/atom/dispatch.loop()', function() {
 
       beforeEach(async () => {
         oldDoc = await builders
-          .metadata()
+          .metadir()
           .path(directoryPath)
           .ino(1)
+          .upToDate()
           .create()
       })
 

--- a/test/unit/local/atom/win_detect_move.js
+++ b/test/unit/local/atom/win_detect_move.js
@@ -63,6 +63,7 @@ if (process.platform === 'win32') {
             srcDoc = await metadataBuilderByKind(kind)
               .path(srcPath)
               .ino(srcIno)
+              .upToDate()
               .create()
             deletedEvent = builders
               .event()
@@ -169,6 +170,7 @@ if (process.platform === 'win32') {
                       .metadir()
                       .path(path.join(srcPath, childName))
                       .ino(childIno)
+                      .upToDate()
                       .create()
                     deletedChildEvent = builders
                       .event()
@@ -380,6 +382,7 @@ if (process.platform === 'win32') {
               await metadataBuilderByKind(kind)
                 .path(deletedPath)
                 .ino(createdIno)
+                .upToDate()
                 .create()
               deletedEvent = builders
                 .event()
@@ -418,6 +421,7 @@ if (process.platform === 'win32') {
                     await metadataBuilderByKind(childKind)
                       .path(path.join(deletedPath, childName))
                       .ino(childIno)
+                      .upToDate()
                       .create()
                     deletedChildEvent = builders
                       .event()
@@ -500,6 +504,7 @@ if (process.platform === 'win32') {
               await metadataBuilderByKind(kind)
                 .path(createdPath)
                 .ino(createdIno)
+                .upToDate()
                 .create()
               deletedEvent = builders
                 .event()

--- a/test/unit/local/chokidar/normalize_paths.js
+++ b/test/unit/local/chokidar/normalize_paths.js
@@ -37,6 +37,7 @@ onPlatform('darwin', () => {
           await builders
             .metadir()
             .path(dirPath.normalize('NFC'))
+            .upToDate()
             .create()
         })
 
@@ -60,6 +61,7 @@ onPlatform('darwin', () => {
           await builders
             .metadir()
             .path(dirPath.normalize('NFD'))
+            .upToDate()
             .create()
         })
 
@@ -89,6 +91,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(dirPath.normalize('NFC'))
+            .upToDate()
             .create()
         })
 
@@ -99,6 +102,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -142,6 +146,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -191,6 +196,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(dirPath.normalize('NFD'))
+            .upToDate()
             .create()
         })
 
@@ -201,6 +207,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -250,6 +257,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -299,6 +307,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(srcDirPath.normalize('NFC'))
+            .upToDate()
             .create()
         })
 
@@ -309,6 +318,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -351,6 +361,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -396,6 +407,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(srcDirPath.normalize('NFD'))
+            .upToDate()
             .create()
         })
 
@@ -406,6 +418,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -451,6 +464,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, filename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -502,6 +516,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(dirPath.normalize('NFC'))
+            .upToDate()
             .create()
         })
 
@@ -512,6 +527,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -543,6 +559,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -577,6 +594,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(dirPath.normalize('NFD'))
+            .upToDate()
             .create()
         })
 
@@ -587,6 +605,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -621,6 +640,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -662,6 +682,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(srcDirPath.normalize('NFC'))
+            .upToDate()
             .create()
         })
 
@@ -672,6 +693,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -714,6 +736,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -759,6 +782,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(srcDirPath.normalize('NFD'))
+            .upToDate()
             .create()
         })
 
@@ -769,6 +793,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFC')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -814,6 +839,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(path.join(dir.path, srcFilename.normalize('NFD')))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -866,6 +892,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(srcDirPath.normalize('NFC'))
+            .upToDate()
             .create()
         })
 
@@ -876,6 +903,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(srcFilename.normalize('NFC'))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -918,6 +946,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(srcFilename.normalize('NFD'))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -963,6 +992,7 @@ onPlatform('darwin', () => {
           dir = await builders
             .metadir()
             .path(srcDirPath.normalize('NFD'))
+            .upToDate()
             .create()
         })
 
@@ -973,6 +1003,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(srcFilename.normalize('NFC'))
               .data('initial content')
+              .upToDate()
               .create()
           })
 
@@ -1018,6 +1049,7 @@ onPlatform('darwin', () => {
               .metafile()
               .path(srcFilename.normalize('NFD'))
               .data('initial content')
+              .upToDate()
               .create()
           })
 

--- a/test/unit/local/chokidar/prepare_events.js
+++ b/test/unit/local/chokidar/prepare_events.js
@@ -26,7 +26,10 @@ onPlatform('darwin', () => {
 
     describe('#oldMetadata()', () => {
       it('resolves with the metadata whose id matches the event path', async function() {
-        const old = await builders.metadata().create()
+        const old = await builders
+          .metadata()
+          .upToDate()
+          .create()
         const resultByEventType = {}
         for (let type of ['add', 'addDir', 'change', 'unlink', 'unlinkDir']) {
           resultByEventType[type] = await prepareEvents.oldMetadata(
@@ -53,11 +56,13 @@ onPlatform('darwin', () => {
           .metafile()
           .path('untouched')
           .data('initial')
+          .upToDate()
           .create()
         const sameContent = await builders
           .metafile()
           .path('sameContent')
           .data('initial')
+          .upToDate()
           .create()
         const events /*: ChokidarEvent[] */ = [
           {
@@ -93,6 +98,7 @@ onPlatform('darwin', () => {
           .metafile()
           .path('énoncé'.normalize('NFC'))
           .data('initial')
+          .upToDate()
           .create()
         const events /*: ChokidarEvent[] */ = [
           {

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -262,6 +262,7 @@ describe('Local', function() {
         .metafile()
         .path('files/my-checkum-is-456')
         .data(content)
+        .upToDate()
         .create()
       await syncDir.outputFile(other.path, content)
 
@@ -703,6 +704,7 @@ describe('Local', function() {
       const doc = await builders
         .metafile()
         .path('FILE-TO-DELETE')
+        .upToDate()
         .create()
       const filePath = syncDir.abspath(doc.path)
       fse.ensureFileSync(filePath)
@@ -716,6 +718,7 @@ describe('Local', function() {
       const doc = await builders
         .metadir()
         .path('FOLDER-TO-DELETE')
+        .upToDate()
         .create()
       const folderPath = syncDir.abspath(doc.path)
       fse.ensureDirSync(folderPath)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -806,8 +806,13 @@ describe('Merge', function() {
         .metafile()
         .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
         .upToDate()
-        .noLocal()
         .create()
+
+      // Remove local attribute for the test
+      delete mergedFile.local
+      const { rev } = await this.pouch.db.put(mergedFile)
+      mergedFile._rev = rev
+
       const sameFile = builders
         .metafile(mergedFile)
         .unmerged('local')
@@ -1227,8 +1232,13 @@ describe('Merge', function() {
         .metafile()
         .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
         .upToDate()
-        .noLocal()
         .create()
+
+      // Remove local attribute for the test
+      delete mergedFile.local
+      const { rev } = await this.pouch.db.put(mergedFile)
+      mergedFile._rev = rev
+
       const sameFile = builders
         .metafile(mergedFile)
         .unmerged('local')
@@ -1696,8 +1706,13 @@ describe('Merge', function() {
         .metadir()
         .updatedAt(new Date(2020, 5, 19, 11, 9, 0))
         .upToDate()
-        .noLocal()
         .create()
+
+      // Remove local attribute for the test
+      delete mergedFolder.local
+      const { rev } = await this.pouch.db.put(mergedFolder)
+      mergedFolder._rev = rev
+
       const sameFolder = builders
         .metadir(mergedFolder)
         .unmerged('local')

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -644,6 +644,7 @@ describe('Merge', function() {
           .metafile()
           .path(path)
           .data('content')
+          .upToDate()
           .create()
         await this.pouch.remove(was)
       })
@@ -2112,6 +2113,7 @@ describe('Merge', function() {
         const previous = await builders
           .metafile()
           .path(path)
+          .upToDate()
           .create()
         await this.pouch.remove(previous)
       })
@@ -2425,6 +2427,7 @@ describe('Merge', function() {
         await builders
           .metafile()
           .path('QUX')
+          .upToDate()
           .create()
         const was = await builders
           .metafile()
@@ -2507,6 +2510,7 @@ describe('Merge', function() {
         await builders
           .metafile()
           .path('QUX')
+          .upToDate()
           .create()
         const doc = builders
           .metafile(was)
@@ -3289,6 +3293,7 @@ describe('Merge', function() {
         const previous = await builders
           .metadir()
           .path(path)
+          .upToDate()
           .create()
         await this.pouch.remove(previous)
       })
@@ -3440,6 +3445,7 @@ describe('Merge', function() {
         await builders
           .metadir()
           .path('LINUX')
+          .upToDate()
           .create()
         const torvalds = await builders
           .metadir()
@@ -3515,6 +3521,7 @@ describe('Merge', function() {
         await builders
           .metadir()
           .path('NUKEM')
+          .upToDate()
           .create()
         const duke = await builders
           .metadir()
@@ -3886,6 +3893,7 @@ describe('Merge', function() {
         const previous = await builders
           .metadir()
           .path(path)
+          .upToDate()
           .create()
         await this.pouch.remove(previous)
       })
@@ -3942,6 +3950,7 @@ describe('Merge', function() {
         const previous = await builders
           .metadata()
           .path(`${parentPath}/${childName}`)
+          .upToDate()
           .create()
         await this.pouch.remove(previous)
       })
@@ -4757,7 +4766,10 @@ describe('Merge', function() {
 
     context('when docType of found record does not match', () => {
       it('does nothing', async function() {
-        const was = await builders.metafile().create()
+        const was = await builders
+          .metafile()
+          .upToDate()
+          .create()
         const doc = builders
           .metadir()
           .path(was.path)
@@ -4990,7 +5002,10 @@ describe('Merge', function() {
 
     context('when docType of found record does not match', () => {
       it('does nothing', async function() {
-        const was = await builders.metadir().create()
+        const was = await builders
+          .metadir()
+          .upToDate()
+          .create()
         const doc = builders
           .metafile()
           .path(was.path)

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -59,6 +59,7 @@ describe('move', () => {
       const src = await builders
         .metadata()
         .path('whatever/src')
+        .upToDate()
         .create()
       const dst = _.defaults({ path: 'whatever/dst' }, src)
 

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -760,7 +760,7 @@ describe('Pouch', function() {
         await builders
           .metafile()
           .path('my-folder/remote-file')
-          .noLocal()
+          .sides({ remote: 1 })
           .create()
 
         await should(this.pouch.localTree()).be.fulfilledWith(

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -193,6 +193,7 @@ describe('Pouch', function() {
         old = await builders
           .metafile()
           .path('doc')
+          .upToDate()
           .create()
         doc = _.cloneDeep(old)
       })
@@ -241,6 +242,7 @@ describe('Pouch', function() {
         old = await builders
           .metafile()
           .path('doc')
+          .upToDate()
           .create()
         doc = _.clone(old)
       })
@@ -267,10 +269,12 @@ describe('Pouch', function() {
         old1 = await builders
           .metafile()
           .path('doc1')
+          .upToDate()
           .create()
         old2 = await builders
           .metafile()
           .path('doc2')
+          .upToDate()
           .create()
 
         doc1 = _.clone(old1)
@@ -771,8 +775,8 @@ describe('Pouch', function() {
       it('resturns the paths of local only documents', async function() {
         const localFile = await builders
           .metafile()
-          .path('my-folder/remote-file')
-          .noRemote()
+          .path('my-folder/local-file')
+          .sides({ local: 1 })
           .create()
 
         await should(this.pouch.localTree()).be.fulfilledWith(

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -780,7 +780,7 @@ describe('remote.Remote', function() {
       const was = await builders
         .metadir()
         .fromRemote(remoteDir)
-        .noRemote()
+        .upToDate()
         .create()
       const doc = builders
         .metadir(was)
@@ -1387,6 +1387,7 @@ describe('remote.Remote', function() {
       file = await builders
         .metafile()
         .fromRemote(remoteFile)
+        .sides({ local: 1 })
         .create()
     })
 

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -872,6 +872,7 @@ describe('RemoteWatcher', function() {
                 .metadir()
                 .fromRemote(oldRemoteDir)
                 .path(oldRemoteDir.path.normalize('NFD'))
+                .upToDate()
                 .create()
 
               const newRemoteFile = builders
@@ -906,6 +907,7 @@ describe('RemoteWatcher', function() {
                 .metadir()
                 .fromRemote(remoteParentDir)
                 .path(remoteParentDir.path.normalize('NFD'))
+                .upToDate()
                 .create()
 
               const newRemoteDir = builders
@@ -948,6 +950,7 @@ describe('RemoteWatcher', function() {
                     .metadir()
                     .fromRemote(remoteParentDir)
                     .path(remoteParentDir.path.normalize('NFD'))
+                    .upToDate()
                     .create()
 
                   const newRemoteDir = builders


### PR DESCRIPTION
In the same way we enforce the presence of a `remote` attribute when
the `sides.remote` attribute is present on a PouchDB record we're
about to save, we should encore the presence of a `local` attribute
when the `sides.local` attribute is present.

Not doing so means we could potentially save incoherent records which
will create issues down the road.
If some records fail to be saved we should be able to find the root
cause and fix it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
