### PR TITLE
core/merge: Unsynced folder move updates children

### DIFF
--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -43,10 +43,6 @@ describe('Test scenarios', function() {
   beforeEach('set up outside dir', async function() {
     await fse.emptyDir(path.resolve(path.join(this.syncPath, '..', 'outside')))
   })
-
-  afterEach(pouchHelpers.cleanDatabase)
-  afterEach(configHelpers.cleanConfig)
-
   beforeEach(async function() {
     helpers = TestHelpers.init(this)
 
@@ -54,6 +50,12 @@ describe('Test scenarios', function() {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+
+  afterEach(async function() {
+    await helpers.stop()
+  })
+  afterEach(pouchHelpers.cleanDatabase)
+  afterEach(configHelpers.cleanConfig)
 
   for (let scenario of scenarios) {
     if (scenario.platforms && !scenario.platforms.includes(platform)) {

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -34,7 +34,11 @@ module.exports = {
   async cleanConfig() {
     // We have to convert Windows paths to Posix paths as `del` does not handle
     // backslash separators anymore.
-    const deletedPath = path.posix.join(...this.syncPath.split(path.sep))
-    return del(deletedPath, { force: process.env.CI })
+    const deletedPath = path.posix.join(...this.basePath.split(path.sep), '**')
+    try {
+      await del([deletedPath], { force: process.env.CI })
+    } catch (err) {
+      //
+    }
   }
 }

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -73,6 +73,11 @@ class TestHelpers {
     autoBind(this)
   }
 
+  async stop() {
+    await this._remote.stop()
+    await this._local.stop()
+  }
+
   async syncAll() {
     this._sync.lifecycle.end('start')
     await this._sync.sync({ manualRun: true })

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -52,7 +52,13 @@ class RemoteTestHelpers {
     for (const p of paths) {
       const name = path.posix.basename(p)
       const parentPath = path.posix.dirname(p)
-      const dirID = (remoteDocsByPath[parentPath + '/'] || {})._id
+      const dirID = (
+        remoteDocsByPath[parentPath + '/'] ||
+        (await this.cozy.files
+          .statByPath('/' + parentPath + '/')
+          .then(this.side.remoteCozy.toRemoteDoc)) ||
+        {}
+      )._id
       if (p.endsWith('/')) {
         remoteDocsByPath[p] = await this.cozy.files
           .createDirectory({


### PR DESCRIPTION
Trying to propagate a folder move when it does not exist on the other
side yet would fail. This is why we transform the move of an unsynced
folder into a creation at its destination path.

However, we did not take into account the possibility that the folder
could have children which path needed to be modified as well.
We also did not take into account the possibility of a conflict at the
destination path.

We're now making sure overwriting, conflict resolution and children
updates are done when transforming the folder move into a folder
creation.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
