### PR TITLE
core/merge: Trash file when modified on same side

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -110,6 +110,8 @@ module.exports = class BaseMetadataBuilder {
     }
     this.noSides()
     this.noRecord()
+    delete this.doc.moveFrom
+    delete this.doc.overwrite
     return this
   }
 


### PR DESCRIPTION
We previously added a rule to cancel any file trashing if the file was
modified on the other side to avoid stressing the user over lost data
(although we always send documents to the local or remote trash).

Unfortunately, the condition we used to detect this situation was not
precise enough and we started cancelling trashing of files that were
previously modified on the same side.
We don't want to cancel the trashing in this case because we assume
that the user is aware that she's deleting the modified version.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
