### PR TITLE
core/merge: Trash source of moved folders

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -316,7 +316,6 @@ function squashMoves(changes /*: LocalChange[] */) {
           (oldPathA && oldPathB && oldPathB.startsWith(oldPathA + path.sep)))
       ) {
         log.debug({ oldpath: b.old.path, path: b.path }, 'descendant move')
-        a.wip = a.wip || b.wip
         if (pathB.substr(pathA.length) === oldPathB.substr(oldPathA.length)) {
           log.debug(
             { oldpath: b.old.path, path: b.path },

--- a/core/merge.js
+++ b/core/merge.js
@@ -532,6 +532,12 @@ class Merge {
     )
 
     for (let doc of docs) {
+      // Don't move children marked for deletion as we can simply propagate the
+      // deletion at their original path.
+      // Besides, as of today, `moveFrom` will have precedence over `deleted` in
+      // Sync and the deletion won't be propagated at all.
+      if (doc.deleted) continue
+
       // Update remote rev of documents which have been updated on the Cozy
       // after we've detected the move.
       const newRemoteRev = _.get(newRemoteRevs, _.get(doc, 'remote._id'))

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -511,6 +511,11 @@ function dissociateLocal(doc /*: Metadata */) {
 
 function markAsUnsyncable(doc /*: SavedMetadata */) {
   removeActionHints(doc)
+  // Cannot be done in removeActionHints as markAsUnmerged uses it as well and
+  // overwrite can be an attribute added before calling Merge (i.e. it can exist
+  // on an unmerged record).
+  delete doc.overwrite
+
   dissociateRemote(doc)
   dissociateLocal(doc)
   doc._deleted = true

--- a/test/scenarios/move_and_trash_dir/atom/linux.json
+++ b/test/scenarios/move_and_trash_dir/atom/linux.json
@@ -1,0 +1,24 @@
+[
+  [
+    {
+      "action": "renamed",
+      "kind": "directory",
+      "path": "dst/subdir",
+      "oldPath": "src/subdir"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "dst/subdir/file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "dst/subdir"
+    }
+  ]
+]

--- a/test/scenarios/move_and_trash_dir/atom/win32.json
+++ b/test/scenarios/move_and_trash_dir/atom/win32.json
@@ -1,0 +1,30 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "src\\subdir"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "directory",
+      "path": "dst\\subdir"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "unknown",
+      "path": "dst\\subdir\\file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "dst\\subdir"
+    }
+  ]
+]

--- a/test/scenarios/move_and_trash_dir/local/darwin.json
+++ b/test/scenarios/move_and_trash_dir/local/darwin.json
@@ -1,0 +1,69 @@
+[
+  {
+    "breakpoints": [0]
+  },
+  {
+    "type": "unlinkDir",
+    "path": "src/subdir"
+  },
+  {
+    "type": "addDir",
+    "path": "dst/subdir",
+    "stats": {
+      "dev": 16777221,
+      "mode": 16877,
+      "nlink": 3,
+      "uid": 501,
+      "gid": 20,
+      "rdev": 0,
+      "blksize": 4096,
+      "ino": 3,
+      "size": 96,
+      "blocks": 0,
+      "atimeMs": 1617042023135.9932,
+      "mtimeMs": 1617042023124.8975,
+      "ctimeMs": 1617042023143.0454,
+      "birthtimeMs": 1617042023121.466,
+      "atime": "2021-03-29T18:20:23.136Z",
+      "mtime": "2021-03-29T18:20:23.125Z",
+      "ctime": "2021-03-29T18:20:23.143Z",
+      "birthtime": "2021-03-29T18:20:23.121Z"
+    }
+  },
+  {
+    "type": "unlink",
+    "path": "src/subdir/file"
+  },
+  {
+    "type": "add",
+    "path": "dst/subdir/file",
+    "stats": {
+      "dev": 16777221,
+      "mode": 33188,
+      "nlink": 1,
+      "uid": 501,
+      "gid": 20,
+      "rdev": 0,
+      "blksize": 4096,
+      "ino": 4,
+      "size": 3,
+      "blocks": 8,
+      "atimeMs": 1617042024272.0288,
+      "mtimeMs": 1617042023125.8157,
+      "ctimeMs": 1617042023125.8157,
+      "birthtimeMs": 1617042023124.8796,
+      "atime": "2021-03-29T18:20:24.272Z",
+      "mtime": "2021-03-29T18:20:23.126Z",
+      "ctime": "2021-03-29T18:20:23.126Z",
+      "birthtime": "2021-03-29T18:20:23.125Z"
+    }
+  },
+  {
+    "type": "unlinkDir",
+    "path": "dst/subdir"
+  },
+  {
+    "type": "unlink",
+    "path": "dst/subdir/file"
+  }
+]

--- a/test/scenarios/move_and_trash_dir/remote/changes.json
+++ b/test/scenarios/move_and_trash_dir/remote/changes.json
@@ -1,0 +1,71 @@
+[
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2aea07afc",
+    "_rev": "2-433e46d7a7576bacc8c497e8c90fea21",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2021-03-28T22:12:46.023252242Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-28T22:12:46.023252242Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-28T22:12:46.023252242Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-03-28T22:12:46.023252242Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "bb1b7ed8dacc99e8de2996d2ae9a65cf",
+          "kind": "",
+          "name": "test-9"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-03-29T00:12:46Z",
+    "dir_id": "bb1b7ed8dacc99e8de2996d2aea06c61",
+    "executable": false,
+    "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
+    "mime": "application/octet-stream",
+    "name": "file",
+    "size": "8",
+    "tags": [],
+    "trashed": true,
+    "type": "file",
+    "updated_at": "2021-03-29T00:12:46Z",
+    "path": "/.cozy_trash/subdir/file"
+  },
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2aea06c61",
+    "_rev": "3-c00f11f2bb85266243e0b1a0c3f48591",
+    "cozyMetadata": {
+      "createdAt": "2021-03-28T22:12:45.998445374Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-28T22:12:51.717778739Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-28T22:12:51.717778739Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ]
+    },
+    "created_at": "2021-03-29T00:12:45Z",
+    "dir_id": "io.cozy.files.trash-dir",
+    "name": "subdir",
+    "path": "/.cozy_trash/subdir",
+    "restore_path": "/dst",
+    "tags": [],
+    "type": "directory",
+    "updated_at": "2021-03-29T00:12:45Z"
+  }
+]

--- a/test/scenarios/move_and_trash_dir/scenario.js
+++ b/test/scenarios/move_and_trash_dir/scenario.js
@@ -1,9 +1,10 @@
 /* @flow */
 
+const { runWithStoppedClient } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  disabled: 'requires handling moveFrom + trashed', // FIXME
   useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },
@@ -19,6 +20,15 @@ module.exports = ({
   ],
   expected: {
     tree: ['dst/', 'src/'],
-    trash: ['file']
+    remoteTrash:
+      process.platform !== 'darwin' && runWithStoppedClient()
+        ? // XXX: subdir is trashed first so it's not empty at that point and thus
+          // is not erased except on macOS where the local sorting algorithm puts
+          // the file trashing first.
+          ['subdir/', 'subdir/file']
+        : // XXX: file is trashed before subdir which is then empty and thus
+          // completely erased.
+          ['file'],
+    localTrash: ['subdir/', 'subdir/file']
   }
 } /*: Scenario */)

--- a/test/scenarios/move_and_trash_file/atom/linux.json
+++ b/test/scenarios/move_and_trash_file/atom/linux.json
@@ -1,0 +1,17 @@
+[
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "dst/file",
+      "oldPath": "src/file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "dst/file"
+    }
+  ]
+]

--- a/test/scenarios/move_and_trash_file/atom/win32.json
+++ b/test/scenarios/move_and_trash_file/atom/win32.json
@@ -1,0 +1,28 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src\\file"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "dst\\file"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "dst\\file"
+    }
+  ]
+]

--- a/test/scenarios/move_and_trash_file/local/darwin.json
+++ b/test/scenarios/move_and_trash_file/local/darwin.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "unlink",
+    "path": "src/file"
+  },
+  {
+    "type": "add",
+    "path": "dst/file",
+    "stats": {
+      "dev": 16777221,
+      "mode": 33188,
+      "nlink": 1,
+      "uid": 501,
+      "gid": 20,
+      "rdev": 0,
+      "blksize": 4096,
+      "ino": 3,
+      "size": 3,
+      "blocks": 8,
+      "atimeMs": 1617042035118.9333,
+      "mtimeMs": 1617042034056.6714,
+      "ctimeMs": 1617042034077.1594,
+      "birthtimeMs": 1617042034055.7148,
+      "atime": "2021-03-29T18:20:35.119Z",
+      "mtime": "2021-03-29T18:20:34.057Z",
+      "ctime": "2021-03-29T18:20:34.077Z",
+      "birthtime": "2021-03-29T18:20:34.056Z"
+    }
+  },
+  {
+    "type": "unlink",
+    "path": "dst/file"
+  }
+]

--- a/test/scenarios/move_and_trash_file/remote/changes.json
+++ b/test/scenarios/move_and_trash_file/remote/changes.json
@@ -1,0 +1,45 @@
+[
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2ae9faab7",
+    "_rev": "3-2cf5a07752a59d32d78802ef8f2c2513",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2021-03-28T22:02:46.925324206Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-28T22:02:52.636373361Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-28T22:02:52.636373361Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-03-28T22:02:46.925324206Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "bb1b7ed8dacc99e8de2996d2ae9a65cf",
+          "kind": "",
+          "name": "test-9"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-03-29T00:02:46Z",
+    "dir_id": "io.cozy.files.trash-dir",
+    "executable": false,
+    "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
+    "mime": "application/octet-stream",
+    "name": "file",
+    "restore_path": "/dst",
+    "size": "8",
+    "tags": [],
+    "trashed": true,
+    "type": "file",
+    "updated_at": "2021-03-29T00:02:46Z",
+    "path": "/.cozy_trash/file"
+  }
+]

--- a/test/scenarios/move_and_trash_file/scenario.js
+++ b/test/scenarios/move_and_trash_file/scenario.js
@@ -3,7 +3,6 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  disabled: 'requires handling moveFrom + trashed', // FIXME
   useCaptures: false,
   init: [
     { ino: 1, path: 'dst/' },

--- a/test/scenarios/move_and_trash_file_from_inside_move/local/darwin.json
+++ b/test/scenarios/move_and_trash_file_from_inside_move/local/darwin.json
@@ -1,6 +1,6 @@
 [
   {
-    "breakpoints": [0, 2, 4]
+    "breakpoints": [0, 4]
   },
   {
     "type": "unlinkDir",

--- a/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
+++ b/test/scenarios/move_and_trash_file_from_inside_move/scenario.js
@@ -1,10 +1,15 @@
 /* @flow */
 
+const { runWithStoppedClient } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
   side: 'local',
-  disabled: 'Does not work yet on all watchers',
+  disabled:
+    process.platform === 'darwin' && runWithStoppedClient()
+      ? 'Does not work on macOS because buffered child events are not modified by parents move events'
+      : undefined,
   init: [
     { ino: 1, path: 'dst/' },
     { ino: 2, path: 'src/' },

--- a/test/scenarios/trash_file_and_move_parent/atom/linux.json
+++ b/test/scenarios/trash_file_and_move_parent/atom/linux.json
@@ -1,0 +1,17 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src/subdir/file"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "directory",
+      "path": "dst/subdir",
+      "oldPath": "src/subdir"
+    }
+  ]
+]

--- a/test/scenarios/trash_file_and_move_parent/atom/win32.json
+++ b/test/scenarios/trash_file_and_move_parent/atom/win32.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src\\subdir\\file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "src\\subdir"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "directory",
+      "path": "dst\\subdir"
+    }
+  ]
+]

--- a/test/scenarios/trash_file_and_move_parent/local/darwin.json
+++ b/test/scenarios/trash_file_and_move_parent/local/darwin.json
@@ -1,0 +1,37 @@
+[
+  {
+    "breakpoints": [0, 1]
+  },
+  {
+    "type": "unlink",
+    "path": "src/subdir/file"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "src/subdir"
+  },
+  {
+    "type": "addDir",
+    "path": "dst/subdir",
+    "stats": {
+      "dev": 16777221,
+      "mode": 16877,
+      "nlink": 2,
+      "uid": 501,
+      "gid": 20,
+      "rdev": 0,
+      "blksize": 4096,
+      "ino": 3,
+      "size": 64,
+      "blocks": 0,
+      "atimeMs": 1617047406453.3965,
+      "mtimeMs": 1617047406220.4062,
+      "ctimeMs": 1617047407736.0093,
+      "birthtimeMs": 1617047406202.5964,
+      "atime": "2021-03-29T19:50:06.453Z",
+      "mtime": "2021-03-29T19:50:06.220Z",
+      "ctime": "2021-03-29T19:50:07.736Z",
+      "birthtime": "2021-03-29T19:50:06.203Z"
+    }
+  }
+]

--- a/test/scenarios/trash_file_and_move_parent/remote/changes.json
+++ b/test/scenarios/trash_file_and_move_parent/remote/changes.json
@@ -1,0 +1,71 @@
+[
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2aea805d3",
+    "_rev": "2-091cd2b8a71ac533ef87622ef2c2cd8d",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2021-03-29T19:40:33.120271413Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-29T19:40:37.425596774Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-29T19:40:37.425596774Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-03-29T19:40:33.120271413Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "bb1b7ed8dacc99e8de2996d2ae9a65cf",
+          "kind": "",
+          "name": "test-9"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-03-29T21:40:33Z",
+    "dir_id": "io.cozy.files.trash-dir",
+    "executable": false,
+    "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
+    "mime": "application/octet-stream",
+    "name": "file",
+    "restore_path": "/src/subdir",
+    "size": "8",
+    "tags": [],
+    "trashed": true,
+    "type": "file",
+    "updated_at": "2021-03-29T21:40:33Z",
+    "path": "/.cozy_trash/file"
+  },
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2aea7fd19",
+    "_rev": "2-26a53a9d21b74cd5e2a55d1dfa7c6a8a",
+    "cozyMetadata": {
+      "createdAt": "2021-03-29T19:40:33.070655213Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-29T19:40:39.026203414Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-29T19:40:39.026203414Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ]
+    },
+    "created_at": "2021-03-29T21:40:33Z",
+    "dir_id": "bb1b7ed8dacc99e8de2996d2aea7ecba",
+    "name": "subdir",
+    "path": "/dst/subdir",
+    "tags": [],
+    "type": "directory",
+    "updated_at": "2021-03-29T21:40:33Z"
+  }
+]

--- a/test/scenarios/trash_file_and_move_parent/scenario.js
+++ b/test/scenarios/trash_file_and_move_parent/scenario.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+const { runWithStoppedClient } = require('../../support/helpers/scenarios')
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  useCaptures: false,
+  disabled: runWithStoppedClient()
+    ? 'Does not work because the parent events are generated first during the intial scan'
+    : undefined,
+  init: [
+    { ino: 1, path: 'dst/' },
+    { ino: 2, path: 'src/' },
+    { ino: 3, path: 'src/subdir/' },
+    { ino: 4, path: 'src/subdir/file' }
+  ],
+  actions: [
+    { type: 'trash', path: 'src/subdir/file' },
+    { type: 'wait', ms: 1500 },
+    { type: 'mv', src: 'src/subdir', dst: 'dst/subdir' },
+    { type: 'wait', ms: 1500 }
+  ],
+  expected: {
+    tree: ['dst/', 'dst/subdir/', 'src/'],
+    trash: ['file']
+  }
+} /*: Scenario */)

--- a/test/unit/local/chokidar/analysis.js
+++ b/test/unit/local/chokidar/analysis.js
@@ -824,8 +824,7 @@ onPlatform('darwin', () => {
               path: newDirPath.normalize('NFD'),
               ino: dirStats.ino,
               stats: dirStats,
-              old: oldDir,
-              wip: undefined
+              old: oldDir
             }
           ])
           should(pendingChanges).deepEqual([])
@@ -908,8 +907,7 @@ onPlatform('darwin', () => {
               path: 'corrigés',
               ino: parent.ino,
               stats: { ino: parent.ino },
-              old: parent,
-              wip: undefined // FIXME: Remove useless wip key
+              old: parent
             },
             {
               sideName,
@@ -1018,8 +1016,7 @@ onPlatform('darwin', () => {
                 path: 'dst/dir',
                 ino: dir.ino,
                 stats: { ino: dir.ino },
-                old: dir,
-                wip: undefined // FIXME: Remove useless wip key
+                old: dir
               },
               {
                 sideName,
@@ -1035,8 +1032,7 @@ onPlatform('darwin', () => {
                 ino: subdir.ino,
                 stats: { ino: subdir.ino },
                 old: subdir,
-                needRefetch: true,
-                wip: undefined // FIXME: Remove useless wip key
+                needRefetch: true
               },
               {
                 sideName,
@@ -1097,8 +1093,7 @@ onPlatform('darwin', () => {
               path: 'dst',
               ino: dirIno,
               stats: { ino: dirIno },
-              old: srcDir,
-              wip: undefined // FIXME: Remove useless wip key
+              old: srcDir
             },
             {
               sideName,
@@ -1153,8 +1148,7 @@ onPlatform('darwin', () => {
               path: 'dst',
               ino: dirIno,
               stats: { ino: dirIno },
-              old: srcDir,
-              wip: undefined // FIXME: Remove useless wip key
+              old: srcDir
             },
             {
               sideName,
@@ -1347,8 +1341,7 @@ onPlatform('darwin', () => {
               path: 'dst',
               stats: dirStats,
               ino: dirStats.ino,
-              old: dirMetadata,
-              wip: undefined
+              old: dirMetadata
             },
             {
               sideName,


### PR DESCRIPTION
When a moved folders is also marked for deletion, Sync will propagate
the move instead of the trashing because the presence of the
`moveFrom` attribute will have precedence over the presence of the
`deleted` attribute.
We could change the move detection in Sync but it seems better to
trash the source of the moved folder and discard the destination
record at the Merge level and simply propagate its deletion at its
original path.

In case the trashed folder was overwriting another document, we make
sure this overwritten record will also be marked for deletion as it
does not exist on the trashing side anymore.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
