### PR TITLE
core/merge: Don't move deleted child with parent

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -532,6 +532,12 @@ class Merge {
     )
 
     for (let doc of docs) {
+      // Don't move children marked for deletion as we can simply propagate the
+      // deletion at their original path.
+      // Besides, as of today, `moveFrom` will have precedence over `deleted` in
+      // Sync and the deletion won't be propagated at all.
+      if (doc.deleted) continue
+
       // Update remote rev of documents which have been updated on the Cozy
       // after we've detected the move.
       const newRemoteRev = _.get(newRemoteRevs, _.get(doc, 'remote._id'))

--- a/test/scenarios/trash_file_and_move_parent/atom/linux.json
+++ b/test/scenarios/trash_file_and_move_parent/atom/linux.json
@@ -1,0 +1,17 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src/subdir/file"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "directory",
+      "path": "dst/subdir",
+      "oldPath": "src/subdir"
+    }
+  ]
+]

--- a/test/scenarios/trash_file_and_move_parent/atom/win32.json
+++ b/test/scenarios/trash_file_and_move_parent/atom/win32.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "src\\subdir\\file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "src\\subdir"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "directory",
+      "path": "dst\\subdir"
+    }
+  ]
+]

--- a/test/scenarios/trash_file_and_move_parent/local/darwin.json
+++ b/test/scenarios/trash_file_and_move_parent/local/darwin.json
@@ -1,0 +1,37 @@
+[
+  {
+    "breakpoints": [0, 1]
+  },
+  {
+    "type": "unlink",
+    "path": "src/subdir/file"
+  },
+  {
+    "type": "unlinkDir",
+    "path": "src/subdir"
+  },
+  {
+    "type": "addDir",
+    "path": "dst/subdir",
+    "stats": {
+      "dev": 16777221,
+      "mode": 16877,
+      "nlink": 2,
+      "uid": 501,
+      "gid": 20,
+      "rdev": 0,
+      "blksize": 4096,
+      "ino": 3,
+      "size": 64,
+      "blocks": 0,
+      "atimeMs": 1617047406453.3965,
+      "mtimeMs": 1617047406220.4062,
+      "ctimeMs": 1617047407736.0093,
+      "birthtimeMs": 1617047406202.5964,
+      "atime": "2021-03-29T19:50:06.453Z",
+      "mtime": "2021-03-29T19:50:06.220Z",
+      "ctime": "2021-03-29T19:50:07.736Z",
+      "birthtime": "2021-03-29T19:50:06.203Z"
+    }
+  }
+]

--- a/test/scenarios/trash_file_and_move_parent/remote/changes.json
+++ b/test/scenarios/trash_file_and_move_parent/remote/changes.json
@@ -1,0 +1,71 @@
+[
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2aea805d3",
+    "_rev": "2-091cd2b8a71ac533ef87622ef2c2cd8d",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2021-03-29T19:40:33.120271413Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-29T19:40:37.425596774Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-29T19:40:37.425596774Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2021-03-29T19:40:33.120271413Z",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "bb1b7ed8dacc99e8de2996d2ae9a65cf",
+          "kind": "",
+          "name": "test-9"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.tools:8080/"
+    },
+    "created_at": "2021-03-29T21:40:33Z",
+    "dir_id": "io.cozy.files.trash-dir",
+    "executable": false,
+    "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
+    "mime": "application/octet-stream",
+    "name": "file",
+    "restore_path": "/src/subdir",
+    "size": "8",
+    "tags": [],
+    "trashed": true,
+    "type": "file",
+    "updated_at": "2021-03-29T21:40:33Z",
+    "path": "/.cozy_trash/file"
+  },
+  {
+    "_id": "bb1b7ed8dacc99e8de2996d2aea7fd19",
+    "_rev": "2-26a53a9d21b74cd5e2a55d1dfa7c6a8a",
+    "cozyMetadata": {
+      "createdAt": "2021-03-29T19:40:33.070655213Z",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.tools:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2021-03-29T19:40:39.026203414Z",
+      "updatedByApps": [
+        {
+          "date": "2021-03-29T19:40:39.026203414Z",
+          "instance": "http://cozy.tools:8080/",
+          "slug": "cozy-desktop"
+        }
+      ]
+    },
+    "created_at": "2021-03-29T21:40:33Z",
+    "dir_id": "bb1b7ed8dacc99e8de2996d2aea7ecba",
+    "name": "subdir",
+    "path": "/dst/subdir",
+    "tags": [],
+    "type": "directory",
+    "updated_at": "2021-03-29T21:40:33Z"
+  }
+]

--- a/test/scenarios/trash_file_and_move_parent/scenario.js
+++ b/test/scenarios/trash_file_and_move_parent/scenario.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+const { runWithStoppedClient } = require('../../support/helpers/scenarios')
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  useCaptures: false,
+  disabled: runWithStoppedClient()
+    ? 'Does not work because the parent events are generated first during the intial scan'
+    : undefined,
+  init: [
+    { ino: 1, path: 'dst/' },
+    { ino: 2, path: 'src/' },
+    { ino: 3, path: 'src/subdir/' },
+    { ino: 4, path: 'src/subdir/file' }
+  ],
+  actions: [
+    { type: 'trash', path: 'src/subdir/file' },
+    { type: 'wait', ms: 1500 },
+    { type: 'mv', src: 'src/subdir', dst: 'dst/subdir' },
+    { type: 'wait', ms: 1500 }
+  ],
+  expected: {
+    tree: ['dst/', 'dst/subdir/', 'src/'],
+    trash: ['file']
+  }
+} /*: Scenario */)


### PR DESCRIPTION
When a moved record is also marked for deletion, Sync will propagate
the move instead of the trashing because the presence of the
`moveFrom` attribute will have precedence over the presence of the
`deleted` attribute.
We could change the move detection in Sync but it seems better not to
move deleted children at all at the Merge level and simply propagate
their deletion at their original path.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
