### PR TITLE
core/merge: Fix trashing of overwriting moves

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -669,17 +669,22 @@ class Merge {
         // Mark source for deletion
         metadata.markSide(side, moveFrom, moveFrom)
         moveFrom.deleted = true
-        // Discard move destination record
-        metadata.markAsUnsyncable(was)
 
-        const docs = [moveFrom, was]
+        const docs = [moveFrom]
         if (overwrite) {
           // Mark overwritten doc for deletion
-          metadata.markSide(side, overwrite, overwrite)
+          metadata.removeActionHints(overwrite)
           overwrite.deleted = true
+          // They share the same _id
+          overwrite._rev = was._rev
+          metadata.markSide(side, overwrite, was)
 
-          // Add it to the front of the list so we make sure it's synced first
-          docs.unshift(overwrite)
+          docs.push(overwrite)
+        } else {
+          // Discard move destination record
+          metadata.markAsUnsyncable(was)
+
+          docs.push(was)
         }
         return this.pouch.bulkDocs(docs)
       }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -309,6 +309,13 @@ module.exports = class BaseMetadataBuilder {
       this.noRemote()
     }
 
+    if (this.doc.overwrite && this.doc.moveFrom) {
+      // Emulate the _id reuse done when merging an overwriting move.
+      const { _id, _rev } = this.doc.overwrite
+      this.doc._id = _id
+      this.doc._rev = _rev
+    }
+
     return _.cloneDeep(this.doc)
   }
 

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -4968,30 +4968,16 @@ describe('Merge', function() {
               _.defaults(
                 {
                   deleted: true,
-                  sides: increasedSides(existing.sides, this.side, 1)
-                },
-                _.omit(existing, ['_id', '_rev'])
-              ),
-              _.defaults(
-                {
-                  deleted: true,
                   sides: increasedSides(src.sides, this.side, 1)
                 },
                 _.omit(src, ['_id', '_rev', '_deleted', 'moveTo'])
               ),
               _.defaults(
                 {
-                  _deleted: true
+                  deleted: true,
+                  sides: increasedSides(was.sides, this.side, 1)
                 },
-                _.omit(was, [
-                  '_id',
-                  '_rev',
-                  'sides',
-                  'moveFrom',
-                  'overwrite',
-                  'local',
-                  'remote'
-                ])
+                _.omit(existing, ['_id', '_rev'])
               )
             ],
             resolvedConflicts: []


### PR DESCRIPTION
When we took care of trashing the overwritten document of a trashed
overwriting move, we made the wrong assumption that the overwritten
and overwriting records would not have the same PouchDB `_id` and thus
could be modified together via a `Pouch.bulkDocs()` call.

It turns out that we reuse the _id (and _rev) of overwritten records
when merging an overwriting move so that only one record with the
destination path exists in PouchDB at the same time (i.e. to avoid
queries mismatches).
Thus, when trashing an overwriting move we'll only update the
destination record as if it was the deleted overwritten record.

We did not catch this problem because our test Metadata builders did
not correctly emulate an overwriting move as they were not reusing the
overwritten record's _id and _rev attributes.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
