### PR TITLE
Fix revoked client error detection on start

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -111,6 +111,17 @@ class Sync {
       return
     }
 
+    // Errors emitted while the remote watcher is starting (e.g. revoked OAuth
+    // client) will not be thrown and thus not handled if this listener is not
+    // attached before starting the watcher.
+    // This results in the Sync starting without a remote watcher.
+    this.remote.watcher.onFatal(err => {
+      this.fatal(err)
+    })
+    this.remote.watcher.onError(err => {
+      this.blockSyncFor({ err })
+    })
+
     try {
       await this.local.start()
       await this.remote.start()
@@ -121,12 +132,6 @@ class Sync {
       return this.fatal(err)
     }
 
-    this.remote.watcher.onError(err => {
-      this.blockSyncFor({ err })
-    })
-    this.remote.watcher.onFatal(err => {
-      this.fatal(err)
-    })
     this.local.watcher.running.catch(err => {
       this.fatal(err)
     })

--- a/gui/main.js
+++ b/gui/main.js
@@ -217,7 +217,7 @@ const showMigrationError = (err /*: Error */) => {
 }
 
 const sendErrorToMainWindow = msg => {
-  if (msg === COZY_CLIENT_REVOKED_MESSAGE) {
+  if (msg.includes(COZY_CLIENT_REVOKED_MESSAGE)) {
     if (notificationsState.revokedAlertShown) return
     notificationsState.revokedAlertShown = true // prevent the alert from appearing twice
     const options = {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -121,7 +121,9 @@ describe('Sync', function() {
 
     context('if remote watcher fails to start', () => {
       beforeEach(function() {
-        this.remote.start = sinon.stub().rejects(new Error('failed'))
+        this.remote.start = sinon.stub().callsFake(() => {
+          this.remote.watcher.fatal(new Error('failed'))
+        })
       })
 
       it('does not start replication', async function() {


### PR DESCRIPTION
The recent changes made to the error management in Sync and the remote
watcher introduced a regression preventing us from correctly detecting
and handling revoked OAuth client errors.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation