### PR TITLE
core/sync: Prevent parallel retry intervals

### DIFF
--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -70,6 +70,9 @@ class SyncError extends Error {
 }
 
 const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
+  // Speed up tests
+  if (process.env.NODE_ENV === 'test') return 500
+
   if (err instanceof remoteErrors.RemoteError) {
     // The error originates from the Remote Watcher and is not a change
     // application error.

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -753,7 +753,7 @@ class Sync {
       }
 
       // Await to make sure we've fetched potential remote changes
-      if (!this.remote.watcher.running) {
+      if (this.remote.watcher && !this.remote.watcher.running) {
         await this.remote.watcher.start()
       }
 
@@ -788,6 +788,8 @@ class Sync {
       this.lifecycle.unblockFor(err.code)
     }
 
+    // Clear any existing interval since we'll replace it
+    clearInterval(this.retryInterval)
     // We'll automatically retry to sync the change after a delay
     this.retryInterval = setInterval(retry, retryDelay)
 
@@ -806,6 +808,7 @@ class Sync {
 
     switch (err.code) {
       case remoteErrors.UNREACHABLE_COZY_CODE:
+        this.remote.watcher.stop()
         this.events.emit('offline')
         break
       case remoteErrors.CONFLICTING_NAME_CODE:


### PR DESCRIPTION
When the remote Cozy becomes unreachable, two processes can throw
errors which will block the synchronization process and initiate a
retry interval:
- the synchronization process itself if the error was thrown while
  trying to propagate a change
- the remote watcher when trying to fetch the latest remote changes

In the synchronization process errors out right before the remote
watcher tries to fetch the latest changes (i.e. the Cozy is thus still
unreachable), the reference to the retry interval initiated by the
synchronization process will be overwritten by the reference to the
retry interval initiated by the remote watcher.
This reference is held by the `Sync.retryInterval` variable.

Loosing the reference to the 1st retry interval means it will run in
parallel to the 2nd one and we won't be able to end it via a call to
`clearInterval()`.

To prevent this situation from happening, we'll clear any existing
interval held by `Sync.retryInterval` before starting a new one and
assigning it to the same variable.

---

In order to limit unnecessary computations and extra errors, we'll
also stop the remote watcher whenever the synchronization process is
blocked because the remote Cozy is unreachable.
It will be restarted by the retry mechanism when the Cozy becomes
available again.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
