### PR TITLE
gui: Avoid unwanted note openings

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -456,7 +456,11 @@ app.on('second-instance', async (event, argv) => {
     log.info({ filePath }, 'second instance invoked with arguments')
 
     // If we found a note to open, stop here. Otherwise, show main window.
-    if (await openNote(filePath, { desktop })) return
+    if (
+      filePath.endsWith('.cozy-note') &&
+      (await openNote(filePath, { desktop }))
+    )
+      return
   }
 
   // Make sure the main window exists before trying to show it
@@ -551,13 +555,16 @@ app.on('ready', async () => {
   if (desktop.config.syncPath) {
     await setupDesktop()
 
-    if (process.argv && process.argv.length > 2) {
-      const { argv } = process
+    const { argv } = process
+    if (argv && argv.length > 2) {
       const filePath = argv[argv.length - 1]
-      log.info({ filePath }, 'main instance invoked with arguments')
+      log.info({ filePath, argv }, 'main instance invoked with arguments')
 
       // If we found a note to open, stop here. Otherwise, start sync app.
-      if (await openNote(filePath, { desktop })) {
+      if (
+        filePath.endsWith('.cozy-note') &&
+        (await openNote(filePath, { desktop }))
+      ) {
         app.quit()
         return
       }


### PR DESCRIPTION
When the client is launched with more than 2 argument (the first 2
being the path to the application and an empty string), we assume the
last one is a path to a Cozy Note on the file system as this is the
way Linux and Windows notify us of an opening request from the file
explorer.

However, when the client is started automatically with the computer,
the `--hidden` argument is added by `auto-launch` to make sure the
client window is not opened right away.
In this case, the client will assume `--hidden` is a path to a note
and will try to open it. Since it's not a path at all, it will fail
with a generic error, triggering the display of an error popup.

This error does not prevent the client from starting however.

We'll now check if the "path" ends with `.cozy-note` to filter out all
situations where the client is invoked with anything else than a Cozy
Note.

It's still a mystery why we haven't spotted this earlier.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
