### PR TITLE
macOS: Ignore custom folder icons

### DIFF
--- a/core/config/.cozyignore
+++ b/core/config/.cozyignore
@@ -40,6 +40,7 @@
 .Trashes
 .VolumeIcon.icns
 Icon
+Icon\r
 
 # Vim
 *.sw[px]


### PR DESCRIPTION
MacOS allows users to use custom folder icons and saves them as a
hidden file of the given folder with the name `Icon\r`.

However, cozy-stack forbids the presence of `\r` in document names so
these icons block the synchronization.

We think it's better to ignore those files rather than blocking the
user.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
