### PR TITLE
core/prep: Transform same path moves into updates

### DIFF
--- a/core/prep.js
+++ b/core/prep.js
@@ -112,9 +112,8 @@ class Prep {
     metadata.ensureValidChecksum(doc)
 
     if (doc.path === was.path) {
-      const msg = 'Invalid move'
-      log.warn({ path, doc, was }, msg)
-      throw new Error(msg)
+      log.warn({ path, doc, was }, 'Invalid move. Updating file')
+      return this.updateFileAsync(side, doc)
     } else if (!was._rev) {
       const msg = 'Missing rev'
       log.warn({ path, doc, was }, msg)
@@ -153,9 +152,8 @@ class Prep {
     metadata.ensureValidPath(was)
 
     if (doc.path === was.path) {
-      const msg = 'Invalid move'
-      log.warn({ path, doc, was }, msg)
-      throw new Error(msg)
+      log.warn({ path, doc, was }, 'Invalid move. Updating folder')
+      return this.putFolderAsync(side, doc)
     } else if (!was._rev) {
       const msg = 'Missing rev'
       log.warn({ path, doc, was }, msg)

--- a/test/unit/prep.js
+++ b/test/unit/prep.js
@@ -183,22 +183,6 @@ describe('Prep', function() {
         ).be.rejectedWith('Invalid checksum')
       })
 
-      it('expects two different paths', async function() {
-        let doc = {
-          path: 'foo/bar',
-          docType: 'file',
-          md5sum: 'VVVVVVVVVVVVVVVVVVVVVQ=='
-        }
-        let was = {
-          path: 'foo/bar',
-          docType: 'file',
-          md5sum: 'VVVVVVVVVVVVVVVVVVVVVQ=='
-        }
-        await should(
-          this.prep.moveFileAsync(this.side, doc, was)
-        ).be.rejectedWith('Invalid move')
-      })
-
       it('expects a revision for was', async function() {
         let doc = {
           path: 'foo/bar',
@@ -213,6 +197,25 @@ describe('Prep', function() {
         await should(
           this.prep.moveFileAsync(this.side, doc, was)
         ).be.rejectedWith('Missing rev')
+      })
+
+      it('calls updateFileAsync if src and dst paths are the same', async function() {
+        sinon.spy(this.prep, 'updateFileAsync')
+
+        let doc = {
+          path: 'foo/bar',
+          docType: 'file',
+          md5sum: 'VVVVVVVVVVVVVVVVVVVVVQ=='
+        }
+        let was = {
+          path: 'foo/bar',
+          docType: 'file',
+          md5sum: 'VVVVVVVVVVVVVVVVVVVVVQ=='
+        }
+        this.prep.moveFileAsync(this.side, doc, was)
+        should(this.prep.updateFileAsync).have.been.calledWith(this.side, doc)
+
+        this.prep.updateFileAsync.restore()
       })
 
       it('calls Merge with the correct fields', async function() {
@@ -258,20 +261,6 @@ describe('Prep', function() {
         ).be.rejectedWith('Invalid path')
       })
 
-      it('expects two different paths', async function() {
-        let doc = {
-          path: 'foo/bar',
-          docType: 'folder'
-        }
-        let was = {
-          path: 'foo/bar',
-          docType: 'folder'
-        }
-        await should(
-          this.prep.moveFolderAsync(this.side, doc, was)
-        ).be.rejectedWith('Invalid move')
-      })
-
       it('expects a revision for was', async function() {
         let doc = {
           path: 'foo/bar',
@@ -284,6 +273,23 @@ describe('Prep', function() {
         await should(
           this.prep.moveFolderAsync(this.side, doc, was)
         ).be.rejectedWith('Missing rev')
+      })
+
+      it('calls putFolderAsync if src and dst paths are the same', async function() {
+        sinon.spy(this.prep, 'putFolderAsync')
+
+        let doc = {
+          path: 'foo/bar',
+          docType: 'folder'
+        }
+        let was = {
+          path: 'foo/bar',
+          docType: 'folder'
+        }
+        this.prep.moveFolderAsync(this.side, doc, was)
+        should(this.prep.putFolderAsync).have.been.calledWith(this.side, doc)
+
+        this.prep.putFolderAsync.restore()
       })
 
       it('calls Merge with the correct fields', async function() {


### PR DESCRIPTION
We should never have to process document moves from one path to the
exact same one. However, we've witnessed it happening in some
situations and we used to throw errors in these cases.

It seems like we should still merge the side metadata in these cases
and transforming the moves into updates seem like a good way to do
that.

It is still unclear how we get into these situations but since the
change does not trigger any test failure it seems pretty safe to test
it if not in production at least in a beta release.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
