### PR TITLE
gui: Hide dock icon on macOS by default

### DIFF
--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -154,8 +154,6 @@ module.exports = class WindowManager {
       }
     })
 
-    this.win.setVisibleOnAllWorkspaces(true)
-
     // noMenu
     this.win.setMenu(null)
     this.win.setAutoHideMenuBar(true)

--- a/gui/main.js
+++ b/gui/main.js
@@ -505,13 +505,11 @@ app.on('open-file', async (event, filePath) => {
 })
 
 app.on('ready', async () => {
-  // Once configured and running in the tray, the app doesn't need to be
-  // visible anymore in macOS dock (and cmd+tab), even when the tray popover
-  // is visible, until another window shows up.
+  // Once configured and running in the tray, the app doesn't need to be visible
+  // anymore in macOS dock (and cmd+tab), even when the tray popover is visible,
+  // until another window shows up.
   if (process.platform === 'darwin') {
-    setTimeout(() => {
-      app.dock.hide()
-    }, 1000)
+    app.dock.hide()
   }
 
   const { session } = require('electron')


### PR DESCRIPTION
Recent changes in Electron might have altered the behavior of
`Window.setVisibleOnAllWorkspaces()` effectively making the app icon in
the macOS dock show whenever we create a new window and call this
function (e.g. the Tray window which is hidden by default).

Besides, it seems that displaying an Electron app icon in the dock
prevents the OS from shutting down, displaying an error message to the
user inviting them to force-kill the application.

Since we don't need to show our windows on all workspaces (we only want
it displayed on the workspace it was opened from) we can stop using
this function and thus kill two birds with one stone by preventing
unexpected icons in the dock and leaving the OS shutdown correctly.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
