### PR TITLE
core/pouch: Migrate path length incompatibilities

### DIFF
--- a/core/incompatibilities/platform.js
+++ b/core/incompatibilities/platform.js
@@ -64,14 +64,15 @@ type NameIncompatibility =
   | NameMaxBytesIncompatibility
   | DirNameMaxBytesIncompatibility
 
-type PathIncompatibility = NameIncompatibility & {path: string}
+type PathIncompatibility = { ...NameIncompatibility, path: string }
 
-export type PathLengthIncompatibility = {
+export type PathLengthIncompatibility = {|
+  type: 'pathMaxBytes',
   path: string,
-  pathBytes?: number,
-  pathMaxBytes?: number,
+  pathBytes: number,
+  pathMaxBytes: number,
   platform: string
-}
+|}
 
 export type PlatformIncompatibility =
   | PathIncompatibility
@@ -323,9 +324,7 @@ const detectPathLengthIncompatibility = (
   const { pathMaxBytes } = restrictionsByPlatform(platform)
   const pathBytes = Buffer.byteLength(path) // TODO: utf16?
   if (pathBytes > pathMaxBytes) {
-    // FIXME: The name is useless, but could not find a way to make flow happy
-    // without it.
-    return { name: path, path, pathBytes, pathMaxBytes, platform }
+    return { type: 'pathMaxBytes', path, pathBytes, pathMaxBytes, platform }
   }
 }
 


### PR DESCRIPTION
Add a `type` attribute to existing path length incompatibilities in
PouchDB records so we can use it to filter incompatibilities more
easily (and simplify our type checking) and remove any Windows path
length incompatibility if the path length is less than the new 32766
characters limit.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
