### PR TITLE
gui/proxy: Prevent browser caching on all requests

### DIFF
--- a/gui/js/proxy.js
+++ b/gui/js/proxy.js
@@ -86,6 +86,17 @@ const setup = async (
     callback(-3) // use chrome validation
   })
 
+  // It's unclear if this actually works or not especially since we can't
+  // control that the Cache-Control header is really set.
+  // See https://github.com/electron/electron/issues/27895.
+  syncSession.webRequest.onHeadersReceived(
+    ({ statusLine, responseHeaders }, callback) => {
+      responseHeaders['Cache-Control'] = ['no-store']
+      statusLine += ' NO CACHE'
+      callback({ responseHeaders, statusLine })
+    }
+  )
+
   app.on(
     'select-client-certificate',
     (event, webContents, url, list, callback) => {

--- a/test/unit/gui/proxy.js
+++ b/test/unit/gui/proxy.js
@@ -122,10 +122,25 @@ describe('gui/js/proxy', function() {
 
       describe('fetch()', () => {
         describe('HTTP', () => {
-          beforeEach(() => global.fetch(httpUrl()))
+          let response
+          beforeEach(async () => {
+            response = await global.fetch(httpUrl())
+          })
 
           it('sets User-Agent', async () => {
             should(received.headers['user-agent']).equal(userAgent)
+          })
+
+          // FIXME: Returned response headers only contain the raw headers which
+          // are not modified by calls to onHeadersReceived.
+          // See https://github.com/electron/electron/issues/27895
+          //
+          // This means we can't see if the Cache-Control header is actually
+          // set.
+          // But it should still be interpreted by Chromium.
+          it.skip('sets reponse Cache-Control header to no-store', async () => {
+            // Prevent Chromium from caching requests to avoid net error loops
+            should(response.headers['Cache-Control']).equal('no-store')
           })
         })
 

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -606,7 +606,9 @@ describe('RemoteCozy', function() {
 
     const stubWarningsResponse = (status /*: number */, data) => {
       cozyStackDouble.stub((req, res) => {
-        if (req.url === '/status/') res.end('{}')
+        // A strict equality check would prevent us from adding query-string
+        // parameters to the request.
+        if (req.url.includes('/status/')) res.end('{}')
         else {
           res.writeHead(status)
           res.end(JSON.stringify(data))


### PR DESCRIPTION
When the client encounters a network issue on Windows or macOS, it
sometimes "caches" this response and will return it to every subsequent
request.

We make the assumption that this "cache" is handled by Chromium and as
such can be disabled by adding the `Cache-Control: no-cache` header to
all responses.
Since we don't want the remote Cozy to do this (and thus disable
useful caches for all clients) we define an Electron response hook to
add it on the client side.

We've seen improvements during a test phase but don't have any hard
evidence that this really solves the issue.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
