### PR TITLE
Improve user communication around synchronization errors

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -791,23 +791,32 @@ class Sync {
       this.remote.watcher.stop()
     }
 
-    switch (err.code) {
-      case remoteErrors.UNREACHABLE_COZY_CODE:
-        this.remote.watcher.stop()
-        this.events.emit('offline')
-        break
-      case remoteErrors.CONFLICTING_NAME_CODE:
-      case remoteErrors.INVALID_FOLDER_MOVE_CODE:
-      case remoteErrors.MISSING_DOCUMENT_CODE:
-      case remoteErrors.MISSING_PARENT_CODE:
+    if (err.code === remoteErrors.UNREACHABLE_COZY_CODE) {
+      this.remote.watcher.stop()
+      this.events.emit('offline')
+    } else if (err instanceof syncErrors.SyncError) {
+      switch (err.code) {
+        case syncErrors.INCOMPATIBLE_DOC_CODE:
+        case syncErrors.MISSING_PERMISSIONS_CODE:
+        case syncErrors.NO_DISK_SPACE_CODE:
+        case remoteErrors.INVALID_METADATA_CODE:
+        case remoteErrors.INVALID_NAME_CODE:
+        case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
+        case remoteErrors.NO_COZY_SPACE_CODE:
+        case remoteErrors.PATH_TOO_DEEP_CODE:
+        case remoteErrors.UNKNOWN_REMOTE_ERROR_CODE:
+        case remoteErrors.USER_ACTION_REQUIRED_CODE:
+          this.events.emit(
+            'user-action-required',
+            err,
+            cause.change && cause.change.seq
+          )
+          break
+        default:
         // Hide the error from the user as we should be able to solve it
-        break
-      default:
-        this.events.emit(
-          'user-action-required',
-          err,
-          cause.change && cause.change.seq
-        )
+      }
+    } else {
+      // Hide the error from the user as we should be able to solve it
     }
   }
 

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -408,6 +408,8 @@ class Sync {
         case remoteErrors.USER_ACTION_REQUIRED_CODE:
           // We will keep retrying to apply the change until it's fixed or the
           // user contacts our support.
+          // See `default` case for other blocking errors for which we'll stop
+          // retrying after 3 failed attempts.
           this.blockSyncFor({ err: syncErr, change })
           break
         case remoteErrors.CONFLICTING_NAME_CODE:
@@ -517,7 +519,7 @@ class Sync {
         default:
           // Don't try more than MAX_SYNC_ATTEMPTS for the same operation
           if (!change.doc.errors || change.doc.errors < MAX_SYNC_ATTEMPTS) {
-            await this.updateErrors(change, syncErr)
+            this.blockSyncFor({ err: syncErr, change })
           } else {
             await this.skipChange(change, syncErr)
           }

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -840,7 +840,12 @@ class Sync {
     } catch (err) {
       // If the doc can't be saved, it's because of a new revision.
       // So, we can skip this revision
-      log.info(`Ignored ${change.seq}`, err)
+      if (err.status === 409) {
+        const was = await this.pouch.byIdMaybe(doc._id)
+        log.info({ err, doc, was }, `Ignored ${change.seq}`)
+      } else {
+        log.info({ err }, `Ignored ${change.seq}`)
+      }
       await this.pouch.setLocalSeq(change.seq)
     }
   }

--- a/core/syncstate.js
+++ b/core/syncstate.js
@@ -8,7 +8,7 @@ const EventEmitter = require('events')
 const deepDiff = require('deep-diff').diff
 
 /*::
-type UserActionStatus = 'Required'|'InProgress'|'Done'
+type UserActionStatus = 'Required'|'InProgress'
 export type UserAction = {
   seq: ?number,
   code: string,
@@ -196,9 +196,7 @@ module.exports = class SyncState extends EventEmitter {
     const userActions =
       newState.syncCurrentSeq != null
         ? updatedUserActions.reduce((actions, action) => {
-            if (action.seq && action.seq === newState.syncCurrentSeq) {
-              return actions.concat({ ...action, status: 'Done' })
-            } else if (action.seq && action.seq <= newState.syncCurrentSeq) {
+            if (action.seq && action.seq <= newState.syncCurrentSeq) {
               return actions
             } else {
               return actions.concat(action)
@@ -287,13 +285,6 @@ module.exports = class SyncState extends EventEmitter {
       case 'user-action-done':
         this.update({
           userActions: removeAction(this.state.userActions, makeAction(args[0]))
-          /*
-          userActions: updateAction(
-            this.state.userActions,
-            makeAction(args[0]),
-            'Done'
-          )
-          */
         })
         break
       case 'user-action-skipped':

--- a/gui/elm/Data/UserAction.elm
+++ b/gui/elm/Data/UserAction.elm
@@ -310,14 +310,14 @@ view code =
             , secondaryInteraction = Nothing
             }
 
-        "NoDiskSpace" ->
-            { title = "Error Your computer's disk space is insufficient"
+        "NeedsRemoteMerge" ->
+            { title = "Error Conflict with remote version"
             , details =
-                [ "Error The {0} `{1}` could not be written to your computer disk because there is not enough space available."
-                , "Error Synchronization will resume as soon as you have freed up space (emptied your Trash, deleted unnecessary files…)."
+                [ "Error The {0} `{1}` has been simultaneously modified on your computer and your Cozy."
+                , "Error This message persists if Cozy is unable to resolve this conflict. In this case rename the version you want to keep and click on \"Give up\"."
                 ]
             , primaryInteraction = Retry "UserAction Retry"
-            , secondaryInteraction = Nothing
+            , secondaryInteraction = GiveUp
             }
 
         "NoCozySpace" ->
@@ -330,14 +330,14 @@ view code =
             , secondaryInteraction = Nothing
             }
 
-        "NeedsRemoteMerge" ->
-            { title = "Error Conflict with remote version"
+        "NoDiskSpace" ->
+            { title = "Error Your computer's disk space is insufficient"
             , details =
-                [ "Error The {0} `{1}` has been simultaneously modified on your computer and your Cozy."
-                , "Error This message persists if Cozy is unable to resolve this conflict. In this case rename the version you want to keep and click on \"Give up\"."
+                [ "Error The {0} `{1}` could not be written to your computer disk because there is not enough space available."
+                , "Error Synchronization will resume as soon as you have freed up space (emptied your Trash, deleted unnecessary files…)."
                 ]
             , primaryInteraction = Retry "UserAction Retry"
-            , secondaryInteraction = GiveUp
+            , secondaryInteraction = Nothing
             }
 
         "PathTooDeep" ->


### PR DESCRIPTION
We try to avoid showing a « Synchronization suspended » status without
any error message or after the error was fixed.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
