### PR TITLE
core/local/chokidar: Don't squash moves into moves

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -312,8 +312,7 @@ function squashMoves(changes /*: LocalChange[] */) {
       // inline of LocalChange.isChildMove
       if (
         a.type === 'DirMove' &&
-        (pathB.startsWith(pathA + path.sep) ||
-          (oldPathA && oldPathB && oldPathB.startsWith(oldPathA + path.sep)))
+        (oldPathA && oldPathB && oldPathB.startsWith(oldPathA + path.sep))
       ) {
         log.debug({ oldpath: b.old.path, path: b.path }, 'descendant move')
         if (pathB.substr(pathA.length) === oldPathB.substr(oldPathA.length)) {

--- a/core/local/chokidar/local_change.js
+++ b/core/local/chokidar/local_change.js
@@ -388,7 +388,7 @@ function fileMoveFromUnlinkAdd(
       ino: fileMove.ino,
       wip: fileMove.wip
     },
-    `unlink + add  = FileMove${fileMove.update ? '(update)' : ''}`
+    `unlink + add = FileMove${fileMove.update ? '(update)' : ''}`
   )
 
   return fileMove


### PR DESCRIPTION
On macOS, since local changes are buffered, when a document is moved
within a folder that is also moved, we end up with a move change for
which the old path (i.e. the path used to query PouchDB for the old
record) won't be valid anymore when it comes to merging this event.

e.g.:

  when doing those 2 moves:
  - `dir` → `my dir`
  - `dir/file` → `my dir/my file`

  the old path of the file move change will be `dir/file` while the
  saved path in the PouchDB record will be `my dir/file` once we've
  merged the directory move.

To handle those cases, we detect when a move is done inside another
move and update its old path to take into account its parent move.

However, the logic used to detect them, would also consider the move
of a document from outside the moved directory into it as a "move
inside a move" and try to "correct" its old path, leading to an
incorrect change.

e.g.:

  when doing those 2 moves:
  - `dir` → `my dir`
  - `file` → `my dir/file`

  the old path of the file move would be changed into `my dir` thus
  generating an invalid folder to file move.

We're now leaving those moves untouched as they should be.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
