### PR TITLE
core/remote/watcher: Fetch resynced folders content

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -164,6 +164,12 @@ class Config {
     }
   }
 
+  // Flags are options that can be activated by the user via the config file.
+  // They can be used to activate incomplete features for example.
+  get flags() /*: { [string]: boolean } */ {
+    return _.get(this.fileConfig, 'flags', {})
+  }
+
   get version() /*: ?string */ {
     return _.get(this.fileConfig, 'creds.client.softwareVersion', '')
   }

--- a/core/merge.js
+++ b/core/merge.js
@@ -201,17 +201,10 @@ class Merge {
         doc._rev = file._rev
 
         // Keep other side metadata if we're updating the deleted side of file
-        if (
-          side === 'remote' &&
-          file.remote &&
-          (file.remote._deleted || file.remote.trashed)
-        ) {
+        if (side === 'remote' && file.remote && file.remote.trashed) {
           doc.local = file.local
           metadata.markSide(side, doc, file)
-        } else if (
-          side === 'local' &&
-          (!file.remote || (!file.remote._deleted && !file.remote.trashed))
-        ) {
+        } else if (side === 'local' && (!file.remote || !file.remote.trashed)) {
           doc.remote = file.remote
           metadata.markSide(side, doc, file)
         } else {

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -97,7 +97,7 @@ export type MetadataLocalInfo = {
   updated_at?: string,
 }
 
-export type MetadataRemoteFile = { ...RemoteFile, path: string }
+export type MetadataRemoteFile = {| ...RemoteFile, path: string |}
 export type MetadataRemoteDir = RemoteDir
 export type MetadataRemoteInfo = MetadataRemoteFile|MetadataRemoteDir
 
@@ -122,7 +122,7 @@ export type Metadata = {
   path: string,
   updated_at: string,
   local: MetadataLocalInfo,
-  remote: MetadataRemoteDir|MetadataRemoteFile,
+  remote: MetadataRemoteInfo,
   tags: string[],
   sides: MetadataSidesInfo,
 
@@ -468,8 +468,7 @@ function ensureValidChecksum(doc /*: Metadata */) {
 // Extract the revision number, or 0 it not found
 function extractRevNumber(doc /*: { _rev: string } */) {
   try {
-    // $FlowFixMe
-    let rev = doc._rev.split('-')[0]
+    const rev = doc._rev.split('-')[0]
     return Number(rev)
   } catch (error) {
     return 0

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -79,6 +79,11 @@ export type RemoteDirTrashing = {
   doc: Metadata,
   was: SavedMetadata
 }
+export type RemoteDirUpdate = {
+  sideName: 'remote',
+  type: 'DirUpdate',
+  doc: Metadata
+}
 export type RemoteIgnoredChange = {
   sideName: 'remote',
   type: 'IgnoredChange',
@@ -115,6 +120,7 @@ export type RemoteChange =
   | RemoteDirMove
   | RemoteDirRestoration
   | RemoteDirTrashing
+  | RemoteDirUpdate
   | RemoteFileAddition
   | RemoteFileDeletion
   | RemoteFileMove
@@ -212,7 +218,7 @@ function upToDate(
 
 function updated(
   doc /*: Metadata */
-) /*: RemoteFileUpdate | RemoteDirAddition */ {
+) /*: RemoteFileUpdate | RemoteDirUpdate */ {
   if (metadata.isFile(doc)) {
     return {
       sideName,
@@ -222,7 +228,7 @@ function updated(
   } else {
     return {
       sideName,
-      type: 'DirAddition',
+      type: 'DirUpdate',
       doc
     }
   }

--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -7,6 +7,7 @@
 /*::
 export type FILE_TYPE = 'file'
 export type DIR_TYPE = 'directory'
+export type FILES_DOCTYPE = 'io.cozy.files'
 */
 
 const DEFAULT_HEARTBEAT = 1000 * 60 // 1 minute

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -136,7 +136,8 @@ module.exports = {
   keepFiles,
   parentDirIds,
   inRemoteTrash,
-  remoteJsonToRemoteDoc
+  remoteJsonToRemoteDoc,
+  jsonApiToRemoteJsonDoc
 }
 
 function specialId(id /*: string */) {
@@ -195,4 +196,34 @@ function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
 
     return remoteFile
   }
+}
+
+function jsonApiToRemoteJsonDoc(
+  json /*: JsonApiDoc */
+) /*: RemoteJsonDoc|RemoteDeletion */ {
+  if (json._deleted) {
+    return ({
+      _id: json.id,
+      _rev: json.rev,
+      _deleted: true
+    } /*: RemoteDeletion */)
+  }
+
+  if (!json.meta || !json.meta.rev) {
+    throw new Error('Missing meta.rev attribute in JsonAPI resource.')
+  }
+
+  return json.attributes.type === DIR_TYPE
+    ? ({
+        _id: json.id,
+        _type: json.type,
+        _rev: json.meta && json.meta.rev,
+        attributes: json.attributes
+      } /*: RemoteJsonDir */)
+    : ({
+        _id: json.id,
+        _type: json.type,
+        _rev: json.meta && json.meta.rev,
+        attributes: json.attributes
+      } /*: RemoteJsonFile */)
 }

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -70,7 +70,13 @@ class Remote /*:: implements Reader, Writer */ {
     this.events = events
     this.remoteCozy = new RemoteCozy(config)
     this.warningsPoller = new RemoteWarningPoller(this.remoteCozy, events)
-    this.watcher = new RemoteWatcher(pouch, prep, this.remoteCozy, events)
+    this.watcher = new RemoteWatcher({
+      config: this.config,
+      pouch: this.pouch,
+      events: this.events,
+      remoteCozy: this.remoteCozy,
+      prep
+    })
 
     autoBind(this)
   }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -17,6 +17,7 @@ const normalizePaths = require('./normalizePaths')
 const logger = require('../../utils/logger')
 
 /*::
+import type { Config } from '../../config'
 import type EventEmitter from 'events'
 import type { Pouch } from '../../pouch'
 import type Prep from '../../prep'
@@ -25,6 +26,14 @@ import type { Metadata, MetadataRemoteInfo, SavedMetadata, RemoteRevisionsByID }
 import type { RemoteChange, RemoteFileMove, RemoteDirMove, RemoteDescendantChange } from '../change'
 import type { RemoteDeletion } from '../document'
 import type { RemoteError } from '../errors'
+
+export type RemoteWatcherOptions = {
+  +config: Config,
+  events: EventEmitter,
+  pouch: Pouch,
+  prep: Prep,
+  remoteCozy: RemoteCozy
+}
 */
 
 const log = logger({
@@ -36,6 +45,7 @@ const sideName = 'remote'
 /** Get changes from the remote Cozy and prepare them for merge */
 class RemoteWatcher {
   /*::
+  config: Config
   pouch: Pouch
   prep: Prep
   remoteCozy: RemoteCozy
@@ -45,11 +55,9 @@ class RemoteWatcher {
   */
 
   constructor(
-    pouch /*: Pouch */,
-    prep /*: Prep */,
-    remoteCozy /*: RemoteCozy */,
-    events /*: EventEmitter */
+    { config, pouch, prep, remoteCozy, events } /*: RemoteWatcherOptions */
   ) {
+    this.config = config
     this.pouch = pouch
     this.prep = prep
     this.remoteCozy = remoteCozy
@@ -331,7 +339,7 @@ class RemoteWatcher {
 
     // TODO: Move to Prep?
     if (!inRemoteTrash(remoteDoc)) {
-      metadata.assignPlatformIncompatibilities(doc, this.prep.config.syncPath)
+      metadata.assignPlatformIncompatibilities(doc, this.config.syncPath)
       const { incompatibilities } = doc
       if (incompatibilities) {
         log.debug({ path, oldpath: was && was.path, incompatibilities })

--- a/core/remote/watcher/normalizePaths.js
+++ b/core/remote/watcher/normalizePaths.js
@@ -33,6 +33,7 @@ const normalizePaths = async (
       c.type === 'FileAddition' ||
       c.type === 'DirAddition' ||
       c.type === 'FileUpdate' ||
+      c.type === 'DirUpdate' ||
       c.type === 'FileMove' ||
       c.type === 'DirMove' ||
       c.type === 'DescendantChange'

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -13,6 +13,7 @@ const FileMetadataBuilder = require('./metadata/file')
 const RemoteDirBuilder = require('./remote/dir')
 const RemoteFileBuilder = require('./remote/file')
 const RemoteNoteBuilder = require('./remote/note')
+const RemoteErasedBuilder = require('./remote/erased')
 const StreamBuilder = require('./stream')
 const AtomEventBuilder = require('./atom_event')
 const { DefaultStatsBuilder, WinStatsBuilder } = require('./stats')
@@ -70,6 +71,12 @@ module.exports = class Builders {
     old /*: ?RemoteFile|MetadataRemoteFile */
   ) /*: RemoteNoteBuilder */ {
     return new RemoteNoteBuilder(this.cozy, old)
+  }
+
+  remoteErased(
+    old /*: ?RemoteFile|MetadataRemoteFile|RemoteDir|MetadataRemoteDir */
+  ) /*: RemoteErasedBuilder */ {
+    return new RemoteErasedBuilder(this.cozy, old)
   }
 
   buildRemoteTree(

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -81,11 +81,6 @@ module.exports = class RemoteBaseBuilder /*:: <T: MetadataRemoteInfo> */ {
     return this.inRootDir()
   }
 
-  erased() /*: this */ {
-    this.remoteDoc._deleted = true
-    return this
-  }
-
   tags(...tags /*: string[] */) /*: this */ {
     this.remoteDoc.tags = tags
     return this

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -52,9 +52,7 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
   async update() /*: Promise<MetadataRemoteDir> */ {
     const cozy = this._ensureCozy()
 
-    const json = this.remoteDoc._deleted
-      ? await cozy.files.destroyById(this.remoteDoc._id)
-      : this.remoteDoc.trashed
+    const json = this.remoteDoc.trashed
       ? await cozy.files.trashById(this.remoteDoc._id, { dontRetry: true })
       : await cozy.files.updateAttributesById(this.remoteDoc._id, {
           dir_id: this.remoteDoc.dir_id,

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -3,7 +3,7 @@
 const _ = require('lodash')
 
 const RemoteBaseBuilder = require('./base')
-const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
+const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
@@ -37,7 +37,7 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
     const cozy = this._ensureCozy()
 
     return _.clone(
-      jsonApiToRemoteDoc(
+      remoteJsonToRemoteDoc(
         await cozy.files.createDirectory({
           name: this.remoteDoc.name,
           dirID: this.remoteDoc.dir_id,
@@ -61,6 +61,6 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
           noSanitize: true
         })
 
-    return _.clone(jsonApiToRemoteDoc(json))
+    return _.clone(remoteJsonToRemoteDoc(json))
   }
 }

--- a/test/support/builders/remote/erased.js
+++ b/test/support/builders/remote/erased.js
@@ -1,0 +1,90 @@
+/* @flow */
+
+const _ = require('lodash')
+
+const { ROOT_DIR_ID } = require('../../../../core/remote/constants')
+const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
+const metadata = require('../../../../core/metadata')
+
+const dbBuilders = require('../db')
+
+/*::
+import type { Cozy } from 'cozy-client-js'
+import type { RemoteFile, RemoteDir, RemoteDeletion } from '../../../../core/remote/document'
+import type { MetadataRemoteFile, MetadataRemoteDir } from '../../../../core/metadata'
+*/
+
+// Build a RemoteDeletion representing a remote Cozy document that was
+// completely deleted:
+//
+//     const doc: RemoteDeletion = builders.remoteErased().build()
+//
+// To actually create and erased the corresponding document on the Cozy, use the
+// async #create() method instead:
+//
+//     const doc: RemoteDeletion = await builders.remoteErased().create()
+//
+module.exports = class RemoteDirBuilder {
+  /*::
+  cozy: ?Cozy
+  remoteDoc: ?RemoteFile|MetadataRemoteFile|RemoteDir|MetadataRemoteDir
+  */
+
+  constructor(
+    cozy /*: ?Cozy */,
+    old /*: ?(RemoteFile|MetadataRemoteFile|RemoteDir|MetadataRemoteDir) */
+  ) {
+    this.cozy = cozy
+    if (old) {
+      this.remoteDoc = {
+        ..._.cloneDeep(old),
+        _rev: dbBuilders.rev(metadata.extractRevNumber(old) + 1)
+      }
+    }
+  }
+
+  _ensureCozy() /*: Cozy */ {
+    if (this.cozy) {
+      return this.cozy
+    } else {
+      throw new Error('Cannot create remote files/dirs without a Cozy client.')
+    }
+  }
+
+  build() /*: RemoteDeletion */ {
+    if (this.remoteDoc) {
+      return {
+        _id: this.remoteDoc._id,
+        _rev: this.remoteDoc._rev,
+        _deleted: true
+      }
+    } else {
+      return {
+        _id: dbBuilders.id(),
+        _rev: dbBuilders.rev(2),
+        _deleted: true
+      }
+    }
+  }
+
+  async create() /*: Promise<RemoteDeletion> */ {
+    const cozy = this._ensureCozy()
+
+    if (this.remoteDoc) {
+      const json = await cozy.files.destroyById(this.remoteDoc._id)
+      return _.clone(jsonApiToRemoteDoc(json))
+    } else {
+      const remoteDir = _.clone(
+        jsonApiToRemoteDoc(
+          await cozy.files.createDirectory({
+            name: '',
+            dirID: ROOT_DIR_ID,
+            noSanitize: true
+          })
+        )
+      )
+      const json = await cozy.files.destroyById(remoteDir._id)
+      return _.clone(jsonApiToRemoteDoc(json))
+    }
+  }
+}

--- a/test/support/builders/remote/erased.js
+++ b/test/support/builders/remote/erased.js
@@ -3,7 +3,7 @@
 const _ = require('lodash')
 
 const { ROOT_DIR_ID } = require('../../../../core/remote/constants')
-const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
+const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
 const metadata = require('../../../../core/metadata')
 
 const dbBuilders = require('../db')
@@ -72,10 +72,10 @@ module.exports = class RemoteDirBuilder {
 
     if (this.remoteDoc) {
       const json = await cozy.files.destroyById(this.remoteDoc._id)
-      return _.clone(jsonApiToRemoteDoc(json))
+      return _.clone(remoteJsonToRemoteDoc(json))
     } else {
       const remoteDir = _.clone(
-        jsonApiToRemoteDoc(
+        remoteJsonToRemoteDoc(
           await cozy.files.createDirectory({
             name: '',
             dirID: ROOT_DIR_ID,
@@ -84,7 +84,7 @@ module.exports = class RemoteDirBuilder {
         )
       )
       const json = await cozy.files.destroyById(remoteDir._id)
-      return _.clone(jsonApiToRemoteDoc(json))
+      return _.clone(remoteJsonToRemoteDoc(json))
     }
   }
 }

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -8,7 +8,7 @@ const _ = require('lodash')
 const RemoteBaseBuilder = require('./base')
 const cozyHelpers = require('../../helpers/cozy')
 
-const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
+const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
 const { FILES_DOCTYPE } = require('../../../../core/remote/constants')
 
 /*::
@@ -103,7 +103,7 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
     const cozy = this._ensureCozy()
 
     const remoteFile /*: RemoteFile */ = _.clone(
-      jsonApiToRemoteDoc(
+      remoteJsonToRemoteDoc(
         await cozy.files.create(this._data, {
           contentType: this.remoteDoc.mime,
           dirID: this.remoteDoc.dir_id,
@@ -157,7 +157,7 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
           updated_at: this.remoteDoc.updated_at,
           noSanitize: true
         })
-    const remoteFile /*: RemoteFile */ = _.clone(jsonApiToRemoteDoc(json))
+    const remoteFile /*: RemoteFile */ = _.clone(remoteJsonToRemoteDoc(json))
     const doc /*: MetadataRemoteFile */ = {
       ...remoteFile,
       path: posix.join(parentDir.attributes.path, this.remoteDoc.name)

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -138,9 +138,8 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
     const cozy = this._ensureCozy()
 
     const parentDir = await cozy.files.statById(this.remoteDoc.dir_id)
-    const json = this.remoteDoc._deleted
-      ? await cozy.files.destroyById(this.remoteDoc._id)
-      : this.remoteDoc.trashed
+
+    const json = this.remoteDoc.trashed
       ? await cozy.files.trashById(this.remoteDoc._id, { dontRetry: true })
       : this._data
       ? await cozy.files.updateById(this.remoteDoc._id, this._data, {

--- a/test/support/builders/remote/note.js
+++ b/test/support/builders/remote/note.js
@@ -7,7 +7,7 @@ const _ = require('lodash')
 const RemoteBaseBuilder = require('./base')
 const cozyHelpers = require('../../helpers/cozy')
 
-const { jsonApiToRemoteDoc } = require('../../../../core/remote/document')
+const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
 const {
   FILES_DOCTYPE,
   NOTE_MIME_TYPE
@@ -134,7 +134,7 @@ module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder /*:: <Metadat
       updatedAt: this.remoteDoc.updated_at || this.remoteDoc.created_at,
       noSanitize: true
     })
-    const remoteFile /*: RemoteFile */ = _.clone(jsonApiToRemoteDoc(data))
+    const remoteFile /*: RemoteFile */ = _.clone(remoteJsonToRemoteDoc(data))
     remoteFile._rev = data.meta.rev
 
     const { data: parentDir } = await files.statById(remoteFile.dir_id)
@@ -156,7 +156,7 @@ module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder /*:: <Metadat
     // else than HTML5 File objects as data.
     // FIXME: update note metadata
     const remoteFile /*: RemoteFile */ = _.clone(
-      jsonApiToRemoteDoc(
+      remoteJsonToRemoteDoc(
         await cozy.files.updateById(this.remoteDoc._id, this._data, {
           dirID: this.remoteDoc.dir_id,
           updatedAt: this.remoteDoc.updated_at,

--- a/test/support/doubles/cozy_stack.js
+++ b/test/support/doubles/cozy_stack.js
@@ -5,10 +5,12 @@ const http = require('http')
 module.exports = class CozyStackDouble {
   constructor() {
     this.clearStub()
+    this.sockets = []
 
     this.hostname = 'localhost'
     this.port = 9090
     this.server = http.createServer((...args) => this._stub(...args))
+    this.server.on('connection', socket => this.sockets.push(socket))
   }
 
   // The URL for RemoteCozy constructor
@@ -42,6 +44,7 @@ module.exports = class CozyStackDouble {
   // Returns a promise that resolves as soon as the server is not listening.
   stop() {
     return new Promise(resolve => {
+      this.sockets.forEach(socket => socket.destroy())
       this.server.close(resolve)
     })
   }

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -218,6 +218,19 @@ describe('core/config', function() {
       })
     })
 
+    describe('flags', () => {
+      it('returns an empty hash by default', function() {
+        should(this.config.flags).deepEqual({})
+      })
+
+      it('returns GUI configuration if any', function() {
+        const flagsConfig = { differentialSync: true }
+        this.config.fileConfig.flags = flagsConfig
+        should(this.config.flags).deepEqual(flagsConfig)
+        should(this.config.flags.differentialSync).be.true()
+      })
+    })
+
     describe('#watcherType', function() {
       it('returns valid watcher type from file config if any', function() {
         this.config.fileConfig.watcherType = 'atom'

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -29,7 +29,6 @@ const {
   createConflictingDoc
 } = metadata
 const { Ignore } = require('../../core/ignore')
-const { FILES_DOCTYPE } = require('../../core/remote/constants')
 const stater = require('../../core/local/stater')
 const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
 const pathUtils = require('../../core/utils/path')
@@ -50,7 +49,6 @@ describe('metadata', function() {
       const remoteDoc /*: MetadataRemoteFile */ = {
         _id: '12',
         _rev: '34',
-        _type: FILES_DOCTYPE,
         class: 'document',
         dir_id: '56',
         executable: false,
@@ -65,8 +63,7 @@ describe('metadata', function() {
         updated_at: '2017-09-08T07:06:05Z',
         cozyMetadata: {
           createdOn: 'alice.mycozy.cloud'
-        },
-        someUnusedProperty: 'unused value'
+        }
       }
       const doc /*: Metadata */ = metadata.fromRemoteDoc(remoteDoc)
 
@@ -90,8 +87,7 @@ describe('metadata', function() {
         executable: false,
         cozyMetadata: {
           createdOn: 'alice.mycozy.cloud'
-        },
-        someUnusedProperty: 'unused value'
+        }
       })
 
       remoteDoc.executable = true

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -27,7 +27,7 @@ const Builders = require('../../support/builders')
 
 /*::
 import type { Metadata, SavedMetadata } from '../../../core/metadata'
-import type { RemoteDoc, JsonApiDoc } from '../../../core/remote/document'
+import type { RemoteDoc, RemoteJsonDoc } from '../../../core/remote/document'
 */
 const CHAT_MIGNON_MOD_PATH = 'test/fixtures/chat-mignon-mod.jpg'
 
@@ -253,7 +253,9 @@ describe('remote.Remote', function() {
 
       await this.remote.addFolderAsync(doc)
 
-      const folder /*: JsonApiDoc */ = await cozy.files.statById(doc.remote._id)
+      const folder /*: RemoteJsonDoc */ = await cozy.files.statById(
+        doc.remote._id
+      )
       const { path, name, type } = remoteDir
       should(folder.attributes).have.properties({
         path,
@@ -289,7 +291,9 @@ describe('remote.Remote', function() {
 
       await this.remote.addFolderAsync(doc)
 
-      const folder /*: JsonApiDoc */ = await cozy.files.statById(doc.remote._id)
+      const folder /*: RemoteJsonDoc */ = await cozy.files.statById(
+        doc.remote._id
+      )
       const { path, name, type } = remoteDir
       should(folder.attributes).have.properties({
         path,
@@ -723,7 +727,9 @@ describe('remote.Remote', function() {
 
       await this.remote.updateFolderAsync(doc)
 
-      const folder /*: JsonApiDoc */ = await cozy.files.statById(doc.remote._id)
+      const folder /*: RemoteJsonDoc */ = await cozy.files.statById(
+        doc.remote._id
+      )
       should(folder.attributes).have.properties({
         path: '/created',
         type: 'directory',
@@ -752,7 +758,7 @@ describe('remote.Remote', function() {
 
       await this.remote.updateFolderAsync(doc)
 
-      const created /*: JsonApiDoc */ = await cozy.files.statByPath(
+      const created /*: RemoteJsonDoc */ = await cozy.files.statByPath(
         '/deleted-dir'
       )
       should(created.attributes).have.properties({
@@ -790,7 +796,9 @@ describe('remote.Remote', function() {
 
       await this.remote.updateFolderAsync(doc)
 
-      const folder /*: JsonApiDoc */ = await cozy.files.statById(doc.remote._id)
+      const folder /*: RemoteJsonDoc */ = await cozy.files.statById(
+        doc.remote._id
+      )
       should(folder._id).equal(remoteDir._id)
       should(folder.attributes).have.properties({
         type: 'directory',

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -18,7 +18,7 @@ const Builders = require('../../support/builders')
 const builders = new Builders({ cozy: cozyHelpers.cozy })
 /*::
 import type { Metadata } from '../../../core/metadata'
-import type { RemoteDoc, JsonApiDoc } from '../../../core/remote/document'
+import type { RemoteDoc } from '../../../core/remote/document'
 */
 
 describe('Remote', function() {

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -466,16 +466,13 @@ describe('RemoteWatcher', function() {
   describe('pullMany', function() {
     let apply
     let findMaybe
-    let remoteDocs /*: MetadataRemoteInfo[] */
+    let remoteDocs
     beforeEach(function() {
       apply = sinon.stub(this.watcher, 'apply')
       findMaybe = sinon.stub(this.remoteCozy, 'findMaybe')
       remoteDocs = [
         builders.remoteFile().build(),
-        builders
-          .remoteFile()
-          .erased()
-          .build()
+        builders.remoteErased().build()
       ]
     })
 
@@ -526,12 +523,9 @@ describe('RemoteWatcher', function() {
       })
 
       it('retries failed changes application until none can be applied', async function() {
-        const remoteDocs /*: MetadataRemoteInfo[] */ = [
+        const remoteDocs = [
           builders.remoteFile().build(),
-          builders
-            .remoteFile()
-            .erased()
-            .build(),
+          builders.remoteErased().build(),
           builders.remoteFile().build()
         ]
         await this.watcher.pullMany(remoteDocs).catch(() => {})

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -51,12 +51,7 @@ describe('RemoteWatcher', function() {
       token: process.env.COZY_STACK_TOKEN
     })
     this.events = new EventEmitter()
-    this.watcher = new RemoteWatcher(
-      this.pouch,
-      this.prep,
-      this.remoteCozy,
-      this.events
-    )
+    this.watcher = new RemoteWatcher(this)
     builders = new Builders({ cozy: cozyHelpers.cozy, pouch: this.pouch })
   })
   afterEach(function() {


### PR DESCRIPTION
When a folder has been unsynced via the differential sync API, it is
seen as deleted by the Desktop client and so are its children.

However, when the same folder is resynced, the Desktop client will
only see a change for the folder.

To make sure we'll resync all its content, we will fetch it and
process all found remote documents as additions.
The way we detect a folder for which we need to fetch the content is
if we detect the addition of a folder whose remote revision is greater
than 1 (i.e. it was not just created on the Cozy).

If a new folder is modified on the Cozy before the client has detected
its addition via the changes feed, we'll treat it as a resynced folder
and fetch its content while we already have it in the feed.
We expect this not to be an issue though. the remote watcher analysis
should detect the second occurrence as an up-to-date change since the
remote revision will be the same.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
