### PR TITLE
gui: Disable Electron's HTTP cache

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -36,6 +36,11 @@ const { app, Menu, Notification, ipcMain, dialog } = require('electron')
 
 const DAILY = 3600 * 24 * 1000
 
+// Disable Electron's Net HTTP cache to prevent net::ERR_FAILED errors on HTTP
+// requests.
+// https://stackoverflow.com/questions/63562516/electron-throws-err-failed-when-making-requests-using-net
+app.commandLine.appendSwitch('disable-http-cache')
+
 // FIXME: https://github.com/electron/electron/issues/10864
 if (process.platform === 'win32') app.setAppUserModelId('io.cozy.desktop')
 


### PR DESCRIPTION
We continue experiencing network errors (e.g. `net::ERR_FAILED`) for
no apparent reasons even though we added a cache busting parameter to
every request.

We try a different approach by disabling Electron's HTTP cache at the
command line level.

We found this solution here: https://stackoverflow.com/questions/63562516/electron-throws-err-failed-when-making-requests-using-net

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
