### PR TITLE
core/local/chokidar: Run initial scan step once

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -48,7 +48,7 @@ import type {
   LocalFileDeletion,
   LocalFileMove
 } from './local_change'
-import type { InitialScan } from './initial_scan'
+import type { InitialScanParams } from './initial_scan'
 */
 
 const log = logger({
@@ -59,13 +59,13 @@ module.exports = function analysis(
   events /*: LocalEvent[] */,
   {
     pendingChanges,
-    initialScan
-  } /*: { pendingChanges: LocalChange[], initialScan: ?InitialScan } */
+    initialScanParams
+  } /*: { pendingChanges: LocalChange[], initialScanParams: ?InitialScanParams } */
 ) /*: LocalChange[] */ {
   const changes /*: LocalChange[] */ = analyseEvents(events, pendingChanges)
   sortBeforeSquash(changes)
   squashMoves(changes)
-  sortChanges(changes, initialScan != null)
+  sortChanges(changes, initialScanParams != null)
   return separatePendingChanges(changes, pendingChanges)
 }
 

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -32,14 +32,14 @@ const logger = require('../../utils/logger')
 
 /*::
 import type { ChokidarEvent } from './event'
-import type { InitialScan } from './initial_scan'
+import type { InitialScanParams } from './initial_scan'
 import type { LocalEvent } from './local_event'
 import type { Metadata } from '../../metadata'
 import type { Pouch } from '../../pouch'
 
 type PrepareEventsOpts = {
   +checksum: (string) => Promise<string>,
-  initialScan: ?InitialScan,
+  initialScanParams: ?InitialScanParams,
   pouch: Pouch,
   syncPath: string
 }
@@ -71,7 +71,7 @@ const oldMetadata = async (
  */
 const step = async (
   events /*: ChokidarEvent[] */,
-  { checksum, initialScan, pouch, syncPath } /*: PrepareEventsOpts */
+  { checksum, initialScanParams, pouch, syncPath } /*: PrepareEventsOpts */
 ) /*: Promise<LocalEvent[]> */ => {
   return Promise.map(
     events,
@@ -86,7 +86,7 @@ const step = async (
 
       if (e.type === 'add' || e.type === 'change') {
         if (
-          initialScan &&
+          initialScanParams && // FIXME: remove this line so we don't recompute unnecessary checksumss after thee initial scan
           e2.old &&
           e2.path.normalize() === e2.old.path.normalize() &&
           e2.old.local &&

--- a/test/unit/local/chokidar/analysis.js
+++ b/test/unit/local/chokidar/analysis.js
@@ -899,7 +899,10 @@ onPlatform('darwin', () => {
           ]
           const pendingChanges = []
           should(
-            analysis(events, { pendingChanges, initialScan: true })
+            analysis(events, {
+              pendingChanges,
+              initialScanParams: { flushed: false }
+            })
           ).deepEqual([
             {
               sideName,
@@ -1001,7 +1004,10 @@ onPlatform('darwin', () => {
             ]
             const pendingChanges = []
             should(
-              analysis(events, { pendingChanges, initialScan: true })
+              analysis(events, {
+                pendingChanges,
+                initialScanParams: { flushed: false }
+              })
             ).deepEqual([
               {
                 sideName,
@@ -1223,7 +1229,7 @@ onPlatform('darwin', () => {
 
         const changes = analysis(events, {
           pendingChanges,
-          initialScan: false
+          initialScanParams: undefined
         })
         changes
           .map(change => [
@@ -1262,7 +1268,7 @@ onPlatform('darwin', () => {
 
         const changes = analysis(events, {
           pendingChanges,
-          initialScan: false
+          initialScanParams: undefined
         })
         changes
           .map(change => [
@@ -1298,7 +1304,7 @@ onPlatform('darwin', () => {
 
         const changes = analysis(events, {
           pendingChanges,
-          initialScan: false
+          initialScanParams: undefined
         })
         changes
           .map(change => [
@@ -1337,7 +1343,7 @@ onPlatform('darwin', () => {
 
         const changes = analysis(events, {
           pendingChanges,
-          initialScan: false
+          initialScanParams: undefined
         })
         changes
           .map(change => [
@@ -1374,7 +1380,7 @@ onPlatform('darwin', () => {
 
           const changes = analysis(events, {
             pendingChanges,
-            initialScan: true
+            initialScanParams: { flushed: false }
           })
           changes
             .map(change => [change.type, change.path])

--- a/test/unit/local/chokidar/prepare_events.js
+++ b/test/unit/local/chokidar/prepare_events.js
@@ -86,7 +86,7 @@ onPlatform('darwin', () => {
         const checksum = sinon.spy()
         await prepareEvents.step(events, {
           checksum,
-          initialScan: true,
+          initialScanParams: { flushed: false },
           pouch: this.pouch,
           syncPath: this.config.syncPath
         })
@@ -114,7 +114,7 @@ onPlatform('darwin', () => {
         const checksum = sinon.spy()
         await prepareEvents.step(events, {
           checksum,
-          initialScan: true,
+          initialScanParams: { flushed: false },
           pouch: this.pouch,
           syncPath: this.config.syncPath
         })


### PR DESCRIPTION
The initial scan step in the Chokidar watcher can be potentially long
when a lot of documents are present in the local synchronization
directory (i.e. there are many events to process).
The step is run as part of the asynchronous events flushing callback
and could thus potentially be run each time events are flushed.

To prevent this, we mark the `initialScan` object (if it exists) as
flushed at the very beginning of the flushing callback.
However, the step itself does not check this attribute before
processing events and so a second flush while an initial scan is being
run could trigger a second initial scan run.

We now check the `flushed` attribute's value before running an initial
scan step and move its assignment to the step itself to co-locate it
with its usage.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
