### PR TITLE
core/remote/cozy: Skip deleted docs on inital sync

### DIFF
--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -30,6 +30,8 @@ describe('Remote', function() {
     this.prep.config = this.config
     this.events = new EventEmitter()
     this.remote = new Remote(this)
+    // Use real OAuth client
+    this.remote.remoteCozy.client = cozyHelpers.cozy
   })
   beforeEach(cozyHelpers.deleteAll)
   beforeEach('create the couchdb folder', async function() {


### PR DESCRIPTION
The remote changes feed contains every change that was ever made on a
Cozy and also changes made on indexes (they're documents as well).
This means that a Cozy that has seen a lot of changes, even for
completely deleted documents, will have a very large changes feed and
thus will require many requests during the initial synchronization of
a new Desktop client.

To avoid losing time in fetching unnecessary documents and in hope of
decreasing the I/O consumption during this phase, we implement a
specific initial fetch that will only fetch the latest version of
remote documents and avoid downloading deleted ones.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
