### PR TITLE
core/remote: Catch 413 errors for large files

### DIFF
--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -11,6 +11,7 @@ export type FILES_DOCTYPE = 'io.cozy.files'
 */
 
 const DEFAULT_HEARTBEAT = 1000 * 60 // 1 minute
+const FIVE_GIGABYTES = 5368709122 // bytes
 
 module.exports = {
   // Doctypes
@@ -33,5 +34,9 @@ module.exports = {
   HEARTBEAT: parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || DEFAULT_HEARTBEAT,
 
   // ToS updated warning code
-  TOS_UPDATED_WARNING_CODE: 'tos-updated'
+  TOS_UPDATED_WARNING_CODE: 'tos-updated',
+
+  // Maximum file size allowed by Swift thus the remote Cozy.
+  // See https://docs.openstack.org/kilo/config-reference/content/object-storage-constraints.html
+  MAX_FILE_SIZE: FIVE_GIGABYTES
 }

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -10,7 +10,12 @@ const { FetchError } = require('cozy-stack-client')
 const { Q } = require('cozy-client')
 const path = require('path')
 
-const { FILES_DOCTYPE, FILE_TYPE, DIR_TYPE } = require('./constants')
+const {
+  FILES_DOCTYPE,
+  FILE_TYPE,
+  DIR_TYPE,
+  MAX_FILE_SIZE
+} = require('./constants')
 const { DirectoryNotFound } = require('./errors')
 const {
   dropSpecialDocs,
@@ -147,7 +152,10 @@ class RemoteCozy {
 
         if (name && dir_id && (await this.isNameTaken({ name, dir_id }))) {
           return new FetchError({ status: 409 }, 'Conflict: name already taken')
-        } else if (!(await this.hasEnoughSpace(contentLength))) {
+        } else if (
+          contentLength > MAX_FILE_SIZE ||
+          !(await this.hasEnoughSpace(contentLength))
+        ) {
           return new FetchError(
             { status: 413 },
             'The file is too big and exceeds the disk quota'

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -159,7 +159,6 @@ class Remote /*:: implements Reader, Writer */ {
     }
 
     const [dirPath, name] = dirAndName(path)
-    // FIXME: stop creating parent folder and manage missing parent error
     const dir = await this.remoteCozy.findDirectoryByPath(dirPath)
 
     const created = await this.remoteCozy.createFile(stream, {

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -141,7 +141,11 @@ const wrapError = (
     // file for example. In this case the sideName will be "local" but the error
     // name will still be "FetchError".
     // If err is a RemoteError, its code will be reused.
-    return new SyncError({ sideName, err: remoteErrors.wrapError(err), doc })
+    return new SyncError({
+      sideName,
+      err: remoteErrors.wrapError(err, doc),
+      doc
+    })
   } else {
     return new SyncError({ sideName, err, doc })
   }

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -396,6 +396,7 @@ class Sync {
         case syncErrors.INCOMPATIBLE_DOC_CODE:
         case syncErrors.MISSING_PERMISSIONS_CODE:
         case syncErrors.NO_DISK_SPACE_CODE:
+        case remoteErrors.FILE_TOO_LARGE_CODE:
         case remoteErrors.INVALID_FOLDER_MOVE_CODE:
         case remoteErrors.INVALID_METADATA_CODE:
         case remoteErrors.INVALID_NAME_CODE:
@@ -803,6 +804,7 @@ class Sync {
         case syncErrors.INCOMPATIBLE_DOC_CODE:
         case syncErrors.MISSING_PERMISSIONS_CODE:
         case syncErrors.NO_DISK_SPACE_CODE:
+        case remoteErrors.FILE_TOO_LARGE_CODE:
         case remoteErrors.INVALID_METADATA_CODE:
         case remoteErrors.INVALID_NAME_CODE:
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:

--- a/gui/elm/Data/UserAction.elm
+++ b/gui/elm/Data/UserAction.elm
@@ -270,6 +270,16 @@ type alias UserActionView =
 view : String -> UserActionView
 view code =
     case code of
+        "FileTooLarge" ->
+            { title = "Error The file is too large"
+            , details =
+                [ "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB."
+                , "Error You need to remove it from your local synchronization folder or reduce its size."
+                ]
+            , primaryInteraction = GiveUp
+            , secondaryInteraction = Nothing
+            }
+
         "IncompatibleDoc" ->
             { title = "Error Document path incompatible with current OS"
             , details =

--- a/gui/elm/Window/Tray/Dashboard.elm
+++ b/gui/elm/Window/Tray/Dashboard.elm
@@ -231,6 +231,9 @@ viewAction helpers model action =
 
         primaryButton =
             case UserAction.primaryInteraction action of
+                UserAction.GiveUp ->
+                    actionButton helpers (UserActionSkipped action) [] "UserAction Give up" Nothing
+
                 UserAction.Retry label ->
                     actionButton helpers (UserActionDone action) [] label Nothing
 

--- a/gui/locales/de.json
+++ b/gui/locales/de.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "Alles erledigt",
   "Folder Please choose an empty directory": "Bitte wähle ein leeres Verzeichnis.",

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "All done",
   "Folder Please choose an empty directory": "Please choose an empty directory.",

--- a/gui/locales/eo.json
+++ b/gui/locales/eo.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "All done",
   "Folder Please choose an empty directory": "Please choose an empty directory.",

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "Efectuado",
   "Folder Please choose an empty directory": "Por favor, escoja una carpeta vacía.",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Chemin incompatible avec l'OS courant",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "Le nom du {0} `{1}` est reservé, contient des caractères interdits ou est trop long pour votre système d'exploitation.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Essayez de le renommer sur votre Cozy en n'utilisant pas de caractère spécial et en choisissant un nom plus court si besoin.",
+  "Error The file is too large": "Le fichier est trop volumineux",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "Le fichier `{0}` n'a pas pû être écrit sur le disque de votre Cozy car il dépasse la taille maximum autorisée par votre Cozy : 5 Gio.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "Déplacez le hors du dossier local de synchronisation ou réduisez sa taille.",
 
   "Folder All done": "C’est bon",
   "Folder Please choose an empty directory": "Veuillez choisir un dossier vide.",

--- a/gui/locales/it_IT.json
+++ b/gui/locales/it_IT.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "Fatto",
   "Folder Please choose an empty directory": "Seleziona una cartella vuota.",

--- a/gui/locales/ja.json
+++ b/gui/locales/ja.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "すべて完了",
   "Folder Please choose an empty directory": "空のディレクトリーを選択してください。",

--- a/gui/locales/nl.json
+++ b/gui/locales/nl.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "Voltooid",
   "Folder Please choose an empty directory": "Kies een lege map.",

--- a/gui/locales/nl_NL.json
+++ b/gui/locales/nl_NL.json
@@ -90,7 +90,7 @@
   "Error Ok": "Oké",
   "Error Syncdir is empty": "Het lijkt erop dat je Cozy-map is geleegd. Bevindt deze zich op een harde schijf die momenteel niet is aangekoppeld? Om gegevensverlies te voorkomen, is de synchronisatie gestopt.",
   "Error Your Cozy is unreachable": "Je Cozy is onbereikbaar",
-  "Error Your Cozy could not be found": "Your Cozy could not be found",
+  "Error Your Cozy could not be found": "Je Cozy is niet aangetroffen",
   "Error This note could not be found": "Deze notitie is niet aangetroffen",
   "Error Unexpected error": "Onverwachte fout",
   "Error Conflict with remote version": "Conflict met externe versie",
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Documentlocatie incompatibel met huidig systeem",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "{0} `{1}`'s naam bevat niet-toegestane of voorbehouden tekens, of is te lang voor je besturingssysteem.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Wijzig de naam op je Cozy en verwijder de speciale tekens. Kie‘ indien nodig, ook een kortere naam.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "Voltooid",
   "Folder Please choose an empty directory": "Kies een lege map.",

--- a/gui/locales/pl.json
+++ b/gui/locales/pl.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "Gotowe",
   "Folder Please choose an empty directory": "Proszę wybrać pusty folder.",

--- a/gui/locales/sq.json
+++ b/gui/locales/sq.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "All done",
   "Folder Please choose an empty directory": "Please choose an empty directory.",

--- a/gui/locales/zh_CN.json
+++ b/gui/locales/zh_CN.json
@@ -114,6 +114,9 @@
   "Error Document path incompatible with current OS": "Document path incompatible with current OS",
   "Error The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.": "The {0} `{1}`'s name either contains forbidden characters or is reserved or is too long for your Operating System.",
   "Error Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.": "Try renaming it on your Cozy without using special characters and choose a shorter name if necessary.",
+  "Error The file is too large": "The file is too large",
+  "Error The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.": "The file `{0}` could not be written to your Cozy's disk because it is larger than the maximum file size allowed by your Cozy: 5 GiB.",
+  "Error You need to remove it from your local synchronization folder or reduce its size.": "You need to remove it from your local synchronization folder or reduce its size.",
 
   "Folder All done": "全部完成",
   "Folder Please choose an empty directory": "请选择一个空目录。",

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -7,13 +7,14 @@ const should = require('should')
 const sinon = require('sinon')
 const stream = require('stream')
 const electronFetch = require('electron-fetch')
-const { FetchError } = require('cozy-client') // Peut-être cozy-stack-client
+const { FetchError } = require('cozy-stack-client')
 const CozyClient = require('cozy-client-js').Client
 
 const {
   ROOT_DIR_ID,
   TRASH_DIR_ID,
-  TRASH_DIR_NAME
+  TRASH_DIR_NAME,
+  MAX_FILE_SIZE
 } = require('../../../core/remote/constants')
 const { RemoteCozy } = require('../../../core/remote/cozy')
 const { DirectoryNotFound } = require('../../../core/remote/errors')
@@ -163,6 +164,21 @@ describe('RemoteCozy', function() {
         ).be.rejectedWith(FetchError, { status: 413 })
 
         fakeSettings.restore()
+      })
+
+      it('returns a 413 FetchError if the file is larger than the max file size', async () => {
+        await should(
+          remoteCozy.createFile(new stream.Readable(), {
+            name: 'foo',
+            dirID: ROOT_DIR_ID,
+            contentType: 'text/plain',
+            contentLength: MAX_FILE_SIZE + 1,
+            checksum: 'md5sum',
+            executable: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          })
+        ).be.rejectedWith(FetchError, { status: 413 })
       })
     })
   })


### PR DESCRIPTION
Based on a restriction in Swift, remote Cozies using this storage
backend limit the size of files to 5 GiB.
See https://docs.openstack.org/kilo/config-reference/content/object-storage-constraints.html

When a client tries to send a file larger than that, the Cozy will
respond with a 413 status error before all the bytes have been sent
(i.e the size is a parameter of the request so the Cozy doesn't need
all the bytes to compute the file length).
However, such short ended requests are not properly handled by
Chromium and thus Electron. In this situation, they won't pass to the
requester the remote response but an in-house error whose message
contains `mojo result is not ok`.

To make sure the Desktop handles those errors properly, we catch those
in-house errors and try to reconstruct the original response.
In the case of large files, we'll check if the size of the file is
larger than 5 GiB, in which case we'll throw a `FetchError` with a
status of 413 as would have been the case if Electron would pass along
the server response.

We take the opportunity to create a specific user facing error for
this situation since the user would otherwise see an error indicating
their Cozy is full.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
