### PR TITLE
core/remote: Recreate 412 errors during uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "react-markdown": "^4.3.1",
     "read": "1.0.7",
     "regedit": "^3.0.3",
+    "secret-event-listener": "1.0.0",
     "semver": "^7.3.2",
     "uuid": "^3.3.2",
     "yargs": "^11.0.0"

--- a/test/support/builders/atom_event.js
+++ b/test/support/builders/atom_event.js
@@ -2,11 +2,11 @@
 
 const _ = require('lodash')
 const path = require('path')
-const crypto = require('crypto')
 
 const events = require('../../../core/local/atom/event')
 
 const statsBuilder = require('./stats')
+const ChecksumBuilder = require('./checksum')
 
 /*::
 import type { Stats } from 'fs'
@@ -135,13 +135,7 @@ module.exports = class AtomEventBuilder {
   }
 
   data(fileContent /*: string */) /*: this */ {
-    return this.md5sum(
-      crypto
-        .createHash('md5')
-        .update(fileContent)
-        .digest()
-        .toString('base64')
-    )
+    return this.md5sum(new ChecksumBuilder(fileContent).build())
   }
 
   noIgnore() /*: this */ {

--- a/test/support/builders/checksum.js
+++ b/test/support/builders/checksum.js
@@ -1,0 +1,51 @@
+/* @flow */
+
+const { Readable } = require('stream')
+const crypto = require('crypto')
+
+module.exports = class ChecksumBuilder {
+  /*::
+  data: string | Buffer | Readable
+  */
+
+  constructor(data /*: string | Buffer | Readable */) {
+    this.data = data
+  }
+
+  build() /*: string */ {
+    const { data } = this
+    if (data instanceof Readable) {
+      throw new Error(
+        'build() can only be called with String data as we will not await a Stream reading'
+      )
+    } else {
+      return crypto
+        .createHash('md5')
+        .update(data)
+        .digest()
+        .toString('base64')
+    }
+  }
+
+  async create() /*: Promise<string> */ {
+    if (this.data instanceof Readable) {
+      const stream = this.data
+      const checksum = crypto.createHash('md5')
+      checksum.setEncoding('base64')
+
+      return new Promise((resolve, reject) => {
+        stream.on('end', function() {
+          checksum.end()
+          resolve(String(checksum.read()))
+        })
+        stream.on('error', function(err) {
+          checksum.end()
+          reject(err)
+        })
+        stream.pipe(checksum)
+      })
+    } else {
+      return this.build()
+    }
+  }
+}

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -17,8 +17,10 @@ const RemoteErasedBuilder = require('./remote/erased')
 const StreamBuilder = require('./stream')
 const AtomEventBuilder = require('./atom_event')
 const { DefaultStatsBuilder, WinStatsBuilder } = require('./stats')
+const ChecksumBuilder = require('./checksum')
 
 /*::
+import type { Readable } from 'stream'
 import type { Cozy } from 'cozy-client-js'
 import type { Metadata, MetadataRemoteFile, MetadataRemoteDir } from '../../../core/metadata'
 import type { Pouch } from '../../../core/pouch'
@@ -172,6 +174,10 @@ module.exports = class Builders {
 
   stream() /*: StreamBuilder */ {
     return new StreamBuilder()
+  }
+
+  checksum(data /*: string | Readable */) /*: ChecksumBuilder */ {
+    return new ChecksumBuilder(data)
   }
 
   event(old /*: ?AtomEvent */) /*: AtomEventBuilder */ {

--- a/test/support/builders/metadata/file.js
+++ b/test/support/builders/metadata/file.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 const mime = require('../../../../core/utils/mime')
-const crypto = require('crypto')
 
 const BaseMetadataBuilder = require('./base')
+const ChecksumBuilder = require('../checksum')
 
 /*::
 import type { Pouch } from '../../../../core/pouch'
@@ -34,11 +34,7 @@ module.exports = class FileMetadataBuilder extends BaseMetadataBuilder {
   data(data /*: string | Buffer */) /*: this */ {
     this._data = data
     this.doc.size = Buffer.from(data).length
-    this.doc.md5sum = crypto
-      .createHash('md5')
-      .update(data)
-      .digest()
-      .toString('base64')
+    this.doc.md5sum = new ChecksumBuilder(data).build()
     return this
   }
 

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-const crypto = require('crypto')
 const fs = require('fs')
 const { posix } = require('path')
 const _ = require('lodash')
 
 const RemoteBaseBuilder = require('./base')
+const ChecksumBuilder = require('../checksum')
 const cozyHelpers = require('../../helpers/cozy')
 
 const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
@@ -74,11 +74,7 @@ module.exports = class RemoteFileBuilder extends RemoteBaseBuilder /*:: <Metadat
     this._data = data
     if (typeof data === 'string') {
       this.remoteDoc.size = Buffer.from(data).length.toString()
-      this.remoteDoc.md5sum = crypto
-        .createHash('md5')
-        .update(data)
-        .digest()
-        .toString('base64')
+      this.remoteDoc.md5sum = new ChecksumBuilder(data).build()
     }
     // FIXME: Assuming doc will be created with data stream
     return this

--- a/test/support/builders/remote/note.js
+++ b/test/support/builders/remote/note.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-const crypto = require('crypto')
 const { posix } = require('path')
 const _ = require('lodash')
 
 const RemoteBaseBuilder = require('./base')
+const ChecksumBuilder = require('../checksum')
 const cozyHelpers = require('../../helpers/cozy')
 
 const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
@@ -103,11 +103,7 @@ module.exports = class RemoteNoteBuilder extends RemoteBaseBuilder /*:: <Metadat
   _updateExport() {
     this._data = `${this._title}\n\n${this._content}`
     this.remoteDoc.size = Buffer.from(this._data).length.toString()
-    this.remoteDoc.md5sum = crypto
-      .createHash('md5')
-      .update(this._data)
-      .digest()
-      .toString('base64')
+    this.remoteDoc.md5sum = new ChecksumBuilder(this._data).build()
   }
 
   build() /*: Object */ {

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -92,23 +92,23 @@ describe('RemoteCozy', function() {
   describe('createFile', () => {
     context('when the name starts or ends with a space', () => {
       it('creates the file with the given name', async () => {
+        const data = builders
+          .stream()
+          .push('')
+          .build()
+        const checksum = builders.checksum('').build()
+
         should(
-          await remoteCozy.createFile(
-            builders
-              .stream()
-              .push('')
-              .build(),
-            {
-              name: ' foo ',
-              dirID: ROOT_DIR_ID,
-              contentType: 'text/plain',
-              contentLength: 0,
-              checksum: '1B2M2Y8AsgTpgAmY7PhCfg==', // md5sum of an empty file
-              executable: false,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString()
-            }
-          )
+          await remoteCozy.createFile(data, {
+            name: ' foo ',
+            dirID: ROOT_DIR_ID,
+            contentType: 'text/plain',
+            contentLength: 0,
+            checksum,
+            executable: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          })
         ).have.properties({
           type: 'file',
           name: ' foo '
@@ -225,22 +225,21 @@ describe('RemoteCozy', function() {
           .data('initial content')
           .create()
 
+        const data = builders
+          .stream()
+          .push('')
+          .build()
+        const checksum = builders.checksum('').build()
+
         should(
-          await remoteCozy.updateFileById(
-            remoteFile._id,
-            builders
-              .stream()
-              .push('')
-              .build(),
-            {
-              contentType: 'text/plain',
-              contentLength: 0,
-              checksum: '1B2M2Y8AsgTpgAmY7PhCfg==', // md5sum of an empty file
-              executable: false,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString()
-            }
-          )
+          await remoteCozy.updateFileById(remoteFile._id, data, {
+            contentType: 'text/plain',
+            contentLength: 0,
+            checksum,
+            executable: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          })
         ).have.properties({
           type: 'file',
           name: ' foo ',

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 
 const Promise = require('bluebird')
-const crypto = require('crypto')
 const EventEmitter = require('events')
 const fse = require('fs-extra')
 const _ = require('lodash')
@@ -78,24 +77,15 @@ describe('remote.Remote', function() {
         .contentType('image/jpeg')
         .dataFromFile(fixture)
         .create()
-
       should(binary.md5sum).equal(expectedChecksum)
+
       const stream = await this.remote.createReadStreamAsync(
         metadata.fromRemoteDoc(binary)
       )
       should.exist(stream)
-      const checksum = crypto.createHash('md5')
-      checksum.setEncoding('base64')
-      stream.pipe(checksum)
-
-      await should(
-        new Promise(resolve => {
-          stream.on('end', function() {
-            checksum.end()
-            resolve(checksum.read())
-          })
-        })
-      ).be.fulfilledWith(expectedChecksum)
+      await should(builders.checksum(stream).create()).be.fulfilledWith(
+        expectedChecksum
+      )
     })
   })
 
@@ -117,8 +107,7 @@ describe('remote.Remote', function() {
 
       this.remote.other = {
         createReadStreamAsync() {
-          const stream = fse.createReadStream(CHAT_MIGNON_MOD_PATH)
-          return Promise.resolve(stream)
+          return fse.createReadStream(CHAT_MIGNON_MOD_PATH)
         }
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7049,6 +7049,11 @@ schema-utils@^0.4.0:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
+secret-event-listener@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/secret-event-listener/-/secret-event-listener-1.0.0.tgz#43f7d980cf6878b80e86fc77cd96c13a3812a536"
+  integrity sha512-6eRmDKmnDl57zawL3Y8XHLuVgIQfwU36D4s5Tg9Qxuu5TfqpHI8jIo9CqKfcdIXMh8b0Mr0tqK9cmfs0hPOexQ==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"


### PR DESCRIPTION
If a local file is modified while we're uploading it to the remote
Cozy and grows larger, we'll end up sending more data than hinted to
the stack via the `Content-Length` request parameter.

In this case, the stack will respond with a 412 error (i.e. invalid
metadata) when we hit the expected file size, thus closing the request
prematurely.
When this happens, Electron throws its cryptic `mojo result is not ok`
error and we don't get the 412 response.

Like we do for 409 and 413 responses, we'll try to recreate the 412
`FetchError` by summing up the lengths of all chunks that were sent to
the stack and comparing the total with the sent `Content-Length`
header.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
