### PR TITLE
dev: Empty debug log file instead of deleting it

### DIFF
--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -41,7 +41,7 @@ const defaultLogger = bunyan.createLogger({
 
 if (process.env.DEBUG) {
   const logPath = 'debug.log'
-  if (fse.existsSync(logPath)) fse.unlinkSync(logPath)
+  if (fse.existsSync(logPath)) fse.outputFile(logPath, '')
   defaultLogger.addStream({ type: 'file', path: logPath, level: 'trace' })
 }
 if (process.env.TESTDEBUG) {


### PR DESCRIPTION
Whenever we run the app in debug mode, a `debug.log` file is created
and logs are written to it.
However, if it already exists, it is deleted, preventing any running
code in debug mode from writing to it until it is launched again.

To avoid this annoying situation, we now empty the file.
