### PR TITLE
core: Add side name to writers

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -27,6 +27,7 @@ const sentry = require('../utils/sentry')
 
 /*::
 import type EventEmitter from 'events'
+import type { SideName } from '../side'
 import type { Config } from '../config'
 import type { Reader } from '../reader'
 import type { Ignore } from '../ignore'
@@ -66,6 +67,7 @@ export type LocalOptions = {
  */
 class Local /*:: implements Reader, Writer */ {
   /*::
+  name: SideName
   prep: Prep
   pouch: Pouch
   events: EventEmitter
@@ -78,6 +80,7 @@ class Local /*:: implements Reader, Writer */ {
   */
 
   constructor(opts /*: LocalOptions */) {
+    this.name = 'local'
     this.prep = opts.prep
     this.pouch = opts.pouch
     this.events = opts.events

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -21,6 +21,7 @@ const timestamp = require('../utils/timestamp')
 
 /*::
 import type EventEmitter from 'events'
+import type { SideName } from '../side'
 import type { Readable } from 'stream'
 import type { Config } from '../config'
 import type { SavedMetadata, MetadataRemoteInfo } from '../metadata'
@@ -55,6 +56,7 @@ const log = logger({
  */
 class Remote /*:: implements Reader, Writer */ {
   /*::
+  name: SideName
   other: Reader
   config: Config
   pouch: Pouch
@@ -65,6 +67,7 @@ class Remote /*:: implements Reader, Writer */ {
   */
 
   constructor({ config, prep, pouch, events } /*: RemoteOptions */) {
+    this.name = 'remote'
     this.config = config
     this.pouch = pouch
     this.events = events

--- a/core/writer.js
+++ b/core/writer.js
@@ -11,6 +11,7 @@ import type { SavedMetadata } from './metadata'
 import type { SideName } from './side'
 
 export interface Writer {
+  name: SideName;
   addFileAsync (doc: SavedMetadata): Promise<void>;
   addFolderAsync (doc: SavedMetadata): Promise<void>;
   overwriteFileAsync (doc: SavedMetadata, old: ?SavedMetadata): Promise<void>;

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon')
 
 /*::
+import type { SideName } from '../../../core/side'
 import type { Writer } from '../../../core/writer'
 */
 
@@ -20,11 +21,12 @@ const METHODS = [
   'diskUsage'
 ]
 
-module.exports = function stubSide() /*: Writer */ {
+module.exports = function stubSide(name /*: SideName */) /*: Writer */ {
   const double = {}
   for (let method of METHODS) {
     double[method] = sinon.stub().resolves()
   }
+  double.name = name
   double.watcher = {}
   double.watcher.running = new Promise(() => {})
   return double

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -56,6 +56,10 @@ describe('Local', function() {
       let tmpPath = syncDir.abspath(TMP_DIR_NAME)
       this.local.tmpPath.should.equal(tmpPath)
     })
+
+    it('has a side name', function() {
+      should(this.local.name).eql('local')
+    })
   })
 
   describe('createReadStream', function() {

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -64,6 +64,10 @@ describe('remote.Remote', function() {
       should.exist(this.remote.remoteCozy)
       should.exist(this.remote.watcher)
     })
+
+    it('has a side name', function() {
+      should(this.remote.name).eql('remote')
+    })
   })
 
   describe('createReadStream', () => {

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -47,8 +47,8 @@ describe('Sync', function() {
   after('clean config directory', configHelpers.cleanConfig)
 
   beforeEach('instanciate sync', function() {
-    this.local = stubSide()
-    this.remote = stubSide()
+    this.local = stubSide('local')
+    this.remote = stubSide('remote')
     this.ignore = new Ignore(['ignored'])
     this.events = new EventEmitter()
     this.sync = new Sync(
@@ -711,14 +711,14 @@ describe('Sync', function() {
         .path('selectSide/1')
         .sides({ remote: 1 })
         .build()
-      should(this.sync.selectSide(doc1)).deepEqual([this.sync.local, 'local'])
+      should(this.sync.selectSide(doc1)).eql(this.sync.local)
 
       const doc2 = builders
         .metafile()
         .path('selectSide/2')
         .sides({ local: 2, remote: 3 })
         .build()
-      should(this.sync.selectSide(doc2)).deepEqual([this.sync.local, 'local'])
+      should(this.sync.selectSide(doc2)).eql(this.sync.local)
     })
 
     it('selects the remote side if local is up-to-date', function() {
@@ -727,14 +727,14 @@ describe('Sync', function() {
         .path('selectSide/3')
         .sides({ local: 1 })
         .build()
-      should(this.sync.selectSide(doc1)).deepEqual([this.sync.remote, 'remote'])
+      should(this.sync.selectSide(doc1)).eql(this.sync.remote)
 
       const doc2 = builders
         .metafile()
         .path('selectSide/4')
         .sides({ local: 4, remote: 3 })
         .build()
-      should(this.sync.selectSide(doc2)).deepEqual([this.sync.remote, 'remote'])
+      should(this.sync.selectSide(doc2)).eql(this.sync.remote)
     })
 
     it('returns an empty array if both sides are up-to-date', function() {
@@ -743,7 +743,7 @@ describe('Sync', function() {
         .path('selectSide/5')
         .sides({ local: 5, remote: 5 })
         .build()
-      should(this.sync.selectSide(doc)).deepEqual([])
+      should(this.sync.selectSide(doc)).be.null()
     })
 
     it('returns an empty array if a local only doc is erased', function() {
@@ -753,7 +753,7 @@ describe('Sync', function() {
         .erased()
         .sides({ local: 5 })
         .build()
-      should(this.sync.selectSide(doc)).deepEqual([])
+      should(this.sync.selectSide(doc)).be.null()
     })
 
     it('returns an empty array if a remote only doc is erased', function() {
@@ -763,7 +763,7 @@ describe('Sync', function() {
         .erased()
         .sides({ remote: 5 })
         .build()
-      should(this.sync.selectSide(doc)).deepEqual([])
+      should(this.sync.selectSide(doc)).be.null()
     })
   })
 


### PR DESCRIPTION
Our writers are meant to write either to the `remote` Cozy or the
`local` filesystem.
Based on that, we were associating with each one a side name, passed
separately as a string.

To simplify some calls and to make sure we can never have a mismatch
between the writer and the associated side name, we added the name to
the writers themselves.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
