### PR TITLE
sync: Handle doc already in trash errors

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -460,6 +460,15 @@ class Sync {
             await this.remote.resolveRemoteConflict(change.doc)
           }
           break
+        case remoteErrors.DOCUMENT_IN_TRASH_CODE:
+          delete change.doc.moveFrom
+          delete change.doc.overwrite
+
+          // Go ahead and mark remote document as trashed
+          change.doc.remote.trashed = true
+
+          await this.updateRevs(change.doc, side.name)
+          break
         case remoteErrors.MISSING_DOCUMENT_CODE:
           if (shouldAttemptRetry(change)) {
             this.blockSyncFor({ err: syncErr, change })

--- a/core/utils/fs.js
+++ b/core/utils/fs.js
@@ -38,7 +38,23 @@ function validName(name /*: string */) {
 }
 
 async function sendToTrash(fullpath /*: string */) {
-  return shell.trashItem(fullpath)
+  try {
+    await shell.trashItem(fullpath)
+  } catch (err) {
+    if (
+      err.message === 'Failed to move item to trash' || // Error message on Linux
+      err.message === 'Failed to parse path' || // Error message on Windows
+      /doesn’t exist/.test(err.message) // Error message on macOS
+    ) {
+      const error = new Error()
+      error.code = 'ENOENT'
+      error.path = fullpath
+      error.message = `${error.code}: No such file or directory, sendToTrash '${error.path}'`
+      throw error
+    }
+
+    throw err
+  }
 }
 
 module.exports = {

--- a/test/unit/local/index.js
+++ b/test/unit/local/index.js
@@ -725,6 +725,22 @@ describe('Local', function() {
       await this.local.trashAsync(doc)
       await should(fse.exists(folderPath)).be.fulfilledWith(false)
     })
+
+    context('when the document is missing on the filesystem', () => {
+      it('does not throw', async function() {
+        const doc = await builders
+          .metafile()
+          .path('FILE-TO-DELETE')
+          .upToDate()
+          .create()
+        const filePath = syncDir.abspath(doc.path)
+        fse.remove(filePath)
+
+        await this.pouch.db.remove(doc)
+        await should(this.local.trashAsync(doc)).be.fulfilled()
+        await should(fse.exists(filePath)).be.fulfilledWith(false)
+      })
+    })
   })
 
   describe('deleteFolderAsync', () => {

--- a/test/unit/utils/fs.js
+++ b/test/unit/utils/fs.js
@@ -7,7 +7,7 @@ const fse = require('fs-extra')
 const path = require('path')
 const should = require('should')
 
-const { hideOnWindows } = require('../../../core/utils/fs')
+const { hideOnWindows, sendToTrash } = require('../../../core/utils/fs')
 
 const configHelpers = require('../../support/helpers/config')
 
@@ -46,5 +46,40 @@ describe('utils/fs', () => {
 
     it('never throws any error', async () =>
       should(hideOnWindows(missingPath)).be.fulfilled())
+  })
+
+  describe('sendToTrash', () => {
+    it('removes the given file from the sync directory', async function() {
+      const fullpath = p => path.join(this.syncPath, p)
+      await fse.ensureDir(fullpath('dir'))
+      await fse.ensureFile(fullpath('dir/file'))
+
+      await should(sendToTrash(fullpath('dir/file'))).be.fulfilled()
+      await should(fse.exists(fullpath('dir'))).be.fulfilledWith(true)
+      await should(fse.exists(fullpath('dir/file'))).be.fulfilledWith(false)
+    })
+
+    it('removes the given directory and its content from the sync directory', async function() {
+      const fullpath = p => path.join(this.syncPath, p)
+      await fse.ensureDir(fullpath('dir'))
+      await fse.ensureFile(fullpath('dir/file'))
+
+      await should(sendToTrash(fullpath('dir'))).be.fulfilled()
+      await should(fse.exists(fullpath('dir'))).be.fulfilledWith(false)
+      await should(fse.exists(fullpath('dir/file'))).be.fulfilledWith(false)
+    })
+
+    it('throws an error with code ENOENT when the document is missing', async function() {
+      const fullpath = p => path.join(this.syncPath, p)
+      try {
+        await fse.remove(fullpath('doc'))
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err
+      }
+
+      await should(sendToTrash(fullpath('doc'))).be.rejectedWith({
+        code: 'ENOENT'
+      })
+    })
   })
 })


### PR DESCRIPTION
Since we've started using Electron's `shell.trashItem()` method to
send local files to the local Trash, errors raised when the file does
not exist anymore have not been properly handled.
This resulted in lots of retries during Sync and PouchDB records left
in the database for no reason.

This situation finds its root in the fact that `trashItem()` does not
raise a `SystemError` with status code `ENOENT` when the document does
not exist but its own error type without any code.

We'll now handle this error (i.e. with message `Failed to move item to
trash`) as if the file was already trashed if it can't be found at the
expected path.
We'll throw the original error otherwise.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
