### PR TITLE
core/merge: Handle moves on the same Pouch record

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -136,7 +136,6 @@ export type Metadata = {
   trashed?: true,
   deleted?: true,
   errors?: number,
-  moveTo?: string, // Destination id
   overwrite?: SavedMetadata,
   childMove?: boolean,
   incompatibilities?: *,
@@ -383,7 +382,7 @@ function ensureValidPath(doc /*: {path: string} */) {
 
 function invariants /*:: <T: Metadata|SavedMetadata> */(doc /*: T */) {
   // If the record is meant to be erased we don't care about invariants
-  if (doc._deleted && !doc.moveTo) return doc
+  if (doc._deleted) return doc
 
   let err
   if (!doc.sides) {
@@ -500,7 +499,6 @@ function isAtLeastUpToDate(sideName /*: SideName */, doc /*: Metadata */) {
 function removeActionHints(doc /*: Metadata */) {
   if (doc.sides) delete doc.sides
   if (doc.moveFrom) delete doc.moveFrom
-  if (doc.moveTo) delete doc.moveTo
 }
 
 function removeNoteMetadata(doc /*: Metadata */) {

--- a/core/move.js
+++ b/core/move.js
@@ -31,7 +31,7 @@ function move(
   // Copy all fields from `src` that are not Sync action hints or PouchDB
   // attributes to `dst` if they're not already defined.
   const pouchdbReserved = ['_id', '_rev', '_deleted']
-  const actionHints = ['moveTo', 'moveFrom', 'overwrite', 'incompatibilities']
+  const actionHints = ['moveFrom', 'overwrite', 'incompatibilities']
   const fields = Object.getOwnPropertyNames(src).filter(
     f => !pouchdbReserved.concat(actionHints).includes(f)
   )
@@ -43,24 +43,14 @@ function move(
     }
   }
 
-  src.moveTo = dst.path
-  src._deleted = true
-
-  delete src.errors
-
-  // Make sure newly moved docs have their fill of sync attempts
-  delete dst.errors
-
   // TODO: Find out wether or not it would make sense to also delete the
   // trashed property on the source, or explain why it doesn't.
   delete dst.trashed
 
   dst.moveFrom = src
+  dst._id = src._id
+  dst._rev = src._rev
 
-  if (!dst.overwrite) {
-    delete dst._id
-    delete dst._rev
-  }
   metadata.markSide(side, dst, src)
 }
 
@@ -80,10 +70,11 @@ function convertToDestinationAddition(
   src /*: SavedMetadata */,
   dst /*: Metadata */
 ) {
-  // Delete source
-  metadata.markAsUnsyncable(src)
+  metadata.removeActionHints(src)
 
   // Create destination
   metadata.markAsUnmerged(dst, side)
+  dst._id = src._id
+  dst._rev = src._rev
   metadata.markSide(side, dst)
 }

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -75,7 +75,6 @@ class Sync {
   local: Local
   pouch: Pouch
   remote: Remote
-  moveTo: ?string
   lifecycle: LifeCycle
   retryInterval: ?IntervalID
   */
@@ -552,7 +551,7 @@ class Sync {
   ) /*: Promise<*> */ {
     const currentRev = metadata.side(doc, side.name)
 
-    if (doc.incompatibilities && side.name === 'local' && doc.moveTo == null) {
+    if (doc.incompatibilities && side.name === 'local') {
       const was = doc.moveFrom
       if (was != null && was.incompatibilities == null) {
         // Move compatible -> incompatible
@@ -577,8 +576,6 @@ class Sync {
       throw new Error(`Unknown docType: ${doc.docType}`)
     } else if (isMarkedForDeletion(doc) && currentRev === 0) {
       // do nothing
-    } else if (doc.moveTo != null) {
-      log.debug({ path: doc.path }, `Ignoring ${doc.docType} move source`)
     } else if (doc.moveFrom != null) {
       const from = (doc.moveFrom /*: SavedMetadata */)
       log.debug(

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -54,6 +54,15 @@ describe('Conflict resolution', () => {
           .build()
       )
       should(await helpers.local.tree()).deepEqual(['foo-conflict-.../'])
+
+      await helpers.flushLocalAndSyncAll()
+      await helpers.pullAndSyncAll()
+
+      should(await helpers.local.tree()).deepEqual(['foo', 'foo-conflict-.../'])
+      should(await helpers.remote.treeWithoutTrash()).deepEqual([
+        'foo',
+        'foo-conflict-.../'
+      ])
     })
   })
 

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -86,10 +86,7 @@ describe('Move', () => {
 
       should(
         helpers.putDocs('path', '_deleted', 'trashed', 'moveFrom')
-      ).deepEqual([
-        { path: path.normalize('src/file'), _deleted: true },
-        { path: path.normalize('dst/file'), moveFrom: oldFile }
-      ])
+      ).deepEqual([{ path: path.normalize('dst/file'), moveFrom: oldFile }])
 
       await helpers.syncAll()
 
@@ -126,10 +123,9 @@ describe('Move', () => {
         oldFile
       )
 
-      should(helpers.putDocs('path', '_deleted', 'trashed')).deepEqual([
-        { path: path.normalize('src/file'), _deleted: true },
-        { path: path.normalize('dst/file') }
-      ])
+      should(
+        helpers.putDocs('path', '_deleted', 'trashed', 'moveFrom')
+      ).deepEqual([{ path: path.normalize('dst/file'), moveFrom: oldFile }])
 
       await helpers.syncAll()
 
@@ -175,12 +171,12 @@ describe('Move', () => {
           'overwrite.path'
         )
       ).deepEqual([
-        { path: path.normalize('src/file'), _deleted: true },
         {
           path: path.normalize('dst/file'),
           moveFrom: oldFile,
           overwrite: { path: path.normalize('dst/file') }
-        }
+        },
+        { path: path.normalize('dst/file'), _deleted: true } // XXX: This is actually called first
       ])
 
       await helpers.syncAll()
@@ -585,25 +581,9 @@ describe('Move', () => {
       should(
         helpers.putDocs('path', '_deleted', 'trashed', 'childMove')
       ).deepEqual([
-        { path: path.normalize('parent/src/dir'), _deleted: true },
         { path: path.normalize('parent/dst/dir') },
-        {
-          path: path.normalize('parent/src/dir/empty-subdir'),
-          _deleted: true,
-          childMove: true
-        },
         { path: path.normalize('parent/dst/dir/empty-subdir') },
-        {
-          path: path.normalize('parent/src/dir/subdir'),
-          _deleted: true,
-          childMove: true
-        },
         { path: path.normalize('parent/dst/dir/subdir') },
-        {
-          path: path.normalize('parent/src/dir/subdir/file'),
-          _deleted: true,
-          childMove: true
-        },
         { path: path.normalize('parent/dst/dir/subdir/file') }
       ])
 
@@ -741,29 +721,17 @@ describe('Move', () => {
           'overwrite.path'
         )
       ).deepEqual([
-        { path: path.normalize('parent/src/dir'), _deleted: true },
         {
           path: path.normalize('parent/dst/dir'),
           overwrite: { path: path.normalize('parent/dst/dir') }
         },
-        {
-          path: path.normalize('parent/src/dir/empty-subdir'),
-          _deleted: true,
-          childMove: true
-        },
         { path: path.normalize('parent/dst/dir/empty-subdir') },
-        {
-          path: path.normalize('parent/src/dir/subdir'),
-          _deleted: true,
-          childMove: true
-        },
         { path: path.normalize('parent/dst/dir/subdir') },
+        { path: path.normalize('parent/dst/dir/subdir/file') },
         {
-          path: path.normalize('parent/src/dir/subdir/file'),
-          _deleted: true,
-          childMove: true
-        },
-        { path: path.normalize('parent/dst/dir/subdir/file') }
+          path: path.normalize('parent/dst/dir'),
+          _deleted: true
+        }
       ])
 
       await helpers.syncAll()

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -290,9 +290,6 @@ describe('Trash', () => {
         })
 
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-          // XXX: Why isn't file deleted? (it works anyway)
-          { path: path.normalize('parent/dir/subdir'), deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
           { path: path.normalize('parent/dir'), deleted: true }
         ])
 
@@ -315,11 +312,6 @@ describe('Trash', () => {
 
         await helpers.remote.pullChanges()
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-          // dir/subdir and dir/empty-subdir are deleted recursively when
-          // deleting dir/ and then deleted again when we merge their own remote
-          // changes.
-          { path: path.normalize('parent/dir/subdir'), deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
           { path: path.normalize('parent/dir'), deleted: true },
           { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
           { path: path.normalize('parent/dir/subdir'), deleted: true },

--- a/test/scenarios/move_dir_and_replace_subfile/scenario.js
+++ b/test/scenarios/move_dir_and_replace_subfile/scenario.js
@@ -3,11 +3,7 @@
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
-  disabled: {
-    // FIXME: Only work on macOS with STOPPED_CLIENT.
-    'local/darwin': 'Generates conflicts',
-    remote: 'Broken on macOS only?'
-  },
+  useCaptures: false,
   init: [
     { ino: 1, path: 'src/' },
     { ino: 2, path: 'src/file', content: 'initial content' }
@@ -17,12 +13,16 @@ module.exports = ({
     { type: 'wait', ms: 1500 },
     { type: 'create_file', path: 'dst/file.tmp', content: 'new content' },
     { type: 'trash', path: 'dst/file' },
-    { type: 'mv', src: 'dst/file.tmp', dst: 'dst/file' }
+    { type: 'mv', src: 'dst/file.tmp', dst: 'dst/file' },
+    { type: 'wait', ms: 1000 }
   ],
   expected: {
     tree: ['dst/', 'dst/file'],
-    // FIXME: old file will end up in the trash with chokidar, not with atom.
-    trash: [],
+    // the remote changes are fetched together and the trashing merged first so
+    // the file is not moved and thus we don't register an overwriting update of
+    // file leading to the trashing being propagated.
+    localTrash: ['file'],
+    remoteTrash: [],
     contents: {
       'dst/file': 'new content'
     }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -77,16 +77,11 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  moveTo(docpath /*: string */) /*: this */ {
-    this.doc.moveTo = path.normalize(docpath)
-    this.doc._deleted = true
-    return this
-  }
-
   moveFrom(was /*: Metadata */) /*: this */ {
-    if (!was.moveTo) throw new Error('Missing moveTo attribute on was')
-
-    this.doc = _.cloneDeep(_.omit(was, ['_id', '_rev', '_deleted', 'moveTo']))
+    this.doc = {
+      ..._.cloneDeep(was),
+      ...this.doc
+    }
     this.doc.moveFrom = was
 
     return this
@@ -174,7 +169,7 @@ module.exports = class BaseMetadataBuilder {
   }
 
   overwrite(existingDoc /*: SavedMetadata */) /*: this */ {
-    this.doc.overwrite = existingDoc
+    this.doc.overwrite = _.cloneDeep(existingDoc)
     return this
   }
 
@@ -309,13 +304,6 @@ module.exports = class BaseMetadataBuilder {
       this.noRemote()
     }
 
-    if (this.doc.overwrite && this.doc.moveFrom) {
-      // Emulate the _id reuse done when merging an overwriting move.
-      const { _id, _rev } = this.doc.overwrite
-      this.doc._id = _id
-      this.doc._rev = _rev
-    }
-
     return _.cloneDeep(this.doc)
   }
 
@@ -330,14 +318,15 @@ module.exports = class BaseMetadataBuilder {
       doc.sides.target = Math.max(doc.sides.local || 0, doc.sides.remote || 0)
     }
 
+    if (this.doc.overwrite) {
+      const { overwrite } = this.doc
+      await pouch.eraseDocument(overwrite)
+    }
     return await pouch.put(doc)
   }
 
   _consolidatePaths() /* void */ {
     metadata.ensureValidPath(this.doc)
-    if (this.doc.moveFrom) {
-      this.doc.moveFrom.moveTo = this.doc.path
-    }
   }
 
   _ensureLocal() /*: void */ {

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -141,6 +141,8 @@ class TestHelpers {
     this.pouch.bulkDocs.reset()
   }
 
+  // XXX: The order of calls is not respected here as we merge the calls of
+  // multiple methods together.
   putDocs(...props /*: string[] */) {
     const results = []
 

--- a/test/unit/local/atom/dispatch.js
+++ b/test/unit/local/atom/dispatch.js
@@ -607,7 +607,6 @@ describe('core/local/atom/dispatch.loop()', function() {
         const src = await builders
           .metafile()
           .path(filePath)
-          .moveTo(newFilePath)
           .ino(1)
           .upToDate()
           .create()
@@ -846,7 +845,6 @@ describe('core/local/atom/dispatch.loop()', function() {
         const src = await builders
           .metadir()
           .path(directoryPath)
-          .moveTo(newDirectoryPath)
           .ino(1)
           .upToDate()
           .create()

--- a/test/unit/local/atom/initial_diff.js
+++ b/test/unit/local/atom/initial_diff.js
@@ -743,7 +743,6 @@ describe('core/local/atom/initial_diff', () => {
       const wasDir = builders
         .metadir()
         .path('foo')
-        .moveTo('foo2')
         .ino(1)
         .upToDate()
         .build()
@@ -756,7 +755,6 @@ describe('core/local/atom/initial_diff', () => {
       const wasFile = builders
         .metafile()
         .path('fizz')
-        .moveTo('fizz2')
         .ino(2)
         .upToDate()
         .build()

--- a/test/unit/local/atom/win_detect_move.js
+++ b/test/unit/local/atom/win_detect_move.js
@@ -130,7 +130,6 @@ if (process.platform === 'win32') {
             context('when doc has been moved in PouchDB', () => {
               beforeEach(async () => {
                 const deletedSrc = await metadataBuilderByKind(kind, srcDoc)
-                  .moveTo(dstPath)
                   .upToDate()
                   .create()
                 await metadataBuilderByKind(kind)

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -53,7 +53,6 @@ onPlatform('darwin', () => {
         const srcFolder4 = await builders
           .metadir()
           .path('folder1/folder4')
-          .moveTo('folder4')
           .upToDate()
           .create()
         const folder4 = await builders
@@ -92,7 +91,6 @@ onPlatform('darwin', () => {
         const srcFile4 = await builders
           .metafile()
           .path('folder1/file4')
-          .moveTo('file4')
           .upToDate()
           .create()
         const file4 = await builders

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -572,9 +572,7 @@ describe('metadata', function() {
       should(sameFolder(c, d)).be.false()
       should(sameFolder(c, e)).be.false()
       should(sameFolder(d, e)).be.false()
-      should(
-        sameFolder(a, _.merge({ _deleted: true, moveTo: b.path }, a))
-      ).be.true()
+      should(sameFolder(a, _.merge({ _deleted: true }, a))).be.true()
       should(
         sameFolder(
           b,
@@ -725,9 +723,7 @@ describe('metadata', function() {
       should(sameFile(d, e)).be.false()
       should(sameFile(d, f)).be.false()
       should(sameFile(e, f)).be.false()
-      should(
-        sameFile(a, _.merge({ _deleted: true, moveTo: b.path }, a))
-      ).be.true()
+      should(sameFile(a, _.merge({ _deleted: true }, a))).be.true()
       should(
         sameFile(
           b,

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -19,7 +19,7 @@ describe('move', () => {
   afterEach('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
 
-  it('transfers all src attributes not already defined in dst', async () => {
+  it('keeps all src attributes not defined in dst', async () => {
     const src = await builders
       .metafile()
       .path('src/file')
@@ -43,13 +43,13 @@ describe('move', () => {
     should(dst).have.properties({
       metadata: src.metadata,
       tags: ['qux', 'courge'],
-      remote: src.remote
+      remote: src.remote,
+      _id: src._id,
+      _rev: src._rev
     })
     // PouchDB reserved attributes are not transfered
-    should(dst._deleted).be.undefined()
-    should(dst._rev).be.undefined()
-    // defined attributes are not overwritten
     should(dst).not.have.property('_deleted')
+    // defined attributes are not overwritten
     should(dst.md5sum).not.eql(src.md5sum)
     should(dst.size).not.eql(src.size)
   })
@@ -90,16 +90,15 @@ describe('move', () => {
       move.convertToDestinationAddition(side, src, dst)
     })
 
-    it('deletes the source document', () => {
-      should(src._deleted).be.true()
+    it('updates the source document', () => {
+      should(dst._id).eql(src._id)
     })
 
-    it('marks the destination document as newly added on `side`', () => {
+    it('marks the document as newly added on `side`', () => {
       should(dst.sides).deepEqual({ target: 1, [side]: 1 })
     })
 
-    it('removes move hints on both documents', () => {
-      should(src).not.have.property('moveTo')
+    it('removes move hints', () => {
       should(dst).not.have.property('moveFrom')
     })
   })

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -336,6 +336,7 @@ describe('remote.Remote', function() {
           .data('bar')
           .changedSide('local')
           .updatedAt(timestamp.build(2015, 12, 16, 16, 12, 1).toISOString())
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `old`'s _id
           .create()
 
         this.remote.other = {
@@ -437,6 +438,7 @@ describe('remote.Remote', function() {
           .data('bar')
           .updatedAt(timestamp.build(2015, 12, 16, 16, 12, 1).toISOString())
           .changedSide('local')
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `old`'s _id
           .create()
 
         this.remote.other = {
@@ -486,6 +488,7 @@ describe('remote.Remote', function() {
           .data('bar')
           .changedSide('local')
           .updatedAt(timestamp.build(2015, 12, 16, 16, 12, 1).toISOString())
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `old`'s _id
           .create()
 
         this.remote.other = {
@@ -530,6 +533,7 @@ describe('remote.Remote', function() {
           .data('bar')
           .changedSide('local')
           .updatedAt(timestamp.build(2015, 10, 16, 16, 12, 1).toISOString())
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `old`'s _id
           .create()
 
         this.remote.other = {
@@ -558,6 +562,7 @@ describe('remote.Remote', function() {
           .data('baz')
           .changedSide('local')
           .updatedAt(timestamp.build(2016, 10, 16, 16, 12, 1).toISOString())
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `doc1`'s _id
           .create()
 
         this.remote.other = {
@@ -587,6 +592,7 @@ describe('remote.Remote', function() {
           .data('boom')
           .changedSide('local')
           .updatedAt(timestamp.build(2017, 10, 16, 16, 12, 1).toISOString())
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `doc2`'s _id
           .create()
         doc3 = {
           ...doc3,
@@ -825,7 +831,6 @@ describe('remote.Remote', function() {
         old = builders
           .metafile()
           .fromRemote(remoteDoc)
-          .moveTo('moved-to/cat7.jpg')
           .changedSide('local')
           .build()
         doc = builders
@@ -867,7 +872,6 @@ describe('remote.Remote', function() {
         const old = builders
           .metadir()
           .fromRemote(created)
-          .moveTo('couchdb-folder/folder-5')
           .changedSide('local')
           .build()
         const doc = builders
@@ -900,7 +904,6 @@ describe('remote.Remote', function() {
         const old = builders
           .metadir()
           .fromRemote(created)
-          .moveTo('couchdb-folder/folder-7')
           .changedSide('local')
           .build()
         const doc = builders
@@ -957,7 +960,6 @@ describe('remote.Remote', function() {
         it('moves the file on the Cozy', async function() {
           const old = builders
             .metafile(file)
-            .moveTo('My Cat.jpg')
             .changedSide('local')
             .build()
           const doc = builders
@@ -1015,7 +1017,6 @@ describe('remote.Remote', function() {
         old = await builders
           .metafile()
           .fromRemote(remote2)
-          .moveTo('moved-to/cat7.jpg')
           .upToDate()
           .create()
       })

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -299,6 +299,7 @@ describe('Sync', function() {
           .overwrite(initial)
           .data('updated content')
           .changedSide('local')
+          .noRecord() // XXX: Prevent Pouch conflict from reusing `initial`'s _id
           .create()
       }
       await this.sync.apply(change)
@@ -365,6 +366,7 @@ describe('Sync', function() {
         .overwrite(initial)
         .data('updated content')
         .changedSide('local')
+        .noRecord() // XXX: Prevent Pouch conflict from reusing `initial`'s _id
         .create()
       await this.sync.applyDoc(doc, this.remote, 'remote')
       should(this.remote.updateFileMetadataAsync).not.have.been.called()
@@ -456,7 +458,6 @@ describe('Sync', function() {
       const was = await builders
         .metafile()
         .path('foo/bar')
-        .moveTo('foo/baz')
         .tags('qux')
         .changedSide('local')
         .create()
@@ -478,7 +479,6 @@ describe('Sync', function() {
         .metafile()
         .path('foo/bar')
         .data('initial content')
-        .moveTo('foo/baz')
         .tags('qux')
         .changedSide('local')
         .create()
@@ -552,7 +552,6 @@ describe('Sync', function() {
         .metadir()
         .path('foobar/bar')
         .tags('qux')
-        .moveTo('foobar/baz')
         .changedSide('local')
         .create()
       const doc = await builders
@@ -894,7 +893,6 @@ describe('Sync', function() {
           file = await builders
             .metafile()
             .path('src')
-            .moveTo('dst')
             .data('initial content')
             .upToDate()
             .create()


### PR DESCRIPTION
Historically, document moves were merged in PouchDB by erasing the
record with the source path and creating a new record with the
destination path as record _ids were mapped to the path.

This way of doing things creates a number of difficulties (e.g.
inconsistencies if one record can be modified/created and not the
other as PouchDB does not offer transactions) and is not necessary
anymore since we've moved to generated _ids.

This change should give us opportunities in the future like linking
documents to their parent directory via its PouchDB record _id instead
of using a path attribute that can change or point to a different
document.

The main difficulty was managing overwrites as we were previously
using the overwritten record's _id as the destination record _id and
can't anymore as the destination record _id is now the same as the
source record _id.
Therefore we now erase the overwritten record from the database, its
data being saved in the destination record's `overwrite` attribute.
We should be on lookout for potential issues arising from this change.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
