### PR TITLE
core/sync: Compare metadata against other side

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -176,13 +176,10 @@ class Remote /*:: implements Reader, Writer */ {
     stopMeasure()
   }
 
-  async overwriteFileAsync(
-    doc /*: SavedMetadata */,
-    old /*: ?SavedMetadata */
-  ) /*: Promise<void> */ {
-    if (old && isNote(old)) {
+  async overwriteFileAsync(doc /*: SavedMetadata */) /*: Promise<void> */ {
+    if (isNote(doc.remote)) {
       log.warn(
-        { path: doc.path, doc, old },
+        { path: doc.path, doc },
         'Local note updates should not be propagated'
       )
       return
@@ -216,7 +213,7 @@ class Remote /*:: implements Reader, Writer */ {
         contentLength: doc.size,
         contentType: doc.mime,
         updatedAt: mostRecentUpdatedAt(doc),
-        ifMatch: old && old.remote ? old.remote._rev : ''
+        ifMatch: doc.remote._rev
       }
     )
     const updated = await this.remoteCozy.updateFileById(

--- a/core/utils/notes.js
+++ b/core/utils/notes.js
@@ -22,7 +22,7 @@ type CozyNoteErrorCode = 'CozyDocumentMissingError' | 'UnreachableError'
 */
 
 const isNote = (
-  doc /*: { mime?: string, metadata?: Object } */
+  doc /*: MetadataRemoteInfo | { mime?: string, metadata?: Object } */
 ) /*: boolean %checks */ => {
   return (
     doc.mime === NOTE_MIME_TYPE &&

--- a/core/utils/timestamp.js
+++ b/core/utils/timestamp.js
@@ -33,13 +33,13 @@ function build(
 
 function spread(date /*: string|Date|Timestamp */) /*: number[] */ {
   const timestamp = new Date(date)
-  const year = timestamp.getFullYear()
-  const month = timestamp.getMonth() + 1 // Months start with 0 in javascript
-  const day = timestamp.getDate()
-  const hours = timestamp.getHours()
-  const minutes = timestamp.getMinutes()
-  const seconds = timestamp.getSeconds()
-  const milliseconds = timestamp.getMilliseconds()
+  const year = timestamp.getUTCFullYear()
+  const month = timestamp.getUTCMonth() + 1 // Months start with 0 in javascript
+  const day = timestamp.getUTCDate()
+  const hours = timestamp.getUTCHours()
+  const minutes = timestamp.getUTCMinutes()
+  const seconds = timestamp.getUTCSeconds()
+  const milliseconds = timestamp.getUTCMilliseconds()
 
   return [year, month, day, hours, minutes, seconds, milliseconds]
 }

--- a/core/writer.js
+++ b/core/writer.js
@@ -14,7 +14,7 @@ export interface Writer {
   name: SideName;
   addFileAsync (doc: SavedMetadata): Promise<void>;
   addFolderAsync (doc: SavedMetadata): Promise<void>;
-  overwriteFileAsync (doc: SavedMetadata, old: ?SavedMetadata): Promise<void>;
+  overwriteFileAsync (doc: SavedMetadata): Promise<void>;
   updateFileMetadataAsync (doc: SavedMetadata): Promise<void>;
   updateFolderAsync (doc: SavedMetadata): Promise<void>;
   moveAsync (doc: SavedMetadata, from: SavedMetadata): Promise<void>;

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -224,16 +224,13 @@ module.exports = class BaseMetadataBuilder {
   }
 
   upToDate() /*: this */ {
-    this.doc.sides = {
-      ...this.doc.sides,
-      target: (this.doc.sides && this.doc.sides.target) || 1
-    }
-    metadata.markAsUpToDate(this.doc)
+    const target = (metadata.target(this.doc) || 1) + 1
+    this.sides({ local: target, remote: target })
     return this
   }
 
   notUpToDate() /*: this */ {
-    this.doc.sides = { target: 1, remote: 1 }
+    this.sides({ remote: 1 })
     return this
   }
 
@@ -382,6 +379,8 @@ module.exports = class BaseMetadataBuilder {
         .data(this._data)
         .executable(this.doc.executable)
         .contentType(this.doc.mime || '')
+        .md5sum(this.doc.md5sum)
+        .size(String(this.doc.size))
     }
 
     this.doc.remote = builder.build()

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -159,7 +159,7 @@ describe('remote.Remote', function() {
       const doc /*: Metadata */ = builders
         .metafile()
         .path('foo')
-        .noRemote()
+        .sides({ local: 1 })
         .build()
       this.remote.other = {
         createReadStreamAsync() {
@@ -211,7 +211,7 @@ describe('remote.Remote', function() {
       const doc = builders
         .metadir()
         .path('couchdb-folder/folder-1')
-        .noRemote()
+        .sides({ local: 1 })
         .updatedAt(timestamp.build(2017, 2, 14, 15, 3, 27))
         .build()
 
@@ -240,7 +240,7 @@ describe('remote.Remote', function() {
       const doc = builders
         .metadir()
         .fromRemote(remoteDir)
-        .noRemote()
+        .sides({ local: 1 })
         .updatedAt(new Date().toISOString())
         .build()
 
@@ -278,7 +278,7 @@ describe('remote.Remote', function() {
       const doc = builders
         .metadir()
         .fromRemote(remoteDir)
-        .noRemote()
+        .sides({ local: 1 })
         .updatedAt(localUpdatedAt)
         .build()
 
@@ -350,7 +350,7 @@ describe('remote.Remote', function() {
           }
         }
 
-        await this.remote.overwriteFileAsync(doc, old)
+        await this.remote.overwriteFileAsync(doc)
 
         const file = await cozy.files.statById(doc.remote._id)
         should(file.attributes).have.properties({
@@ -392,7 +392,7 @@ describe('remote.Remote', function() {
           }
         }
 
-        await should(this.remote.overwriteFileAsync(doc, old)).be.rejectedWith({
+        await should(this.remote.overwriteFileAsync(doc)).be.rejectedWith({
           status: 412
         })
 
@@ -406,7 +406,7 @@ describe('remote.Remote', function() {
         const doc /*: Metadata */ = builders
           .metafile()
           .path('foo')
-          .noRemote()
+          .changedSide('local')
           .build()
         this.remote.other = {
           createReadStreamAsync() {
@@ -452,7 +452,7 @@ describe('remote.Remote', function() {
           }
         }
 
-        await this.remote.overwriteFileAsync(_.cloneDeep(doc), old)
+        await this.remote.overwriteFileAsync(_.cloneDeep(doc))
 
         const file = await cozy.files.statById(doc.remote._id)
         should(file.attributes).have.properties({
@@ -503,9 +503,7 @@ describe('remote.Remote', function() {
         }
 
         try {
-          await should(
-            this.remote.overwriteFileAsync(doc, old)
-          ).be.rejectedWith({
+          await should(this.remote.overwriteFileAsync(doc)).be.rejectedWith({
             name: 'FetchError',
             status: 413
           })
@@ -547,7 +545,7 @@ describe('remote.Remote', function() {
           }
         }
 
-        await this.remote.overwriteFileAsync(doc1, old)
+        await this.remote.overwriteFileAsync(doc1)
 
         const update1 = await cozy.files.statById(doc1.remote._id)
         should(
@@ -576,7 +574,7 @@ describe('remote.Remote', function() {
           }
         }
 
-        await this.remote.overwriteFileAsync(doc2, doc1)
+        await this.remote.overwriteFileAsync(doc2)
 
         const update2 = await cozy.files.statById(doc2.remote._id)
         should(
@@ -617,7 +615,7 @@ describe('remote.Remote', function() {
           }
         }
 
-        await this.remote.overwriteFileAsync(doc3, doc2)
+        await this.remote.overwriteFileAsync(doc3)
 
         const update3 = await cozy.files.statById(doc3.remote._id)
         should(
@@ -790,7 +788,7 @@ describe('remote.Remote', function() {
       const doc = builders
         .metadir(was)
         .updatedAt('2015-02-03T02:02:02.000Z')
-        .noRemote()
+        .sides({ local: 1 })
         .build()
 
       await this.remote.updateFolderAsync(doc)


### PR DESCRIPTION
When synchronizing changes (other than a move or a deletion) on a
previously synchronized document, we need to compare the modified
metadata against a "previous" version to detect what needs to be
updated (i.e. either metadata or content, or nothing when it's just a
timestamp change).

We used to rely on the `sides` counters to decide how far to go back
in the PouchDB record's history to fetch this previous version.
However, this method is fragile and, in fact, unnecessary now that we
store the complete local and remote metadata in the record.

Thus, to propagate a local change to the remote Cozy, we can compare
the actual document's metadata against its remote metadata.
The same goes for propagating remote changes to the local filesystem.

This method has the added advantage of simplifying the overwrite
request as we already have the remote `_rev` to use in the `If-Match`
header (i.e. the defense mechanism used to avoid overwriting a
document that has changed since last we've fetched it).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation