### PR TITLE
core/remote: Find remote parents in local Pouch

### DIFF
--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -183,9 +183,10 @@ class Pouch {
   }
 
   async put /*:: <T: Metadata|SavedMetadata> */(
-    doc /*: T */
+    doc /*: T */,
+    { checkInvariants = true } /*: { checkInvariants: boolean } */ = {}
   ) /*: Promise<SavedMetadata> */ {
-    metadata.invariants(doc)
+    if (checkInvariants) metadata.invariants(doc)
     log.debug(
       { path: doc.path, _deleted: doc._deleted, doc },
       'Saving metadata...'

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -7,7 +7,6 @@
 const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const path = require('path')
-const { posix, sep } = path
 
 const { isNote } = require('../utils/notes')
 const logger = require('../utils/logger')
@@ -148,17 +147,7 @@ class Remote /*:: implements Reader, Writer */ {
       )
       metadata.updateRemote(doc, dir)
     } catch (err) {
-      if (err.status !== 409) {
-        throw err
-      }
-
-      // TODO: stop linking docs like this. Throw the error and let the remote
-      // watcher do its job.
-      log.info({ path }, 'Folder already exists')
-      const remotePath = '/' + posix.join(...doc.path.split(sep))
-      const dir = await this.remoteCozy.findDirectoryByPath(remotePath)
-      metadata.updateRemote(doc, dir)
-      return this.updateFolderAsync(doc)
+      throw err
     }
   }
 
@@ -283,18 +272,7 @@ class Remote /*:: implements Reader, Writer */ {
       )
       metadata.updateRemote(doc, newRemoteDoc)
     } catch (err) {
-      if (err.status !== 404) {
-        throw err
-      }
-
-      log.warn({ path }, "Directory doesn't exist anymore. Recreating it...")
-      const [newParentPath, newName] = dirAndName(path)
-      const newParent = await this.findDirectoryByPath(newParentPath)
-
-      const newRemoteDoc = await this.remoteCozy.createDirectory(
-        newDocumentAttributes(newName, newParent._id, doc.updated_at)
-      )
-      metadata.updateRemote(doc, newRemoteDoc)
+      throw err
     }
   }
 

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -13,8 +13,11 @@ const { isNote } = require('../utils/notes')
 const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
 const conflicts = require('../utils/conflicts')
+const pathUtils = require('../utils/path')
 const metadata = require('../metadata')
+const { ROOT_DIR_ID, DIR_TYPE } = require('./constants')
 const { RemoteCozy } = require('./cozy')
+const { DirectoryNotFound } = require('./errors')
 const { RemoteWarningPoller } = require('./warning_poller')
 const { RemoteWatcher } = require('./watcher')
 const timestamp = require('../utils/timestamp')
@@ -24,7 +27,7 @@ import type EventEmitter from 'events'
 import type { SideName } from '../side'
 import type { Readable } from 'stream'
 import type { Config } from '../config'
-import type { SavedMetadata, MetadataRemoteInfo } from '../metadata'
+import type { SavedMetadata, MetadataRemoteInfo, MetadataRemoteDir } from '../metadata'
 import type { Pouch } from '../pouch'
 import type Prep from '../prep'
 import type { RemoteDoc } from './document'
@@ -42,6 +45,21 @@ export type RemoteOptions = {
 const log = logger({
   component: 'RemoteWriter'
 })
+
+// A simplified version of the remote Root directory which will be used when
+// looking for the parent directory's _id of documents at the root of the Cozy.
+// The only information we care about are its _id, type and path.
+const ROOT_DIR /*: MetadataRemoteDir */ = {
+  _id: ROOT_DIR_ID,
+  _rev: '1',
+  dir_id: '',
+  name: '',
+  tags: [],
+  created_at: '',
+  updated_at: '',
+  type: DIR_TYPE,
+  path: '/'
+}
 
 /** `Remote` is the class that interfaces cozy-desktop with the remote Cozy.
  *
@@ -122,9 +140,7 @@ class Remote /*:: implements Reader, Writer */ {
     log.info({ path }, 'Creating folder...')
 
     const [parentPath, name] = dirAndName(doc.path)
-    const parent /*: RemoteDoc */ = await this.remoteCozy.findDirectoryByPath(
-      parentPath
-    )
+    const parent /*: RemoteDoc */ = await this.findDirectoryByPath(parentPath)
 
     try {
       const dir = await this.remoteCozy.createDirectory(
@@ -136,6 +152,8 @@ class Remote /*:: implements Reader, Writer */ {
         throw err
       }
 
+      // TODO: stop linking docs like this. Throw the error and let the remote
+      // watcher do its job.
       log.info({ path }, 'Folder already exists')
       const remotePath = '/' + posix.join(...doc.path.split(sep))
       const dir = await this.remoteCozy.findDirectoryByPath(remotePath)
@@ -149,6 +167,9 @@ class Remote /*:: implements Reader, Writer */ {
     log.info({ path }, 'Uploading new file...')
     const stopMeasure = measureTime('RemoteWriter#addFile')
 
+    const [parentPath, name] = dirAndName(path)
+    const parent = await this.findDirectoryByPath(parentPath)
+
     let stream
     try {
       stream = await this.other.createReadStreamAsync(doc)
@@ -161,11 +182,8 @@ class Remote /*:: implements Reader, Writer */ {
       throw err
     }
 
-    const [dirPath, name] = dirAndName(path)
-    const dir = await this.remoteCozy.findDirectoryByPath(dirPath)
-
     const created = await this.remoteCozy.createFile(stream, {
-      ...newDocumentAttributes(name, dir._id, doc.updated_at),
+      ...newDocumentAttributes(name, parent._id, doc.updated_at),
       checksum: doc.md5sum,
       executable: doc.executable || false,
       contentLength: doc.size,
@@ -270,13 +288,11 @@ class Remote /*:: implements Reader, Writer */ {
       }
 
       log.warn({ path }, "Directory doesn't exist anymore. Recreating it...")
-      const [newParentDirPath, newName] = dirAndName(path)
-      const newParentDir = await this.remoteCozy.findDirectoryByPath(
-        newParentDirPath
-      )
+      const [newParentPath, newName] = dirAndName(path)
+      const newParent = await this.findDirectoryByPath(newParentPath)
 
       const newRemoteDoc = await this.remoteCozy.createDirectory(
-        newDocumentAttributes(newName, newParentDir._id, doc.updated_at)
+        newDocumentAttributes(newName, newParent._id, doc.updated_at)
       )
       metadata.updateRemote(doc, newRemoteDoc)
     }
@@ -297,14 +313,14 @@ class Remote /*:: implements Reader, Writer */ {
       }`
     )
 
-    const [newDirPath, newName] /*: [string, string] */ = dirAndName(path)
-    const newDir /*: RemoteDoc */ = await this.remoteCozy.findDirectoryByPath(
-      newDirPath
+    const [newParentPath, newName] /*: [string, string] */ = dirAndName(path)
+    const newParent /*: MetadataRemoteDir */ = await this.findDirectoryByPath(
+      newParentPath
     )
 
     const attrs = {
       name: newName,
-      dir_id: newDir._id,
+      dir_id: newParent._id,
       updated_at: mostRecentUpdatedAt(newMetadata)
     }
     const opts = {
@@ -404,11 +420,31 @@ class Remote /*:: implements Reader, Writer */ {
   }
 
   async findDocByPath(fpath /*: string */) /*: Promise<?MetadataRemoteInfo> */ {
-    const [dir, name] = dirAndName(fpath)
-    const { _id: dirID } = await this.remoteCozy.findDirectoryByPath(dir)
+    const [parentPath, name] = dirAndName(fpath)
+    const { _id: dirID } = await this.findDirectoryByPath(parentPath)
 
     const results = await this.remoteCozy.search({ dir_id: dirID, name })
     if (results.length > 0) return results[0]
+  }
+
+  async findDirectoryByPath(
+    path /*: string */
+  ) /*: Promise<MetadataRemoteDir> */ {
+    if (path === '.') return ROOT_DIR
+
+    // XXX: We use the synced path instead of the remote path here as the goal
+    // is to find parent directories of documents during the synchronization of
+    // their changes and the parent can have been moved or renamed on the local
+    // filesystem and not on the remote Cozy yet.
+    // For now, the synced path is updated whenever the local or remote paths
+    // are changed but we'll need to review this when we start updating it only
+    // after a move has been fully synchronzed.
+    const dir = await this.pouch.bySyncedPath(pathUtils.remoteToLocal(path))
+    if (!dir || dir.docType !== 'folder' || !dir.remote) {
+      throw new DirectoryNotFound(path, this.config.cozyUrl)
+    }
+
+    return dir.remote
   }
 
   async resolveRemoteConflict(
@@ -447,12 +483,10 @@ class Remote /*:: implements Reader, Writer */ {
 
 /** Extract the remote parent path and leaf name from a local path */
 function dirAndName(localPath /*: string */) /*: [string, string] */ {
-  const dir =
-    '/' +
-    localPath
-      .split(path.sep)
-      .slice(0, -1)
-      .join('/')
+  const dir = path
+    .dirname(localPath)
+    .split(path.sep)
+    .join('/')
   const name = path.basename(localPath)
   return [dir, name]
 }

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -1030,7 +1030,7 @@ class Sync {
       const sourceSideName = otherSide(err.sideName)
       metadata.markSide(sourceSideName, doc, doc)
 
-      await this.pouch.db.put(doc)
+      await this.pouch.put(doc, { checkInvariants: false })
     } catch (err) {
       // If the doc can't be saved, it's because of a new revision.
       // So, we can skip this revision

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -343,22 +343,43 @@ describe('Add', () => {
             local: ['parent/', 'parent/dir/'],
             remote: ['parent/', 'parent/dir/']
           })
-          should(helpers.putDocs('path', 'remote', 'sides')).deepEqual([
+          should(
+            helpers.putDocs('path', 'local.path', 'remote', 'sides', 'errors')
+          ).deepEqual([
             // Adding children modifies the parent folder's metadata on the
             // filesystem triggering a call to Pouch.put with the local changes.
             {
               path: 'parent',
+              local: { path: 'parent' },
               remote: savedParent.remote,
               sides: { target: 2, local: 2, remote: 2 }
             },
             {
               path: path.normalize('parent/dir'),
+              local: { path: path.normalize('parent/dir') },
               sides: { target: 1, local: 1 }
+            },
+            // We encounter a conflict error since a remote doc with the same
+            // path already exists.
+            {
+              path: path.normalize('parent/dir'),
+              local: { path: path.normalize('parent/dir') },
+              sides: { target: 2, local: 2 },
+              errors: 1
+            },
+            // The conflict is solved once the remote watcher fetches the remote
+            // doc and links it to the local one during Merge.
+            {
+              path: path.normalize('parent/dir'),
+              local: { path: path.normalize('parent/dir') },
+              remote: updatedDir.remote,
+              sides: { target: 3, local: 2, remote: 3 }
             },
             {
               path: path.normalize('parent/dir'),
+              local: { path: path.normalize('parent/dir') },
               remote: updatedDir.remote,
-              sides: { target: 2, local: 2, remote: 2 }
+              sides: { target: 4, local: 4, remote: 4 }
             }
           ])
         })

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -198,9 +198,10 @@ class RemoteTestHelpers {
     newPath /*: string */
   ) {
     const [newDirPath, newName] /*: [string, string] */ = dirAndName(newPath)
-    const newDir /*: RemoteDoc */ = await this.side.remoteCozy.findDirectoryByPath(
-      newDirPath
-    )
+    const newDir /*: RemoteDoc */ =
+      newDirPath === '.'
+        ? await this.side.remoteCozy.findDir(ROOT_DIR_ID)
+        : await this.side.remoteCozy.findDirectoryByPath(`/${newDirPath}`)
     const attrs = {
       name: newName,
       dir_id: newDir._id,

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -12,10 +12,10 @@ const should = require('should')
 const metadata = require('../../../core/metadata')
 const Prep = require('../../../core/prep')
 const remote = require('../../../core/remote')
-const { Remote } = remote
 const { DirectoryNotFound } = require('../../../core/remote/errors')
 const { ROOT_DIR_ID, TRASH_DIR_ID } = require('../../../core/remote/constants')
 const { FetchError } = require('../../../core/remote/cozy')
+const { remoteJsonToRemoteDoc } = require('../../../core/remote/document')
 const timestamp = require('../../../core/utils/timestamp')
 const { CONFLICT_REGEXP } = require('../../../core/utils/conflicts')
 
@@ -35,14 +35,14 @@ describe('remote.Remote', function() {
 
   before('instanciate config', configHelpers.createConfig)
   before('register OAuth client', configHelpers.registerClient)
-  before('instanciate pouch', pouchHelpers.createDatabase)
-  before('prepare builders', function() {
+  beforeEach('instanciate pouch', pouchHelpers.createDatabase)
+  beforeEach('prepare builders', function() {
     builders = new Builders({ cozy, pouch: this.pouch })
   })
-  before('instanciate remote', function() {
+  beforeEach('instanciate remote', function() {
     this.prep = sinon.createStubInstance(Prep)
     this.events = new EventEmitter()
-    this.remote = new Remote(this)
+    this.remote = new remote.Remote(this)
     // TODO: find out why the client built by `new Remote()` doesn't behave
     // correctly (i.e. its auth isn't totally set and we can end up getting
     // errors from `cozy-client-js` because it's missing a `client_secret`).
@@ -55,8 +55,13 @@ describe('remote.Remote', function() {
       .name('couchdb-folder')
       .inRootDir()
       .create()
+    await builders
+      .metadir()
+      .fromRemote(couchdbFolder)
+      .upToDate()
+      .create()
   })
-  after('clean pouch', pouchHelpers.cleanDatabase)
+  afterEach('clean pouch', pouchHelpers.cleanDatabase)
   after('clean config directory', configHelpers.cleanConfig)
 
   describe('constructor', () => {
@@ -172,6 +177,23 @@ describe('remote.Remote', function() {
         .and.not.have.property('remote')
     })
 
+    it('rejects with a DirectoryNotFound error if its parent is missing on the Cozy', async function() {
+      const doc /*: Metadata */ = builders
+        .metafile()
+        .path('dir/foo')
+        .sides({ local: 1 })
+        .build()
+      this.remote.other = {
+        createReadStreamAsync() {
+          // XXX: we should not care if the file exists locally or not
+          return fse.readFile('dir/foo')
+        }
+      }
+      await should(this.remote.addFileAsync(doc)).be.rejectedWith(
+        DirectoryNotFound
+      )
+    })
+
     it('rejects if there is not enough space on the Cozy', async function() {
       sinon
         .stub(this.remote.remoteCozy, 'createFile')
@@ -207,10 +229,10 @@ describe('remote.Remote', function() {
   })
 
   describe('addFolderAsync', () => {
-    it('adds a folder to couchdb', async function() {
+    it('adds a folder on the remote Cozy', async function() {
       const doc = builders
         .metadir()
-        .path('couchdb-folder/folder-1')
+        .path('folder-1')
         .sides({ local: 1 })
         .updatedAt(timestamp.build(2017, 2, 14, 15, 3, 27))
         .build()
@@ -221,7 +243,7 @@ describe('remote.Remote', function() {
 
       const folder = await cozy.files.statById(doc.remote._id)
       should(folder.attributes).have.properties({
-        path: '/couchdb-folder/folder-1',
+        path: '/folder-1',
         name: 'folder-1',
         type: 'directory'
       })
@@ -821,6 +843,11 @@ describe('remote.Remote', function() {
           .name('moved-to')
           .inRootDir()
           .create()
+        await builders
+          .metadir()
+          .fromRemote(newDir)
+          .upToDate()
+          .create()
         const remoteDoc = await builders
           .remoteFile()
           .name('cat6.jpg')
@@ -867,56 +894,24 @@ describe('remote.Remote', function() {
           .createdAt(2018, 1, 2, 5, 31, 30, 564)
           .updatedAt(2018, 1, 2, 5, 31, 30, 564)
           .create()
-        const old = builders
+        const old = await builders
           .metadir()
           .fromRemote(created)
           .changedSide('local')
-          .build()
-        const doc = builders
+          .create()
+        const doc = await builders
           .metadir()
           .moveFrom(old)
           .path('couchdb-folder/folder-5')
           .updatedAt('2018-07-31T05:37:43.770Z')
-          .build()
+          .create()
+
         await this.remote.moveAsync(doc, old)
+
         const folder = await cozy.files.statById(doc.remote._id)
         should(folder.attributes).have.properties({
           dir_id: couchdbFolder._id,
           name: 'folder-5',
-          type: 'directory'
-        })
-        should(timestamp.roundedRemoteDate(folder.attributes.updated_at)).equal(
-          doc.updated_at
-        )
-      })
-
-      it('adds a folder to the Cozy if the folder does not exist', async function() {
-        const couchdbFolder = await cozy.files.statByPath('/couchdb-folder')
-        const created = await builders
-          .remoteDir()
-          .name('folder-6')
-          .inDir({ _id: couchdbFolder._id, path: '/couchdb-folder' })
-          .createdAt(2018, 1, 2, 5, 31, 30, 564)
-          .updatedAt(2018, 1, 2, 5, 31, 30, 564)
-          .create()
-        const old = builders
-          .metadir()
-          .fromRemote(created)
-          .changedSide('local')
-          .build()
-        const doc = builders
-          .metadir()
-          .moveFrom(old)
-          .path('couchdb-folder/folder-7')
-          .updatedAt('2018-07-31T05:37:43.770Z')
-          .build()
-
-        await this.remote.moveAsync(doc, old)
-
-        const folder = await cozy.files.statById(doc.remote._id)
-        should(folder.attributes).have.properties({
-          dir_id: couchdbFolder._id,
-          name: 'folder-7',
           type: 'directory'
         })
         should(timestamp.roundedRemoteDate(folder.attributes.updated_at)).equal(
@@ -997,6 +992,11 @@ describe('remote.Remote', function() {
           .remoteDir()
           .name('moved-to')
           .inRootDir()
+          .create()
+        await builders
+          .metadir()
+          .fromRemote(newDir)
+          .upToDate()
           .create()
 
         existingRemote = await builders
@@ -1250,10 +1250,10 @@ describe('remote.Remote', function() {
   })
 
   describe('ping', () => {
-    before(function() {
+    beforeEach(function() {
       sinon.stub(this.remote.remoteCozy, 'diskUsage')
     })
-    after(function() {
+    afterEach(function() {
       this.remote.remoteCozy.diskUsage.restore()
     })
 
@@ -1265,6 +1265,112 @@ describe('remote.Remote', function() {
     it('resolves to false if we cannot successfuly fetch the remote disk usage', async function() {
       this.remote.remoteCozy.diskUsage.rejects()
       await should(this.remote.ping()).be.fulfilledWith(false)
+    })
+  })
+
+  describe('findDirectoryByPath', () => {
+    let oldRemoteDir, newRemoteDir, oldDir, dir
+    beforeEach(async function() {
+      oldRemoteDir = await builders
+        .remoteDir()
+        .name('old')
+        .create()
+      oldDir = await builders
+        .metadir()
+        .fromRemote(oldRemoteDir)
+        .upToDate()
+        .create()
+      dir = await builders
+        .metadir()
+        .moveFrom(oldDir)
+        .path('dir')
+        .changedSide('local')
+        .create()
+      newRemoteDir = await builders
+        .remoteDir()
+        .name('dir')
+        .create()
+    })
+
+    it('returns the directory metadata saved in PouchDB', async function() {
+      await should(this.remote.findDirectoryByPath('dir')).be.fulfilledWith(
+        dir.remote
+      )
+      should(dir.remote).have.properties({
+        _id: oldRemoteDir._id,
+        _rev: oldRemoteDir._rev
+      })
+      should(dir.remote).not.have.properties({
+        _id: newRemoteDir._id,
+        _rev: newRemoteDir._rev
+      })
+    })
+
+    it('handles different local and remote paths formats', async function() {
+      // XXX: The synced path of this directory on Windows will be
+      // `whatever\childDir` and since we search by synced path, this tests that
+      // we handle the conversion.
+      const childDir = await builders
+        .metadir()
+        .path('whatever/childDir')
+        .upToDate()
+        .create()
+
+      await should(
+        this.remote.findDirectoryByPath('whatever/childDir')
+      ).be.fulfilledWith(childDir.remote)
+    })
+
+    it('returns the remote root directory for path .', async function() {
+      // $FlowFixMe Root is a directory
+      const root /*: RemoteDir */ = remoteJsonToRemoteDoc(
+        // XXX: We call the cozy-client-js method directly to increase the
+        // likelyhood that the remote document is unaltered.
+        await this.remote.remoteCozy.client.files.statById(ROOT_DIR_ID)
+      )
+
+      should(await this.remote.findDirectoryByPath('.')).have.properties({
+        _id: root._id,
+        name: root.name,
+        path: root.path,
+        dir_id: root.dir_id,
+        type: root.type
+      })
+    })
+
+    it('returns a DirectoryNotFound error if the directory cannot be found in PouchDB', async function() {
+      await builders
+        .remoteDir()
+        .name('missing')
+        .create()
+
+      await should(this.remote.findDirectoryByPath('missing')).be.rejectedWith(
+        DirectoryNotFound
+      )
+    })
+
+    it('returns a DirectoryNotFound error if the local document is not a directory', async function() {
+      await builders
+        .metafile()
+        .path('wrong-type')
+        .upToDate()
+        .create()
+
+      await should(
+        this.remote.findDirectoryByPath('wrong-type')
+      ).be.rejectedWith(DirectoryNotFound)
+    })
+
+    it('returns a DirectoryNotFound error if the directory has no remote side', async function() {
+      await builders
+        .metadir()
+        .path('no-remote')
+        .sides({ local: 1 })
+        .create()
+
+      await should(
+        this.remote.findDirectoryByPath('no-remote')
+      ).be.rejectedWith(DirectoryNotFound)
     })
   })
 
@@ -1337,13 +1443,13 @@ describe('remote.Remote', function() {
 describe('remote', function() {
   describe('.dirAndName()', () => {
     it('returns the remote path and name', function() {
-      should(remote.dirAndName('foo')).deepEqual(['/', 'foo'])
+      should(remote.dirAndName('foo')).deepEqual(['.', 'foo'])
       should(remote.dirAndName(path.normalize('foo/bar'))).deepEqual([
-        '/foo',
+        'foo',
         'bar'
       ])
       should(remote.dirAndName(path.normalize('foo/bar/baz'))).deepEqual([
-        '/foo/bar',
+        'foo/bar',
         'baz'
       ])
     })


### PR DESCRIPTION
When we're looking for a directory by path (usually the parent
directory of another document), we make a request to the remote Cozy,
even if the directory probably hasn't changed since the last time we
requested it, just to get its `_id` and use it as the `dir_id` of its
direct children.

This is inefficient both for the Desktop client and the remote Cozy
and slows down the entire synchronization.
This is inefficient because we probably already have the information
we're looking for in the local PouchDB.

Besides, when we look for the parent directory of a document during
its synchronization, we should reason about the information on which
previous steps like Merge were based on and changed.
For example, when adding a file to a directory on the local
filesystem, we should be looking for the remote _id of the folder
whose local path is the parent of our file and not for a remote folder
with the same path.

As a corollary of this change, we'll now throw an error when
propagating an action on a directory results in some kind of conflict
and won't link different directories together anymore.
Those errors will be caught by Sync and we can then decide what's the
best course of action to solve the problem.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation