### PR TITLE
test: Change default instance into cozy.localhost

### DIFF
--- a/core/utils/sentry.js
+++ b/core/utils/sentry.js
@@ -27,7 +27,7 @@ const { COZY_NO_SENTRY, DEBUG, TESTDEBUG } = process.env
 const SENTRY_REF = `ed6d0a175d504ead84851717b9bdb72e:324375dbe2ae4bbf8c212ae4eaf26289`
 const SENTRY_DSN = `https://${SENTRY_REF}@sentry.cozycloud.cc/91`
 const DOMAIN_TO_ENV = {
-  'cozy.tools': 'development',
+  'cozy.localhost': 'development',
   'cozy.works': 'development',
   'cozy.rocks': 'production',
   'mycozy.cloud': 'production'

--- a/dev/remote/generate-test-env.js
+++ b/dev/remote/generate-test-env.js
@@ -10,7 +10,7 @@ const proxy = require('../../gui/js/proxy')
 const cozyUrl =
   chooseCozyUrl(process.env.BUILD_JOB) ||
   process.env.COZY_URL ||
-  'http://cozy.tools:8080'
+  'http://cozy.localhost:8080'
 const passphrase = process.env.COZY_PASSPHRASE || 'cozy'
 const storage = new cozy.MemoryStorage()
 

--- a/doc/developer/requirements.md
+++ b/doc/developer/requirements.md
@@ -126,7 +126,7 @@ yarn docker:exec apt-get install git  # So we can install cozy apps
 You can also run any cozy-stack command with the `yarn cozy-stack` script, e.g.:
 
 ```
-yarn cozy-stack apps install --domain cozy.tools:8080 drive 'git://github.com/cozy/cozy-drive.git#build-drive'
+yarn cozy-stack apps install --domain cozy.localhost:8080 drive 'git://github.com/cozy/cozy-drive.git#build-drive'
 ```
 
 ## Complete your setup

--- a/doc/developer/setup.md
+++ b/doc/developer/setup.md
@@ -54,7 +54,7 @@ If you need to update translations, you'll need a Transifex API token at this st
 yarn start
 ```
 
-N.B.: the address of the development cozy-stack is http://cozy.tools:8080. Don't forget the protocol part when creating the connection in cozy-desktop for the first time or it won't find the server.
+N.B.: the address of the development cozy-stack is http://cozy.localhost:8080. Don't forget the protocol part when creating the connection in cozy-desktop for the first time or it won't find the server.
 
 ## Run tests
 

--- a/doc/developer/test.md
+++ b/doc/developer/test.md
@@ -18,7 +18,7 @@ for testing cozy-desktop. See options in [`test/mocha.opt`][2].
 
 Unit, integration & scenario tests require that you have a Cozy stack up.
 It's also expected that you have an instance registered for
-`cozy.tools:8080` with the
+`cozy.localhost:8080` with the
 [test passphrase](../../test/support/helpers/passphrase.js).
 You can start a cozy-stack via the provided docker-compose file:
 

--- a/test/elm/AddressTest.elm
+++ b/test/elm/AddressTest.elm
@@ -53,10 +53,10 @@ suite =
                 \_ ->
                     correctAddress "http://camille-nimbus.com"
                         |> Expect.equal "http://camille-nimbus.com"
-            , test "cozy.tools" <|
+            , test "cozy.localhost" <|
                 \_ ->
-                    correctAddress "http://cozy.tools:8080"
-                        |> Expect.equal "http://cozy.tools:8080"
+                    correctAddress "http://cozy.localhost:8080"
+                        |> Expect.equal "http://cozy.localhost:8080"
 
             -- , test "localhost" <|
             --     \_ ->

--- a/test/property/stack.js
+++ b/test/property/stack.js
@@ -19,7 +19,7 @@ class Stack {
 
   constructor(dir /*: string */) {
     this.dir = dir
-    this.instance = 'test.desktop.cozy.tools:8080'
+    this.instance = 'test.desktop.cozy.localhost:8080'
     this.child = null
     this.stopped = null
   }

--- a/test/scenarios/add_file/remote/changes.json
+++ b/test/scenarios/add_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:55:49.83171091Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:55:49.83171091Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:55:49.83171091Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:55:49.81Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/add_trash_dir/remote/changes.json
+++ b/test/scenarios/add_trash_dir/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:55:55.861807049Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:55:57.439582008Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:55:57.439582008Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/add_trash_file/remote/changes.json
+++ b/test/scenarios/add_trash_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:05.792317347Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:07.359115896Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:07.359115896Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:05.739Z",
     "dir_id": "io.cozy.files.trash-dir",

--- a/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/remote/changes.json
+++ b/test/scenarios/case_and_encoding/identical_additions/complex_dirs/linux/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.09609933Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.09609933Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.09609933Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.196174026Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.196174026Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.196174026Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -58,14 +58,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.239203422Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.239203422Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.239203422Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -78,7 +78,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:15.212Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d61e99",
@@ -100,14 +100,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.292603683Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.292603683Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.292603683Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -120,7 +120,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:15.263Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d61e99",
@@ -141,14 +141,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.373309531Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.373309531Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.373309531Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -167,14 +167,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.426754647Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.426754647Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.426754647Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -193,14 +193,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.495708894Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.495708894Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.495708894Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -220,14 +220,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.538252579Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.538252579Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.538252579Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -240,7 +240,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:15.512Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d644e2",
@@ -262,14 +262,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.588379623Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.588379623Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.588379623Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -282,7 +282,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:15.561Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d644e2",
@@ -303,14 +303,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:15.662825709Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:15.662825709Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:15.662825709Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/remote/changes.json
+++ b/test/scenarios/case_and_encoding/identical_additions/dir_file/linux/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:23.710434397Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:23.710434397Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:23.710434397Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:23.780940261Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:23.780940261Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:23.780940261Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -58,14 +58,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:23.819438222Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:23.819438222Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:23.819438222Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -78,7 +78,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:23.795Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d67216",
@@ -100,14 +100,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:23.86733506Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:23.86733506Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:23.86733506Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -120,7 +120,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:23.841Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/changes.json
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:31.794890746Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:31.794890746Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:31.794890746Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:31.769Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d685f6",

--- a/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/remote/changes.json
+++ b/test/scenarios/create_accentuated_file_in_accentued_dir/with_same_encoding/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:39.613158505Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:39.613158505Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:39.613158505Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:56:39.587Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d693f4",

--- a/test/scenarios/create_dir_into_moved_one/remote/changes.json
+++ b/test/scenarios/create_dir_into_moved_one/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:39.919107298Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:47.293287859Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:47.293287859Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:56:47.387765801Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:56:47.387765801Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:56:47.387765801Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/create_dirs/remote/changes.json
+++ b/test/scenarios/create_dirs/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:02.803701872Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:57:02.803701872Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:57:02.803701872Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:02.871511187Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:57:02.871511187Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:57:02.871511187Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_a_to_b_and_create_a/remote/changes.json
+++ b/test/scenarios/move_a_to_b_and_create_a/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:18.833290925Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:57:25.996861242Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:57:25.996861242Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:57:18Z",
     "dir_id": "io.cozy.files.root-dir",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:26.039536357Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:57:26.039536357Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:57:26.039536357Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -68,7 +68,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:57:26.012Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/remote/changes.json
+++ b/test/scenarios/move_a_to_c_and_b_to_a_dir_dir_delay/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:26.273669468Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:57:33.89317453Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:57:33.89317453Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:26.351033151Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:57:35.4764456Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:57:35.4764456Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_and_replace_file_with_update/remote/changes.json
+++ b/test/scenarios/move_and_replace_file_with_update/remote/changes.json
@@ -11,14 +11,14 @@
     "cozyMetadata": {
       "createdAt": "2021-02-04T18:33:19.494714203Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-02-04T18:33:21.143288534Z",
       "updatedByApps": [
         {
           "date": "2021-02-04T18:33:21.143288534Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -31,7 +31,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-02-04T19:33:19Z",
     "dir_id": "b6e003719af69912d43deb6e85978383",
@@ -63,14 +63,14 @@
     "cozyMetadata": {
       "createdAt": "2021-02-04T18:33:19.327659039Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-02-04T18:33:21.302850573Z",
       "updatedByApps": [
         {
           "date": "2021-02-04T18:33:21.302850573Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -83,7 +83,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-02-04T19:33:19Z",
     "dir_id": "b6e003719af69912d43deb6e85978383",

--- a/test/scenarios/move_and_trash_dir/remote/changes.json
+++ b/test/scenarios/move_and_trash_dir/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2021-03-28T22:12:46.023252242Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-03-28T22:12:46.023252242Z",
       "updatedByApps": [
         {
           "date": "2021-03-28T22:12:46.023252242Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-03-29T00:12:46Z",
     "dir_id": "bb1b7ed8dacc99e8de2996d2aea06c61",
@@ -47,14 +47,14 @@
     "cozyMetadata": {
       "createdAt": "2021-03-28T22:12:45.998445374Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-03-28T22:12:51.717778739Z",
       "updatedByApps": [
         {
           "date": "2021-03-28T22:12:51.717778739Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_and_trash_file/remote/changes.json
+++ b/test/scenarios/move_and_trash_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2021-03-28T22:02:46.925324206Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-03-28T22:02:52.636373361Z",
       "updatedByApps": [
         {
           "date": "2021-03-28T22:02:52.636373361Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-03-29T00:02:46Z",
     "dir_id": "io.cozy.files.trash-dir",

--- a/test/scenarios/move_and_update_file/remote/changes.json
+++ b/test/scenarios/move_and_update_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:57:56.910709114Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:04.258710692Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:04.258710692Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:57:56Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d76e23",

--- a/test/scenarios/move_dir_a_to_b_and_create_a/remote/changes.json
+++ b/test/scenarios/move_dir_a_to_b_and_create_a/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2021-01-11T17:30:54.2230352Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-01-11T17:30:54.2230352Z",
       "updatedByApps": [
         {
           "date": "2021-01-11T17:30:54.2230352Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2021-01-11T17:30:54.0330867Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-01-11T17:31:04.4092106Z",
       "updatedByApps": [
         {
           "date": "2021-01-11T17:31:04.4092106Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2021-01-11T17:31:05.0789219Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-01-11T17:31:05.0789219Z",
       "updatedByApps": [
         {
           "date": "2021-01-11T17:31:05.0789219Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -84,14 +84,14 @@
     "cozyMetadata": {
       "createdAt": "2021-01-11T17:31:05.1562798Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-01-11T17:31:05.1562798Z",
       "updatedByApps": [
         {
           "date": "2021-01-11T17:31:05.1562798Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -104,7 +104,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-01-11T17:31:05.069Z",
     "dir_id": "44eda9ed473e1a680edbc55ee3628969",
@@ -125,14 +125,14 @@
     "cozyMetadata": {
       "createdAt": "2021-01-11T17:31:05.3132835Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-01-11T17:31:05.3132835Z",
       "updatedByApps": [
         {
           "date": "2021-01-11T17:31:05.3132835Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -152,14 +152,14 @@
     "cozyMetadata": {
       "createdAt": "2021-01-11T17:31:05.3886124Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-01-11T17:31:05.3886124Z",
       "updatedByApps": [
         {
           "date": "2021-01-11T17:31:05.3886124Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -172,7 +172,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-01-11T17:31:05.304Z",
     "dir_id": "44eda9ed473e1a680edbc55ee3629b3a",

--- a/test/scenarios/move_dir_a_to_b_to_c_to_b/remote/changes.json
+++ b/test/scenarios/move_dir_a_to_b_to_c_to_b/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:05.609145568Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:15.897367392Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:15.897367392Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_dir_and_replace_subfile/remote/changes.json
+++ b/test/scenarios/move_dir_and_replace_subfile/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:17.623963179Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:24.521725433Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:24.521725433Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -32,14 +32,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:17.665852582Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:26.176477248Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:26.176477248Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -52,7 +52,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:58:17Z",
     "dir_id": "io.cozy.files.trash-dir",
@@ -75,14 +75,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:26.091216958Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:26.252185855Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:26.252185855Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -95,7 +95,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T12:58:26.049Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d7a0cf",

--- a/test/scenarios/move_dir_and_update_subfile/remote/changes.json
+++ b/test/scenarios/move_dir_and_update_subfile/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:26.484915846Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:33.691631647Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:33.691631647Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -32,14 +32,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:26.510302985Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:35.248445343Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:35.248445343Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -52,7 +52,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:58:26Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d7c19a",

--- a/test/scenarios/move_dir_from_the_outside/remote/changes.json
+++ b/test/scenarios/move_dir_from_the_outside/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-05-11T10:37:51.445441543Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-05-11T10:37:51.445441543Z",
       "updatedByApps": [
         {
           "date": "2020-05-11T10:37:51.445441543Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-05-11T10:37:51.571928038Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-05-11T10:37:51.571928038Z",
       "updatedByApps": [
         {
           "date": "2020-05-11T10:37:51.571928038Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2020-05-11T10:37:51.335391471Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-05-11T10:37:52.530263735Z",
       "updatedByApps": [
         {
           "date": "2020-05-11T10:37:52.530263735Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_dir_into_created_one/remote/changes.json
+++ b/test/scenarios/move_dir_into_created_one/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:42.724966381Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:42.724966381Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:42.724966381Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:35.515928593Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:42.778326546Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:42.778326546Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_dir_parent_and_child/remote/changes.json
+++ b/test/scenarios/move_dir_parent_and_child/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:43.045115655Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:51.371051737Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:51.371051737Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:43.111577872Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:43.111577872Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:43.111577872Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:43.147553871Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:43.147553871Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:43.147553871Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -83,14 +83,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:43.06860534Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:51.458402039Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:51.458402039Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -110,14 +110,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:43.181511747Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:58:51.62186488Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:58:51.62186488Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -130,7 +130,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:58:43Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d7efad",

--- a/test/scenarios/move_dir_reversed_events/remote/changes.json
+++ b/test/scenarios/move_dir_reversed_events/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:58:51.972637424Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:01.301737907Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:01.301737907Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_dir_successive_same_level/remote/changes.json
+++ b/test/scenarios/move_dir_successive_same_level/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:01.694446735Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:01.694446735Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:01.694446735Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:01.715973705Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:01.715973705Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:01.715973705Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:01.667793899Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:09.607106867Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:09.607106867Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_dir_successive_with_delay/remote/changes.json
+++ b/test/scenarios/move_dir_successive_with_delay/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:10.218697335Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:10.218697335Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:10.218697335Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:10.25443986Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:10.25443986Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:10.25443986Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:10.193337299Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:18.737512445Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:18.737512445Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_dir_with_content/remote/changes.json
+++ b/test/scenarios/move_dir_with_content/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:19.155478001Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:19.155478001Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:19.155478001Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:19.192165157Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:19.192165157Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:19.192165157Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:19.12488365Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:26.739028255Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:26.739028255Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_file/remote/changes.json
+++ b/test/scenarios/move_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:14.366000905Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:21.759568204Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:21.759568204Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:14Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d95457",

--- a/test/scenarios/move_file_a_to_b_to_c_to_b/remote/changes.json
+++ b/test/scenarios/move_file_a_to_b_to_c_to_b/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:27.035733397Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:38.215491248Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:38.215491248Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:59:27Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d8d067",

--- a/test/scenarios/move_file_inside_move/remote/changes.json
+++ b/test/scenarios/move_file_inside_move/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:40.130492604Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:46.983428214Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:46.983428214Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:59:40Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d8ff93",
@@ -47,14 +47,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:40.08741172Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:40.08741172Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:40.08741172Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -73,14 +73,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:40.110089387Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:40.110089387Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:40.110089387Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -99,14 +99,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:40.063395674Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:47.041525075Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:47.041525075Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -126,14 +126,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:40.202676647Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:47.119715644Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:47.119715644Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -146,7 +146,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:59:40Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d8ff93",

--- a/test/scenarios/move_file_reversed_events/remote/changes.json
+++ b/test/scenarios/move_file_reversed_events/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:47.472365141Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T12:59:55.041672475Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T12:59:55.041672475Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:59:47Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d907ad",

--- a/test/scenarios/move_file_successive/remote/changes.json
+++ b/test/scenarios/move_file_successive/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:05.141144794Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:14.019526605Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:14.019526605Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:05Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d945e2",

--- a/test/scenarios/move_file_successive_2/remote/changes.json
+++ b/test/scenarios/move_file_successive_2/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T12:59:55.396172016Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:04.618362435Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:04.618362435Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T14:59:55Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d92cdb",

--- a/test/scenarios/move_files_a_to_c_and_b_to_a/remote/changes.json
+++ b/test/scenarios/move_files_a_to_c_and_b_to_a/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:22.067899701Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:29.713761413Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:29.713761413Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:22Z",
     "dir_id": "io.cozy.files.root-dir",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:22.11201078Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:31.288314923Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:31.288314923Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -68,7 +68,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:22Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/move_from_inside_move/remote/changes.json
+++ b/test/scenarios/move_from_inside_move/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:31.591637605Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:31.591637605Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:31.591637605Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:31.569319834Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:38.801368294Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:38.801368294Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -57,14 +57,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:31.612696125Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:38.884197995Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:38.884197995Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_overwriting_dir/trashed_first/remote/changes.json
+++ b/test/scenarios/move_overwriting_dir/trashed_first/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.245494554Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.245494554Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.245494554Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:39Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d9c065",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.31439444Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.31439444Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.31439444Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -68,7 +68,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:39Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d9c065",
@@ -90,14 +90,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.372224088Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.372224088Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.372224088Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -110,7 +110,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:39Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d9cefb",
@@ -132,14 +132,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.423209937Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.423209937Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.423209937Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -152,7 +152,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:39Z",
     "dir_id": "b6f32dd442095bfe2c3639f240d9cefb",
@@ -173,14 +173,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.210506558Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.210506558Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.210506558Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -199,14 +199,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.181542001Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:47.333794174Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:47.333794174Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -226,14 +226,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.518194908Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.518194908Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.518194908Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -252,14 +252,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.746605331Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:39.746605331Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:39.746605331Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -278,14 +278,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:39.493995137Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:47.41997183Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:47.41997183Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_overwriting_file/trashed_first/remote/changes.json
+++ b/test/scenarios/move_overwriting_file/trashed_first/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:47.781067863Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:55.326804613Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:55.326804613Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:47Z",
     "dir_id": "io.cozy.files.trash-dir",
@@ -49,14 +49,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:47.853575138Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:00:55.355053437Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:00:55.355053437Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -69,7 +69,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:00:47Z",
     "dir_id": "b6f32dd442095bfe2c3639f240da38b3",

--- a/test/scenarios/move_replace_then_edit_moved_file/remote/changes.json
+++ b/test/scenarios/move_replace_then_edit_moved_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2021-02-11T16:18:59.140067866Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-02-11T16:18:59.140067866Z",
       "updatedByApps": [
         {
           "date": "2021-02-11T16:18:59.140067866Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-02-11T16:18:59.084Z",
     "dir_id": "cbb3a5ef2ccde3b8fc6e07b82d371d57",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2021-02-11T16:18:56.967059352Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-02-11T16:18:59.722622052Z",
       "updatedByApps": [
         {
           "date": "2021-02-11T16:18:59.722622052Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -68,7 +68,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-02-11T17:18:56Z",
     "dir_id": "cbb3a5ef2ccde3b8fc6e07b82d37191e",

--- a/test/scenarios/move_then_replace_file/remote/changes.json
+++ b/test/scenarios/move_then_replace_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2021-04-22T17:01:07.128108416Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-04-22T17:01:07.759258867Z",
       "updatedByApps": [
         {
           "date": "2021-04-22T17:01:07.759258867Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-04-22T19:01:07Z",
     "dir_id": "io.cozy.files.root-dir",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2021-04-22T17:01:07.832770276Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-04-22T17:01:07.832770276Z",
       "updatedByApps": [
         {
           "date": "2021-04-22T17:01:07.832770276Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -68,7 +68,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-04-22T17:01:07.809Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/move_two_dirs/remote/changes.json
+++ b/test/scenarios/move_two_dirs/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:05.302691695Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:12.61133301Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:12.61133301Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:05.325598003Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:14.192510917Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:14.192510917Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_two_dirs_same_prefix/remote/changes.json
+++ b/test/scenarios/move_two_dirs_same_prefix/remote/changes.json
@@ -5,14 +5,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:55.774410867Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:03.424525492Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:03.424525492Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -31,14 +31,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:00:55.795931207Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:04.998589089Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:04.998589089Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/move_two_files/remote/changes.json
+++ b/test/scenarios/move_two_files/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:14.565669257Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:21.964819813Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:21.964819813Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:01:14Z",
     "dir_id": "b6f32dd442095bfe2c3639f240dab900",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:14.627397078Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:23.552327993Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:23.552327993Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -68,7 +68,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:01:14Z",
     "dir_id": "b6f32dd442095bfe2c3639f240dab900",

--- a/test/scenarios/replace_dir_with_file/remote/changes.json
+++ b/test/scenarios/replace_dir_with_file/remote/changes.json
@@ -11,14 +11,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:31.186360202Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:31.186360202Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:31.186360202Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -31,7 +31,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T13:01:31.162Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/replace_file_with_dir/remote/changes.json
+++ b/test/scenarios/replace_file_with_dir/remote/changes.json
@@ -10,14 +10,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:39.328875938Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:39.328875938Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:39.328875938Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/replace_file_with_file/remote/changes.json
+++ b/test/scenarios/replace_file_with_file/remote/changes.json
@@ -11,14 +11,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:47.249747366Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:47.249747366Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:47.249747366Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -31,7 +31,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-10-03T13:01:47.216Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/scenarios/trash_dir_with_content/remote/changes.json
+++ b/test/scenarios/trash_dir_with_content/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:56.403985205Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:56.403985205Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:56.403985205Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:01:56Z",
     "dir_id": "b6f32dd442095bfe2c3639f240db2b14",
@@ -47,14 +47,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:56.329258536Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:56.329258536Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:56.329258536Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -73,14 +73,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:56.369093407Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:01:56.369093407Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:01:56.369093407Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]
@@ -99,14 +99,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:01:56.288042207Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:02:04.037701968Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:02:04.037701968Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/trash_file_and_move_parent/remote/changes.json
+++ b/test/scenarios/trash_file_and_move_parent/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2021-03-29T19:40:33.120271413Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-03-29T19:40:37.425596774Z",
       "updatedByApps": [
         {
           "date": "2021-03-29T19:40:37.425596774Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-03-29T21:40:33Z",
     "dir_id": "io.cozy.files.trash-dir",
@@ -48,14 +48,14 @@
     "cozyMetadata": {
       "createdAt": "2021-03-29T19:40:33.070655213Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-03-29T19:40:39.026203414Z",
       "updatedByApps": [
         {
           "date": "2021-03-29T19:40:39.026203414Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ]

--- a/test/scenarios/update_delete_then_replace_file/remote/changes.json
+++ b/test/scenarios/update_delete_then_replace_file/remote/changes.json
@@ -26,14 +26,14 @@
     "cozyMetadata": {
       "createdAt": "2021-02-05T10:10:46.467398538Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-02-05T10:10:46.467398538Z",
       "updatedByApps": [
         {
           "date": "2021-02-05T10:10:46.467398538Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -46,7 +46,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-02-05T10:10:46.447Z",
     "dir_id": "b6e003719af69912d43deb6e859c9b82",
@@ -73,14 +73,14 @@
     "cozyMetadata": {
       "createdAt": "2021-02-05T10:10:44.040683249Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2021-02-05T10:10:47.148293698Z",
       "updatedByApps": [
         {
           "date": "2021-02-05T10:10:47.148293698Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -93,7 +93,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2021-02-05T11:10:44Z",
     "dir_id": "b6e003719af69912d43deb6e859c8bf9",

--- a/test/scenarios/update_file/remote/changes.json
+++ b/test/scenarios/update_file/remote/changes.json
@@ -6,14 +6,14 @@
     "cozyMetadata": {
       "createdAt": "2020-10-03T13:02:04.378204286Z",
       "createdByApp": "cozy-desktop",
-      "createdOn": "http://cozy.tools:8080/",
+      "createdOn": "http://cozy.localhost:8080/",
       "doctypeVersion": "1",
       "metadataVersion": 1,
       "updatedAt": "2020-10-03T13:02:10.779502498Z",
       "updatedByApps": [
         {
           "date": "2020-10-03T13:02:10.779502498Z",
-          "instance": "http://cozy.tools:8080/",
+          "instance": "http://cozy.localhost:8080/",
           "slug": "cozy-desktop"
         }
       ],
@@ -26,7 +26,7 @@
         },
         "slug": "cozy-desktop"
       },
-      "uploadedOn": "http://cozy.tools:8080/"
+      "uploadedOn": "http://cozy.localhost:8080/"
     },
     "created_at": "2020-09-03T15:02:04Z",
     "dir_id": "io.cozy.files.root-dir",

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -4,14 +4,14 @@ set -x
 
 # Retrieve test client ID
 client_id=$(cozy-stack instances client-oauth \
-  cozy.tools:8080 \
-  http://cozy.tools/ \
+  cozy.localhost:8080 \
+  http://cozy.localhost/ \
   test \
   github.com/cozy-labs/cozy-desktop)
 
 # Retrieve test token
 token=$(cozy-stack instances token-oauth \
-  cozy.tools:8080 \
+  cozy.localhost:8080 \
   "$client_id" \
   io.cozy.files io.cozy.settings)
 

--- a/test/support/helpers/cozy.js
+++ b/test/support/helpers/cozy.js
@@ -30,7 +30,7 @@ const {
 } = require('../../../core/remote/constants')
 
 // The URL of the Cozy instance used for tests
-const COZY_URL = process.env.COZY_URL || 'http://cozy.tools:8080'
+const COZY_URL = process.env.COZY_URL || 'http://cozy.localhost:8080'
 
 if (!process.env.COZY_STACK_TOKEN) {
   const domain = COZY_URL.replace('http://', '')

--- a/test/unit/utils/sentry.js
+++ b/test/unit/utils/sentry.js
@@ -32,10 +32,10 @@ describe('Sentry', function() {
   describe('toSentryContext', function() {
     it('properly parse all urls', function() {
       sentry
-        .toSentryContext('https://somedevcozy.cozy.tools:8080')
+        .toSentryContext('https://somedevcozy.cozy.localhost:8080')
         .should.deepEqual({
-          domain: 'cozy.tools',
-          instance: 'somedevcozy.cozy.tools',
+          domain: 'cozy.localhost',
+          instance: 'somedevcozy.cozy.localhost',
           environment: 'development'
         })
 


### PR DESCRIPTION
In `cozy-app-dev` docker image we use for tests and development, the
default `cozy.tools` Cozy instance has been replaced by
`cozy.localhost` so our tests should use this instance as well.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
