### PR TITLE
dev: Small changes

### DIFF
--- a/.jq
+++ b/.jq
@@ -16,10 +16,14 @@ def redactNote(obj):
 
 def cleanNote:
   .
-  | if isempty(.doc | objects) |not then redactNote(.doc) else . end
-  | if isempty(.was | objects) |not then redactNote(.was) else . end
-  | if isempty(.remoteDoc | objects) |not then redactNote(.remoteDoc) else . end
-  | if isempty(.note | objects) |not then redactNote(.note) else . end
+  | if isempty(.doc | objects) | not then redactNote(.doc) else . end
+  | if isempty(.was | objects) | not then redactNote(.was) else . end
+  | if isempty(.remoteDoc | objects) | not then redactNote(.remoteDoc) else . end
+  | if isempty(.note | objects) | not then redactNote(.note) else . end
+  | if isempty(.file | objects) | not then redactNote(.file) else . end
+  | if isempty(.err | objects) | not then .
+    | .err |= (. | redactNote(.doc))
+    else . end
   | if isempty(.change | objects) | not then .
     | .change |= (. | redactNote(.doc))
     | .change |= (. | redactNote(.was))
@@ -145,6 +149,15 @@ def path(pattern):
     )
       | strings
       | test(pattern)
+  );
+
+def shortPath:
+  (
+    .
+    | if isempty(.path | strings) | not then .path |= (. | split("\\") | last) else . end
+    | if isempty(.path | strings) | not then .path |= (. | split("/") | last) else . end
+    | if isempty(.oldpath | strings) | not then .oldpath |= (. | split("\\") | last) else . end
+    | if isempty(.oldpath | strings) | not then .oldpath |= (. | split("/") | last) else . end
   );
 
 # Include/exclude GUI stuff:

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -10,8 +10,8 @@ DEBUG=1
 EOF
 
 # Install cozy apps
-yarn docker:exec apt-get update
-yarn docker:exec apt-get install -y --no-install-recommends git
+apt-get update
+apt-get install -y --no-install-recommends git
 for app in home settings drive photos collect; do
-  yarn cozy-stack apps install "$app"
+  cozy-stack apps install "$app"
 done

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "capture:manual": "env-cmd .env.test electron ./dev/chokidar.js",
     "clean": "rimraf core/lib/ core/tmp/ gui/elm.js gui/app.css* gui/dist/",
     "cozy-stack": "yarn docker:exec cozy-stack",
-    "dev:setup": "bash ./dev/setup.sh",
+    "dev:setup": "yarn docker:exec /cozy-desktop/dev/setup.sh",
     "dev:elm": "yarn watch:css & yarn watch:elm & python2 -m SimpleHTTPServer 8000",
     "dist": "electron-builder build",
     "dist:all": "yarn dist --x64 --ia32",


### PR DESCRIPTION
# jq: Redact notes in errors and add shortPath  
Redacting notes in errors prevents us from reading the content of
  notes in log files and has the benefit of reducing the amount of text
  displayed when searching through log files.

  The `shortPath` helper keeps only the name of files and directories in
  the `path` field of log lines to increase the readability of logs when
  we don't care about the whole hierarchy.

# dev: Run setup script inside Docker container
Avoid depending on `bash` to run the dev script and run it directly
  within the `cozy-app-dev` Docker container.

  It also makes it easier to port the script to run it outside Docker.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
