### PR TITLE
tests: Enable Chokidar scenarios without captures

### DIFF
--- a/test/scenarios/move_and_replace_file_with_update/scenario.js
+++ b/test/scenarios/move_and_replace_file_with_update/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -13,6 +15,7 @@ module.exports = ({
     { ino: 4, path: 'dst/file2', content: 'overwritten content' }
   ],
   actions: [
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'update_file', path: 'dst/file1', content: 'updated content' },
     { type: 'mv', src: 'src/file2', dst: 'dst/file2' },
     { type: 'wait', ms: 500 },

--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -11,7 +13,7 @@ module.exports = ({
   ],
   actions: [
     { type: 'mv', src: 'src/file', dst: 'dst/file' },
-    { type: 'wait', ms: 500 },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 500 },
     { type: 'update_file', path: 'dst/file', content: 'updated content' },
     { type: 'wait', ms: 1000 }
   ],

--- a/test/scenarios/move_replace_then_edit_moved_file/scenario.js
+++ b/test/scenarios/move_replace_then_edit_moved_file/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -11,11 +13,11 @@ module.exports = ({
   ],
   actions: [
     { type: 'mv', src: 'src/file', dst: 'dst/file' },
-    { type: 'wait', ms: 500 },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 500 },
     { type: 'create_file', path: 'src/file', content: 'new content' },
-    { type: 'wait', ms: 500 },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 500 },
     { type: 'update_file', path: 'dst/file', content: 'updated content' },
-    { type: 'wait', ms: 1500 }
+    { type: 'wait', ms: 1000 }
   ],
   expected: {
     tree: ['dst/', 'dst/file', 'src/', 'src/file'],

--- a/test/scenarios/move_then_replace_file/scenario.js
+++ b/test/scenarios/move_then_replace_file/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -8,6 +10,7 @@ module.exports = ({
   init: [{ ino: 1, path: 'file.ods', content: 'initial content' }],
   actions: [
     { type: 'mv', src: 'file.ods', dst: 'other-file.ods' },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'create_file', path: 'file.ods', content: 'new content' },
     { type: 'wait', ms: 1000 }
   ],

--- a/test/scenarios/ods_update_through_osl_tmp_file/scenario.js
+++ b/test/scenarios/ods_update_through_osl_tmp_file/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -8,7 +10,9 @@ module.exports = ({
   init: [{ ino: 1, path: 'file.ods', content: 'initial content' }],
   actions: [
     { type: 'mv', src: 'file.ods', dst: 'file.ods.osl-tmp' },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'create_file', path: 'file.ods' },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'update_file', path: 'file.ods', content: 'updated content #1' },
     { type: 'delete', path: 'file.ods.osl-tmp' },
     { type: 'wait', ms: 1000 }

--- a/test/scenarios/replace_file_with_file/scenario.js
+++ b/test/scenarios/replace_file_with_file/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -7,8 +9,9 @@ module.exports = ({
   init: [{ ino: 1, path: 'file', content: 'initial content' }],
   actions: [
     { type: 'delete', path: 'file' },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'create_file', path: 'file', content: 'new content' },
-    { type: 'wait', ms: 1500 }
+    { type: 'wait', ms: 1000 }
   ],
   expected: {
     tree: ['file'],

--- a/test/scenarios/update_delete_then_replace_file/scenario.js
+++ b/test/scenarios/update_delete_then_replace_file/scenario.js
@@ -1,6 +1,9 @@
 /* @flow */
 
-const { runWithStoppedClient } = require('../../support/helpers/scenarios')
+const {
+  runOnHFS,
+  runWithStoppedClient
+} = require('../../support/helpers/scenarios')
 
 /*:: import type { Scenario } from '..' */
 
@@ -20,6 +23,7 @@ module.exports = ({
     { ino: 7, path: 'src/file2', content: 'moved content' }
   ],
   actions: [
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'update_file', path: 'src/file1', content: 'updated content' },
     { type: 'mv', src: 'src/file2', dst: 'final/file2' },
     { type: 'wait', ms: 500 },

--- a/test/scenarios/update_file/scenario.js
+++ b/test/scenarios/update_file/scenario.js
@@ -1,11 +1,17 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
   useCaptures: false,
   init: [{ ino: 1, path: 'file', content: 'initial content' }],
-  actions: [{ type: 'update_file', path: 'file', content: 'new content' }],
+  actions: [
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
+    { type: 'update_file', path: 'file', content: 'new content' },
+    { type: 'wait', ms: 1000 }
+  ],
   expected: {
     tree: ['file'],
     trash: [],

--- a/test/scenarios/update_through_unignored_tmp_file/scenario.js
+++ b/test/scenarios/update_through_unignored_tmp_file/scenario.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+const { runOnHFS } = require('../../support/helpers/scenarios')
+
 /*:: import type { Scenario } from '..' */
 
 module.exports = ({
@@ -7,10 +9,13 @@ module.exports = ({
   useCaptures: false,
   init: [{ ino: 1, path: 'file.ods', content: 'initial content' }],
   actions: [
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'mv', src: 'file.ods', dst: 'other-file.ods' },
     { type: 'create_file', path: 'file.ods' },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'update_file', path: 'file.ods', content: 'updated content #1' },
     { type: 'delete', path: 'other-file.ods' },
+    { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
     { type: 'update_file', path: 'file.ods', content: 'updated content #2' },
     { type: 'wait', ms: 1000 }
   ],

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -90,6 +90,11 @@ module.exports.runWithStoppedClient = () => {
   return isTruthyVar(STOPPED_CLIENT)
 }
 
+module.exports.runOnHFS = () => {
+  const { COZY_DESKTOP_FS } = process.env
+  return COZY_DESKTOP_FS === 'HFS+'
+}
+
 // TODO: Refactor to function
 module.exports.scenarios = glob
   .sync(path.join(scenariosDir, '**/scenario.js*'), {})


### PR DESCRIPTION
Test captures are a way to get reproducible scenarios runs by saving
the local or remote events once and pushing them to the watchers on
later runs after the actual actions of the scenarios have been applied.
However, some scenarios can only succeed by getting events when each
action is actually applied as they would otherwise contain outdated
values (e.g. file inodes for a move event if we have run a file
update afterwards).

This is why we introduced a way to run scenarios without using the
captures. We started with local Atom scenarios since this watcher's
behavior is more dependent on timing but we now face issues with
Chokidar scenarios as well.

We will introduce the same mechanism for remote scenarios when
  needed.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
