### PR TITLE
core/local/chokidar: Fix analysis defaultSorter

### DIFF
--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -466,20 +466,22 @@ const defaultSorter = (a /*: LocalChange */, b /*: LocalChange */) => {
   if (localChange.isChildDelete(a, b)) return bFirst
 
   // a is deleted what b added
-  if (localChange.delPath(a) === localChange.addPath(b)) return aFirst
+  if (localChange.samePath(localChange.delPath(a), localChange.addPath(b)))
+    return aFirst
   // b is deleting what a added
-  if (localChange.delPath(b) === localChange.addPath(a)) return bFirst
+  if (localChange.samePath(localChange.delPath(b), localChange.addPath(a)))
+    return bFirst
 
   // both adds at same path (seen with move + add)
   if (
     localChange.addPath(a) &&
-    localChange.addPath(a) === localChange.addPath(b)
+    localChange.samePath(localChange.addPath(a), localChange.addPath(b))
   )
     return aFirst
   // both deletes at same path (seen with delete + move)
   if (
     localChange.delPath(a) &&
-    localChange.delPath(a) === localChange.delPath(b)
+    localChange.samePath(localChange.delPath(a), localChange.delPath(b))
   )
     return bFirst
 

--- a/core/local/chokidar/local_change.js
+++ b/core/local/chokidar/local_change.js
@@ -40,6 +40,7 @@ module.exports = {
   addPath,
   delPath,
   updatePath,
+  samePath,
   childOf,
   lower,
   isChildDelete,
@@ -244,6 +245,9 @@ function delPath(a /*: LocalChange */) /*: ?string */ {
 }
 function updatePath(a /*: LocalChange */) /*: ?string */ {
   return isUpdate(a) ? a.path.normalize() : null
+}
+function samePath(p1 /*: ?string */, p2 /*: ?string */) /*: boolean */ {
+  return p1 != null && p2 != null && p1.normalize() === p2.normalize()
 }
 function childOf(p /*: ?string */, c /*: ?string */) /*: boolean */ {
   return (

--- a/test/unit/local/chokidar/analysis.js
+++ b/test/unit/local/chokidar/analysis.js
@@ -832,6 +832,47 @@ onPlatform('darwin', () => {
       })
     })
 
+    describe('FileReplacement(x/x)', () => {
+      describe('unlink(x) + add(x)', () => {
+        it('is a deleted then added file', () => {
+          const path = 'whatever'
+          const old /*: Metadata */ = builders
+            .metafile()
+            .path(path)
+            .ino(1)
+            .build()
+          const stats = { ino: 532806 }
+          const events /*: LocalEvent[] */ = [
+            { type: 'unlink', path, old },
+            { type: 'add', path, stats, old: null }
+          ]
+          const pendingChanges /*: LocalChange[] */ = []
+
+          const changes = analysis(events, { pendingChanges })
+          should({ changes, pendingChanges }).deepEqual({
+            changes: [
+              {
+                sideName,
+                type: 'FileDeletion',
+                ino: old.ino,
+                path,
+                old
+              },
+              {
+                sideName,
+                type: 'FileAddition',
+                path,
+                ino: stats.ino,
+                stats,
+                md5sum: undefined // XXX: We're just not computing it
+              }
+            ],
+            pendingChanges: []
+          })
+        })
+      })
+    })
+
     describe('FileUpdate(é/à)', () => {
       const dirStats = { ino: 765 }
       const fileStats = { ino: 766 }


### PR DESCRIPTION
The `defaultSorter()` sort method used after the initial scan by the
Chokidar watcher to sort changes before merging them is supposed to
sort deletion changes before addition changes on the same path.

However, the way we compared those changes was flawed and in the
case the deletion change would come before the addition change
before sorting, our algorithm would switch places between them (i.e.
the "deleted path" of the addition change would be null and equal to
the "added path" of the deletion change).

We now make sure only non-null and normalized paths can be deemed
equal.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
