### PR TITLE
core/chokidar: Fix file move and update detection

### DIFF
--- a/test/scenarios/move_and_update_file/scenario.js
+++ b/test/scenarios/move_and_update_file/scenario.js
@@ -12,8 +12,8 @@ module.exports = ({
     { ino: 3, path: 'src/file', content: 'initial content' }
   ],
   actions: [
-    { type: 'mv', src: 'src/file', dst: 'dst/file' },
     { type: 'wait', ms: runOnHFS() ? 1000 : 500 },
+    { type: 'mv', src: 'src/file', dst: 'dst/file' },
     { type: 'update_file', path: 'dst/file', content: 'updated content' },
     { type: 'wait', ms: 1000 }
   ],

--- a/test/scenarios/replace_file_with_file/scenario.js
+++ b/test/scenarios/replace_file_with_file/scenario.js
@@ -8,8 +8,8 @@ module.exports = ({
   useCaptures: false,
   init: [{ ino: 1, path: 'file', content: 'initial content' }],
   actions: [
-    { type: 'delete', path: 'file' },
     { type: 'wait', ms: runOnHFS() ? 1000 : 0 },
+    { type: 'delete', path: 'file' },
     { type: 'create_file', path: 'file', content: 'new content' },
     { type: 'wait', ms: 1000 }
   ],


### PR DESCRIPTION
In case a file is modified right after being moved (i.e. within the
buffering period), we want to make sure the `FileMove` event will be
marked as an update only if its `md5sum` AND `mtime` have changed or
the following `FileUpdate` event is included into it.

Since we don't have access to filesystem events when documents are
changed while the client was stopped, we have logic to detect when a
`FileMove` is also a `FileUpdate`. In this case, the `FileMove` will
be marked as an update and, once all changes have been detected,
we'll generate a custom `FileUpdate` change to make sure it is
merged.
However, when the client is running, if we have:
- a file move followed by a file modification where the inode has
  changed (e.g. when we're applying a remote file move + update on
  the local filesystem)
- a slow checksum computing for the `FileMove` leading to the
  `FileUpdate` checksum being returned
then we'll have both an inaccurate `FileMove` change with update
(i.e. the checksum corresponds to the file update one) AND a
`FileUpdate` change.
At this point, if the generated `FileUpdate` change (i.e. from the
`FileMove`) is sorted after the actual `FileUpdate` change then we'll
end up merging a correct file update (the second one) and then the
inaccurate one, with the wrong modification date and potentially, the
wrong size.

This would finally lead to synchronization error as the sent data
size would not match the size saved in PouchDB.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
