### PR TITLE
fix when using no 443 or 80 port url with https.

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -102,6 +102,10 @@ class App {
       }
       cozyUrl = `https://${cozyUrl}`
     }
+    //fix issue when using no 443 or 80 port url.
+    if (cozyUrl.indexOf('http') !== 0) {
+      cozyUrl = `https://${cozyUrl}`
+    }
     return new url.URL(cozyUrl)
   }
 


### PR DESCRIPTION
# Fix a bug using no 443 or 80 port url. juse like "https://scjtqs.cozy.scjtqs.com:8443"

This is a bug when i init app with a url like "https://scjtqs.cozy.scjtqs.com:8443".
It workd well on mobile
![image](https://user-images.githubusercontent.com/24914774/130560364-a9913ff7-4a69-4294-809d-541fa800bd9d.png)

so i fix it.

![image](https://user-images.githubusercontent.com/24914774/130560431-6f0f119f-09ac-4914-ad2e-7079dd989b54.png)


Please make sure the following boxes are checked:

- [x] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
