### PR TITLE
core/local/chokidar: Run initial scan on empty dir

### DIFF
--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -211,18 +211,17 @@ class LocalWatcher {
     this.events.emit('local-start')
 
     let events = rawEvents.filter(hasPath) // @TODO handle root dir events
-    if (events.length > 0) {
-      // We need to destructure `this` otherwise Flow won't detect that
-      // `this.initialScanParams` is not null even within the conditional block.
-      const { buffer, pouch, initialScanParams } = this
-      if (initialScanParams != null && !initialScanParams.flushed) {
-        events = await initialScan.step(events, {
-          initialScanParams,
-          buffer,
-          pouch
-        })
-      }
+    // We need to destructure `this` otherwise Flow won't detect that
+    // `this.initialScanParams` is not null even within the conditional block.
+    const { buffer, pouch, initialScanParams } = this
+    if (initialScanParams != null && !initialScanParams.flushed) {
+      events = await initialScan.step(events, {
+        initialScanParams,
+        buffer,
+        pouch
+      })
     }
+
     if (events.length === 0) {
       if (this.initialScanParams != null) this.initialScanParams.resolve()
       return

--- a/test/scenarios/create_dir_into_moved_one/local/darwin.json
+++ b/test/scenarios/create_dir_into_moved_one/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0, 2]
+  },
+  {
     "type": "unlinkDir",
     "path": "src/dir1"
   },

--- a/test/scenarios/move_dir_a_to_b_to_c_to_b/local/darwin.json
+++ b/test/scenarios/move_dir_a_to_b_to_c_to_b/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0, 3, 5]
+  },
+  {
     "type": "unlinkDir",
     "path": "src/A"
   },

--- a/test/scenarios/move_dir_into_created_one/local/darwin.json
+++ b/test/scenarios/move_dir_into_created_one/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0]
+  },
+  {
     "type": "unlinkDir",
     "path": "dir1"
   },

--- a/test/scenarios/move_dir_reversed_events/local/darwin.json
+++ b/test/scenarios/move_dir_reversed_events/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0]
+  },
+  {
     "type": "unlinkDir",
     "path": "src/dir"
   },

--- a/test/scenarios/move_dir_successive_same_level/local/darwin.json
+++ b/test/scenarios/move_dir_successive_same_level/local/darwin.json
@@ -1,6 +1,6 @@
 [
   {
-    "breakpoints": [0, 1, 6]
+    "breakpoints": [0, 6]
   },
   {
     "type": "unlinkDir",

--- a/test/scenarios/move_dir_successive_same_level/scenario.js
+++ b/test/scenarios/move_dir_successive_same_level/scenario.js
@@ -17,7 +17,6 @@ module.exports = ({
     { type: 'mv', src: 'parent/src/dir', dst: 'parent/dst1/dir' },
     { type: 'mv', src: 'parent/dst1/dir', dst: 'parent/dst2/dir' }
   ],
-  // FIXME: eventsBreakpoints: [0, 1, 5],
   expected: {
     tree: [
       'parent/',

--- a/test/scenarios/move_dir_successive_with_delay/local/darwin.json
+++ b/test/scenarios/move_dir_successive_with_delay/local/darwin.json
@@ -1,6 +1,6 @@
 [
   {
-    "breakpoints": [0, 1]
+    "breakpoints": [0, 6]
   },
   {
     "type": "unlinkDir",

--- a/test/scenarios/move_dir_with_content/local/darwin.json
+++ b/test/scenarios/move_dir_with_content/local/darwin.json
@@ -1,6 +1,6 @@
 [
   {
-    "breakpoints": [0, 1, 6]
+    "breakpoints": [0,  6]
   },
   {
     "type": "unlinkDir",

--- a/test/scenarios/move_two_dirs/local/darwin.json
+++ b/test/scenarios/move_two_dirs/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0, 2]
+  },
+  {
     "type": "unlinkDir",
     "path": "src/dir1"
   },

--- a/test/scenarios/move_two_dirs_same_prefix/local/darwin.json
+++ b/test/scenarios/move_two_dirs_same_prefix/local/darwin.json
@@ -1,5 +1,8 @@
 [
   {
+    "breakpoints": [0, 2]
+  },
+  {
     "type": "unlinkDir",
     "path": "src/dir1"
   },


### PR DESCRIPTION
If the local synchronization directory is empty when we start the
Desktop client, then the only event we'll receive and flush will be
for the synchronization directory itself (i.e. there aren't any
documents to emit `add` or `addDir` events). This event has no path
(i.e. events paths are relative to the synchronization directory
itself) and thus will be filtered out at the beginning of the
`onFlush` call.

This means that we won't have any events to call the initial scan
step on. However, we do need to run the step since the detection of
offline deletions is part of it.
Without this call we won't detect that the directory has been
emptied for example.

Some macOS scenarios started failing once this fix was introduced
but only for meaningless breakpoints (i.e. flushing points that don't
make sense in regards to the situation we are testing).
Those breakpoints won't be tested anymore.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
