### PR TITLE
core/local/atom: Keep Windows parent move events

### DIFF
--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -258,6 +258,15 @@ async function winDetectMove(
 
       assignDebugInfos(event, found)
 
+      for (const pendingItem of pendingItems) {
+        if (areParentChildPaths(pendingItem.event.path, event.path)) {
+          // Refresh parent events timeouts as matching events for them will
+          // probably come after all their children's firt event.
+          // $FlowFixMe TimeoutID.refresh() is available since Node v10
+          pendingItem.timeout.refresh()
+        }
+      }
+
       const timeout = setTimeout(() => {
         output([pendingItems.shift().event])
         sendReadyBatches(pendingItems, output)

--- a/core/local/atom/win_detect_move.js
+++ b/core/local/atom/win_detect_move.js
@@ -229,9 +229,9 @@ function sendReadyBatches(
     if (waiting[0].deletedIno || waiting[0].event.action === 'created') {
       break
     }
+    clearTimeout(waiting[0].timeout)
     const item = waiting.shift()
-    clearTimeout(item.timeout)
-    output([item.event])
+    if (item) output([item.event])
   }
 }
 
@@ -268,7 +268,8 @@ async function winDetectMove(
       }
 
       const timeout = setTimeout(() => {
-        output([pendingItems.shift().event])
+        const pendingItem = pendingItems.shift()
+        if (pendingItem) output([pendingItem.event])
         sendReadyBatches(pendingItems, output)
       }, DELAY)
       pendingItems.push({ event, deletedIno, timeout })


### PR DESCRIPTION
On Windows, moves trigger couples of `deleted` and `created` events
that we need to match to rebuild a `renamed` event.
If a directory with content is moved then we'll get a lot of `deleted`
events for its children between the directory's `deleted` and
`created` events.

Refreshing the timeout of the pending directory's `deleted` event
should make it more likely that we'll match it with its `created`
event.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
