### PR TITLE
Fix Onboarding addresses auto-correction and validation

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -96,9 +96,9 @@ class App {
 
   // Parse the URL
   parseCozyUrl(cozyUrl /*: string */) {
-    if (cozyUrl.indexOf(':') === -1) {
-      if (cozyUrl.indexOf('.') === -1) {
-        cozyUrl += '.cozycloud.cc'
+    if (!cozyUrl.includes('://')) {
+      if (!cozyUrl.includes('.')) {
+        cozyUrl += '.mycozy.cloud'
       }
       cozyUrl = `https://${cozyUrl}`
     }

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -33,7 +33,7 @@ describe('App', function() {
     it('parses zoe as https://zoe.cozycloud.cc', function() {
       let parsed = App.prototype.parseCozyUrl('zoe')
       parsed.protocol.should.equal('https:')
-      parsed.host.should.equal('zoe.cozycloud.cc')
+      parsed.host.should.equal('zoe.mycozy.cloud')
     })
 
     it('parses http://localhost:9104', function() {
@@ -41,6 +41,15 @@ describe('App', function() {
       parsed.protocol.should.equal('http:')
       parsed.hostname.should.equal('localhost')
       parsed.port.should.equal('9104')
+    })
+
+    it('parses https://toto.cozy.claude.fr:8084', function() {
+      let parsed = App.prototype.parseCozyUrl(
+        'https://toto.cozy.claude.fr:8084'
+      )
+      parsed.protocol.should.equal('https:')
+      parsed.hostname.should.equal('toto.cozy.claude.fr')
+      parsed.port.should.equal('8084')
     })
   })
 


### PR DESCRIPTION
- Allow port in HTTPS Cozy URL
  Thanks @scjtqs for reporting this issue and offering a fix.
- Fix app name removal from entered address
- Auto-correct My Toutatice URLs

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation