### PR TITLE
refactor: Bypass Cozy-Client to only use StackClient

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -593,7 +593,14 @@ async function fetchInitialChanges(
       limit: 1,
       descending: true
     })
-  const remoteDocs = await client.queryAll(Q(FILES_DOCTYPE))
+  
+  let resp = await client.stackClient.collection(FILES_DOCTYPE).all({limit: 1000})
+  const remoteDocs = resp.data
+
+  while(resp && resp.next){
+      resp = await client.stackClient.collection(FILES_DOCTYPE).all({limit: 1000, bookmark:resp.bookmark })
+      remoteDocs.push(...resp.data)
+  }
 
   return { last_seq, remoteDocs }
 }


### PR DESCRIPTION
We don't need all the redux stuff coming from Cozy-Client. 
It can consume a lot of RAM (on large cozy) for... nothing
We only need to query Cozy-Stack and return the result, so 
let's use Cozy-Stack-Client directly. 

I also increased the limit to reduce the number of network calls

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
