### PR TITLE
core/remote: Speed up initial changes fetch

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -593,7 +593,18 @@ async function fetchInitialChanges(
       limit: 1,
       descending: true
     })
-  const remoteDocs = await client.queryAll(Q(FILES_DOCTYPE))
+
+  let resp = await client.stackClient
+    .collection(FILES_DOCTYPE)
+    .all({ limit: 1000 })
+  let remoteDocs = resp.data
+
+  while (resp && resp.next) {
+    resp = await client.stackClient
+      .collection(FILES_DOCTYPE)
+      .all({ limit: 1000, bookmark: resp.bookmark })
+    remoteDocs = remoteDocs.concat(resp.data)
+  }
 
   return { last_seq, remoteDocs }
 }


### PR DESCRIPTION
We don't need all the Redux heavy lifting coming from Cozy-Client. It
can consume a lot of RAM (on large Cozy) for no good reason here. We
only need to query the remote Cozy and return the result, so we'll use
Cozy-Stack-Client directly.

The request limit was also increased to reduce the number of network
calls.

Thanks @Crash-- for this optimization.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
