### PR TITLE
core/remote/document: Provide default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.30.1 - 2021-09-27
+
+Improvements for all users:
+
+- We've optimized the initial listing of documents present on the remote Cozy to
+  limit the number of necessary network requests and the CPU and RAM usage. This
+  should also result in a quicker listing.
+
+Improvements for Windows and macOS users:
+
+- The improvement introduced in the latest version around the trashing of
+  complete folders (i.e. keeping their hierarchy in the Trash) would in turn
+  generate visible errors in the main window and pause the synchronization until
+  the remote trashing of all the documents in the folder would be fully
+  synchronized.
+  We're now making sure the trashing of a folder is swift and does not result in
+  unnecessary errors.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.30.1-beta.1 - 2021-09-21
 
 Improvements for all users:

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -21,6 +21,7 @@ const {
 const { DirectoryNotFound } = require('./errors')
 const {
   dropSpecialDocs,
+  withDefaultValues,
   remoteJsonToRemoteDoc,
   jsonApiToRemoteJsonDoc,
   keepFiles,
@@ -392,9 +393,9 @@ class RemoteCozy {
       results.map(async result => {
         if (result.type === FILE_TYPE) {
           const parentDir /*: RemoteDir */ = await this.findDir(result.dir_id)
-          return this._withPath(result, parentDir)
+          return this._withPath(withDefaultValues(result), parentDir)
         }
-        return result
+        return withDefaultValues(result)
       })
     )
   }
@@ -575,7 +576,7 @@ async function fetchChangesFromFeed(
       limit: batchSize
     }
   )
-  remoteDocs = remoteDocs.concat(results.map(r => r.doc))
+  remoteDocs = remoteDocs.concat(results.map(r => withDefaultValues(r.doc)))
 
   if (pending === 0) {
     return { last_seq, remoteDocs }
@@ -603,7 +604,7 @@ async function fetchInitialChanges(
     resp = await client.stackClient
       .collection(FILES_DOCTYPE)
       .all({ limit: 1000, bookmark: resp.bookmark })
-    remoteDocs = remoteDocs.concat(resp.data)
+    remoteDocs = remoteDocs.concat(resp.data.map(withDefaultValues))
   }
 
   return { last_seq, remoteDocs }

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -64,13 +64,13 @@ export type RemoteDeletion = {|
 export type JsonApiFileAttributes = {|
   type: FILE,
   class?: string, // file only
-  dir_id: string,
+  dir_id?: string,
   executable?: boolean,
   md5sum?: string,
   mime?: string,
-  name: string,
+  name?: string,
   size?: string, // file only
-  tags: string[],
+  tags?: string[],
   trashed?: true,
   created_at: string,
   updated_at: string,
@@ -81,10 +81,10 @@ export type JsonApiFileAttributes = {|
 
 export type JsonApiDirAttributes = {|
   type: DIR,
-  dir_id: string,
-  name: string,
+  dir_id?: string,
+  name?: string,
   path?: string, // folder only
-  tags: string[],
+  tags?: string[],
   trashed?: true,
   created_at: string,
   updated_at: string,
@@ -140,6 +140,7 @@ module.exports = {
   keepFiles,
   parentDirIds,
   inRemoteTrash,
+  withDefaultValues,
   remoteJsonToRemoteDoc,
   jsonApiToRemoteJsonDoc
 }
@@ -178,6 +179,31 @@ function inRemoteTrash(
   )
 }
 
+// The following attributes can be omitted by cozy-stack if not defined
+function withDefaultValues /*:: <T: JsonApiDirAttributes|JsonApiFileAttributes> */(
+  attributes /*: T */
+) /*: T */ {
+  if (attributes.type === DIR_TYPE) {
+    return {
+      ...attributes,
+      dir_id: attributes.dir_id || '',
+      name: attributes.name || '',
+      path: attributes.path || '',
+      tags: attributes.tags || []
+    }
+  } else {
+    return {
+      ...attributes,
+      class: attributes.class || 'application',
+      dir_id: attributes.dir_id || '',
+      md5sum: attributes.md5sum || '',
+      mime: attributes.mime || 'application/octet-stream',
+      name: attributes.name || '',
+      tags: attributes.tags || []
+    }
+  }
+}
+
 function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
   json /*: T */
 ) /*: RemoteDoc */ {
@@ -186,7 +212,7 @@ function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
       type: DIR_TYPE,
       _id: json._id,
       _rev: json._rev,
-      ...json.attributes
+      ...withDefaultValues(json.attributes)
     } /*: RemoteDir */)
 
     return remoteDir
@@ -195,7 +221,7 @@ function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
       type: FILE_TYPE,
       _id: json._id,
       _rev: json._rev,
-      ...json.attributes
+      ...withDefaultValues(json.attributes)
     } /*: RemoteFile */)
 
     return remoteFile

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.30.1-beta.1",
+  "version": "3.30.1",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -15,6 +15,9 @@ const { onPlatform } = require('../support/helpers/platform')
 
 const { ROOT_DIR_ID, TRASH_DIR_ID } = require('../../core/remote/constants')
 
+const logger = require('../../core/utils/logger')
+const log = new logger({ component: 'TEST' })
+
 /*::
 import type { SavedMetadata } from '../../core/metadata'
 */
@@ -302,13 +305,7 @@ describe('Move', () => {
         await cozy.files.updateById(file._id, 'updated file content', {})
         await helpers.pullAndSyncAll()
         const was = await pouch.byRemoteId(file._id)
-        await helpers._remote.moveAsync(
-          {
-            ...was,
-            path: path.normalize('src/file2')
-          },
-          was
-        )
+        await helpers.remote.move(was.remote, path.normalize('src/file2'))
         await helpers.pullAndSyncAll()
 
         should(await helpers.docByPath('src/file2')).match({
@@ -351,13 +348,7 @@ describe('Move', () => {
           await cozy.files.updateById(file._id, 'updated file content', {})
           await helpers.remote.pullChanges()
           const was = await pouch.byRemoteId(file._id)
-          await helpers._remote.moveAsync(
-            {
-              ...was,
-              path: path.normalize('src/file2')
-            },
-            was
-          )
+          await helpers.remote.move(was.remote, path.normalize('src/file2'))
           await helpers.pullAndSyncAll()
 
           should(await helpers.docByPath('src/file2')).match({
@@ -635,13 +626,7 @@ describe('Move', () => {
 
     it('from remote client', async () => {
       const was = await pouch.byRemoteId(dir._id)
-      await helpers._remote.moveAsync(
-        {
-          ...was,
-          path: path.normalize('parent/dst/dir')
-        },
-        was
-      )
+      await helpers.remote.move(was.remote, path.normalize('parent/dst/dir'))
 
       await helpers.remote.pullChanges()
 
@@ -871,6 +856,7 @@ describe('Move', () => {
       })
 
       it('local', async () => {
+        log.info('TEST START')
         should(await helpers.local.tree()).deepEqual([
           'parent/',
           'parent/dst/',
@@ -908,13 +894,7 @@ describe('Move', () => {
           'parent/src/dir/subdir/file'
         ])
         const was = await pouch.byRemoteId(dir._id)
-        await helpers._remote.moveAsync(
-          {
-            ...was,
-            path: path.normalize('parent/src/dir2')
-          },
-          was
-        )
+        await helpers.remote.move(was.remote, path.normalize('parent/src/dir2'))
         await helpers.remote.pullChanges()
         await helpers.syncAll()
 
@@ -986,13 +966,7 @@ describe('Move', () => {
         await cozy.files.updateById(file._id, 'updated file content', {})
         await helpers.remote.pullChanges()
         const was = await pouch.byRemoteId(dir._id)
-        await helpers._remote.moveAsync(
-          {
-            ...was,
-            path: path.normalize('parent/src/dir2')
-          },
-          was
-        )
+        await helpers.remote.move(was.remote, path.normalize('parent/src/dir2'))
         await helpers.remote.pullChanges()
         await helpers.syncAll()
 
@@ -1074,13 +1048,7 @@ describe('Move', () => {
           'parent/src/dir/subdir/file'
         ])
         const was = await pouch.byRemoteId(dir._id)
-        await helpers._remote.moveAsync(
-          {
-            ...was,
-            path: path.normalize('parent/dst/dir')
-          },
-          was
-        )
+        await helpers.remote.move(was.remote, path.normalize('parent/dst/dir'))
         await helpers.pullAndSyncAll()
         should(await helpers.trees('metadata', 'remote')).deepEqual({
           remote: [

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -16,6 +16,7 @@ const {
   MAX_FILE_SIZE
 } = require('../../../core/remote/constants')
 const { RemoteCozy } = require('../../../core/remote/cozy')
+const { withDefaultValues } = require('../../../core/remote/document')
 const { DirectoryNotFound } = require('../../../core/remote/errors')
 
 const configHelpers = require('../../support/helpers/config')
@@ -475,7 +476,9 @@ describe('RemoteCozy', function() {
       // `since` is not '0' so we don't try to run an initial fetch which is not
       // faked here.
       const { docs } = await remoteCozy.changes('')
-      should(docs.map(doc => ({ doc }))).eql(docsOnServer)
+      should(docs.map(doc => ({ doc }))).eql(
+        docsOnServer.map(({ doc }) => ({ doc: withDefaultValues(doc) }))
+      )
     })
   })
 


### PR DESCRIPTION
The remote cozy-stack is now filtering more attributes if their values
aren't defined in CouchDB. This means that we won't receive their
default JSON equivalent anymore and we should provide default values
by ourselves.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
