### PR TITLE
deps: Bump cozy-client to v27.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "chai": "^4.2.0",
     "chai-like": "^1.1.1",
     "chokidar": "^3.5.0",
-    "cozy-client": "^24.1.3",
+    "cozy-client": "^27.0.1",
     "cozy-client-js": "^0.19.0",
     "cozy-stack-client": "^24.0.0",
     "deep-diff": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,10 +1730,10 @@ cozy-client-js@^0.19.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@^24.1.3:
-  version "24.1.3"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-24.1.3.tgz#9040db19694d195d43875698cc2c590de95db383"
-  integrity sha512-V++9snIIhEnMg5BwRE6L8b45s1NdEKPlZ0fr6gNYR42NwkiYJk0Q1epIzoYcrk5dDM2bE5Vnmoz5/pdNTwSpuw==
+cozy-client@^27.0.1:
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-27.0.1.tgz#d350adfe7ffed462273bb3a7798bafff707c766d"
+  integrity sha512-wA/m3HyR2zWybOLuQUyzONsjemJ+MVL66hDZvblTcX0GFNfyw+4snkG/QG6INXZRknIGsH6ZCR8Ah2Pag4mSQQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
@@ -1742,19 +1742,19 @@ cozy-client@^24.1.3:
     cozy-device-helper "^1.12.0"
     cozy-flags "2.7.1"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^24.0.0"
+    cozy-stack-client "^27.0.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
     node-fetch "^2.6.1"
-    open "^7.0.2"
+    open "7.4.2"
     prop-types "^15.6.2"
     react-redux "^7.2.0"
     redux "3 || 4"
     redux-thunk "^2.3.0"
     server-destroy "^1.0.1"
     sift "^6.0.0"
-    url-search-params-polyfill "^7.0.0"
+    url-search-params-polyfill "^8.0.0"
 
 cozy-device-helper@^1.12.0:
   version "1.12.0"
@@ -1787,6 +1787,16 @@ cozy-stack-client@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-24.0.0.tgz#972a475d403a71b7d39874c0f6cf06f77c3a610b"
   integrity sha512-dPXTrZp201twWv0bLy7a6w9+wWU1YZzhEL1M44cvE7+VDyByi1Llp7x1k8Uzu1I5akEIR0RTVHPFXnN3CKjlzg==
+  dependencies:
+    cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^27.0.0:
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-27.0.0.tgz#a3462169aceabf5758679aaacfe030ba2497bc5f"
+  integrity sha512-iWCsmZmAVanfVdz4g5W7wJqNs5uqOk1SQffvz0M/MxCO3loYM/2fB5fdSYi63VOvrAiaZELqdAVPRE+i0uqNcQ==
   dependencies:
     cozy-flags "2.7.1"
     detect-node "^2.0.4"
@@ -5831,10 +5841,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-open@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.0.2.tgz#fb3681f11f157f2361d2392307548ca1792960e8"
-  integrity sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==
+open@7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
@@ -8364,10 +8374,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-search-params-polyfill@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-7.0.1.tgz#b900cd9a0d9d2ff757d500135256f2344879cbff"
-  integrity sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ==
+url-search-params-polyfill@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz#9e69e4dba300a71ae7ad3cead62c7717fd99329f"
+  integrity sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
  This version brings:
  - better `queryAll` performance
  - automatic OAuth token refreshing
  - correct file references modifications response (i.e. now includes
    `meta` object, and `data` is always an Array)

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
