### PR TITLE
core/remote: No folder content changes duplication

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -205,8 +205,10 @@ class RemoteWatcher {
             { path: change.doc.path },
             'Fetching content of unknwon folder...'
           )
-          const children = await this.remoteCozy.getDirectoryContent(
+          const children = (await this.remoteCozy.getDirectoryContent(
             change.doc.remote
+          )).filter(child =>
+            docs.every(doc => doc._id !== child._id || doc._rev !== child._rev)
           )
           const childChanges = await this.analyse(
             children,


### PR DESCRIPTION
We make sure the same change will only get analyzed and merged once,
even if it was fetched again as part of a folder content listing.

When fetching remote changes, what can look to be a remote folder
re-included in the client's synchronization (i.e. it's a addition but
it's revision is greater than 1) may as well be a new folder that was
updated remotely before we got a chance to fetch it.
In this case, its content will already be present in the feed and we
should not waste time analyzing and merging it.

Simply comparing content changes' _ids and _revs with changes fetched
from the feed can tell us if they're duplicates or not.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
