### PR TITLE
core: Fetch and merge flags from remote Cozy

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -8,6 +8,7 @@ const OldCozyClient = require('cozy-client-js').Client
 const CozyClient = require('cozy-client').default
 const { FetchError } = require('cozy-stack-client')
 const { Q } = require('cozy-client')
+const cozyFlags = require('cozy-flags').default
 const path = require('path')
 const addSecretEventListener = require('secret-event-listener')
 
@@ -566,6 +567,21 @@ class RemoteCozy {
     } = this.config
     const oauthClient = { _id: clientID, _type: OAUTH_CLIENTS_DOCTYPE }
     await files.removeNotSynchronizedDirectories(oauthClient, [dir])
+  }
+
+  async flags() /*: Promise<Object> */ {
+    const client = await this.newClient()
+    // Fetch flags from the remote Cozy and store them in the local `cozyFlags`
+    // store.
+    await cozyFlags.initialize(client)
+
+    // Build a map of flags with their current value
+    const flags = {}
+    for (const flag of cozyFlags.list()) {
+      flags[flag] = cozyFlags(flag)
+    }
+
+    return flags
   }
 }
 

--- a/core/utils/flags.js
+++ b/core/utils/flags.js
@@ -1,0 +1,23 @@
+/**
+ * @module core/utils/flags
+ * @flow
+ */
+
+const { RemoteCozy } = require('../remote/cozy')
+
+/*::
+import type { Config } from '../config'
+*/
+
+const flags = async (config /*: Config */) => {
+  const remoteCozy = new RemoteCozy(config)
+  const remoteFlags = await remoteCozy.flags()
+  const localFlags = config.flags
+
+  return {
+    ...remoteFlags,
+    ...localFlags
+  }
+}
+
+module.exports = flags

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "chokidar": "^3.5.0",
     "cozy-client": "^27.1.0",
     "cozy-client-js": "^0.19.0",
+    "cozy-flags": "^2.8.0",
     "cozy-stack-client": "^24.0.0",
     "deep-diff": "^1.0.2",
     "dtrace-provider": "^0.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,13 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
+cozy-flags@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.8.0.tgz#1dfe47910811defa9af0cab97b53ba4b8a00095a"
+  integrity sha512-EVAb1jkBqIaXzz5IghCHvR/xatcT5tnQvhmBVEU2SDDftA+m5GdPZ4XjkjhVY2R34Rn3bAxQzhPTqwAL8fOOSQ==
+  dependencies:
+    microee "^0.0.6"
+
 cozy-interapp@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"


### PR DESCRIPTION
Local flags can be useful in some situations but they have limitations
as well:
- they can't be used until we have saved a local config since they're
  part of it
- they can't be enabled or disabled globally

We're mostly trying to address the second issue here. Being able to
enable a feature globally via a context will be helpful when releasing
the partial synchronization as we need to enable it in the Desktop and
Settings application as the same time.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
