### PR TITLE
core/remote: Use remote partial sync flag

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -195,7 +195,12 @@ class RemoteWatcher {
   ) /*: Promise<void> */ {
     let changes = await this.analyse(docs, await this.olds(docs))
 
-    if (process.env.NODE_ENV === 'test' || this.config.flags.differentialSync) {
+    if (
+      process.env.NODE_ENV === 'test' ||
+      this.config.flags[
+        'settings.partial-desktop-sync.show-synced-folders-selection'
+      ]
+    ) {
       for (const change of changes) {
         if (
           change.type === 'DirAddition' &&

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -224,10 +224,16 @@ describe('core/config', function() {
       })
 
       it('returns GUI configuration if any', function() {
-        const flagsConfig = { differentialSync: true }
+        const flagsConfig = {
+          'settings.partial-desktop-sync.show-synced-folders-selection': true
+        }
         this.config.fileConfig.flags = flagsConfig
         should(this.config.flags).deepEqual(flagsConfig)
-        should(this.config.flags.differentialSync).be.true()
+        should(
+          this.config.flags[
+            'settings.partial-desktop-sync.show-synced-folders-selection'
+          ]
+        ).be.true()
       })
     })
 


### PR DESCRIPTION
We'll want to use the same flag as the Settings app to enable partial
synchronization to release them together.
Thus we start using the new `flags` module which merges remote and
local flags.

The new partial synchronization flag name is:
`settings.partial-desktop-sync.show-synced-folders-selection`

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
