### PR TITLE
core/utils: Add remote capabilities module

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -157,8 +157,6 @@ class App {
     fse.ensureDirSync(syncPath)
     this.config.cozyUrl = cozyUrl
     this.config.syncPath = syncPath
-    // FIXME: fetch and save remote capabilities instead of caching them in the
-    // config the first time we fetch them.
     this.config.persist()
     log.info(
       'The remote Cozy has properly been configured ' +

--- a/core/config.js
+++ b/core/config.js
@@ -218,21 +218,6 @@ class Config {
     return this.fileConfig.creds.token
   }
 
-  get capabilities() /*: { flatSubdomains?: boolean } */ {
-    return _.get(this.fileConfig, 'instance.capabilities', {})
-  }
-
-  set capabilities({ flatSubdomains } /*: { flatSubdomains?: boolean } */) {
-    if (flatSubdomains != null) {
-      _.set(
-        this.fileConfig,
-        'instance.capabilities.flatSubdomains',
-        flatSubdomains
-      )
-      this.persist()
-    }
-  }
-
   // Flags are options that can be activated by the user via the config file.
   // They can be used to activate incomplete features for example.
   get flags() /*: { [string]: boolean } */ {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -413,15 +413,6 @@ class Remote /*:: implements Reader, Writer */ {
     }
   }
 
-  async usesFlatDomains() /*: Promise<boolean> */ {
-    let { flatSubdomains } = this.config.capabilities
-    if (flatSubdomains == null) {
-      ;({ flatSubdomains } = await this.remoteCozy.capabilities())
-      this.config.capabilities = { flatSubdomains }
-    }
-    return flatSubdomains
-  }
-
   async findDocByPath(fpath /*: string */) /*: Promise<?MetadataRemoteInfo> */ {
     const [parentPath, name] = dirAndName(fpath)
     const { _id: dirID } = await this.findDirectoryByPath(parentPath)

--- a/core/utils/capabilities.js
+++ b/core/utils/capabilities.js
@@ -1,0 +1,34 @@
+/**
+ * @module core/utils/capabilities
+ * @flow
+ */
+
+const { RemoteCozy } = require('../remote/cozy')
+const logger = require('./logger')
+/*::
+import type { Config } from '../config'
+*/
+
+const log = logger({
+  component: 'capabilities'
+})
+
+const store = {}
+
+const capabilities = async (config /*: Config */) => {
+  try {
+    if (Object.keys(store).length === 0) {
+      const remoteCozy = new RemoteCozy(config)
+      const remoteCapabilities = await remoteCozy.capabilities()
+      Object.assign(store, remoteCapabilities)
+    }
+  } catch (err) {
+    log.error(
+      { err },
+      'could not fetch remote capabilities; returning local cache'
+    )
+  }
+  return store
+}
+
+module.exports = capabilities

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -208,16 +208,6 @@ describe('core/config', function() {
       })
     })
 
-    describe('capabilities', function() {
-      it('accepts object with flatSubdomains key', function() {
-        this.config.capabilities = { flatSubdomains: false }
-        should(this.config.capabilities.flatSubdomains).be.false()
-
-        this.config.capabilities = { flatSubdomains: true }
-        should(this.config.capabilities.flatSubdomains).be.true()
-      })
-    })
-
     describe('flags', () => {
       it('returns an empty hash by default', function() {
         should(this.config.flags).deepEqual({})


### PR DESCRIPTION
We add a new module similar to the `flags` module, allowing us to
fetch the capabilities of the remote Cozy with just a valid `Config`.

This will allow us to use this data in places where we don't easily
have access to an instance of `Remote` or `RemoteCozy`.

The remote capabilities are stored locally for the duration of the
Desktop session. This will limit the number of requests made to the
Cozy for data that rarely changes.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
