### PR TITLE
gui/elm: Configure partial sync during Onboarding

### DIFF
--- a/gui/elm/Data/AddressConfig.elm
+++ b/gui/elm/Data/AddressConfig.elm
@@ -1,0 +1,21 @@
+module Data.AddressConfig exposing (AddressConfig, init, setError)
+
+
+type alias AddressConfig =
+    { address : String
+    , error : String
+    , busy : Bool
+    }
+
+
+init : AddressConfig
+init =
+    { address = ""
+    , error = ""
+    , busy = False
+    }
+
+
+setError : AddressConfig -> String -> AddressConfig
+setError addressConfig error =
+    { addressConfig | error = error, busy = False }

--- a/gui/elm/Data/SyncFolderConfig.elm
+++ b/gui/elm/Data/SyncFolderConfig.elm
@@ -1,6 +1,7 @@
 module Data.SyncFolderConfig exposing
     ( SyncFolderConfig
     , isValid
+    , setError
     , valid
     )
 
@@ -26,3 +27,15 @@ isValid model =
 
         Just _ ->
             False
+
+
+setError : SyncFolderConfig -> String -> SyncFolderConfig
+setError folderConfig error =
+    { folderConfig
+        | error =
+            if error == "" then
+                Nothing
+
+            else
+                Just error
+    }

--- a/gui/elm/Ports.elm
+++ b/gui/elm/Ports.elm
@@ -24,7 +24,6 @@ port module Ports exposing
     , openFile
     , quitAndInstall
     , registerRemote
-    , registrationDone
     , registrationError
     , remove
     , sendMail
@@ -95,9 +94,6 @@ port quitAndInstall : () -> Cmd msg
 
 
 port registerRemote : String -> Cmd msg
-
-
-port registrationDone : (Bool -> msg) -> Sub msg
 
 
 port registrationError : (String -> msg) -> Sub msg

--- a/gui/elm/Window/Onboarding.elm
+++ b/gui/elm/Window/Onboarding.elm
@@ -8,6 +8,7 @@ module Window.Onboarding exposing
     , view
     )
 
+import Data.SyncConfig as SyncConfig exposing (SyncConfig)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Locale exposing (Helpers)
@@ -48,7 +49,7 @@ init folder platform =
 type Msg
     = WelcomeMsg Welcome.Msg
     | AddressMsg Address.Msg
-    | RegistrationDone
+    | RegistrationDone SyncConfig
     | FolderMsg Folder.Msg
 
 
@@ -71,8 +72,13 @@ update msg model =
             in
             ( { model | context = context }, Cmd.map AddressMsg cmd )
 
-        RegistrationDone ->
-            ( { model | page = FolderPage }, Cmd.none )
+        RegistrationDone syncConfig ->
+            ( { model
+                | page = FolderPage
+                , context = Context.setSyncConfig model.context syncConfig
+              }
+            , Cmd.none
+            )
 
         FolderMsg subMsg ->
             let
@@ -90,7 +96,7 @@ subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
         [ Ports.registrationError (AddressMsg << Address.RegistrationError)
-        , Ports.registrationDone (always RegistrationDone)
+        , SyncConfig.gotSyncConfig RegistrationDone
         , Ports.folderError (FolderMsg << Folder.SetError)
         , Ports.folder (FolderMsg << Folder.FillFolder)
         ]

--- a/gui/elm/Window/Onboarding.elm
+++ b/gui/elm/Window/Onboarding.elm
@@ -13,6 +13,7 @@ import Html.Attributes exposing (..)
 import Locale exposing (Helpers)
 import Ports
 import Window.Onboarding.Address as Address
+import Window.Onboarding.Context as Context exposing (Context)
 import Window.Onboarding.Folder as Folder
 import Window.Onboarding.Welcome as Welcome
 
@@ -29,18 +30,14 @@ type Page
 
 type alias Model =
     { page : Page
-    , platform : String
-    , address : Address.Model
-    , folder : Folder.Model
+    , context : Context
     }
 
 
 init : String -> String -> Model
 init folder platform =
     { page = WelcomePage
-    , platform = platform
-    , address = Address.init
-    , folder = Folder.init folder
+    , context = Context.init platform folder
     }
 
 
@@ -69,20 +66,20 @@ update msg model =
 
         AddressMsg subMsg ->
             let
-                ( address, cmd ) =
-                    Address.update subMsg model.address
+                ( context, cmd ) =
+                    Address.update subMsg model.context
             in
-            ( { model | address = address }, Cmd.map AddressMsg cmd )
+            ( { model | context = context }, Cmd.map AddressMsg cmd )
 
         RegistrationDone ->
             ( { model | page = FolderPage }, Cmd.none )
 
         FolderMsg subMsg ->
             let
-                ( folder, cmd ) =
-                    Folder.update subMsg model.folder
+                ( context, cmd ) =
+                    Folder.update subMsg model.context
             in
-            ( { model | folder = folder }, Cmd.map FolderMsg cmd )
+            ( { model | context = context }, cmd )
 
 
 
@@ -113,7 +110,7 @@ view helpers model =
             , ( "on-step-folder", model.page == FolderPage )
             ]
         ]
-        [ Html.map WelcomeMsg (Welcome.view helpers model.platform)
-        , Html.map AddressMsg (Address.view helpers model.address)
-        , Html.map FolderMsg (Folder.view helpers model.folder)
+        [ Html.map WelcomeMsg (Welcome.view helpers model.context)
+        , Html.map AddressMsg (Address.view helpers model.context)
+        , Html.map FolderMsg (Folder.view helpers model.context)
         ]

--- a/gui/elm/Window/Onboarding/Context.elm
+++ b/gui/elm/Window/Onboarding/Context.elm
@@ -1,0 +1,38 @@
+module Window.Onboarding.Context exposing (Context, init, setAddressConfig, setFolderConfig, setSyncConfig)
+
+import Data.AddressConfig as AddressConfig exposing (AddressConfig)
+import Data.SyncConfig as SyncConfig exposing (SyncConfig)
+import Data.SyncFolderConfig as SyncFolderConfig exposing (SyncFolderConfig)
+import Url exposing (Url)
+
+
+type alias Context =
+    { platform : String
+    , addressConfig : AddressConfig
+    , folderConfig : SyncFolderConfig
+    , syncConfig : SyncConfig
+    }
+
+
+init : String -> String -> Context
+init platform folder =
+    { platform = platform
+    , addressConfig = AddressConfig.init
+    , folderConfig = SyncFolderConfig.valid folder
+    , syncConfig = SyncConfig.init
+    }
+
+
+setAddressConfig : Context -> AddressConfig -> Context
+setAddressConfig context addressConfig =
+    { context | addressConfig = addressConfig }
+
+
+setSyncConfig : Context -> SyncConfig -> Context
+setSyncConfig context syncConfig =
+    { context | syncConfig = syncConfig }
+
+
+setFolderConfig : Context -> SyncFolderConfig -> Context
+setFolderConfig context folderConfig =
+    { context | folderConfig = folderConfig }

--- a/gui/elm/Window/Onboarding/Folder.elm
+++ b/gui/elm/Window/Onboarding/Folder.elm
@@ -5,6 +5,7 @@ module Window.Onboarding.Folder exposing
     , view
     )
 
+import Data.SyncConfig as SyncConfig
 import Data.SyncFolderConfig as SyncFolderConfig exposing (SyncFolderConfig)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -12,6 +13,8 @@ import Html.Events exposing (..)
 import Icons exposing (..)
 import Locale exposing (Helpers)
 import Ports
+import Url
+import Util.Conditional exposing (viewIf)
 import Window.Onboarding.Context as Context exposing (Context)
 
 
@@ -60,48 +63,68 @@ update msg context =
 
 view : Helpers -> Context -> Html Msg
 view helpers context =
+    let
+        { partialSyncEnabled } =
+            context.syncConfig.flags
+    in
     div
-        [ classList
-            [ ( "step", True )
-            , ( "step-folder", True )
-            , ( "step-error", not (isValid context.folderConfig) )
-            ]
-        ]
+        [ class "step step-folder" ]
         [ div
             [ class "step-content" ]
-            [ if isValid context.folderConfig then
-                Icons.bigTick
-
-              else
-                Icons.bigCross
+            [ Icons.bigTick
             , h1 []
                 [ text <|
-                    helpers.t <|
-                        if isValid context.folderConfig then
-                            "Folder All done"
-
-                        else
-                            "Folder Please choose another folder"
+                    helpers.t "Folder You're all set!"
                 ]
-            , p [ class "folder-helper" ]
+            , p [ class "u-mb-0" ]
                 [ text <|
-                    helpers.t "Folder Select a location for your Cozy folder:"
+                    helpers.t "Folder You can now synchronize your Cozy with this computer."
                 ]
-            , div [ class "coz-form-group" ]
-                [ a
-                    [ class "folder__selector"
-                    , href "#"
-                    , onClick ChooseFolder
+            , div [ class "u-mt-1" ]
+                [ ul [ class "u-mb-0 u-pl-1" ]
+                    [ viewIf partialSyncEnabled <|
+                        li []
+                            [ span [ class "folder__config-option__title" ]
+                                [ text <| helpers.t "Folder Selective synchronization" ]
+                            , text " - "
+                            , text <| helpers.t "Folder By default all the documents on your Cozy will be synchronized."
+                            , selectiveSyncLink helpers context
+                            ]
+                    , li [ class "u-mt-1" ]
+                        [ span [ class "folder__config-option__title" ]
+                            [ text <| helpers.t "Folder Location on the computer" ]
+                        , text " - "
+                        , text <| helpers.t "Folder The documents selected on your Cozy will be synchronized on this computer in "
+                        , span [ class "folder__path" ] [ text context.folderConfig.folder ]
+                        , text "."
+                        , a [ class "u-ml-half u-primaryColor", href "#", onClick ChooseFolder ]
+                            [ text <|
+                                helpers.t "Folder Modify"
+                            ]
+                        ]
                     ]
-                    [ text context.folderConfig.folder ]
-                , p [ class "error-message" ]
-                    [ text <| helpers.t <| Maybe.withDefault "" context.folderConfig.error ]
+                , if isValid context.folderConfig then
+                    text ""
+
+                  else
+                    p [ class "u-error u-mb-0 u-lh-tiny" ]
+                        [ text <|
+                            helpers.interpolate [ context.folderConfig.folder ]
+                                "Folder You cannot synchronize your data directly in "
+                        , span [ class "folder__path" ]
+                            [ text context.folderConfig.folder
+                            ]
+                        , br [] []
+                        , text <|
+                            helpers.t "Folder Please choose another location"
+                        ]
 
                 -- TODO: Link to the relevant FAQ section?
                 -- TODO: Include button to reset to default?
+                -- TODO: Show different error messages?
                 ]
             , a
-                [ class "btn"
+                [ class "btn u-mt-2"
                 , href "#"
                 , if isValid context.folderConfig then
                     onClick StartSync
@@ -109,6 +132,29 @@ view helpers context =
                   else
                     attribute "disabled" "true"
                 ]
-                [ span [] [ text (helpers.t "Folder Use Cozy Drive") ] ]
+                [ span [] [ text (helpers.t "Folder Start synchronization") ] ]
             ]
+        ]
+
+
+selectiveSyncLink : Helpers -> Context -> Html Msg
+selectiveSyncLink helpers context =
+    let
+        { deviceId } =
+            context.syncConfig
+
+        settingsUrl =
+            SyncConfig.buildAppUrl context.syncConfig "settings"
+
+        configurationUrl =
+            case settingsUrl of
+                Just url ->
+                    String.join "/" [ Url.toString url, "#/connectedDevices", deviceId ]
+
+                Nothing ->
+                    ""
+    in
+    a [ class "u-ml-half u-primaryColor", href configurationUrl ]
+        [ text <|
+            helpers.t "Folder Modify"
         ]

--- a/gui/elm/Window/Onboarding/Welcome.elm
+++ b/gui/elm/Window/Onboarding/Welcome.elm
@@ -8,6 +8,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Icons exposing (..)
 import Locale exposing (Helpers)
+import Window.Onboarding.Context as Context exposing (Context)
 
 
 
@@ -22,8 +23,8 @@ type Msg
 -- VIEW
 
 
-view : Helpers -> String -> Html Msg
-view helpers platform =
+view : Helpers -> Context -> Html Msg
+view helpers context =
     div
         [ classList
             [ ( "step", True )
@@ -41,7 +42,7 @@ view helpers platform =
                 ]
                 [ span [] [ text (helpers.t "Welcome Sign in to your Cozy") ] ]
             , a
-                [ href ("https://cozy.io/en/try-it/?from=desktop-" ++ platform)
+                [ href ("https://cozy.io/en/try-it/?from=desktop-" ++ context.platform)
                 , class "more-info"
                 ]
                 [ text (helpers.t "Address Don't have an account? Request one here") ]

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -6,6 +6,8 @@
 const { BrowserWindow, ipcMain, shell } = require('electron')
 const _ = require('lodash')
 const path = require('path')
+const capabilities = require('../../core/utils/capabilities')
+const flags = require('../../core/utils/flags')
 
 const ELMSTARTUP = 400
 
@@ -87,6 +89,18 @@ module.exports = class WindowManager {
 
   send(...args) {
     this.win && this.win.webContents && this.win.webContents.send(...args)
+  }
+
+  async sendSyncConfig() {
+    const { cozyUrl, deviceName, deviceId } = this.desktop.config
+    this.send(
+      'sync-config',
+      cozyUrl,
+      deviceName,
+      deviceId,
+      await capabilities(this.desktop.config),
+      await flags(this.desktop.config)
+    )
   }
 
   hash() {

--- a/gui/locales/de.json
+++ b/gui/locales/de.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "Alles erledigt",
   "Folder Please choose an empty directory": "Bitte wähle ein leeres Verzeichnis.",
-  "Folder Please choose another folder": "Bitte wähle einen anderen Ordner",
   "Folder Select a location for your Cozy folder:": "Wähle einen Ort für deinen Cozy Ordner:",
   "Folder Use Cozy Drive": "Cozy Drive verwenden",
   "Folder You cannot synchronize your whole system or personal folder": "Du kannst nicht dein gesamtes System oder einen persönlichen Ordner synchronisieren.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Falsche Cozy Adresse?",
   "Password You don't have filled the password!": "Sie haben das Passwort nicht ausgefüllt:",
   "Password Your password for the cozy address:": "Ihr Passwort für die Cozy Adresse:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Falls du dies nicht getan hast, kontaktiere uns über contact@cozycloud.cc",
   "Revoked Reconnect": "Wiederverbinden",

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "All done",
   "Folder Please choose an empty directory": "Please choose an empty directory.",
-  "Folder Please choose another folder": "Please choose another folder",
   "Folder Select a location for your Cozy folder:": "Select a location for your Cozy folder:",
   "Folder Use Cozy Drive": "Use Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "You cannot synchronize your whole system or personal folder.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Wrong cozy address?",
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/eo.json
+++ b/gui/locales/eo.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "All done",
   "Folder Please choose an empty directory": "Please choose an empty directory.",
-  "Folder Please choose another folder": "Please choose another folder",
   "Folder Select a location for your Cozy folder:": "Select a location for your Cozy folder:",
   "Folder Use Cozy Drive": "Use Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "You cannot synchronize your whole system or personal folder.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Wrong cozy address?",
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "Efectuado",
   "Folder Please choose an empty directory": "Por favor, escoja una carpeta vacía.",
-  "Folder Please choose another folder": "Por favor, escoja otra carpeta",
   "Folder Select a location for your Cozy folder:": "Seleccione la ubicación de su carpeta Cozy.",
   "Folder Use Cozy Drive": "Usar Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "Usted no puede sincronizar el conjunto de su sistema o de una carpeta persona",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "¿Dirección cozy erronea?",
   "Password You don't have filled the password!": "¡Usted no ha escrito la contraseña!",
   "Password Your password for the cozy address:": "Su contraseña para la direccion cozy:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "En caso de que no pueda, contáctenos en contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "Le dossier distant `{0}` a été exclu de la synchronisation vers ce client.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "Le dossier local avec le même chemin peut soit être lié avec le dossier distant qui sera re-synchronisé soit renommé pour résoudre ce conflit.",
 
+  "Folder You're all set!": "Tout est prêt !",
+  "Folder You can now synchronize your Cozy with this computer.": "Vous pouvez maintenant synchroniser votre Cozy avec cet ordinateur.",
+  "Folder Selective synchronization": "Synchronisation sélective",
+  "Folder By default all the documents on your Cozy will be synchronized.": "Par défaut tous les documents de votre Cozy seront synchronisés.",
+  "Folder Location on the computer": "Emplacement sur l'ordinateur",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "Les documents sélectionnés dans votre Cozy seront synchronisés sur cet ordinateur dans ",
+  "Folder Modify": "Modifier",
+  "Folder You cannot synchronize your data directly in ": "Impossible de synchroniser directement vos données dans ",
+  "Folder Please choose another location": "Veuillez choisir un autre emplacement",
+  "Folder Start synchronization": "Lancer la synchronisation",
+
   "Folder All done": "C’est bon",
   "Folder Please choose an empty directory": "Veuillez choisir un dossier vide.",
-  "Folder Please choose another folder": "Veuillez choisir un autre répertoire",
   "Folder Select a location for your Cozy folder:": "Choisir un emplacement pour votre répertoire Cozy :",
   "Folder Use Cozy Drive": "Utiliser Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "Vous ne pouvez pas synchroniser tout votre système ou dossier personnel.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Mauvaise adresse Cozy ?",
   "Password You don't have filled the password!": "Vous n’avez pas rempli le mot de passe !",
   "Password Your password for the cozy address:": "Le mot de passe pour cette adresse Cozy :",
+
+  "Quotation Start": "« ",
+  "Quotation End": " »",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Dans le cas contraire, contactez nous sur contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnecter",

--- a/gui/locales/it_IT.json
+++ b/gui/locales/it_IT.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "Fatto",
   "Folder Please choose an empty directory": "Seleziona una cartella vuota.",
-  "Folder Please choose another folder": "Seleziona un altra cartella",
   "Folder Select a location for your Cozy folder:": "Seleziona una posizione per la tua cartella Cozy:",
   "Folder Use Cozy Drive": "Usa Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "Non puoi sincronizzare il tuo intero sistema o una cartella personale.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Indirizzo cozy sbagliato?",
   "Password You don't have filled the password!": "Non hai inserito la password!",
   "Password Your password for the cozy address:": "La tua password per l'indirizzo cozy:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/ja.json
+++ b/gui/locales/ja.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "すべて完了",
   "Folder Please choose an empty directory": "空のディレクトリーを選択してください。",
-  "Folder Please choose another folder": "別のフォルダーを選択してください",
   "Folder Select a location for your Cozy folder:": "Cozy フォルダーの場所を選択してください:",
   "Folder Use Cozy Drive": "Cozy デスクトップを使用する",
   "Folder You cannot synchronize your whole system or personal folder": "システム全体または個人フォルダーを同期できません。",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "cozy アドレスが間違っていますか?",
   "Password You don't have filled the password!": "パスワードが入力されていません!",
   "Password Your password for the cozy address:": "cozy アドレスのパスワード:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "行っていない場合は contact@cozycloud.cc にご連絡ください",
   "Revoked Reconnect": "再接続",

--- a/gui/locales/nl.json
+++ b/gui/locales/nl.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "Voltooid",
   "Folder Please choose an empty directory": "Kies een lege map.",
-  "Folder Please choose another folder": "Kies een andere map",
   "Folder Select a location for your Cozy folder:": "Kies een locatie voor je Cozy-map:",
   "Folder Use Cozy Drive": "Cozy Drive gebruiken",
   "Folder You cannot synchronize your whole system or personal folder": "Je kunt niet je hele systeem of persoonlijke map synchroniseren.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Verkeerd Cozy-adres?",
   "Password You don't have filled the password!": "Je hebt geen wachtwoord ingevoerd!",
   "Password Your password for the cozy address:": "Je wachtwoord voor het Cozy-adres:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Als dat niet het geval is, neem dan contact met ons op via contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/nl_NL.json
+++ b/gui/locales/nl_NL.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "De externe map `{0}` is uitgesloten van synchronisatie op dit apparaat.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "De lokale map op dezelfde locatie kan worden gekoppeld aan de externe map, welke opnieuw gesynchroniseerd wordt om dit probleem op te lossen.",
 
+  "Folder You're all set!": "Klaar is Kees!",
+  "Folder You can now synchronize your Cozy with this computer.": "Je kunt vanaf nu synchroniseren met deze computer.",
+  "Folder Selective synchronization": "Selectieve synchronisatie",
+  "Folder By default all the documents on your Cozy will be synchronized.": "Standaard worden alle documenten op je Cozy gesynchroniseerd.",
+  "Folder Location on the computer": "Computerlocatie",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "De geselecteerde documenten worden gesynchroniseerd naar",
+  "Folder Modify": "Aanpassen",
+  "Folder You cannot synchronize your data directly in ": "Je kunt geen gegevens synchroniseren naar",
+  "Folder Please choose another location": "Kies een andere locatie",
+  "Folder Start synchronization": "Synchronisatie starten",
+
   "Folder All done": "Voltooid",
   "Folder Please choose an empty directory": "Kies een lege map.",
-  "Folder Please choose another folder": "Kies een andere map",
   "Folder Select a location for your Cozy folder:": "Kies een locatie voor je Cozy-map:",
   "Folder Use Cozy Drive": "Cozy Drive gebruiken",
   "Folder You cannot synchronize your whole system or personal folder": "Je kunt niet je hele systeem of persoonlijke map synchroniseren.",
@@ -193,6 +203,9 @@
   "Password You don't have filled the password!": "Je hebt geen wachtwoord ingevoerd!",
   "Password Your password for the cozy address:": "Je wachtwoord voor het Cozy-adres:",
 
+  "Quotation Start": "“",
+  "Quotation End": "”",
+
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Als dat niet zo is, neem dan contact met ons op via contact@cozycloud.cc",
   "Revoked Reconnect": "Opnieuw verbinden",
   "Revoked Synchronization with your Cozy is unavailable, maybe you revoked this computer?": "Synchronisatie is niet beschikbaar. Heb je de machtiging voor deze computer ingetrokken?",
@@ -207,8 +220,8 @@
   "Settings Sync": "Synchroniseren",
   "Settings Version": "Versie",
   "Settings Synchronize manually": "Handmatig synchroniseren",
-  "Settings Configure": "Configure",
-  "Settings Selective synchronization": "Selective synchronization",
+  "Settings Configure": "Instellen",
+  "Settings Selective synchronization": "Selectieve synchronisatie",
 
   "SyncDirEmpty Detail": "Om gegevensverlies te voorkomen, is de synchronisatie gestopt. Als je synchronisatie wilt afdwingen, verwijder dan je Cozy-map.",
   "SyncDirEmpty Message": "Het lijkt erop dat je Cozy-map is geleegd. Bevindt deze zich op een harde schijf die momenteel niet is aangekoppeld?",

--- a/gui/locales/pl.json
+++ b/gui/locales/pl.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "Gotowe",
   "Folder Please choose an empty directory": "Proszę wybrać pusty folder.",
-  "Folder Please choose another folder": "Proszę wybrać inny folder",
   "Folder Select a location for your Cozy folder:": "Wskaż miejsce dla folderu Cozy",
   "Folder Use Cozy Drive": "Użyj Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "Nie możesz synchronizować całego Twojego systemu lub folderu osobistego.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Niepoprawny adres Cozy?",
   "Password You don't have filled the password!": "Nie wpisałeś hasła?",
   "Password Your password for the cozy address:": "Twoje hasło do adresu Cozy:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/sq.json
+++ b/gui/locales/sq.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "All done",
   "Folder Please choose an empty directory": "Please choose an empty directory.",
-  "Folder Please choose another folder": "Please choose another folder",
   "Folder Select a location for your Cozy folder:": "Select a location for your Cozy folder:",
   "Folder Use Cozy Drive": "Use Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "You cannot synchronize your whole system or personal folder.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Wrong cozy address?",
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/zh_CN.json
+++ b/gui/locales/zh_CN.json
@@ -123,9 +123,19 @@
   "Error The remote directory `{0}` was excluded from the synchronization on this device.": "The remote directory `{0}` was excluded from the synchronization on this device.",
   "Error The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.": "The local directory with the same path can either be linked to the remote one which will be synchronized again or be renamed to solve this conflict.",
 
+  "Folder You're all set!": "You're all set!",
+  "Folder You can now synchronize your Cozy with this computer.": "You can now synchronize your Cozy with this computer.",
+  "Folder Selective synchronization": "Selective synchronization",
+  "Folder By default all the documents on your Cozy will be synchronized.": "By default all the documents on your Cozy will be synchronized.",
+  "Folder Location on the computer": "Location on the computer",
+  "Folder The documents selected on your Cozy will be synchronized on this computer in ": "The documents selected on your Cozy will be synchronized on this computer in ",
+  "Folder Modify": "Modify",
+  "Folder You cannot synchronize your data directly in ": "You cannot synchronize your data directly in ",
+  "Folder Please choose another location": "Please choose another location",
+  "Folder Start synchronization": "Start synchronization",
+
   "Folder All done": "全部完成",
   "Folder Please choose an empty directory": "请选择一个空目录。",
-  "Folder Please choose another folder": "请选择另一个文件夹",
   "Folder Select a location for your Cozy folder:": "请选择你的 Cozy 文件夹的位置：",
   "Folder Use Cozy Drive": "Use Cozy Drive",
   "Folder You cannot synchronize your whole system or personal folder": "You cannot synchronize your whole system or personal folder.",
@@ -192,6 +202,9 @@
   "Password Wrong cozy address?": "Wrong cozy address?",
   "Password You don't have filled the password!": "You don't have filled the password!",
   "Password Your password for the cozy address:": "Your password for the cozy address:",
+
+  "Quotation Start": "“",
+  "Quotation End": "”",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/main.js
+++ b/gui/main.js
@@ -19,8 +19,6 @@ const {
 const migrations = require('../core/pouch/migrations')
 const config = require('../core/config')
 const winRegistry = require('../core/utils/win_registry')
-const capabilities = require('../core/utils/capabilities')
-const flags = require('../core/utils/flags')
 
 const autoLaunch = require('./js/autolaunch')
 const lastFiles = require('./js/lastfiles')
@@ -151,15 +149,7 @@ const showWindow = async bounds => {
     try {
       await trayWindow.show(bounds)
 
-      const { cozyUrl, deviceName, deviceId } = desktop.config
-      trayWindow.send(
-        'sync-config',
-        cozyUrl,
-        deviceName,
-        deviceId,
-        await capabilities(desktop.config),
-        await flags(desktop.config)
-      )
+      trayWindow.sendSyncConfig()
 
       const files = await lastFiles.list()
       for (const file of files) {

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -60,9 +60,6 @@ ipcRenderer.on('registration-error', (event, err) => {
   err = errMessage(err)
   elmectron.ports.registrationError.send(err)
 })
-ipcRenderer.on('registration-done', () => {
-  elmectron.ports.registrationDone.send(true)
-})
 elmectron.ports.registerRemote.subscribe(url => {
   ipcRenderer.send('register-remote', {
     cozyUrl: url,

--- a/gui/styles/_wizard.styl
+++ b/gui/styles/_wizard.styl
@@ -1,3 +1,6 @@
+@require './node_modules/cozy-ui/stylus/settings/icons.styl'
+@require './node_modules/cozy-ui/stylus/settings/palette.styl'
+
 .wizard
   overflow hidden
   width 100vw
@@ -81,27 +84,56 @@ a.more-info
   color var(--slateGrey)
 
 
-.folder__selector
-  @extend $form-select select
-  width: 100%
-  font-size: 1.1em
-  line-height: 1em
-  margin 0
-  text-align left
-  text-decoration: none
+.folder__config-option__title
+  font-weight bold
+
+.folder__path
+  $iconSpace = 1.1rem
+
+  font-weight bold
+  font-style italic
+
+  padding-left $iconSpace
+
+  &:before
+    @extend $icon
+    display: inline-block
+    vertical-align: middle
+    -webkit-mask-image: embedurl('./node_modules/cozy-ui/assets/icons/ui/folder.svg')
+    -webkit-mask-position: center
+    -webkit-mask-size: cover
+    mask-image: embedurl('./node_modules/cozy-ui/assets/icons/ui/folder.svg')
+    mask-position: center
+    mask-size: cover
+
+    position absolute
+    width 1rem
+    height 1rem
+    margin-left - $iconSpace
+    content ''
+    background-color var(--slateGrey)
+
+    /.u-error &
+      background-color var(--errorColor)
 
 .step-address
   left 100vw
 
 .step-folder
   left 200vw
+  text-align left
+
   .svg-wrapper
     background-color: var(--emerald)
+    margin-bottom 0
+
+  h1
+    text-align center
+    margin-top 2rem
+
   &.step-error
     .folder-helper
       color var(--black)
-    .folder__selector
-      border-color: var(--pomegranate)
     .error-message
       margin .5em 0
 


### PR DESCRIPTION
Once the OAuth client used to communicate with the remote Cozy has
been created, we can offer users to configure the partial
synchronization of their remote folders.

To this end, we modify the Folder page of the Onboarding to display a
link to the OAuth client's configuration within the remote Settings
app.

For now, this link will only be displayed if the partial
synchronization flag is enabled on the Cozy.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
