### PR TITLE
core/remote/watcher: Use flags module

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -15,6 +15,7 @@ const { inRemoteTrash } = require('../document')
 const squashMoves = require('./squashMoves')
 const normalizePaths = require('./normalizePaths')
 const logger = require('../../utils/logger')
+const flags = require('../../utils/flags')
 
 /*::
 import type { Config } from '../../config'
@@ -196,10 +197,10 @@ class RemoteWatcher {
     let changes = await this.analyse(docs, await this.olds(docs))
 
     if (
-      process.env.NODE_ENV === 'test' ||
-      this.config.flags[
+      (await flags(this.config))[
         'settings.partial-desktop-sync.show-synced-folders-selection'
-      ]
+      ] ||
+      process.env.NODE_ENV === 'test'
     ) {
       for (const change of changes) {
         if (


### PR DESCRIPTION
We want to be able to enable/disable a feature via a flag on the
remote Cozy or the local Config.

Checking the value of the local Config flags does not allow for that
while the new `flags` module does.
When we changed the partial synchronization flag in the
`RemoteWatcher`, we forgot to start using the module instead of the
Config.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
