### PR TITLE
core: Allow local Cozy Note updates

### DIFF
--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -8,7 +8,6 @@ const autoBind = require('auto-bind')
 const Promise = require('bluebird')
 const path = require('path')
 
-const { isNote } = require('../utils/notes')
 const logger = require('../utils/logger')
 const measureTime = require('../utils/perfs')
 const pathUtils = require('../utils/path')
@@ -203,14 +202,6 @@ class Remote /*:: implements Reader, Writer */ {
   }
 
   async overwriteFileAsync(doc /*: SavedMetadata */) /*: Promise<void> */ {
-    if (isNote(doc.remote)) {
-      log.warn(
-        { path: doc.path, doc },
-        'Local note updates should not be propagated'
-      )
-      return
-    }
-
     const { path } = doc
     log.info({ path }, 'Uploading new file version...')
 


### PR DESCRIPTION
Until recent changes were made to `cozy-stack`, changes made to the
Markdown export of Cozy Notes could not be re-imported as actual Cozy
Note changes and would break the note, rendering it unusable as such.
Therefore, we would prevent such local changes by considering them as
conflicts.

Now that local content changes made to the export can be re-imported,
we can remove these protections.
We updated the tests to make sure the changes are actually taken into
account and don't create conflicts. They should probably be removed
after a while since this is the expected behavior of local file
changes.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
