### PR TITLE
core/sync: Await skipChange calls

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -515,7 +515,7 @@ class Sync {
                   { path, err, change, sentry: true },
                   'Parent directory could not be found either on Cozy or PouchDB. Abandoning.'
                 )
-                this.skipChange(change, err)
+                await this.skipChange(change, err)
               } else if (parent.remote) {
                 // We're in a fishy situation where we have a folder whose synced
                 // path is the parent path of our document but its remote path is
@@ -525,7 +525,7 @@ class Sync {
                   { path, err, change, sentry: true },
                   'Parent directory is desynchronized. Abandoning.'
                 )
-                this.skipChange(change, err)
+                await this.skipChange(change, err)
               } else {
                 // Solve 3. or 4.
                 await this.remote.addFolderAsync(parent)


### PR DESCRIPTION
The `Sync.skipChange()` method is asynchronous as it saves data in
PouchDB and its calls should be awaited.
We forgot to await 2 calls when dealing with missing parent errors. If
the change was the only one to synchronize or computing the dependency
tree was simply faster than the write into PouchDB then we could see
the change we wanted to skip being retried once more.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
