### PR TITLE
Fix error management for unreachable Cozy

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -570,18 +570,23 @@ class RemoteCozy {
   }
 
   async flags() /*: Promise<Object> */ {
-    const client = await this.newClient()
-    // Fetch flags from the remote Cozy and store them in the local `cozyFlags`
-    // store.
-    await cozyFlags.initialize(client)
+    try {
+      const client = await this.newClient()
+      // Fetch flags from the remote Cozy and store them in the local `cozyFlags`
+      // store.
+      await cozyFlags.initialize(client)
 
-    // Build a map of flags with their current value
-    const flags = {}
-    for (const flag of cozyFlags.list()) {
-      flags[flag] = cozyFlags(flag)
+      // Build a map of flags with their current value
+      const flags = {}
+      for (const flag of cozyFlags.list()) {
+        flags[flag] = cozyFlags(flag)
+      }
+
+      return flags
+    } catch (err) {
+      log.error({ err }, 'could not fetch remote flags')
+      return {}
     }
-
-    return flags
   }
 }
 

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -59,6 +59,8 @@
   "CGUUpdated Their acceptance is required to continue using your Cozy.": "Their acceptance is required to continue using your Cozy.",
   "CGUUpdated Read the new ToS": "Read the new ToS",
 
+  "Cozy client has been revoked": "Cozy client has been revoked",
+
   "Dashboard Dashboard": "Dashboard",
   "Dashboard Error:": "Error:",
   "Dashboard left PLURAL": "left",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -59,6 +59,8 @@
   "CGUUpdated Their acceptance is required to continue using your Cozy.": "Leur acceptation est requise pour continuer à utiliser votre Cozy.",
   "CGUUpdated Read the new ToS": "Lire les nouvelles CGU",
 
+  "Cozy client has been revoked": "Le client Cozy a été révoqué",
+
   "Dashboard Dashboard": "Tableau de bord",
   "Dashboard Error:": "Erreur :",
   "Dashboard left PLURAL": "restants",

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -82,11 +82,14 @@ ipcRenderer.on(
   (event, address, deviceName, deviceId, capabilities, flags) => {
     const partialSyncEnabled =
       flags['settings.partial-desktop-sync.show-synced-folders-selection']
+    const flatSubdomains = capabilities.flatSubdomains
     elmectron.ports.syncConfig.send({
       address,
       deviceName,
       deviceId,
-      capabilities,
+      capabilities: {
+        flatSubdomains: flatSubdomains != null ? flatSubdomains : true
+      },
       flags: {
         partialSyncEnabled:
           partialSyncEnabled != null ? partialSyncEnabled : false


### PR DESCRIPTION
When a Cozy is unreachable (e.g. because it's been revoked), requests
for flags and capabilities will fail and should be handled.
Besides, if the Cozy has been revoked, we should display the specific
error pop-up inviting the user to reconnect their Desktop client instead
of displaying the generic "Synchronization impossible" status.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
