### PR TITLE
Stop preventing modified folder deletions

### DIFF
--- a/core/local/atom/dispatch.js
+++ b/core/local/atom/dispatch.js
@@ -248,7 +248,7 @@ actions = {
 
   deletedfile: async (event, { pouch, prep }) => {
     const was /*: ?Metadata */ = await pouch.byLocalPath(event.path)
-    if (!was || was.deleted) {
+    if (!was || was.trashed) {
       log.debug({ event }, 'Assuming file already removed')
       // The file was already marked as deleted in pouchdb
       // => we can ignore safely this event
@@ -260,7 +260,7 @@ actions = {
 
   deleteddirectory: async (event, { pouch, prep }) => {
     const was /*: ?Metadata */ = await pouch.byLocalPath(event.path)
-    if (!was || was.deleted) {
+    if (!was || was.trashed) {
       log.debug({ event }, 'Assuming dir already removed')
       // The dir was already marked as deleted in pouchdb
       // => we can ignore safely this event

--- a/core/local/atom/incomplete_fixer.js
+++ b/core/local/atom/incomplete_fixer.js
@@ -274,7 +274,7 @@ function step(
           )
           if (
             incompleteForExistingDoc &&
-            !incompleteForExistingDoc.deleted &&
+            !incompleteForExistingDoc.trashed &&
             (item.event.action === 'created' || item.event.action === 'scan')
           ) {
             // Simply drop the incomplete event since we already have a document at this
@@ -282,7 +282,7 @@ function step(
             keepEvent(event, { incompletes, batch })
           } else if (
             incompleteForExistingDoc &&
-            !incompleteForExistingDoc.deleted &&
+            !incompleteForExistingDoc.trashed &&
             item.event.action === 'modified'
           ) {
             // Keep the completed modified event to make sure we don't miss any

--- a/core/local/atom/win_identical_renaming.js
+++ b/core/local/atom/win_identical_renaming.js
@@ -92,7 +92,7 @@ const fixIdenticalRenamed = async (event, { byLocalPath }) => {
   if (event.path === event.oldPath) {
     const doc /*: ?Metadata */ = await byLocalPath(event.path)
 
-    if (doc && !doc.deleted && doc.path !== event.oldPath) {
+    if (doc && !doc.trashed && doc.path !== event.oldPath) {
       _.set(event, [STEP_NAME, 'oldPathBeforeFix'], event.oldPath)
       event.oldPath = doc.path
     }

--- a/core/local/chokidar/prepare_events.js
+++ b/core/local/chokidar/prepare_events.js
@@ -60,7 +60,7 @@ const oldMetadata = async (
 ) /*: Promise<?Metadata> */ => {
   if (e.old) return e.old
   const old /*: ?Metadata */ = await pouch.bySyncedPath(e.path)
-  if (old && !old.deleted) return old
+  if (old && !old.trashed) return old
 }
 
 /**

--- a/core/merge.js
+++ b/core/merge.js
@@ -739,7 +739,7 @@ class Merge {
 
   async trashFileAsync(
     side /*: SideName */,
-    trashed /*: SavedMetadata|{path: string} */,
+    trashed /*: SavedMetadata */,
     doc /*: Metadata */
   ) /*: Promise<void> */ {
     const { path } = trashed
@@ -809,19 +809,12 @@ class Merge {
 
   async trashFolderAsync(
     side /*: SideName */,
-    trashed /*: SavedMetadata|{path: string} */,
+    trashed /*: SavedMetadata */,
     doc /*: Metadata */
   ) /*: Promise<*> */ {
     const { path } = trashed
     log.debug({ path }, 'trashFolderAsync')
-    let was /*: ?SavedMetadata */
-    // $FlowFixMe _id exists in SavedMetadata
-    if (trashed._id != null) {
-      was = await this.pouch.byIdMaybe(trashed._id)
-    } else {
-      was = await this.pouch.bySyncedPath(trashed.path)
-    }
-
+    const was /*: ?SavedMetadata */ = await this.pouch.byIdMaybe(trashed._id)
     if (!was) {
       log.debug({ path }, 'Nothing to trash')
       return

--- a/core/merge.js
+++ b/core/merge.js
@@ -848,16 +848,10 @@ class Merge {
     const children = await this.pouch.byRecursivePath(was.path, {
       descending: true
     })
-    const hasOutOfDateChild =
-      Array.from(children).find(
-        child => !metadata.isUpToDate(side, child) && !child.deleted
-      ) != null
-    if (!hasOutOfDateChild) {
-      for (const child of children) {
-        await this.doTrash(side, child)
-      }
-      await this.doTrash(side, was)
+    for (const child of children) {
+      await this.doTrash(side, child)
     }
+    await this.doTrash(side, was)
   }
 
   // Remove a file from PouchDB

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -149,7 +149,6 @@ export type Metadata = {
   class?: string,
 
   trashed?: true,
-  deleted?: true,
   errors?: number,
   overwrite?: SavedMetadata,
   childMove?: boolean,

--- a/core/move.js
+++ b/core/move.js
@@ -43,11 +43,9 @@ function move(
     }
   }
 
-  // TODO: Find out wether or not it would make sense to also delete the
-  // trashed property on the source, or explain why it doesn't.
-  delete dst.trashed
-
   dst.moveFrom = src
+  // TODO: remove `_id` and `_rev` from the exception list above and stop
+  // assigning them manually.
   dst._id = src._id
   dst._rev = src._rev
 

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -171,7 +171,7 @@ class Pouch {
       .filter(
         row =>
           !row.key.startsWith('_') && // Filter out design docs
-          !row.doc.deleted && // Filter out docs already marked for deletion
+          !row.doc.trashed && // Filter out docs already marked for deletion
           // Keep only docs that have existed locally
           row.doc.sides &&
           row.doc.sides.local &&

--- a/core/pouch/migrations.js
+++ b/core/pouch/migrations.js
@@ -324,6 +324,26 @@ const migrations /*: Migration[] */ = [
         return doc
       })
     }
+  },
+  {
+    baseSchemaVersion: 12,
+    targetSchemaVersion: 13,
+    description: 'Merge trashed and deleted attributes into trashed',
+    affectedDocs: (docs /*: SavedMetadata[] */) /*: SavedMetadata[] */ => {
+      // $FlowFixMe `deleted` has been removed from Metadata thus this migration
+      return docs.filter(doc => doc.deleted != null)
+    },
+    run: (docs /*: SavedMetadata[] */) /*: SavedMetadata[] */ => {
+      return docs.map(doc => {
+        // $FlowFixMe `deleted` has been removed from Metadata
+        if (doc.deleted) {
+          doc.trashed = true
+        }
+        // $FlowFixMe `deleted` has been removed from Metadata
+        delete doc.deleted
+        return doc
+      })
+    }
   }
 ]
 

--- a/core/prep.js
+++ b/core/prep.js
@@ -124,7 +124,7 @@ class Prep {
       return
     }
     if (side === 'local' && docIgnored) {
-      return this.merge.deleteFileAsync(side, was)
+      return this.merge.trashFileAsync(side, was, was)
     } else if (side === 'local' && wasIgnored) {
       return this.merge.addFileAsync(side, doc)
     } else {
@@ -164,7 +164,7 @@ class Prep {
       return
     }
     if (side === 'local' && docIgnored) {
-      return this.merge.deleteFolderAsync(side, was)
+      return this.merge.trashFolderAsync(side, was, was)
     } else if (side === 'local' && wasIgnored) {
       return this.merge.putFolderAsync(side, doc)
     } else {

--- a/core/prep.js
+++ b/core/prep.js
@@ -4,11 +4,8 @@
  */
 
 const autoBind = require('auto-bind')
-const { clone } = require('lodash')
-const { join } = require('path')
 
 const metadata = require('./metadata')
-const { TRASH_DIR_NAME } = require('./remote/constants')
 const logger = require('./utils/logger')
 
 /*::
@@ -185,15 +182,16 @@ class Prep {
     metadata.ensureValidPath(was)
 
     if (!doc) {
-      doc = clone(was)
-      doc.path = join(TRASH_DIR_NAME, was.path)
+      // XXX: Local deletions don't generate new records as we don't have any
+      // information about deleted files and folders (while we have new metadata
+      // for remote documents that were trashed).
+      return this.merge.trashFileAsync(side, was, was)
+    } else {
+      metadata.ensureValidPath(doc)
+      doc.docType = 'file'
+
+      return this.merge.trashFileAsync(side, was, doc)
     }
-
-    metadata.ensureValidPath(doc)
-    doc.trashed = true
-    doc.docType = 'file'
-
-    return this.merge.trashFileAsync(side, was, doc)
   }
 
   // TODO add comments + tests
@@ -206,15 +204,16 @@ class Prep {
     metadata.ensureValidPath(was)
 
     if (!doc) {
-      doc = clone(was)
-      doc.path = join(TRASH_DIR_NAME, was.path)
+      // XXX: Local deletions don't generate new records as we don't have any
+      // information about deleted files and folders (while we have new metadata
+      // for remote documents that were trashed).
+      return this.merge.trashFolderAsync(side, was, was)
+    } else {
+      metadata.ensureValidPath(doc)
+      doc.docType = 'folder'
+
+      return this.merge.trashFolderAsync(side, was, doc)
     }
-
-    metadata.ensureValidPath(doc)
-    doc.trashed = true
-    doc.docType = 'folder'
-
-    return this.merge.trashFolderAsync(side, was, doc)
   }
 
   // Expectations:

--- a/core/prep.js
+++ b/core/prep.js
@@ -178,7 +178,7 @@ class Prep {
   // TODO add comments + tests
   async trashFileAsync(
     side /*: SideName */,
-    was /*: SavedMetadata|{path: string} */,
+    was /*: SavedMetadata */,
     doc /*: ?Metadata */
   ) {
     log.debug({ path: doc && doc.path, oldpath: was.path }, 'trashFileAsync')
@@ -193,14 +193,13 @@ class Prep {
     doc.trashed = true
     doc.docType = 'file'
 
-    // TODO metadata.shouldIgnore
     return this.merge.trashFileAsync(side, was, doc)
   }
 
   // TODO add comments + tests
   async trashFolderAsync(
     side /*: SideName */,
-    was /*: SavedMetadata|{path: string} */,
+    was /*: SavedMetadata */,
     doc /*: ?Metadata */
   ) {
     log.debug({ path: doc && doc.path, oldpath: was.path }, 'trashFolderAsync')
@@ -215,7 +214,6 @@ class Prep {
     doc.trashed = true
     doc.docType = 'folder'
 
-    // TODO metadata.shouldIgnore
     return this.merge.trashFolderAsync(side, was, doc)
   }
 

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -322,6 +322,19 @@ class RemoteCozy {
     return { last_seq, docs }
   }
 
+  async fetchLastSeq() {
+    const client = await this.newClient()
+    const { last_seq } = await client
+      .collection(FILES_DOCTYPE)
+      .fetchChangesRaw({
+        since: '0',
+        descending: true,
+        limit: 1,
+        includeDocs: false
+      })
+    return last_seq
+  }
+
   async completeRemoteDocs(
     rawDocs /*: Array<RemoteDoc|RemoteDeletion> */
   ) /*: Promise<Array<MetadataRemoteInfo|RemoteDeletion>> */ {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -182,7 +182,9 @@ class Remote /*:: implements Reader, Writer */ {
     } catch (err) {
       if (err.code === 'ENOENT') {
         log.warn({ path }, 'Local file does not exist anymore.')
-        doc.deleted = true // XXX: This prevents the doc to be saved with new revs
+        // FIXME: with this deletion marker, the record will be erased from
+        // PouchDB while the remote document will remain.
+        doc.trashed = true
         return doc
       }
       throw err
@@ -210,7 +212,9 @@ class Remote /*:: implements Reader, Writer */ {
     } catch (err) {
       if (err.code === 'ENOENT') {
         log.warn({ path }, 'Local file does not exist anymore.')
-        doc.deleted = true // XXX: This prevents the doc to be saved with new revs
+        // FIXME: with this deletion marker, the record will be erased from
+        // PouchDB while the remote document will remain.
+        doc.trashed = true
         return doc
       }
       throw err

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -160,7 +160,7 @@ class Remote /*:: implements Reader, Writer */ {
             'could not fetch conflicting directory'
           )
         }
-        if (remoteDoc && (await this.isExcludedFromSync(remoteDoc))) {
+        if (remoteDoc && this.isExcludedFromSync(remoteDoc)) {
           throw new ExcludedDirError(path)
         }
       }
@@ -452,9 +452,7 @@ class Remote /*:: implements Reader, Writer */ {
     return conflict
   }
 
-  async isExcludedFromSync(
-    doc /*: MetadataRemoteInfo */
-  ) /*: Promise<boolean> */ {
+  isExcludedFromSync(doc /*: MetadataRemoteInfo */) /*: boolean */ {
     const {
       client: { clientID }
     } = this.config

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -215,7 +215,7 @@ describe('Move', () => {
 
         should(
           helpers.putDocs('path', 'deleted', 'trashed', 'moveFrom')
-        ).deepEqual([{ path: path.normalize('src/file'), deleted: true }])
+        ).deepEqual([{ path: path.normalize('src/file'), trashed: true }])
 
         await helpers.syncAll()
 
@@ -264,7 +264,7 @@ describe('Move', () => {
           ).deepEqual([
             {
               path: intermediaryPath,
-              deleted: true
+              trashed: true
             }
           ])
 
@@ -756,17 +756,17 @@ describe('Move', () => {
         ).deepEqual([
           {
             path: path.normalize('parent/src/dir/subdir/file'),
-            deleted: true
+            trashed: true
           },
           {
             path: path.normalize('parent/src/dir/subdir'),
-            deleted: true
+            trashed: true
           },
           {
             path: path.normalize('parent/src/dir/empty-subdir'),
-            deleted: true
+            trashed: true
           },
-          { path: path.normalize('parent/src/dir'), deleted: true }
+          { path: path.normalize('parent/src/dir'), trashed: true }
         ])
 
         await helpers.syncAll()
@@ -811,17 +811,17 @@ describe('Move', () => {
           ).deepEqual([
             {
               path: path.normalize('parent/dst/dir/subdir/file'),
-              deleted: true
+              trashed: true
             },
             {
               path: path.normalize('parent/dst/dir/subdir'),
-              deleted: true
+              trashed: true
             },
             {
               path: path.normalize('parent/dst/dir/empty-subdir'),
-              deleted: true
+              trashed: true
             },
-            { path: path.normalize('parent/dst/dir'), deleted: true }
+            { path: path.normalize('parent/dst/dir'), trashed: true }
           ])
 
           await helpers.syncAll()

--- a/test/integration/permanent_deletion.js
+++ b/test/integration/permanent_deletion.js
@@ -22,13 +22,13 @@ describe('Permanent deletion remote', () => {
   afterEach(pouchHelpers.cleanDatabase)
   after(configHelpers.cleanConfig)
 
-  beforeEach(function() {
+  beforeEach(async function() {
     helpers = TestHelpers.init(this)
-    helpers.local.setupTrash()
+    await helpers.local.setupTrash()
+    await helpers.remote.ignorePreviousChanges()
   })
 
   it('file', async () => {
-    await helpers.remote.ignorePreviousChanges()
     const file = await cozy.files.create('File content', { name: 'file' })
     await helpers.remote.pullChanges()
     await helpers.syncAll()

--- a/test/integration/permanent_deletion.js
+++ b/test/integration/permanent_deletion.js
@@ -39,7 +39,7 @@ describe('Permanent deletion remote', () => {
     await helpers.remote.pullChanges()
 
     should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-      { path: 'file', deleted: true }
+      { path: 'file', trashed: true }
     ])
 
     await helpers.syncAll()

--- a/test/integration/sync_state.js
+++ b/test/integration/sync_state.js
@@ -24,12 +24,12 @@ describe('Sync state', () => {
 
   let events, helpers
 
-  beforeEach(function() {
+  beforeEach(async function() {
     helpers = TestHelpers.init(this)
     events = helpers.events
     sinon.spy(events, 'emit')
-    // await helpers.local.setupTrash()
-    // await helpers.remote.ignorePreviousChanges()
+
+    await helpers.remote.ignorePreviousChanges()
   })
 
   it('1 sync error (missing remote file)', async () => {

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -56,7 +56,10 @@ describe('Trash', () => {
 
     context('on the local filesystem', () => {
       it('trashes the file on the remote Cozy', async () => {
-        await prep.trashFileAsync('local', { path: 'parent/file' })
+        const doc = await helpers.pouch.bySyncedPath(
+          path.normalize('parent/file')
+        )
+        await prep.trashFileAsync('local', doc)
 
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
           { path: path.normalize('parent/file'), deleted: true }
@@ -285,9 +288,10 @@ describe('Trash', () => {
 
     context('on the local filesystem', () => {
       it('trashes the directory on the remote Cozy', async () => {
-        await prep.trashFolderAsync('local', {
-          path: path.normalize('parent/dir')
-        })
+        const doc = await helpers.pouch.bySyncedPath(
+          path.normalize('parent/dir')
+        )
+        await prep.trashFolderAsync('local', doc)
 
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
           { path: path.normalize('parent/dir'), deleted: true }

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -294,6 +294,10 @@ describe('Trash', () => {
         await prep.trashFolderAsync('local', doc)
 
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+          // Recursively trash parent/dir; children are trashed first
+          { path: path.normalize('parent/dir/subdir/file'), deleted: true },
+          { path: path.normalize('parent/dir/subdir'), deleted: true },
+          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
           { path: path.normalize('parent/dir'), deleted: true }
         ])
 
@@ -316,10 +320,11 @@ describe('Trash', () => {
 
         await helpers.remote.pullChanges()
         should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-          { path: path.normalize('parent/dir'), deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
+          // Recursively trash parent/dir; children are trashed first
+          { path: path.normalize('parent/dir/subdir/file'), deleted: true },
           { path: path.normalize('parent/dir/subdir'), deleted: true },
-          { path: path.normalize('parent/dir/subdir/file'), deleted: true }
+          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
+          { path: path.normalize('parent/dir'), deleted: true }
         ])
 
         await helpers.syncAll()

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -61,8 +61,8 @@ describe('Trash', () => {
         )
         await prep.trashFileAsync('local', doc)
 
-        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-          { path: path.normalize('parent/file'), deleted: true }
+        should(helpers.putDocs('path', 'trashed')).deepEqual([
+          { path: path.normalize('parent/file'), trashed: true }
         ])
         await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
 
@@ -177,8 +177,8 @@ describe('Trash', () => {
 
         await helpers.remote.pullChanges()
 
-        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
-          { path: path.normalize('parent/file'), deleted: true }
+        should(helpers.putDocs('path', 'trashed')).deepEqual([
+          { path: path.normalize('parent/file'), trashed: true }
         ])
         await should(pouch.db.get(file._id)).be.rejectedWith({ status: 404 })
 
@@ -293,12 +293,12 @@ describe('Trash', () => {
         )
         await prep.trashFolderAsync('local', doc)
 
-        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+        should(helpers.putDocs('path', 'trashed')).deepEqual([
           // Recursively trash parent/dir; children are trashed first
-          { path: path.normalize('parent/dir/subdir/file'), deleted: true },
-          { path: path.normalize('parent/dir/subdir'), deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
-          { path: path.normalize('parent/dir'), deleted: true }
+          { path: path.normalize('parent/dir/subdir/file'), trashed: true },
+          { path: path.normalize('parent/dir/subdir'), trashed: true },
+          { path: path.normalize('parent/dir/empty-subdir'), trashed: true },
+          { path: path.normalize('parent/dir'), trashed: true }
         ])
 
         await helpers.syncAll()
@@ -319,12 +319,12 @@ describe('Trash', () => {
         await cozy.files.trashById(dir._id)
 
         await helpers.remote.pullChanges()
-        should(helpers.putDocs('path', 'deleted', 'trashed')).deepEqual([
+        should(helpers.putDocs('path', 'trashed')).deepEqual([
           // Recursively trash parent/dir; children are trashed first
-          { path: path.normalize('parent/dir/subdir/file'), deleted: true },
-          { path: path.normalize('parent/dir/subdir'), deleted: true },
-          { path: path.normalize('parent/dir/empty-subdir'), deleted: true },
-          { path: path.normalize('parent/dir'), deleted: true }
+          { path: path.normalize('parent/dir/subdir/file'), trashed: true },
+          { path: path.normalize('parent/dir/subdir'), trashed: true },
+          { path: path.normalize('parent/dir/empty-subdir'), trashed: true },
+          { path: path.normalize('parent/dir'), trashed: true }
         ])
 
         await helpers.syncAll()

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -154,16 +154,16 @@ describe('Update file', () => {
     beforeEach(async () => {
       await helpers.remote.ignorePreviousChanges()
       await helpers.local.syncDir.outputFile(existingPath, 'existing content')
-      await helpers.flushLocalAndSyncAll()
-      await helpers.local.syncDir.remove(existingPath)
-      await helpers.local.syncDir.removeParentDir(existingPath)
-      await helpers.flushLocalAndSyncAll()
-
       await helpers.local.syncDir.outputFile(
         path.normalize('src/file'),
         'initial content'
       )
       await helpers.flushLocalAndSyncAll()
+
+      await helpers.local.syncDir.remove(existingPath)
+      await helpers.local.syncDir.removeParentDir(existingPath)
+      await helpers.flushLocalAndSyncAll()
+
       await helpers.local.syncDir.move('src', 'dst')
       await helpers.local.scan()
     })

--- a/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
+++ b/test/scenarios/move_overwriting_dir/not_trashed/scenario.js
@@ -62,7 +62,7 @@ module.exports = ({
             'dir/deletedFile',
             'dir/subdir/',
             'file', // XXX: content is trashed before on disk
-            'file (__cozy__: ...)' // XXX: content is trashed before on disk
+            'file (...)' // XXX: content is trashed before on disk
           ],
     contents: {
       'dst/dir/deletedFile': 'should be kept',

--- a/test/scenarios/update_delete_then_replace_file/scenario.js
+++ b/test/scenarios/update_delete_then_replace_file/scenario.js
@@ -40,7 +40,7 @@ module.exports = ({
     tree: ['dst/', 'final/', 'final/file2', 'src/', 'src/file1'],
     remoteTrash: [
       'file2', // src/file2
-      'file2 (__cozy__: ...)' // final/file2
+      'file2 (...)' // final/file2
     ],
     localTrash: [
       'file2' // src/file2

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -70,12 +70,16 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  moveFrom(was /*: Metadata */) /*: this */ {
+  moveFrom(
+    was /*: Metadata */,
+    { childMove = false } /*: { childMove?: boolean } */ = {}
+  ) /*: this */ {
     this.doc = {
       ..._.cloneDeep(was),
       ...this.doc
     }
     this.doc.moveFrom = was
+    if (childMove) this.doc.moveFrom.childMove = true
 
     return this
   }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -171,11 +171,6 @@ module.exports = class BaseMetadataBuilder {
     return this
   }
 
-  deleted() /*: this */ {
-    this.doc.deleted = true
-    return this
-  }
-
   erased() /*: this */ {
     this.doc._deleted = true
     return this
@@ -375,6 +370,10 @@ module.exports = class BaseMetadataBuilder {
         .contentType(this.doc.mime || '')
         .md5sum(this.doc.md5sum)
         .size(String(this.doc.size))
+    }
+
+    if (this.doc.trashed) {
+      builder = builder.trashed()
     }
 
     this.doc.remote = builder.build()

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -29,5 +29,10 @@ module.exports = function stubSide(name /*: SideName */) /*: Writer */ {
   double.name = name
   double.watcher = {}
   double.watcher.running = new Promise(() => {})
+
+  if (name === 'remote') {
+    double.isExcludedFromSync = sinon.stub.returns()
+  }
+
   return double
 }

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -151,10 +151,14 @@ class RemoteTestHelpers {
     const ellipsizeDate = opts.ellipsize
       ? conflictHelpers.ellipsizeDate
       : _.identity
-    return relPaths
-      .sort()
-      .map(ellipsizeDate)
-      .map(p => p.replace(/\(__cozy__: \d+\)/, '(__cozy__: ...)'))
+    return (
+      relPaths
+        .sort()
+        // XXX: replace Desktop conflict dates with ...
+        .map(ellipsizeDate)
+        // XXX: replace random conflit suffix for trashed files with same name
+        .map(p => p.replace(/\(\d+\)/, '(...)'))
+    )
   }
 
   async treeWithoutTrash(

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -44,7 +44,7 @@ class RemoteTestHelpers {
   }
 
   async ignorePreviousChanges() {
-    const { last_seq } = await this.side.remoteCozy.changes()
+    const last_seq = await this.side.remoteCozy.fetchLastSeq()
     await this.pouch.setRemoteSeq(last_seq)
   }
 

--- a/test/unit/local/chokidar/initial_scan.js
+++ b/test/unit/local/chokidar/initial_scan.js
@@ -65,7 +65,7 @@ onPlatform('darwin', () => {
         await builders
           .metadir()
           .path('.cozy_trash/folder5')
-          .deleted()
+          .trashed()
           .changedSide('remote')
           .create()
         // File still exists
@@ -103,7 +103,7 @@ onPlatform('darwin', () => {
         builders
           .metafile()
           .path('folder1/file5')
-          .deleted()
+          .trashed()
           .changedSide('local')
           .create()
         const initialScan = { paths: ['folder1', 'file1'].map(metadata.id) }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -4405,7 +4405,7 @@ describe('Merge', function() {
       })
 
       context('and the record was modified on the same side', () => {
-        it('keeps the deletion marker and updates sides info', async function() {
+        it('does nothing', async function() {
           const was = await builders
             .metafile()
             .deleted()
@@ -4425,16 +4425,7 @@ describe('Merge', function() {
           )
 
           should(sideEffects).deepEqual({
-            savedDocs: [
-              _.defaults(
-                {
-                  sides: increasedSides(was.sides, this.side, 1),
-                  [this.side]: doc[this.side],
-                  deleted: true
-                },
-                _.omit(was, ['_rev'])
-              )
-            ],
+            savedDocs: [],
             resolvedConflicts: []
           })
         })
@@ -4918,7 +4909,7 @@ describe('Merge', function() {
       })
 
       context('and the record was modified on the same side', () => {
-        it('keeps the deletion marker and updates sides info', async function() {
+        it('does nothing', async function() {
           const was = await builders
             .metadir()
             .deleted()
@@ -4938,16 +4929,7 @@ describe('Merge', function() {
           )
 
           should(sideEffects).deepEqual({
-            savedDocs: [
-              _.defaults(
-                {
-                  sides: increasedSides(was.sides, this.side, 1),
-                  [this.side]: doc[this.side],
-                  deleted: true
-                },
-                _.omit(was, ['_rev'])
-              )
-            ],
+            savedDocs: [],
             resolvedConflicts: []
           })
         })

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -125,6 +125,7 @@ describe('Merge', function() {
       })
       return conflict
     })
+    this.merge.remote.isExcludedFromSync = sinon.stub().returns(false)
     builders = new Builders({ cozy: cozyHelpers.cozy, pouch: this.pouch })
   })
   afterEach('clean pouch', pouchHelpers.cleanDatabase)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -4443,11 +4443,17 @@ describe('Merge', function() {
 
     context('when no records are found in Pouch', () => {
       it('does nothing', async function() {
-        const was = builders.metafile().build()
+        const was = await builders
+          .metafile()
+          .upToDate()
+          .create()
         const doc = builders
           .metafile(was)
           .trashed()
           .build()
+
+        // Erase record from PouchDB
+        await this.pouch.eraseDocument(was)
 
         const sideEffects = await mergeSideEffects(this, () =>
           this.merge.trashFileAsync(
@@ -4950,11 +4956,17 @@ describe('Merge', function() {
 
     context('when no records are found in Pouch', () => {
       it('does nothing', async function() {
-        const was = builders.metadir().build()
+        const was = await builders
+          .metadir()
+          .upToDate()
+          .create()
         const doc = builders
           .metadir(was)
           .trashed()
           .build()
+
+        // Erase record from PouchDB
+        await this.pouch.eraseDocument(was)
 
         const sideEffects = await mergeSideEffects(this, () =>
           this.merge.trashFolderAsync(

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -3934,39 +3934,6 @@ describe('Merge', function() {
     })
   })
 
-  describe('trashFolderAsync', () => {
-    it('does not trash a folder if the other side has added a new file in it', async function() {
-      const was = await builders
-        .metadir()
-        .path('trashed-folder')
-        .upToDate()
-        .create()
-      await builders
-        .metafile()
-        .path('trashed-folder/file')
-        .sides({ [otherSide(this.side)]: 1 })
-        .create()
-      const doc = await builders
-        .metadir(was)
-        .path(`.cozy_trash/${was.path}`)
-        .trashed()
-        .build()
-
-      const sideEffects = await mergeSideEffects(this, () =>
-        this.merge.trashFolderAsync(
-          this.side,
-          _.cloneDeep(was),
-          _.cloneDeep(doc)
-        )
-      )
-
-      should(sideEffects).deepEqual({
-        savedDocs: [],
-        resolvedConflicts: []
-      })
-    })
-  })
-
   describe('deleteFileAsync', () => {
     context('when a record is found in Pouch', () => {
       it('deletes a file', async function() {

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -609,7 +609,7 @@ describe('Pouch', function() {
         await builders
           .metafile()
           .path('deleted')
-          .deleted()
+          .trashed()
           .changedSide('local')
           .create()
 

--- a/test/unit/prep.js
+++ b/test/unit/prep.js
@@ -2,11 +2,9 @@
 
 const sinon = require('sinon')
 const should = require('should')
-const path = require('path')
 
 const { Ignore } = require('../../core/ignore')
 const Prep = require('../../core/prep')
-const { TRASH_DIR_NAME } = require('../../core/remote/constants')
 
 describe('Prep', function() {
   beforeEach('instanciate prep', function() {
@@ -367,7 +365,7 @@ describe('Prep', function() {
         .then(() => should.fail(), err => err.should.match(/Invalid path/))
     })
 
-    it('generates a doc when none is passed', async function() {
+    it('calls Merge with the trashed record when none is passed', async function() {
       const was = {
         path: 'file-to-be-trashed',
         md5sum: 'rcg7GeeTSRscbqD9i0bNnw=='
@@ -375,13 +373,9 @@ describe('Prep', function() {
 
       await this.prep.trashFileAsync(this.side, was)
 
-      should(this.merge.trashFileAsync).be.calledOnce()
-      should(this.merge.trashFileAsync).be.calledWith(this.side, was, {
-        ...was,
-        path: path.join(TRASH_DIR_NAME, was.path),
-        trashed: true,
-        docType: 'file'
-      })
+      should(this.merge.trashFileAsync)
+        .be.calledOnce()
+        .and.be.calledWith(this.side, was, was)
     })
 
     // FIXME
@@ -403,18 +397,14 @@ describe('Prep', function() {
         .then(() => should.fail(), err => err.should.match(/Invalid path/))
     })
 
-    it('generates a doc when none is passed', async function() {
+    it('calls Merge with the trashed record when none is passed', async function() {
       const was = { path: 'folder-to-be-trashed' }
 
       await this.prep.trashFolderAsync(this.side, was)
 
-      should(this.merge.trashFolderAsync).be.calledOnce()
-      should(this.merge.trashFolderAsync).be.calledWith(this.side, was, {
-        ...was,
-        path: path.join(TRASH_DIR_NAME, was.path),
-        trashed: true,
-        docType: 'folder'
-      })
+      should(this.merge.trashFolderAsync)
+        .be.calledOnce()
+        .and.be.calledWith(this.side, was, was)
     })
 
     // FIXME

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -173,7 +173,7 @@ describe('remote.Remote', function() {
       }
       await this.remote.addFileAsync(doc)
       should(doc)
-        .have.property('deleted')
+        .have.property('trashed')
         .and.not.have.property('remote')
     })
 
@@ -381,7 +381,7 @@ describe('remote.Remote', function() {
         await this.remote.overwriteFileAsync(doc)
 
         should(doc)
-          .have.property('deleted')
+          .have.property('trashed')
           .and.not.have.propertyByPath('remote')
       })
 

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -2455,7 +2455,7 @@ describe('RemoteWatcher', function() {
         const trashedFile = builders
           .metafile()
           .fromRemote(origFile)
-          .deleted()
+          .trashed()
           .build()
         const newFile = builders
           .remoteFile(origFile)
@@ -2484,7 +2484,7 @@ describe('RemoteWatcher', function() {
         const trashedFile = builders
           .metafile()
           .fromRemote(origFile)
-          .deleted()
+          .trashed()
           .changedSide('local')
           .build()
         const movedFile = builders

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -361,9 +361,9 @@ describe('Sync', function() {
           this.remote
         )
         should(this.remote.trashAsync).not.have.been.called()
-        should(
-          await this.pouch.bySyncedPath(deletedChild.path)
-        ).have.properties(Object.keys(deletedChild))
+        // XXX: the child change is erased after we've skipped it since it is
+        // marked as `deleted`.
+        should(await this.pouch.bySyncedPath(deletedChild.path)).be.undefined()
       } finally {
         this.sync.trashWithParentOrByItself.restore()
       }
@@ -599,7 +599,7 @@ describe('Sync', function() {
       const doc = await builders
         .metafile()
         .path('foo')
-        .deleted()
+        .trashed()
         .changedSide('remote')
         .create()
       await this.sync.applyDoc(doc, this.local, 'local')
@@ -610,7 +610,7 @@ describe('Sync', function() {
       const doc = await builders
         .metafile()
         .path('tmp/fooz')
-        .deleted()
+        .trashed()
         .sides({ local: 2 })
         .create()
       await this.sync.applyDoc(doc, this.remote, 'remote')
@@ -668,7 +668,7 @@ describe('Sync', function() {
       const doc = await builders
         .metadir()
         .path('baz')
-        .deleted()
+        .trashed()
         .changedSide('remote')
         .create()
       await this.sync.applyDoc(doc, this.local, 'local')
@@ -679,7 +679,7 @@ describe('Sync', function() {
       const doc = await builders
         .metadir()
         .path('tmp/foobaz')
-        .deleted()
+        .trashed()
         .sides({ local: 2 })
         .create()
       await this.sync.applyDoc(doc, this.remote, 'remote')


### PR DESCRIPTION
While we were preventing the deletion of a folder whose content has
changed on the other side, this is getting in the way of the partial
synchronization feature.
Since this content can always be retrieved from the Trash either on the
local OS or the remote Cozy, we believe it is safe and easier to trash
the folder anyway.

We tried to merge logic handling trashed and deleted folders together
(thus all the refactoring done in this PR) but it still requires a lot
of work to be done, especially on the types side so we'll leave this for
another time while keeping the refactoring already done.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
