### PR TITLE
Releave v3.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.32.0 - 2022-01-18
+
+Improvements for all users:
+
+- Selective synchronization is available behind the
+  `settings.partial-desktop-sync.show-synced-folders-selection` flag.
+- The core of the synchronization process can handle selective synchronization
+  without flags (only the configuration of the selective synchronization remains
+  hidden behind a flag).
+- The selective synchronization flag is fetched from the remote Cozy for every
+  use case.
+- We fixed an issue in our synchronization process which could lead to
+  unnecessary metadata updates.
+- When the app's OAuth client is revoked on the remote Cozy, fetching the Cozy's
+  flags and capabilities won't result into an error anymore and the revocation
+  pop-up will displayed again instead of the generic "Synchronization
+  impossible" status.
+- GUI state updates will now be queued up to avoid having two close updates
+  overwrite each other and ending in a de-synchronized state between the app's
+  main Window and the systray.
+- Most remote folder deletion situations should be handled and the same goes for
+  remote folder exclusions as part of the selective synchronization.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.32.0-beta.3 - 2022-01-05
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.32.0-beta.3",
+  "version": "3.32.0",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- Selective synchronization is available behind the
  `settings.partial-desktop-sync.show-synced-folders-selection` flag.
- The core of the synchronization process can handle selective
  synchronization without flags (only the configuration of the selective
  synchronization remains hidden behind a flag).
- The selective synchronization flag is fetched from the remote Cozy for
  every use case.
- We fixed an issue in our synchronization process which could lead to
  unnecessary metadata updates.
- When the app's OAuth client is revoked on the remote Cozy, fetching
  the Cozy's flags and capabilities won't result into an error anymore
  and the revocation pop-up will displayed again instead of the generic
  "Synchronization impossible" status.
- GUI state updates will now be queued up to avoid having two close
  updates overwrite each other and ending in a de-synchronized state
  between the app's main Window and the systray.
- Most remote folder deletion situations should be handled and the same
  goes for remote folder exclusions as part of the selective
  synchronization.
