### PR TITLE
dev: Fix devtools opening

### DIFF
--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -20,7 +20,7 @@ module.exports = class OnboardingWM extends WindowManager {
   windowOptions() {
     return {
       title: 'ONBOARDING',
-      show: true,
+      show: false,
       center: true,
       width: ONBOARDING_SCREEN_WIDTH,
       height: ONBOARDING_SCREEN_HEIGHT

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -117,8 +117,8 @@ module.exports = class TrayWM extends WindowManager {
 
   show(trayPos) {
     this.log.debug('show')
+    super.show()
     this.placeWithTray(DASHBOARD_SCREEN_WIDTH, DASHBOARD_SCREEN_HEIGHT, trayPos)
-    this.win.show()
     return Promise.resolve(this.win)
   }
 

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -57,10 +57,19 @@ module.exports = class WindowManager {
     return true
   }
 
-  show() {
-    if (!this.win) return this.create()
+  async show() {
+    if (!this.win) await this.create()
     this.log.debug('show')
+
+    // devTools
+    if (process.env.WATCH === 'true' || process.env.DEBUG === 'true') {
+      const devtools = new BrowserWindow()
+      this.win.webContents.setDevToolsWebContents(devtools.webContents)
+      this.win.webContents.openDevTools({ mode: 'detach' })
+    }
+
     this.win.show()
+
     return Promise.resolve(this.win)
   }
 
@@ -205,11 +214,6 @@ module.exports = class WindowManager {
     }).catch(err => log.error({ err, sentry: true }, 'failed showing window'))
 
     this.win.loadURL(`file://${opts.indexPath}${this.hash()}`)
-
-    // devTools
-    if (process.env.WATCH === 'true' || process.env.DEBUG === 'true') {
-      this.win.webContents.openDevTools({ mode: 'detach' })
-    }
 
     return windowCreated
   }


### PR DESCRIPTION
With Electron v12.x the DevTools window will only show up if it's
opened after the related BrowserWindow's content has already been
loaded (i.e. `loadUrl` or `loadFile` has been called).

Also, opening the tools when creating a new BrowserWindow means we
would always open them for the main window (i.e. the tray window)
while we don't necessarily want to work on it.

Therefore, we'll now open the DevTools only when calling the `show()`
method (we load the content while the window is still hidden to avoid
showing loading content).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
