### PR TITLE
gui: Fix Updater spinner's vertical alignment

### DIFF
--- a/gui/styles/_statusbar.styl
+++ b/gui/styles/_statusbar.styl
@@ -18,23 +18,22 @@
     white-space: nowrap;
 
   .status_img
-    flex 0 0 3em
+    flex 0 0 4em
 
     img.status__icon
       @extend $icon-24
 
       display: block
-      margin-left: 25%
+      margin-left 1em
       padding: 0.2em
       vertical-align: middle
       border-radius: 1.5em
 
     .spin
-      @extend $icon-16
+      @extend $icon-24
       @extend $spin
       background-color: var(--primaryColor)
-      margin-left: 1em
-      margin-top: 1em
+      margin-left 1em
 
   &.blue
     .status__icon--uptodate

--- a/gui/styles/_wizard.styl
+++ b/gui/styles/_wizard.styl
@@ -53,17 +53,18 @@ a.more-info
   font-size: 1.1em
   margin 1em 0 0 0
 
-  // TODO figure out why we need to add that for
-  // properly placed spinner
-  &[aria-busy=true] > span::after
-    content ''
-    position relative
-    top .4rem
-    left .5rem
+  &[aria-busy=true] > span
+    // We want a busy spinner vertically aligned with the text, not centered
+    align-items unset
 
-    @extend $icon-16
-    @extend $spin
-    background-color: var(--primaryContrastTextColor)
+    &::after
+      content ''
+      position relative
+      left .5rem
+
+      @extend $icon-16
+      @extend $spin
+      background-color: var(--primaryContrastTextColor)
 
 
 .step-address .coz-form-group

--- a/gui/styles/app.styl
+++ b/gui/styles/app.styl
@@ -4,12 +4,6 @@
 @require './node_modules/cozy-ui/stylus/settings/fontstack.styl'
 @require './node_modules/cozy-ui/stylus/utilities/typography.styl'
 
-@keyframes spin
-  from
-    transform translateY(-50%) rotate(0deg)
-  to
-    transform translateY(-50%) rotate(360deg)
-
 @keyframes rotate
   from
     transform rotate(0deg)


### PR DESCRIPTION
The method used to vertically center the spinner displayed in the
Updater window when no download progress information is available is
a Firefox experimental feature which has no effects in Chromium, the
browser used to render Desktop's views.

Besides, this hack was only necessary because the `spin` animation was
redefined in our own CSS because, in turn, we were adding an
unnecessary top margin on the main window's status bar spinner icon.

One fix leading to the other, we now have centered spinners in both
the status bar and the updater window.
We took the opportunity to use the same size for the status bar
spinner as the other status bar icons and to align these with the file
icons displayed below in the Recent tab.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
