### PR TITLE
core/remote: Optimize directory content fetching

### DIFF
--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -21,6 +21,7 @@ const {
   migrate,
   migrationLog
 } = require('./migrations')
+const remoteConstants = require('../remote/constants')
 
 /*::
 import type { Config } from '../config'
@@ -621,7 +622,7 @@ class Pouch {
   async getRemoteSeq() /*: Promise<string> */ {
     const doc = await this.byIdMaybe('_local/remoteSeq')
     if (doc) return doc.seq
-    else return '0'
+    else return remoteConstants.INITIAL_SEQ
   }
 
   // Set last remote replication sequence

--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -39,5 +39,8 @@ module.exports = {
 
   // Maximum file size allowed by Swift thus the remote Cozy.
   // See https://docs.openstack.org/kilo/config-reference/content/object-storage-constraints.html
-  MAX_FILE_SIZE: FIVE_GIGABYTES
+  MAX_FILE_SIZE: FIVE_GIGABYTES,
+
+  // Initial CouchDB sequence
+  INITIAL_SEQ: '0'
 }

--- a/test/integration/sync_state.js
+++ b/test/integration/sync_state.js
@@ -34,7 +34,9 @@ describe('Sync state', () => {
 
   it('1 sync error (missing remote file)', async () => {
     const remoteFile = builders.remoteFile().build()
-    await helpers._remote.watcher.pullMany([remoteFile])
+    await helpers._remote.watcher.pullMany([remoteFile], {
+      isInitialFetch: true // XXX: avoid unnecessary remote requests
+    })
     await helpers.syncAll()
     should(events.emit.args).containDeepOrdered([
       ['sync-start'],

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -179,7 +179,7 @@ class RemoteTestHelpers {
   }
 
   async simulateChanges(docs /*: * */) {
-    await this.side.watcher.pullMany(docs)
+    await this.side.watcher.pullMany(docs, { isInitialFetch: false })
   }
 
   async readFile(path /*: string */) {


### PR DESCRIPTION
Directories content retrieval as part of the selective synchronization
can be quite costly and is particularly useless during the initial
content retrieval.
As such, we optimize both use cases to limit the number of requests and
thus memory consumption and retrieval time.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
