### PR TITLE
gui: Create a general purpose confirmation process

### DIFF
--- a/gui/elm/Data/Confirmation.elm
+++ b/gui/elm/Data/Confirmation.elm
@@ -1,4 +1,4 @@
-port module Data.Confirmation exposing (ConfirmationID, askForConfirmation, gotConfirmation, newId)
+port module Data.Confirmation exposing (Confirmation, ConfirmationID, askForConfirmation, gotConfirmation, newId)
 
 -- Careful! To be sure to match requests with responses, you need to have the
 -- same ConfirmationID as the first tuple member in both functions.
@@ -14,8 +14,13 @@ type ConfirmationID
     = ConfirmationID String
 
 
-type alias EncodedConfirmationID =
-    String
+type alias Confirmation =
+    { id : ConfirmationID
+    , title : String
+    , message : String
+    , detail : String
+    , mainAction : String
+    }
 
 
 newId : String -> ConfirmationID
@@ -23,27 +28,50 @@ newId id =
     ConfirmationID id
 
 
-port confirm : ( EncodedConfirmationID, String ) -> Cmd msg
+
+-- Ports
 
 
-port confirmations : (( EncodedConfirmationID, Bool ) -> msg) -> Sub msg
+type alias EncodedConfirmation =
+    { id : String
+    , title : String
+    , message : String
+    , detail : String
+    , mainAction : String
+    }
 
 
-askForConfirmation : ConfirmationID -> String -> Cmd msg
-askForConfirmation id message =
-    confirm ( encode id, message )
+port confirm : EncodedConfirmation -> Cmd msg
+
+
+port confirmations : (( String, Bool ) -> msg) -> Sub msg
+
+
+askForConfirmation : Confirmation -> Cmd msg
+askForConfirmation confirmation =
+    confirm (encode confirmation)
 
 
 gotConfirmation : (( ConfirmationID, Bool ) -> msg) -> Sub msg
 gotConfirmation msg =
-    confirmations (msg << decode)
+    confirmations (msg << decodeId)
 
 
-encode : ConfirmationID -> EncodedConfirmationID
-encode (ConfirmationID id) =
+encode : Confirmation -> EncodedConfirmation
+encode { id, title, message, detail, mainAction } =
+    { id = encodeId id
+    , title = title
+    , message = message
+    , detail = detail
+    , mainAction = mainAction
+    }
+
+
+encodeId : ConfirmationID -> String
+encodeId (ConfirmationID id) =
     id
 
 
-decode : ( EncodedConfirmationID, Bool ) -> ( ConfirmationID, Bool )
-decode ( id, confirmed ) =
+decodeId : ( String, Bool ) -> ( ConfirmationID, Bool )
+decodeId ( id, confirmed ) =
     ( ConfirmationID id, confirmed )

--- a/gui/elm/Ports.elm
+++ b/gui/elm/Ports.elm
@@ -8,7 +8,6 @@
 port module Ports exposing
     ( autoLauncher
     , autolaunch
-    , cancelUnlink
     , chooseFolder
     , closeApp
     , focus
@@ -43,9 +42,6 @@ port autoLauncher : Bool -> Cmd msg
 
 
 port autolaunch : (Bool -> msg) -> Sub msg
-
-
-port cancelUnlink : (Bool -> msg) -> Sub msg
 
 
 port chooseFolder : () -> Cmd msg

--- a/gui/elm/Window/Tray.elm
+++ b/gui/elm/Window/Tray.elm
@@ -111,7 +111,7 @@ update msg model =
         GotConfirmation ( id, confirmed ) ->
             let
                 ( settings, cmd ) =
-                    Settings.update (Settings.ReinitializationConfirmed ( id, confirmed )) model.settings
+                    Settings.update (Settings.GotConfirmation ( id, confirmed )) model.settings
             in
             ( { model | settings = settings }, Cmd.map SettingsMsg cmd )
 
@@ -190,7 +190,6 @@ subscriptions model =
         , Ports.newRelease (SettingsMsg << Settings.NewRelease)
         , Settings.gotDiskSpace (SettingsMsg << Settings.UpdateDiskSpace)
         , Ports.autolaunch (SettingsMsg << Settings.AutoLaunchSet)
-        , Ports.cancelUnlink (always (SettingsMsg Settings.CancelUnlink))
         , Ports.reinitialization (SettingsMsg << Settings.GotReinitializationStatus)
         ]
 

--- a/gui/elm/Window/Tray/Settings.elm
+++ b/gui/elm/Window/Tray/Settings.elm
@@ -10,7 +10,7 @@ port module Window.Tray.Settings exposing
     )
 
 import Data.Bytes as Bytes exposing (Bytes)
-import Data.Confirmation as Confirmation exposing (ConfirmationID, askForConfirmation)
+import Data.Confirmation as Confirmation exposing (Confirmation, ConfirmationID, askForConfirmation)
 import Data.Status exposing (Status(..))
 import Data.SyncConfig as SyncConfig exposing (SyncConfig)
 import Html exposing (..)
@@ -85,7 +85,7 @@ type Msg
     | CloseApp
     | Sync
     | EndManualSync
-    | ReinitializationRequested String
+    | ReinitializationRequested Confirmation
     | ReinitializationConfirmed ( ConfirmationID, Bool )
     | GotReinitializationStatus String
 
@@ -131,8 +131,8 @@ update msg model =
         EndManualSync ->
             ( { model | manualSyncRequested = False }, Cmd.none )
 
-        ReinitializationRequested question ->
-            ( model, askForConfirmation reinitializationConfirmationId question )
+        ReinitializationRequested confirmation ->
+            ( model, askForConfirmation confirmation )
 
         ReinitializationConfirmed ( id, confirmed ) ->
             if id == reinitializationConfirmationId && confirmed == True then
@@ -353,6 +353,28 @@ quitButton helpers model =
 
 reinitializationButton : Helpers -> Model -> Html Msg
 reinitializationButton helpers model =
+    let
+        confirmation =
+            { id = reinitializationConfirmationId
+            , title = helpers.t "Reinitialization"
+            , message = helpers.t "Reinitialization Are you sure you want to reinitialize the synchronization?"
+            , detail =
+                helpers.t "Reinitialization Beware,"
+                    ++ "\n"
+                    ++ helpers.t
+                        "Reinitialization - if some document deletions were not synchronized, these documents will re-appear if you don't delete them beforehand on the other side;"
+                    ++ "\n"
+                    ++ helpers.t
+                        "Reinitialization - if some files exist on both sides but have different content then conflicts will be created so you can choose the version you wish to keep;"
+                    ++ "\n"
+                    ++ helpers.t
+                        "Reinitialization - if some files are only present on your Cozy or your computer, they will be added to the other side;"
+                    ++ "\n"
+                    ++ helpers.t
+                        "Reinitialization - files already identical on both sides won't be impacted."
+            , mainAction = helpers.t "Reinitialization Reinitialize"
+            }
+    in
     a
         [ class "c-btn c-btn--danger-outline"
         , href "#"
@@ -360,26 +382,7 @@ reinitializationButton helpers model =
             attribute "aria-busy" "true"
 
           else
-            onClick
-                (ReinitializationRequested
-                    (helpers.t "Reinitialization Beware,"
-                        ++ "\n"
-                        ++ helpers.t
-                            "Reinitialization - if some document deletions were not synchronized, these documents will re-appear if you don't delete them beforehand on the other side;"
-                        ++ "\n"
-                        ++ helpers.t
-                            "Reinitialization - if some files exist on both sides but have different content then conflicts will be created so you can choose the version you wish to keep;"
-                        ++ "\n"
-                        ++ helpers.t
-                            "Reinitialization - if some files are only present on your Cozy or your computer, they will be added to the other side;"
-                        ++ "\n"
-                        ++ helpers.t
-                            "Reinitialization - files already identical on both sides won't be impacted."
-                        ++ "\n\n"
-                        ++ helpers.t
-                            "Reinitialization Are you sure you want to reinitialize the synchronization?"
-                    )
-                )
+            onClick (ReinitializationRequested confirmation)
         ]
         [ span [] [ text (helpers.t "Settings Reinitialize") ] ]
 

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -183,6 +183,18 @@ module.exports = class TrayWM extends WindowManager {
 
   ipcEvents() {
     return {
+      confirm: async (event, { id, title, message, detail, mainAction }) => {
+        const { response } = await dialog.showMessageBox(this.win, {
+          type: 'question',
+          title,
+          message,
+          detail,
+          buttons: [translate('Cancel'), mainAction],
+          cancelId: 0,
+          defaultId: 1
+        })
+        event.sender.send('confirmation', { id, confirmed: response === 1 })
+      },
       'go-to-cozy': (event, showInWeb) => {
         if (showInWeb) {
           shell.openExternal(this.desktop.config.cozyUrl)

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -112,7 +112,10 @@ module.exports = class TrayWM extends WindowManager {
 
   create() {
     let pReady = super.create()
-    if (!this.desktop.config.gui.visibleOnBlur) {
+    if (
+      process.env.WATCH !== 'true' &&
+      !this.desktop.config.gui.visibleOnBlur
+    ) {
       this.win.on('blur', this.onBlur.bind(this))
     }
     return pReady

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -63,14 +63,39 @@ module.exports = class WindowManager {
 
     // devTools
     if (process.env.WATCH === 'true' || process.env.DEBUG === 'true') {
-      const devtools = new BrowserWindow()
-      this.win.webContents.setDevToolsWebContents(devtools.webContents)
-      this.win.webContents.openDevTools({ mode: 'detach' })
+      this.showDevTools()
     }
 
     this.win.show()
 
     return Promise.resolve(this.win)
+  }
+
+  showDevTools() {
+    if (!this.win || this.win.webContents.isDestroyed()) return
+
+    if (!this.devtools) {
+      this.devtools = new BrowserWindow({ show: false })
+      this.devtools.on('closed', () => {
+        this.win.webContents.closeDevTools()
+        this.devtools = null
+      })
+      this.win.webContents.setDevToolsWebContents(this.devtools.webContents)
+    }
+
+    this.win.on('hide', () => this.hideDevTools())
+    this.win.on('closed', () => this.hideDevTools())
+
+    this.win.webContents.openDevTools({ mode: 'detach' })
+    this.devtools.show()
+  }
+
+  hideDevTools() {
+    if (this.devtools) {
+      this.devtools.hide()
+
+      if (this.win) this.win.webContents.closeDevTools()
+    }
   }
 
   hide() {

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -270,7 +270,6 @@
   "TwoPanes Recents": "Recents",
   "TwoPanes Settings": "Settings",
 
-  "Unlink Cancel": "Cancel",
   "Unlink Detail": "Your file will no longer be synchronized with your Cozy.",
   "Unlink Message": "Are you sure you want to unlink your Cozy?",
   "Unlink OK": "Log out",

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -215,12 +215,14 @@
   "Quotation Start": "“",
   "Quotation End": "”",
 
+  "Reinitialization": "Reinitialization",
   "Reinitialization Beware,": "Beware,",
   "Reinitialization - if some document deletions were not synchronized, these documents will re-appear if you don't delete them beforehand on the other side;": "- if some document deletions were not synchronized, these documents will re-appear if you don't delete them beforehand on the other side;",
   "Reinitialization - if some files exist on both sides but have different content then conflicts will be created so you can choose the version you wish to keep;": "- if some files exist on both sides but have different content then conflicts will be created so you can choose the version you wish to keep;",
   "Reinitialization - if some files are only present on your Cozy or your computer, they will be added to the other side;": "- if some files are only present on your Cozy or your computer, they will be added to the other side;",
   "Reinitialization - files already identical on both sides won't be impacted.": "- files already identical on both sides won't be impacted.",
   "Reinitialization Are you sure you want to reinitialize the synchronization?": "Are you sure you want to reinitialize the synchronization?",
+  "Reinitialization Reinitialize": "Reinitialize",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "In case you didn't, contact us at contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnect",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -215,12 +215,14 @@
   "Quotation Start": "« ",
   "Quotation End": " »",
 
+  "Reinitialization": "Réinitialisation",
   "Reinitialization Beware,": "Attention,",
   "Reinitialization - if some document deletions were not synchronized, these documents will re-appear if you don't delete them beforehand on the other side;": "- si des suppressions de dossiers ou fichiers ont été réalisées sans pouvoir être synchronisées, ces documents réapparaitront si vous ne les supprimez pas préalablement aussi du côté opposé ;",
   "Reinitialization - if some files exist on both sides but have different content then conflicts will be created so you can choose the version you wish to keep;": "- si des fichiers existent des deux côtés mais diffèrent en version, alors des doublons (conflict) seront ajoutés pour vous permettre de choisir celui que vous souhaitez conserver ;",
   "Reinitialization - if some files are only present on your Cozy or your computer, they will be added to the other side;": "- si des fichiers sont présents uniquement sur votre Cozy ou votre ordinateur ils seront recréés pour être identiques ;",
   "Reinitialization - files already identical on both sides won't be impacted.": "- les fichiers déjà identiques ne seront pas impactés.",
   "Reinitialization Are you sure you want to reinitialize the synchronization?": "Confirmez-vous vouloir réinitialiser la synchronisation ?",
+  "Reinitialization Reinitialize": "Réinitialiser",
 
   "Revoked In case you didn't, contact us at contact@cozycloud.cc": "Dans le cas contraire, contactez nous sur contact@cozycloud.cc",
   "Revoked Reconnect": "Reconnecter",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -270,7 +270,6 @@
   "TwoPanes Recents": "Récents",
   "TwoPanes Settings": "Préférences",
 
-  "Unlink Cancel": "Annuler",
   "Unlink Detail": "Vos fichiers ne seront plus synchronisés avec votre Cozy.",
   "Unlink Message": "Confirmez-vous vouloir vous déconnecter de votre Cozy ?",
   "Unlink OK": "Se déconnecter",

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -140,9 +140,6 @@ ipcRenderer.on('go-to-tab', (event, tab) => {
   elmectron.ports.gototab.send(tab)
 })
 
-ipcRenderer.on('cancel-unlink', () => {
-  elmectron.ports.cancelUnlink.send(true)
-})
 elmectron.ports.unlinkCozy.subscribe(() => {
   ipcRenderer.send('unlink-cozy')
 })

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -48,8 +48,11 @@ const errMessage = err => {
   }
 }
 
-elmectron.ports.confirm.subscribe(([id, msg]) => {
-  elmectron.ports.confirmations.send([id, window.confirm(msg)])
+elmectron.ports.confirm.subscribe(confirmation => {
+  ipcRenderer.send('confirm', confirmation)
+})
+ipcRenderer.on('confirmation', (event, { id, confirmed }) => {
+  elmectron.ports.confirmations.send([id, confirmed])
 })
 
 ipcRenderer.on('update-downloading', (event, progressObj) => {


### PR DESCRIPTION
Refactor the existing synchronization reinitialization confirmation 
request to create a general purpose confirmation process that can be 
used in different situations.
We take the opportunity to make sure the confirmation request is never 
hidden when the main window loses focus and does not prevent using the 
app's GUI afterwards.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
