### PR TITLE
core/remote: Don't fetch content of excluded dirs

### DIFF
--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -473,7 +473,8 @@ class RemoteCozy {
   ) /*: Promise<{ nextDirs: $ReadOnlyArray<MetadataRemoteDir>, docs: $ReadOnlyArray<MetadataRemoteInfo> }> */ {
     const queryDef = Q(FILES_DOCTYPE)
       .where({
-        dir_id: { $in: dirs.map(dir => dir._id) }
+        dir_id: { $in: dirs.map(dir => dir._id) },
+        name: { $gt: null }
       })
       .indexFields(['dir_id', 'name'])
       .sortBy([{ dir_id: 'asc' }, { name: 'asc' }])
@@ -491,9 +492,14 @@ class RemoteCozy {
         dir => dir._id === remoteJson.attributes.dir_id
       )
       const remoteDoc = await this.toRemoteDoc(remoteJson, parentDir)
-      docs.push(remoteDoc)
 
-      if (remoteDoc.type === DIR_TYPE) nextDirs.push(remoteDoc)
+      if (!this.isExcludedDirectory(remoteDoc)) {
+        docs.push(remoteDoc)
+
+        if (remoteDoc.type === DIR_TYPE) {
+          nextDirs.push(remoteDoc)
+        }
+      }
     }
     return { nextDirs, docs }
   }

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -512,6 +512,17 @@ class RemoteCozy {
     }
   }
 
+  isExcludedDirectory(doc /*: RemoteDoc */) /*: boolean */ {
+    const {
+      client: { clientID }
+    } = this.config
+    return (
+      doc.type === 'directory' &&
+      doc.not_synchronized_on != null &&
+      doc.not_synchronized_on.find(({ id }) => id === clientID) != null
+    )
+  }
+
   async isEmpty(id /*: string */) /*: Promise<boolean> */ {
     const dir = await this.client.files.statById(id)
     if (dir.attributes.type !== 'directory') {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -162,7 +162,7 @@ class Remote /*:: implements Reader, Writer */ {
             'could not fetch conflicting directory'
           )
         }
-        if (remoteDoc && this.isExcludedFromSync(remoteDoc)) {
+        if (remoteDoc && this.remoteCozy.isExcludedDirectory(remoteDoc)) {
           throw new ExcludedDirError(path)
         }
       }
@@ -466,17 +466,6 @@ class Remote /*:: implements Reader, Writer */ {
     await this.moveAsync(conflict, newMetadata)
 
     return conflict
-  }
-
-  isExcludedFromSync(doc /*: MetadataRemoteInfo */) /*: boolean */ {
-    const {
-      client: { clientID }
-    } = this.config
-    return (
-      doc.type === 'directory' &&
-      doc.not_synchronized_on != null &&
-      doc.not_synchronized_on.find(({ id }) => id === clientID) != null
-    )
   }
 
   async includeInSync(doc /*: SavedMetadata */) /*: Promise<*> */ {

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -1,9 +1,14 @@
 /* @flow */
 
 const _ = require('lodash')
+const CozyClient = require('cozy-client').default
 
 const RemoteBaseBuilder = require('./base')
 const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
+const {
+  FILES_DOCTYPE,
+  OAUTH_CLIENTS_DOCTYPE
+} = require('../../../../core/remote/constants')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
@@ -33,20 +38,58 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
     this.remoteDoc.type = 'directory'
   }
 
+  excludedFrom(clientIds /*: string[] */) /*: this */ {
+    this.remoteDoc.not_synchronized_on = clientIds.map(id => ({
+      type: OAUTH_CLIENTS_DOCTYPE,
+      id
+    }))
+    return this
+  }
+
+  async newClient(cozy /*: Cozy */) /*: Promise<CozyClient> */ {
+    let client /*: CozyClient */
+    return (async (cozy /*: Cozy */) /*: Promise<CozyClient> */ => {
+      if (!client) {
+        if (cozy._oauth) {
+          // Make sure we have an authorized client to build a new client from.
+          await cozy.authorize()
+          client = await CozyClient.fromOldOAuthClient(cozy)
+        } else {
+          client = await CozyClient.fromOldClient(cozy)
+        }
+      }
+      return client
+    })(cozy)
+  }
+
   async create() /*: Promise<MetadataRemoteDir> */ {
     const cozy = this._ensureCozy()
 
-    return _.clone(
-      remoteJsonToRemoteDoc(
-        await cozy.files.createDirectory({
-          name: this.remoteDoc.name,
-          dirID: this.remoteDoc.dir_id,
-          createdAt: this.remoteDoc.created_at,
-          updatedAt: this.remoteDoc.updated_at,
-          noSanitize: true
-        })
-      )
-    )
+    const json = await cozy.files.createDirectory({
+      name: this.remoteDoc.name,
+      dirID: this.remoteDoc.dir_id,
+      createdAt: this.remoteDoc.created_at,
+      updatedAt: this.remoteDoc.updated_at,
+      noSanitize: true
+    })
+
+    if (
+      this.remoteDoc.not_synchronized_on &&
+      this.remoteDoc.not_synchronized_on.length
+    ) {
+      for (const { id, type } of this.remoteDoc.not_synchronized_on) {
+        const client = await this.newClient(cozy)
+        const files = client.collection(FILES_DOCTYPE)
+        await files.addNotSynchronizedDirectories({ _id: id, _type: type }, [
+          json
+        ])
+      }
+
+      const excluded = await cozy.files.statById(json._id)
+      return _.clone(remoteJsonToRemoteDoc(excluded))
+    }
+
+    return _.clone(remoteJsonToRemoteDoc(json))
   }
 
   async update() /*: Promise<MetadataRemoteDir> */ {
@@ -60,6 +103,32 @@ module.exports = class RemoteDirBuilder extends RemoteBaseBuilder /*:: <Metadata
           updated_at: this.remoteDoc.updated_at,
           noSanitize: true
         })
+
+    if (
+      _.difference(
+        this.remoteDoc.not_synchronized_on,
+        json.attributes.not_synchronized_on || []
+      ).length
+    ) {
+      for (const { id, type } of json.attributes.not_synchronized_on || []) {
+        const client = await this.newClient(cozy)
+        const files = client.collection(FILES_DOCTYPE)
+        await files.removeNotSynchronizedDirectories({ _id: id, _type: type }, [
+          json
+        ])
+      }
+
+      for (const { id, type } of this.remoteDoc.not_synchronized_on || []) {
+        const client = await this.newClient(cozy)
+        const files = client.collection(FILES_DOCTYPE)
+        await files.addNotSynchronizedDirectories({ _id: id, _type: type }, [
+          json
+        ])
+      }
+
+      const excluded = await cozy.files.statById(json._id)
+      return _.clone(remoteJsonToRemoteDoc(excluded))
+    }
 
     return _.clone(remoteJsonToRemoteDoc(json))
   }

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -30,9 +30,5 @@ module.exports = function stubSide(name /*: SideName */) /*: Writer */ {
   double.watcher = {}
   double.watcher.running = new Promise(() => {})
 
-  if (name === 'remote') {
-    double.isExcludedFromSync = sinon.stub.returns()
-  }
-
   return double
 }

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -125,7 +125,6 @@ describe('Merge', function() {
       })
       return conflict
     })
-    this.merge.remote.isExcludedFromSync = sinon.stub().returns(false)
     builders = new Builders({ cozy: cozyHelpers.cozy, pouch: this.pouch })
   })
   afterEach('clean pouch', pouchHelpers.cleanDatabase)

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -965,6 +965,26 @@ describe('RemoteCozy', function() {
       ).be.rejectedWith(/test error/)
     })
   })
+
+  describe('#isExcludedDirectory', () => {
+    it('returns false for files', () => {
+      const file = builders.remoteFile().build()
+      should(remoteCozy.isExcludedDirectory(file)).be.false()
+    })
+
+    it('returns false for a directory that is not excluded from the client sync', () => {
+      const dir = builders.remoteDir().build()
+      should(remoteCozy.isExcludedDirectory(dir)).be.false()
+    })
+
+    it('returns true for a directory excluded from the client sync', () => {
+      const dir = builders
+        .remoteDir()
+        .excludedFrom(['fakeId1', remoteCozy.config.deviceId, 'fakeId2'])
+        .build()
+      should(remoteCozy.isExcludedDirectory(dir)).be.true()
+    })
+  })
 })
 
 describe('RemoteCozy.newClient', () => {


### PR DESCRIPTION
When a directory is re-included in the synchronization of a Desktop
client, we recursively fetch its content because it won't be present
in the changes feed (only the parent directory is modified when
re-including it).

When doing so, we should not fetch excluded sub-directories and their
content as they're still excluded.

We're filtering them out on the client side because doing it on the
server side would mean filtering without an index (it would require
the usage of `$exists: false` since the `not_synchronized_on`
attribute is not always present on directories and is never present on
files).

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
