### PR TITLE
core/lochokidar/normalize_paths: Normalize only when needed

### DIFF
--- a/test/support/helpers/platform.js
+++ b/test/support/helpers/platform.js
@@ -15,6 +15,8 @@ module.exports = {
   onMacOSAtMost,
   onPlatforms,
   onPlatform,
+  onAPFS,
+  onHFS,
   localUpdatedAt
 }
 
@@ -70,6 +72,22 @@ function onPlatforms(
 
 function onPlatform(platform /*: string */, spec /*: Function */) {
   onPlatforms([platform], spec)
+}
+
+function onAPFS(spec /*: Function */) {
+  const isNotHFSTest = process.env.COZY_DESKTOP_FS !== 'HFS+'
+
+  const describeOrSkip = isNotHFSTest ? describe : describe.skip
+
+  describeOrSkip('on APFS filesystem', spec)
+}
+
+function onHFS(spec /*: Function */) {
+  const isNotAPFS = process.env.COZY_DESKTOP_FS !== 'APFS'
+
+  const describeOrSkip = isNotAPFS ? describe : describe.skip
+
+  describeOrSkip('on HFS+ filesystem', spec)
 }
 
 function localUpdatedAt(date /*: string|Date */) /*: string */ {

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -921,7 +921,7 @@ describe('RemoteWatcher', function() {
         context(
           'in renamed accented folder with different local/remote normalizations',
           () => {
-            it('is identified as a descendant change with old parent normalization', async function() {
+            it('is identified as a descendant change within current parent path', async function() {
               const oldRemoteDir = builders
                 .remoteDir()
                 .name('énoncés'.normalize('NFC'))
@@ -960,75 +960,17 @@ describe('RemoteWatcher', function() {
                 [oldDir, oldFile]
               )
 
-              const oldNFDName = oldRemoteDir.name.normalize('NFD')
-              const newNFDName = newRemoteDir.name.normalize('NFD')
+              const oldDirName = path.basename(oldDir.path)
+
               should(dirChange).have.property('type', 'DirMove')
               should(dirChange.doc).have.property(
                 'path',
-                oldDir.path.replace(oldNFDName, newNFDName)
+                oldDir.path.replace(oldDirName, newRemoteDir.name)
               )
               should(fileChange).have.property('type', 'DescendantChange')
               should(fileChange.doc).have.property(
                 'path',
-                oldFile.path.replace(oldNFDName, newNFDName)
-              )
-            })
-          }
-        )
-
-        context(
-          'in renamed folder with different local/remote normalizations',
-          () => {
-            it('is identified as a descendant change with old parent normalization', async function() {
-              const oldRemoteDir = builders
-                .remoteDir()
-                .name('énoncés'.normalize('NFC'))
-                .build()
-              const oldDir = await builders
-                .metadir()
-                .fromRemote(oldRemoteDir)
-                .path(oldRemoteDir.path.normalize('NFD'))
-                .upToDate()
-                .create()
-              const oldRemoteFile = builders
-                .remoteFile()
-                .inDir(oldRemoteDir)
-                .name('file')
-                .build()
-              const oldFile = await builders
-                .metafile()
-                .fromRemote(oldRemoteFile)
-                .path(path.join(oldDir.path, oldRemoteFile.name))
-                .upToDate()
-                .create()
-
-              const newRemoteDir = builders
-                .remoteDir(oldRemoteDir)
-                .name('corrigés'.normalize('NFC'))
-                .shortRev(metadata.extractRevNumber(oldDir.remote) + 1)
-                .build()
-              const newRemoteFile = builders
-                .remoteFile(oldRemoteFile)
-                .inDir(newRemoteDir)
-                .shortRev(metadata.extractRevNumber(oldFile.remote) + 1)
-                .build()
-
-              const [dirChange, fileChange] = await this.watcher.analyse(
-                [newRemoteDir, newRemoteFile],
-                [oldDir, oldFile]
-              )
-
-              const oldNFDName = oldRemoteDir.name.normalize('NFD')
-              const newNFDName = newRemoteDir.name.normalize('NFD')
-              should(dirChange).have.property('type', 'DirMove')
-              should(dirChange.doc).have.property(
-                'path',
-                oldDir.path.replace(oldNFDName, newNFDName)
-              )
-              should(fileChange).have.property('type', 'DescendantChange')
-              should(fileChange.doc).have.property(
-                'path',
-                oldFile.path.replace(oldNFDName, newNFDName)
+                oldFile.path.replace(oldDirName, newRemoteDir.name)
               )
             })
           }


### PR DESCRIPTION
HFS+ filesystems automatically re-encode utf-8 characters of document
names using the NFD norm when they were encoded with the NFC norm in
the first place. On the other hand, most filesystems and,
specifically, the remote Cozy filesystem, encode utf-8 characters with
the NFC norm.
This means that documents created on these systems will be
automatically renamed when Desktop creates them on the local HFS+
filesystem, generating unnecessary name changes.

We implemented a re-normalization process to try and keep the previous
normalization of document names in our local PouchDB database but we
did not account for cases where both norms coexist in the same
document name. In these cases, the re-normalization wouldn't work
(because we could not detect the one norm used) and, worse, conflicts
were created.

We're now implementing a simpler version of the re-normalization which
consists of reusing the name of a document as it exists in PouchDB if
only its normalization has changed. When documents are renamed, we
won't try to save the new name using the old normalization anymore
since the name is changing anyway.
We shouldn't really have to deal with specific norms anymore with this
process.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
