### PR TITLE
core/remote/watcher: Fetch directories one by one

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -157,7 +157,8 @@ export type Metadata = {
   fileid?: string,
   moveFrom?: SavedMetadata,
   cozyMetadata?: Object,
-  metadata?: Object
+  metadata?: Object,
+  needsContentFetching: boolean
 }
 
 export type SavedMetadata = PouchRecord & Metadata
@@ -244,7 +245,8 @@ function fromRemoteDir(remoteDir /*: MetadataRemoteDir */) /*: Metadata */ {
     docType: localDocType(remoteDir.type),
     path: pathUtils.remoteToLocal(remoteDir.path),
     created_at: timestamp.roundedRemoteDate(remoteDir.created_at),
-    updated_at: timestamp.roundedRemoteDate(remoteDir.updated_at)
+    updated_at: timestamp.roundedRemoteDate(remoteDir.updated_at),
+    needsContentFetching: false
   }
 
   const fields = Object.getOwnPropertyNames(remoteDir).filter(
@@ -276,7 +278,8 @@ function fromRemoteFile(remoteFile /*: MetadataRemoteFile */) /*: Metadata */ {
     size: parseInt(remoteFile.size, 10),
     executable: !!remoteFile.executable,
     created_at: timestamp.roundedRemoteDate(remoteFile.created_at),
-    updated_at: timestamp.roundedRemoteDate(remoteFile.updated_at)
+    updated_at: timestamp.roundedRemoteDate(remoteFile.updated_at),
+    needsContentFetching: false
   }
 
   const fields = Object.getOwnPropertyNames(remoteFile).filter(
@@ -808,7 +811,8 @@ function buildDir(
     docType: 'folder',
     updated_at: stats.mtime.toISOString(),
     ino: stats.ino,
-    tags: []
+    tags: [],
+    needsContentFetching: false
   }
   // FIXME: we should probably not set remote at this point
   if (remote) {
@@ -845,7 +849,8 @@ function buildFile(
     class: className,
     size,
     executable,
-    tags: []
+    tags: [],
+    needsContentFetching: false
   }
   // FIXME: we should probably not set remote at this point
   if (remote) {

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -420,6 +420,10 @@ class Pouch {
     return results.rows.map(row => row.doc)
   }
 
+  async needingContentFetching() /*: Promise<SavedMetadata[]> */ {
+    return await this.getAll('needsContentFetching')
+  }
+
   /* Views */
 
   // Create all required views in the database
@@ -430,7 +434,8 @@ class Pouch {
           this.addByPathView,
           this.addByLocalPathView,
           this.addByChecksumView,
-          this.addByRemoteIdView
+          this.addByRemoteIdView,
+          this.addNeedsContentFetchingView
         ],
         err => {
           if (err) reject(err)
@@ -534,6 +539,16 @@ class Pouch {
       }
     }.toString()
     await this.createDesignDoc('byRemoteId', query)
+  }
+
+  async addNeedsContentFetchingView() {
+    const query = function(doc) {
+      if (doc.needsContentFetching && !doc.trashed) {
+        // $FlowFixMe
+        return emit(doc._id) // eslint-disable-line no-undef
+      }
+    }.toString()
+    await this.createDesignDoc('needsContentFetching', query)
   }
 
   // Create or update given design doc

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -173,7 +173,7 @@ class RemoteWatcher {
 
       this.events.emit('remote-start')
       this.events.emit('buffering-end')
-      await this.pullMany(docs, { isInitialFetch })
+      await this.processRemoteChanges(docs, { isInitialFetch })
 
       let target = -1
       target = (await this.pouch.db.changes({ limit: 1, descending: true }))
@@ -203,11 +203,9 @@ class RemoteWatcher {
     return await this.pouch.allByRemoteIds(remoteIds)
   }
 
-  /** Pull multiple changed or deleted docs
-   *
-   * FIXME: Misleading method name?
+  /** Process multiple changed or deleted docs
    */
-  async pullMany(
+  async processRemoteChanges(
     docs /*: $ReadOnlyArray<MetadataRemoteInfo|RemoteDeletion> */,
     { isInitialFetch } /*: { isInitialFetch: boolean } */
   ) /*: Promise<void> */ {
@@ -240,7 +238,7 @@ class RemoteWatcher {
     const errors = await this.applyAll(changes)
     if (errors.length) throw errors[0].err
 
-    log.trace('Done with pull.')
+    log.trace('Done with changes processing.')
   }
 
   async analyse(

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -56,7 +56,8 @@ module.exports = class BaseMetadataBuilder {
         docType: 'folder', // To make flow happy (overridden by subclasses)
         path: 'foo',
         tags: [],
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
+        needsContentFetching: false
       }
     }
     this.buildLocal = true

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -179,7 +179,9 @@ class RemoteTestHelpers {
   }
 
   async simulateChanges(docs /*: * */) {
-    await this.side.watcher.pullMany(docs, { isInitialFetch: false })
+    await this.side.watcher.processRemoteChanges(docs, {
+      isInitialFetch: false
+    })
   }
 
   async readFile(path /*: string */) {

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -98,7 +98,8 @@ describe('metadata', function() {
         executable: false,
         cozyMetadata: {
           createdOn: 'alice.mycozy.cloud'
-        }
+        },
+        needsContentFetching: false
       })
 
       remoteDoc.executable = true
@@ -135,7 +136,8 @@ describe('metadata', function() {
           created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
           updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
         },
-        tags: ['foo']
+        tags: ['foo'],
+        needsContentFetching: false
       })
     })
   })

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -873,7 +873,7 @@ describe('RemoteCozy', function() {
       })
     })
 
-    it('returns the whole directory content, including the content of subdirectories', async () => {
+    it('returns the direct children of the directory', async () => {
       const tree = await builders.createRemoteTree([
         'dir/',
         'dir/subdir/',
@@ -894,13 +894,7 @@ describe('RemoteCozy', function() {
       ).be.fulfilledWith([
         tree['dir/file'],
         tree['dir/other-subdir/'],
-        tree['dir/other-subdir/next-level/'],
-        tree['dir/other-subdir/next-level/last-level/'],
-        tree['dir/other-subdir/next-level/last-level/content'],
-        tree['dir/subdir/'],
-        tree['dir/subdir/file'],
-        tree['dir/subdir/subsubdir/'],
-        tree['dir/subdir/subsubdir/last']
+        tree['dir/subdir/']
       ])
     })
 
@@ -920,40 +914,12 @@ describe('RemoteCozy', function() {
       const client = await remoteCozy.newClient()
       const files = client.collection(FILES_DOCTYPE)
       await files.addNotSynchronizedDirectories(oauthClient, [
-        tree['dir/subdir/subsubdir/'],
-        tree['dir/other-subdir/']
+        tree['dir/subdir/']
       ])
 
       await should(
         remoteCozy.getDirectoryContent(tree['dir/'])
-      ).be.fulfilledWith([tree['dir/subdir/'], tree['dir/subdir/file']])
-    })
-
-    it('requests content level by level and not directory by directory', async () => {
-      const tree = await builders.createRemoteTree([
-        'dir/',
-        'dir/file',
-        'dir/subdir/',
-        'dir/subdir/file',
-        'dir/subdir/subsubdir/',
-        'dir/subdir/subsubdir/last',
-        'dir/other-subdir/',
-        'dir/other-subdir/next-level/',
-        'dir/other-subdir/next-level/last-level/',
-        'dir/other-subdir/next-level/last-level/content',
-        'other-dir/',
-        'other-dir/content'
-      ])
-
-      const client = await remoteCozy.newClient()
-      const querySpy = sinon.spy(client, 'query')
-      try {
-        await remoteCozy.getDirectoryContent(tree['dir/'], { client })
-
-        should(querySpy).have.callCount(4)
-      } finally {
-        querySpy.restore()
-      }
+      ).be.fulfilledWith([tree['dir/other-subdir/']])
     })
 
     it('does not fail on an empty directory', async () => {
@@ -962,34 +928,6 @@ describe('RemoteCozy', function() {
         .name('dir')
         .create()
       await should(remoteCozy.getDirectoryContent(dir)).be.fulfilledWith([])
-    })
-
-    it('fails on a sub-directory content request failure', async () => {
-      const tree = await builders.createRemoteTree([
-        'dir/',
-        'dir/subdir/',
-        'dir/subdir/subsubdir/',
-        'dir/subdir/file',
-        'dir/file',
-        'dir/subdir/subsubdir/last',
-        'hello.txt',
-        'other-dir/',
-        'other-dir/content'
-      ])
-
-      const stubbedClient = await remoteCozy.newClient()
-      const originalQuery = stubbedClient.query.bind(stubbedClient)
-      sinon.stub(stubbedClient, 'query').callsFake(async queryDef => {
-        if (queryDef.selector.dir_id.$in.includes(tree['dir/subdir/']._id)) {
-          throw new Error('test error')
-        } else {
-          return originalQuery(queryDef)
-        }
-      })
-
-      await should(
-        remoteCozy.getDirectoryContent(tree['dir/'], { client: stubbedClient })
-      ).be.rejectedWith(/test error/)
     })
   })
 


### PR DESCRIPTION
When a directory is re-included in a Desktop client's synchronization,
we need to manually fetch its content.

We used to do so sub-directory by sub-directory but this would require
a lot of fetch requests from the client on a large Cozy and could lead
to client crashes.
We then tried to fetch them layer by layer using a more complex Mango
query. Unfortunately, these requests could not make use of CouchDB
indexes and would be so slow on a large Cozy that we would never get a
response before the request would time out.

We're now trying a different approach. We'll fetch these
sub-directories one by one but we won't fetch all of them before
processing them. Instead, we'll merge a directory's direct content
before fetching the next sibling.
Sub-directories fetched in this process will be marked as needing a
content fetch so we can resume from where we stopped in case the
client is stopped.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
