### PR TITLE
ci: Fix Github Actions cache generation

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -51,7 +51,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:
@@ -103,7 +103,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:
@@ -151,7 +151,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:
@@ -197,7 +197,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -56,7 +56,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:
@@ -109,7 +109,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:
@@ -163,7 +163,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:
@@ -219,7 +219,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v2-beta
         with:


### PR DESCRIPTION
To generate the key that will determine if a new cache entry should be
generated or if an existing cache entry can be loaded, we would use
the Github Actions `hashFiles` helper on the directory containing
`yarn.lock`, thus on our entire code base plus the generated test
directories.

While this seemed to work, `hashFiles` was actually silently failing
to parse a directory generated during tests.
Github decided to throw an error instead and thus our builds started
to fail (i.e. only the cache generation failed).

Since this cache is meant for our Node and Electron dependencies, we
can generate the key by hashing only `yarn.lock` and thus fix this
issue.
