### PR TITLE
core/remote: Fetch file changes with path

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -54,7 +54,13 @@ const { SIDE_NAMES, otherSide } = require('./side')
 
 /*::
 import type { PlatformIncompatibility } from './incompatibilities/platform'
-import type { RemoteBase, RemoteFile, RemoteDir, RemoteDeletion } from './remote/document'
+import type {
+  CouchDBDeletion,
+  CouchDBDoc,
+  RemoteBase,
+  RemoteDir,
+  RemoteFile,
+} from './remote/document'
 import type { Stats } from './local/stater'
 import type { Ignore } from './ignore'
 import type { SideName } from './side'
@@ -229,7 +235,9 @@ function localDocType(remoteDocType /*: string */) /*: string */ {
 // Transform a remote document into metadata, as stored in Pouch.
 // Please note the path is not normalized yet!
 // Normalization is done as a side effect of metadata.invalidPath() :/
-function fromRemoteDoc(remoteDoc /*: MetadataRemoteInfo */) /*: Metadata */ {
+function fromRemoteDoc(
+  remoteDoc /*: CouchDBDoc|MetadataRemoteInfo */
+) /*: Metadata */ {
   const doc =
     remoteDoc.type === REMOTE_FILE_TYPE
       ? fromRemoteFile(remoteDoc)

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -5,7 +5,7 @@
  */
 
 /*::
-import type { RemoteDoc, RemoteDeletion } from './document'
+import type { RemoteDoc, CouchDBDeletion } from './document'
 import type { Metadata, SavedMetadata } from '../metadata'
 */
 

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -30,7 +30,7 @@ import type {
   RemoteRevisionsByID
 } from '../../metadata'
 import type { RemoteChange, RemoteFileMove, RemoteDirMove, RemoteDescendantChange } from '../change'
-import type { RemoteDeletion } from '../document'
+import type { CouchDBDeletion, CouchDBDoc } from '../document'
 import type { RemoteError } from '../errors'
 
 export type RemoteWatcherOptions = {
@@ -49,7 +49,7 @@ const log = logger({
 const sideName = 'remote'
 
 const folderMightHaveBeenExcluded = (
-  remoteDir /*: MetadataRemoteDir */
+  remoteDir /*: CouchDBDoc */
 ) /*: boolean %checks */ => {
   // A folder newly created has a rev number of 1.
   // Once exluded, its rev number is at least 2.
@@ -58,11 +58,10 @@ const folderMightHaveBeenExcluded = (
 }
 
 const needsContentFetching = (
-  remoteDoc /*: MetadataRemoteInfo|RemoteDeletion */,
+  remoteDoc /*: CouchDBDoc */,
   { isRecursiveFetch = false } /*: { isRecursiveFetch: boolean } */ = {}
 ) /*: boolean %checks */ => {
   return (
-    !remoteDoc._deleted &&
     remoteDoc.type === 'directory' &&
     (folderMightHaveBeenExcluded(remoteDoc) || isRecursiveFetch)
   )
@@ -231,7 +230,7 @@ class RemoteWatcher {
   }
 
   async olds(
-    remoteDocs /*: $ReadOnlyArray<MetadataRemoteInfo|RemoteDeletion> */
+    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */
   ) /*: Promise<SavedMetadata[]> */ {
     const remoteIds = remoteDocs.reduce(
       (ids, doc) => ids.add(doc._id),
@@ -243,7 +242,7 @@ class RemoteWatcher {
   /** Process multiple changed or deleted docs
    */
   async processRemoteChanges(
-    docs /*: $ReadOnlyArray<MetadataRemoteInfo|RemoteDeletion> */,
+    docs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */,
     {
       isInitialFetch = false,
       isRecursiveFetch = false
@@ -262,7 +261,7 @@ class RemoteWatcher {
   }
 
   async analyse(
-    remoteDocs /*: $ReadOnlyArray<MetadataRemoteInfo|RemoteDeletion> */,
+    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */,
     olds /*: SavedMetadata[] */,
     {
       isInitialFetch = false,
@@ -292,7 +291,7 @@ class RemoteWatcher {
   }
 
   identifyAll(
-    remoteDocs /*: $ReadOnlyArray<MetadataRemoteInfo|RemoteDeletion> */,
+    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */,
     olds /*: SavedMetadata[] */,
     {
       isInitialFetch = false,
@@ -317,7 +316,7 @@ class RemoteWatcher {
   }
 
   identifyChange(
-    remoteDoc /*: MetadataRemoteInfo|RemoteDeletion */,
+    remoteDoc /*: CouchDBDoc|CouchDBDeletion */,
     was /*: ?SavedMetadata */,
     previousChanges /*: Array<RemoteChange> */,
     originalMoves /*: Array<RemoteDirMove|RemoteDescendantChange> */,
@@ -390,7 +389,7 @@ class RemoteWatcher {
    * the trash just after, it looks like it appeared directly on the trash.
    */
   identifyExistingDocChange(
-    remoteDoc /*: MetadataRemoteInfo */,
+    remoteDoc /*: CouchDBDoc */,
     was /*: ?SavedMetadata */,
     previousChanges /*: Array<RemoteChange> */,
     originalMoves /*: Array<RemoteDirMove|RemoteDescendantChange> */,

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -11,6 +11,7 @@ const _ = require('lodash')
 
 const { IncompatibleDocError } = require('../incompatibilities/platform')
 const metadata = require('../metadata')
+const remoteDocument = require('../remote/document')
 const remoteErrors = require('../remote/errors')
 const { otherSide } = require('../side')
 const logger = require('../utils/logger')
@@ -463,7 +464,7 @@ class Sync {
             delete change.doc.overwrite
 
             // Go ahead and mark remote document as trashed
-            change.doc.remote.trashed = true
+            change.doc.remote = remoteDocument.trashedDoc(change.doc.remote)
 
             await this.updateRevs(change.doc, sideName)
             break

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -67,7 +67,6 @@ module.exports = class RemoteBaseBuilder /*:: <T: MetadataRemoteInfo> */ {
   }
 
   trashed() /*: this */ {
-    this.remoteDoc.trashed = true
     this.remoteDoc.restore_path = posix.dirname(this.remoteDoc.path)
     return this.inDir({
       _id: TRASH_DIR_ID,
@@ -76,7 +75,6 @@ module.exports = class RemoteBaseBuilder /*:: <T: MetadataRemoteInfo> */ {
   }
 
   restored() /*: this */ {
-    if (this.remoteDoc.trashed) delete this.remoteDoc.trashed
     if (this.remoteDoc.restore_path) delete this.remoteDoc.restore_path
     return this.inRootDir()
   }

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -4,7 +4,10 @@ const _ = require('lodash')
 const CozyClient = require('cozy-client').default
 
 const RemoteBaseBuilder = require('./base')
-const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
+const {
+  inRemoteTrash,
+  remoteJsonToRemoteDoc
+} = require('../../../../core/remote/document')
 const {
   FILES_DOCTYPE,
   OAUTH_CLIENTS_DOCTYPE
@@ -97,7 +100,7 @@ module.exports = class RemoteDirBuilder extends (
   async update() /*: Promise<MetadataRemoteDir> */ {
     const cozy = this._ensureCozy()
 
-    const json = this.remoteDoc.trashed
+    const json = inRemoteTrash(this.remoteDoc)
       ? await cozy.files.trashById(this.remoteDoc._id, { dontRetry: true })
       : await cozy.files.updateAttributesById(this.remoteDoc._id, {
           dir_id: this.remoteDoc.dir_id,

--- a/test/support/builders/remote/erased.js
+++ b/test/support/builders/remote/erased.js
@@ -10,19 +10,19 @@ const dbBuilders = require('../db')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
-import type { RemoteFile, RemoteDir, RemoteDeletion } from '../../../../core/remote/document'
+import type { RemoteFile, RemoteDir, CouchDBDeletion } from '../../../../core/remote/document'
 import type { MetadataRemoteFile, MetadataRemoteDir } from '../../../../core/metadata'
 */
 
-// Build a RemoteDeletion representing a remote Cozy document that was
+// Build a CouchDBDeletion representing a remote Cozy document that was
 // completely deleted:
 //
-//     const doc: RemoteDeletion = builders.remoteErased().build()
+//     const doc: CouchDBDeletion = builders.remoteErased().build()
 //
 // To actually create and erased the corresponding document on the Cozy, use the
 // async #create() method instead:
 //
-//     const doc: RemoteDeletion = await builders.remoteErased().create()
+//     const doc: CouchDBDeletion = await builders.remoteErased().create()
 //
 module.exports = class RemoteErasedBuilder {
   /*::
@@ -51,7 +51,7 @@ module.exports = class RemoteErasedBuilder {
     }
   }
 
-  build() /*: RemoteDeletion */ {
+  build() /*: CouchDBDeletion */ {
     if (this.remoteDoc) {
       return {
         _id: this.remoteDoc._id,
@@ -67,7 +67,7 @@ module.exports = class RemoteErasedBuilder {
     }
   }
 
-  async create() /*: Promise<RemoteDeletion> */ {
+  async create() /*: Promise<CouchDBDeletion> */ {
     const cozy = this._ensureCozy()
 
     if (this.remoteDoc) {

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -8,7 +8,10 @@ const RemoteBaseBuilder = require('./base')
 const ChecksumBuilder = require('../checksum')
 const cozyHelpers = require('../../helpers/cozy')
 
-const { remoteJsonToRemoteDoc } = require('../../../../core/remote/document')
+const {
+  inRemoteTrash,
+  remoteJsonToRemoteDoc
+} = require('../../../../core/remote/document')
 const { FILES_DOCTYPE } = require('../../../../core/remote/constants')
 
 /*::
@@ -116,6 +119,16 @@ module.exports = class RemoteFileBuilder extends (
     return this
   }
 
+  trashed() /*: this */ {
+    this.remoteDoc.trashed = true
+    return super.trashed()
+  }
+
+  restored() /*: this */ {
+    this.remoteDoc.trashed = false
+    return super.restored()
+  }
+
   async create() /*: Promise<MetadataRemoteFile> */ {
     const cozy = this._ensureCozy()
 
@@ -156,7 +169,7 @@ module.exports = class RemoteFileBuilder extends (
 
     const parentDir = await cozy.files.statById(this.remoteDoc.dir_id)
 
-    const json = this.remoteDoc.trashed
+    const json = inRemoteTrash(this.remoteDoc)
       ? await cozy.files.trashById(this.remoteDoc._id, { dontRetry: true })
       : this._data
       ? await cozy.files.updateById(this.remoteDoc._id, this._data, {

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -74,7 +74,8 @@ describe('metadata', function () {
         updated_at: '2017-09-08T07:06:05Z',
         cozyMetadata: {
           createdOn: 'alice.mycozy.cloud'
-        }
+        },
+        trashed: false
       }
       const doc /*: Metadata */ = metadata.fromRemoteDoc(remoteDoc)
 

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -42,7 +42,7 @@ import type {
 } from '../../../core/remote/change'
 import type {
   RemoteDoc,
-  RemoteDeletion,
+  CouchDBDeletion,
   RemoteFile,
   RemoteDir
 } from '../../../core/remote/document'
@@ -580,7 +580,7 @@ describe('RemoteWatcher', function () {
 
       apply.callCount.should.equal(2)
       // Changes are sorted before applying (first one was given Metadata since
-      // it is valid while the second one got the original RemoteDeletion since
+      // it is valid while the second one got the original CouchDBDeletion since
       // it is ignored)
       should(apply.args[0][0].doc).deepEqual(validMetadata(remoteDocs[0]))
       should(apply.args[1][0].doc).deepEqual(remoteDocs[1])
@@ -677,7 +677,7 @@ describe('RemoteWatcher', function () {
     })
 
     it('tries to apply a deletion otherwise', async function () {
-      const remoteDeletion /*: RemoteDeletion */ = {
+      const remoteDeletion /*: CouchDBDeletion */ = {
         _id: 'missing',
         _rev: 'whatever',
         _deleted: true


### PR DESCRIPTION
Files don't have a `path` attribute in the remote CouchDB (only
directories do) but we still rely on this attribute in Desktop so we
rebuild it using their parent's path.

However, the dedicated files' changes feed now has an option to
populate this attribute before it is sent to the client.

This greatly simplifies our changes feed interaction code and types.
Also, this forces us to use the `cozy-client` changes feed method
since the one in `cozy-client-js` does not use the dedicated files
feed and thus cannot return file changes with a `path`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
