### PR TITLE
WIP: core/remote/watcher: Update revs of all child moves

### DIFF
--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -65,7 +65,7 @@ export type RemoteDirMove = {
   doc: Metadata,
   was: SavedMetadata,
   needRefetch?: true,
-  descendantMoves?: RemoteDescendantChange[]
+  descendantMoves: RemoteDescendantChange[]
 }
 export type RemoteDirRestoration = {
   sideName: 'remote',
@@ -109,8 +109,8 @@ export type RemoteDescendantChange = {
   type: 'DescendantChange',
   doc: Metadata,
   was: SavedMetadata,
-  ancestorPath: string,
-  descendantMoves?: RemoteDescendantChange[],
+  ancestor: RemoteDirMove|RemoteDescendantChange,
+  descendantMoves: RemoteDescendantChange[],
   update?: boolean
 }
 
@@ -320,9 +320,12 @@ function includeDescendant(
   parent /*: RemoteDirMove|RemoteDescendantChange */,
   e /*: RemoteDescendantChange */
 ) {
-  parent.descendantMoves = parent.descendantMoves || []
-  parent.descendantMoves.push(e, ...(e.descendantMoves || []))
-  delete e.descendantMoves
+  if (isDescendant(parent) && parent.ancestor) {
+    includeDescendant(parent.ancestor, e)
+  } else {
+    parent.descendantMoves.push(e, ...e.descendantMoves)
+  }
+  e.descendantMoves = []
 }
 
 const createdPath = (a /*: RemoteChange */) /*: ?string */ =>

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -530,9 +530,10 @@ class RemoteWatcher {
         case 'DescendantChange':
           log.debug(
             { path, remoteId: change.doc.remote._id },
-            `${_.get(change, 'doc.docType')} was moved as descendant of ${
-              change.ancestorPath
-            }`
+            `${_.get(change, 'doc.docType')} was moved as descendant of ${_.get(
+              change,
+              'ancestor.doc.path'
+            )}`
           )
           break
         case 'IgnoredChange':
@@ -600,8 +601,7 @@ class RemoteWatcher {
               change.was.childMove = false
             }
             const newRemoteRevs /*: RemoteRevisionsByID */ = {}
-            const descendants = change.descendantMoves || []
-            for (let descendant of descendants) {
+            for (const descendant of change.descendantMoves) {
               if (descendant.doc.remote) {
                 newRemoteRevs[descendant.doc.remote._id] =
                   descendant.doc.remote._rev
@@ -613,7 +613,7 @@ class RemoteWatcher {
               change.was,
               newRemoteRevs
             )
-            for (let descendant of descendants) {
+            for (const descendant of change.descendantMoves) {
               if (descendant.update) {
                 await this.prep.updateFileAsync(sideName, descendant.doc)
               }

--- a/core/remote/watcher/squashMoves.js
+++ b/core/remote/watcher/squashMoves.js
@@ -30,7 +30,8 @@ const buildChange = (sideName, doc, was) => {
       sideName,
       type: 'DirMove',
       doc,
-      was
+      was,
+      descendantMoves: []
     }
   }
 }
@@ -99,7 +100,11 @@ const buildDescendantChange = (
     type: 'DescendantChange',
     doc: _.clone(child.doc),
     was: _.clone(child.was),
-    ancestorPath: parent.doc.path
+    ancestor: parent,
+    descendantMoves:
+      child.type === 'DirMove' || child.type === 'DescendantChange'
+        ? child.descendantMoves
+        : []
   }
   if (child.type === 'FileMove') descendantChange.update = _.clone(child.update)
 
@@ -127,7 +132,8 @@ const buildMoveInsideMove = (
       type: 'DirMove',
       doc: _.clone(child.doc),
       was: correctedSrc,
-      needRefetch: true
+      needRefetch: true,
+      descendantMoves: child.descendantMoves
     }
   }
 }
@@ -214,7 +220,6 @@ const squashMoves = (
   const change = buildChange(sideName, doc, was)
   encounteredMoves.push(_.cloneDeep(change))
 
-  // TODO: ignore descendants
   for (const previousChange of previousChanges) {
     if (
       previousChange.type === 'FileTrashing' &&


### PR DESCRIPTION
  Sub-directories of sub-directories of moved directories wouldn't get
  their new remote revision saved in PouchDB thus triggering 412 errors
  on following local updates.

  Now descendant moves go up to the top-most directory move and their
  revisions are updated.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
