### PR TITLE
core/remote/watcher: Update revs of moved children

### DIFF
--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -65,7 +65,7 @@ export type RemoteDirMove = {
   doc: Metadata,
   was: SavedMetadata,
   needRefetch?: true,
-  descendantMoves?: RemoteDescendantChange[]
+  descendantMoves: RemoteDescendantChange[]
 }
 export type RemoteDirRestoration = {
   sideName: 'remote',
@@ -109,8 +109,8 @@ export type RemoteDescendantChange = {
   type: 'DescendantChange',
   doc: Metadata,
   was: SavedMetadata,
-  ancestorPath: string,
-  descendantMoves?: RemoteDescendantChange[],
+  ancestor: RemoteDirMove|RemoteDescendantChange,
+  descendantMoves: RemoteDescendantChange[],
   update?: boolean
 }
 
@@ -320,9 +320,12 @@ function includeDescendant(
   parent /*: RemoteDirMove|RemoteDescendantChange */,
   e /*: RemoteDescendantChange */
 ) {
-  parent.descendantMoves = parent.descendantMoves || []
-  parent.descendantMoves.push(e, ...(e.descendantMoves || []))
-  delete e.descendantMoves
+  if (isDescendant(parent) && parent.ancestor) {
+    includeDescendant(parent.ancestor, e)
+  } else {
+    parent.descendantMoves.push(e, ...e.descendantMoves)
+  }
+  e.descendantMoves = []
 }
 
 const createdPath = (a /*: RemoteChange */) /*: ?string */ =>

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -530,9 +530,10 @@ class RemoteWatcher {
         case 'DescendantChange':
           log.debug(
             { path, remoteId: change.doc.remote._id },
-            `${_.get(change, 'doc.docType')} was moved as descendant of ${
-              change.ancestorPath
-            }`
+            `${_.get(change, 'doc.docType')} was moved as descendant of ${_.get(
+              change,
+              'ancestor.doc.path'
+            )}`
           )
           break
         case 'IgnoredChange':
@@ -600,8 +601,7 @@ class RemoteWatcher {
               change.was.childMove = false
             }
             const newRemoteRevs /*: RemoteRevisionsByID */ = {}
-            const descendants = change.descendantMoves || []
-            for (let descendant of descendants) {
+            for (const descendant of change.descendantMoves) {
               if (descendant.doc.remote) {
                 newRemoteRevs[descendant.doc.remote._id] =
                   descendant.doc.remote._rev
@@ -613,7 +613,7 @@ class RemoteWatcher {
               change.was,
               newRemoteRevs
             )
-            for (let descendant of descendants) {
+            for (const descendant of change.descendantMoves) {
               if (descendant.update) {
                 await this.prep.updateFileAsync(sideName, descendant.doc)
               }

--- a/core/remote/watcher/squashMoves.js
+++ b/core/remote/watcher/squashMoves.js
@@ -30,7 +30,8 @@ const buildChange = (sideName, doc, was) => {
       sideName,
       type: 'DirMove',
       doc,
-      was
+      was,
+      descendantMoves: []
     }
   }
 }
@@ -98,7 +99,11 @@ const buildDescendantChange = (
     type: 'DescendantChange',
     doc: _.clone(child.doc),
     was: _.clone(child.was),
-    ancestorPath: parent.doc.path
+    ancestor: parent,
+    descendantMoves:
+      child.type === 'DirMove' || child.type === 'DescendantChange'
+        ? child.descendantMoves
+        : []
   }
   if (child.type === 'FileMove') descendantChange.update = _.clone(child.update)
 
@@ -126,7 +131,8 @@ const buildMoveInsideMove = (
       type: 'DirMove',
       doc: _.clone(child.doc),
       was: correctedSrc,
-      needRefetch: true
+      needRefetch: true,
+      descendantMoves: child.descendantMoves
     }
   }
 }
@@ -213,7 +219,6 @@ const squashMoves = (
   const change = buildChange(sideName, doc, was)
   encounteredMoves.push(_.cloneDeep(change))
 
-  // TODO: ignore descendants
   for (const previousChange of previousChanges) {
     if (
       previousChange.type === 'FileTrashing' &&

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -1551,36 +1551,43 @@ describe('RemoteWatcher', function () {
             old
           )
 
+        const movedSubsubdir = {
+          type: 'DescendantChange',
+          oldPath: path.normalize('src/parent/child'),
+          path: path.normalize('dst/parent/child'),
+          ancestorPath: path.normalize('dst/parent'),
+          descendantMoves: []
+        }
+        const movedSubdir = {
+          type: 'DescendantChange',
+          oldPath: path.normalize('src/parent'),
+          path: path.normalize('dst/parent'),
+          ancestorPath: 'dst',
+          descendantMoves: []
+        }
+        const movedDir = {
+          type: 'DirMove',
+          oldPath: 'src',
+          path: 'dst',
+          ancestorPath: undefined,
+          descendantMoves: [movedSubdir, movedSubsubdir]
+        }
+
+        const mapChange = change => ({
+          type: change.type,
+          oldPath: change.was.path,
+          path: change.doc.path,
+          ancestorPath: change.ancestor && change.ancestor.doc.path,
+          descendantMoves: change.descendantMoves.map(mapChange)
+        })
         const shouldBeExpected = result => {
           result.should.have.length(3)
           result
-            .map(x => ({
-              type: x.type,
-              oldPath: x.was.path,
-              path: x.doc.path,
-              ancestorPath: x.ancestorPath
-            }))
-            .sort((a, b) => a.path - b.path)
-            .should.deepEqual([
-              {
-                type: 'DirMove',
-                oldPath: 'src',
-                path: 'dst',
-                ancestorPath: undefined
-              },
-              {
-                type: 'DescendantChange',
-                oldPath: path.normalize('src/parent'),
-                path: path.normalize('dst/parent'),
-                ancestorPath: 'dst'
-              },
-              {
-                type: 'DescendantChange',
-                oldPath: path.normalize('src/parent/child'),
-                path: path.normalize('dst/parent/child'),
-                ancestorPath: path.normalize('dst/parent')
-              }
-            ])
+            .map(mapChange)
+            .sort(({ path: pathA }, { path: pathB }) => {
+              return pathA < pathB ? -1 : pathA > pathB ? 1 : 0
+            })
+            .should.deepEqual([movedDir, movedSubdir, movedSubsubdir])
         }
 
         shouldBeExpected(


### PR DESCRIPTION
Sub-directories of sub-directories of moved directories wouldn't get
their new remote revision saved in PouchDB thus triggering 412 errors
on following local updates.

Now descendant moves go up to the top-most directory move and the
revisions of all descendants are updated.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
