### PR TITLE
ci: Fix linux packages build

### DIFF
--- a/.github/actions/build-and-publish/action.yaml
+++ b/.github/actions/build-and-publish/action.yaml
@@ -33,6 +33,7 @@ runs:
           # Install build dependencies:
           # - `libopenjp2-tools` for the basic build
           # - the others for cross-compiling 32 bit apps on a 64 bit machine
+          sudo apt update
           sudo apt install --no-install-recommends -y libopenjp2-tools gcc-multilib g++-multilib
         fi
         yarn dist:all


### PR DESCRIPTION
We need to install extra linux packages to build our app on this
platform and unfortunately we were not updating the package list
before installing them.

This list has changed and the packages could not be installed anymore.
Simply updating the list before installing the packages fixes the
issue.
