### PR TITLE
Add file versions manipulation methods

### DIFF
--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -8,6 +8,7 @@
 export type FILE_TYPE = 'file'
 export type DIR_TYPE = 'directory'
 export type FILES_DOCTYPE = 'io.cozy.files'
+export type VERSIONS_DOCTYPE = 'io.cozy.files.versions'
 */
 
 const DEFAULT_HEARTBEAT = 1000 * 60 // 1 minute
@@ -17,6 +18,7 @@ module.exports = {
   // Doctypes
   FILES_DOCTYPE: 'io.cozy.files',
   OAUTH_CLIENTS_DOCTYPE: 'io.cozy.oauth.clients',
+  VERSIONS_DOCTYPE: 'io.cozy.files.versions',
 
   // Files document type
   DIR_TYPE: 'directory',

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -229,7 +229,8 @@ module.exports = {
   trashedDoc,
   withDefaultValues,
   remoteJsonToRemoteDoc,
-  jsonApiToRemoteJsonDoc
+  jsonApiToRemoteJsonDoc,
+  jsonFileVersionToRemoteFileVersion
 }
 
 function isFile(
@@ -265,25 +266,34 @@ function trashedDoc /*::<T: { type: FILE, trashed: boolean } | { type: DIR, path
 }
 
 // The following attributes can be omitted by cozy-stack if not defined
-function withDefaultValues /*:: <T: JsonApiDirAttributes|JsonApiFileAttributes> */(
+function withDefaultValues /*:: <T: JsonApiDirAttributes|JsonApiFileAttributes|JsonApiFileVersionAttributes> */(
   attributes /*: T */
 ) /*: T */ {
-  if (attributes.type === DIR_TYPE) {
-    return {
-      ...attributes,
-      dir_id: attributes.dir_id || '',
-      name: attributes.name || '',
-      path: attributes.path || '',
-      tags: attributes.tags || []
+  if (attributes.type) {
+    if (attributes.type === DIR_TYPE) {
+      return {
+        ...attributes,
+        dir_id: attributes.dir_id || '',
+        name: attributes.name || '',
+        path: attributes.path || '',
+        tags: attributes.tags || []
+      }
+    } else {
+      return {
+        ...attributes,
+        class: attributes.class || 'application',
+        dir_id: attributes.dir_id || '',
+        md5sum: attributes.md5sum || '',
+        mime: attributes.mime || 'application/octet-stream',
+        name: attributes.name || '',
+        tags: attributes.tags || []
+      }
     }
   } else {
     return {
       ...attributes,
-      class: attributes.class || 'application',
-      dir_id: attributes.dir_id || '',
       md5sum: attributes.md5sum || '',
-      mime: attributes.mime || 'application/octet-stream',
-      name: attributes.name || '',
+      size: attributes.size || '0',
       tags: attributes.tags || []
     }
   }
@@ -365,5 +375,19 @@ function jsonApiToRemoteJsonDoc(
           attributes,
           relationships
         } /*: RemoteJsonFile */)
+  }
+}
+
+function jsonFileVersionToRemoteFileVersion(
+  version /*: JsonApiFileVersion */
+) /*: RemoteFileVersion */ {
+  return {
+    _id: version._id,
+    _rev: version._rev,
+    _type: version._type,
+    cozyMetadata: version.cozyMetadata,
+    metadata: version.metadata,
+    relationships: version.relationships,
+    ...withDefaultValues(version.attributes)
   }
 }

--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -17,8 +17,15 @@ const {
 /*::
 import type {
   FILE_TYPE as FILE,
-  DIR_TYPE as DIR
+  DIR_TYPE as DIR,
+  VERSIONS_DOCTYPE,
 } from './constants'
+
+// ('contents') => Array<JsonApiRef>
+// ('file') => ?JsonApiRef
+// ('old_versions') => Array<JsonApiFileVersion>
+// ('referenced_by') => Array<JsonApiRef>
+export type RemoteRelations = any => any
 
 export type RemoteFileAttributes = {|
   type: FILE,
@@ -50,10 +57,25 @@ export type RemoteBase = {|
   cozyMetadata?: Object,
   metadata?: Object,
   restore_path?: string,
+  relations: RemoteRelations
 |}
 export type RemoteFile = {| ...RemoteBase, ...RemoteFileAttributes |}
+export type FullRemoteFile = {| ...RemoteFile, path: string |}
 export type RemoteDir = {| ...RemoteBase, ...RemoteDirAttributes |}
 export type RemoteDoc = RemoteFile|RemoteDir
+
+export type RemoteFileVersion = {|
+  _id: string,
+  _rev: string,
+  _type: VERSIONS_DOCTYPE,
+  cozyMetadata: Object,
+  md5sum: string,
+  metadata?: Object,
+  relationships: JsonApiRelationShips,
+  size: string,
+  tags: string[],
+  updated_at: string,
+|}
 
 export type CouchDBChange = {|
   id: string,
@@ -74,7 +96,15 @@ type CommonCouchDBAttributes = {|
   updated_at: string,
   tags: string[],
 |}
-export type CouchDBDoc = {|
+export type CouchDBDir = {|
+  ...CommonCouchDBAttributes,
+  type: DIR,
+  not_synchronized_on?: Array<{
+    id: string,
+    type: string
+  }>,
+|}
+export type CouchDBFile = {|
   ...CommonCouchDBAttributes,
   type: FILE,
   class: string,
@@ -83,14 +113,8 @@ export type CouchDBDoc = {|
   mime: string,
   size: string,
   trashed: boolean,
-|} | {|
-  ...CommonCouchDBAttributes,
-  type: DIR,
-  not_synchronized_on?: Array<{
-    id: string,
-    type: string
-  }>,
 |}
+export type CouchDBDoc = CouchDBDir | CouchDBFile
 export type CouchDBDeletion = {|
   _id: string,
   _rev: string,
@@ -134,12 +158,16 @@ export type RemoteJsonFile = {|
   _rev: string,
   _type: string,
   attributes: JsonApiFileAttributes,
+  relations?: RemoteRelations,
+  relationships: JsonApiRelationShips,
 |}
 export type RemoteJsonDir = {|
   _id: string,
   _rev: string,
   _type: string,
   attributes: JsonApiDirAttributes,
+  relations?: RemoteRelations,
+  relationships: JsonApiRelationShips,
 |}
 export type RemoteJsonDoc = RemoteJsonFile|RemoteJsonDir
 
@@ -148,6 +176,31 @@ type JsonApiRef = {
   id: string,
   type: string,
 }
+
+type JsonApiFileVersionAttributes = {|
+  md5sum: string,
+  size: string,
+  tags: string[],
+  updated_at: string,
+|}
+
+export type JsonApiFileVersion = {|
+  _id: string,
+  _rev: string,
+  _type: VERSIONS_DOCTYPE,
+  attributes: JsonApiFileVersionAttributes,
+  cozyMetadata: Object,
+  metadata?: Object,
+  relationships: JsonApiRelationShips,
+|}
+
+type JsonApiRelationShips = {|
+  contents?: { data?: JsonApiRef[] },
+  file?: { data: JsonApiRef },
+  old_versions?: { data?: JsonApiFileVersion[] },
+  referenced_by?: { data?: JsonApiRef | JsonApiRef[] },
+|}
+
 
 type JsonApiDeletion = {|
   id: string,
@@ -164,7 +217,7 @@ type JsonApiDoc =
     },
     links: Object,
     attributes: JsonApiFileAttributes|JsonApiDirAttributes,
-    relationships: { [string]: { data?: JsonApiRef | JsonApiRef[] } }
+    relationships: JsonApiRelationShips
   |}
   | JsonApiDeletion
 */
@@ -236,6 +289,27 @@ function withDefaultValues /*:: <T: JsonApiDirAttributes|JsonApiFileAttributes> 
   }
 }
 
+// It appears the `relations` attribute is not always added to remote documents
+// by `cozy-client-js` so we use a function always returning an empty array in
+// this case.
+// Also, when a remote file has never been modified, its `old_versions` relation
+// will return `undefined` instead of an empty Array so we'll default the
+// returned value to an empty Array instead.
+function withDefaultRelations /*::<T: ?RemoteRelations> */(
+  relations /*: T */
+) /*: { relations: RemoteRelations } */ {
+  if (relations != null) {
+    const originalRelations = relations
+    return {
+      relations: relation => originalRelations(relation) || []
+    }
+  } else {
+    return {
+      relations: () => []
+    }
+  }
+}
+
 function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
   json /*: T */
 ) /*: RemoteDoc */ {
@@ -244,7 +318,8 @@ function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
       type: DIR_TYPE,
       _id: json._id,
       _rev: json._rev,
-      ...withDefaultValues(json.attributes)
+      ...withDefaultValues(json.attributes),
+      ...withDefaultRelations(json.relations)
     } /*: RemoteDir */)
 
     return remoteDir
@@ -253,7 +328,8 @@ function remoteJsonToRemoteDoc /*:: <T: RemoteJsonDoc> */(
       type: FILE_TYPE,
       _id: json._id,
       _rev: json._rev,
-      ...withDefaultValues(json.attributes)
+      ...withDefaultValues(json.attributes),
+      ...withDefaultRelations(json.relations)
     } /*: RemoteFile */)
 
     return remoteFile
@@ -269,23 +345,25 @@ function jsonApiToRemoteJsonDoc(
       _rev: json.rev,
       _deleted: true
     } /*: CouchDBDeletion */)
-  }
-
-  if (!json.meta || !json.meta.rev) {
+  } else if (!json.meta || !json.meta.rev) {
     throw new Error('Missing meta.rev attribute in JsonAPI resource.')
-  }
+  } else {
+    const { attributes, id, type, relationships } = json
 
-  return json.attributes.type === DIR_TYPE
-    ? ({
-        _id: json.id,
-        _type: json.type,
-        _rev: json.meta && json.meta.rev,
-        attributes: json.attributes
-      } /*: RemoteJsonDir */)
-    : ({
-        _id: json.id,
-        _type: json.type,
-        _rev: json.meta && json.meta.rev,
-        attributes: json.attributes
-      } /*: RemoteJsonFile */)
+    return attributes.type === DIR_TYPE
+      ? ({
+          _id: id,
+          _type: type,
+          _rev: json.meta.rev,
+          attributes,
+          relationships
+        } /*: RemoteJsonDir */)
+      : ({
+          _id: id,
+          _type: type,
+          _rev: json.meta.rev,
+          attributes,
+          relationships
+        } /*: RemoteJsonFile */)
+  }
 }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -30,7 +30,7 @@ import type {
   RemoteRevisionsByID
 } from '../../metadata'
 import type { RemoteChange, RemoteFileMove, RemoteDirMove, RemoteDescendantChange } from '../change'
-import type { CouchDBDeletion, CouchDBDoc } from '../document'
+import type { CouchDBDeletion, CouchDBDoc, FullRemoteFile, RemoteDir } from '../document'
 import type { RemoteError } from '../errors'
 
 export type RemoteWatcherOptions = {
@@ -230,7 +230,7 @@ class RemoteWatcher {
   }
 
   async olds(
-    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */
+    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion|FullRemoteFile|RemoteDir> */
   ) /*: Promise<SavedMetadata[]> */ {
     const remoteIds = remoteDocs.reduce(
       (ids, doc) => ids.add(doc._id),
@@ -242,7 +242,7 @@ class RemoteWatcher {
   /** Process multiple changed or deleted docs
    */
   async processRemoteChanges(
-    docs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */,
+    docs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion|FullRemoteFile|RemoteDir> */,
     {
       isInitialFetch = false,
       isRecursiveFetch = false
@@ -261,7 +261,7 @@ class RemoteWatcher {
   }
 
   async analyse(
-    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */,
+    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion|FullRemoteFile|RemoteDir> */,
     olds /*: SavedMetadata[] */,
     {
       isInitialFetch = false,
@@ -291,7 +291,7 @@ class RemoteWatcher {
   }
 
   identifyAll(
-    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion> */,
+    remoteDocs /*: $ReadOnlyArray<CouchDBDoc|CouchDBDeletion|FullRemoteFile|RemoteDir> */,
     olds /*: SavedMetadata[] */,
     {
       isInitialFetch = false,
@@ -316,7 +316,7 @@ class RemoteWatcher {
   }
 
   identifyChange(
-    remoteDoc /*: CouchDBDoc|CouchDBDeletion */,
+    remoteDoc /*: CouchDBDoc|CouchDBDeletion|FullRemoteFile|RemoteDir */,
     was /*: ?SavedMetadata */,
     previousChanges /*: Array<RemoteChange> */,
     originalMoves /*: Array<RemoteDirMove|RemoteDescendantChange> */,
@@ -389,7 +389,7 @@ class RemoteWatcher {
    * the trash just after, it looks like it appeared directly on the trash.
    */
   identifyExistingDocChange(
-    remoteDoc /*: CouchDBDoc */,
+    remoteDoc /*: CouchDBDoc|FullRemoteFile|RemoteDir */,
     was /*: ?SavedMetadata */,
     previousChanges /*: Array<RemoteChange> */,
     originalMoves /*: Array<RemoteDirMove|RemoteDescendantChange> */,

--- a/core/utils/array.js
+++ b/core/utils/array.js
@@ -1,0 +1,38 @@
+/**
+ * @module core/utils/array
+ * @flow
+ */
+
+const _ = require('lodash')
+
+/*::
+type Direction = 'asc'|'desc'
+*/
+
+const sortBy = (
+  sortAttr /*: { [string]: Direction } */,
+  options /*: ?Object */ = {}
+) => {
+  return (a /*: Object */, b /*: Object */) /*: number */ => {
+    const [attr, direction] = Object.entries(sortAttr)[0]
+    const asc = direction === 'asc'
+
+    const attrA = _.get(a, attr)
+    const attrB = _.get(b, attr)
+
+    const order =
+      typeof attrA === 'string'
+        ? attrA.localeCompare(attrB, undefined, options)
+        : attrA - attrB
+
+    return asc ? order : -order
+  }
+}
+
+// Use `-` (minus) to sort versions by modification date from the most
+// recent to the least recent.
+//(a, b) => -a.updated_at.localeCompare(b.updated_at, { numeric: true })
+
+module.exports = {
+  sortBy
+}

--- a/core/utils/notes.js
+++ b/core/utils/notes.js
@@ -17,6 +17,7 @@ import { Config } from '../config'
 import { Pouch } from '../pouch'
 import { Remote } from '../remote'
 import type { Metadata, MetadataRemoteInfo } from '../metadata'
+import type { FullRemoteFile, RemoteDir } from '../remote/document'
 
 type CozyNoteErrorCode = 'CozyDocumentMissingError' | 'UnreachableError'
 */
@@ -84,7 +85,7 @@ const localDoc = async (
 const remoteDoc = async (
   localDoc /*: Metadata */,
   { config, remote } /*: { config: Config, remote: Remote } */
-) /*: Promise<MetadataRemoteInfo> */ => {
+) /*: Promise<FullRemoteFile|RemoteDir> */ => {
   try {
     return await remote.remoteCozy.find(localDoc.remote._id)
   } catch (err) {

--- a/dev/capture/remote.js
+++ b/dev/capture/remote.js
@@ -20,6 +20,8 @@ const Builders = require('../../test/support/builders')
 
 /*::
 import type { MetadataRemoteInfo } from '../../core/metadata'
+import type { FullRemoteFile, RemoteDir } from '../../core/remote/document'
+import type { RemoteTree } from '../../test/support/helpers/remote'
 */
 
 // eslint-disable-next-line no-console,no-unused-vars
@@ -38,8 +40,8 @@ const createInitialTree = async function (
   if (!scenario.init) return
 
   const builders = new Builders({ cozy, pouch })
-  const remoteDocs /*: { [string]: MetadataRemoteInfo } */ = {}
-  const remoteDocsToTrash /*: MetadataRemoteInfo[] */ = []
+  const remoteDocs /*: RemoteTree */ = {}
+  const remoteDocsToTrash /*: Array<FullRemoteFile|RemoteDir> */ = []
 
   debug('[init]')
   for (const initDoc of scenario.init) {

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -353,12 +353,11 @@ describe('Platform incompatibilities', () => {
   })
 
   it('move remote dir with incompatible metadata & remote content', async () => {
-    const remoteDocs /*: { [string]: MetadataRemoteInfo } */ =
-      await helpers.remote.createTree([
-        'dir/',
-        'dir/sub:dir/',
-        'dir/sub:dir/file'
-      ])
+    const remoteDocs = await helpers.remote.createTree([
+      'dir/',
+      'dir/sub:dir/',
+      'dir/sub:dir/file'
+    ])
     await helpers.pullAndSyncAll()
 
     // Simulate remote move

--- a/test/support/builders/index.js
+++ b/test/support/builders/index.js
@@ -25,11 +25,10 @@ import type { Cozy } from 'cozy-client-js'
 import type { Metadata, MetadataRemoteFile, MetadataRemoteDir } from '../../../core/metadata'
 import type { Pouch } from '../../../core/pouch'
 import type { Warning } from '../../../core/remote/cozy'
-import type { RemoteDoc, RemoteFile, RemoteDir } from '../../../core/remote/document'
+import type { FullRemoteFile, RemoteDir } from '../../../core/remote/document'
 import type { AtomEvent } from '../../../core/local/atom/event'
 import type { StatsBuilder } from './stats'
-
-export type RemoteTree = { [string]: MetadataRemoteFile|MetadataRemoteDir }
+import type { RemoteTree } from '../helpers/remote'
 */
 
 // Test data builders facade.
@@ -61,24 +60,20 @@ module.exports = class Builders {
     return new FileMetadataBuilder(this.pouch, old)
   }
 
-  remoteDir(old /*: ?RemoteDir|MetadataRemoteDir */) /*: RemoteDirBuilder */ {
+  remoteDir(old /*: ?RemoteDir */) /*: RemoteDirBuilder */ {
     return new RemoteDirBuilder(this.cozy, old)
   }
 
-  remoteFile(
-    old /*: ?RemoteFile|MetadataRemoteFile */
-  ) /*: RemoteFileBuilder */ {
+  remoteFile(old /*: ?FullRemoteFile */) /*: RemoteFileBuilder */ {
     return new RemoteFileBuilder(this.cozy, old)
   }
 
-  remoteNote(
-    old /*: ?RemoteFile|MetadataRemoteFile */
-  ) /*: RemoteNoteBuilder */ {
+  remoteNote(old /*: ?FullRemoteFile */) /*: RemoteNoteBuilder */ {
     return new RemoteNoteBuilder(this.cozy, old)
   }
 
   remoteErased(
-    old /*: ?RemoteFile|MetadataRemoteFile|RemoteDir|MetadataRemoteDir */
+    old /*: ?FullRemoteFile|RemoteDir */
   ) /*: RemoteErasedBuilder */ {
     return new RemoteErasedBuilder(this.cozy, old)
   }

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -16,16 +16,12 @@ const statsBuilder = require('../stats')
 import type fs from 'fs-extra'
 import type {
   Metadata,
-  MetadataRemoteInfo,
-  MetadataRemoteFile,
-  MetadataRemoteDir,
   MetadataSidesInfo,
   SavedMetadata,
 } from '../../../../core/metadata'
 import type { Pouch } from '../../../../core/pouch'
-import type { RemoteDoc } from '../../../../core/remote/document'
+import type { FullRemoteFile, RemoteDir } from '../../../../core/remote/document'
 import type { SideName } from '../../../../core/side'
-import type RemoteBaseBuilder from '../remote/base'
 */
 
 const SOME_MEANINGLESS_TIME_OFFSET = 2000 // 2 seconds
@@ -64,7 +60,7 @@ module.exports = class BaseMetadataBuilder {
     this.buildRemote = true
   }
 
-  fromRemote(remoteDoc /*: MetadataRemoteInfo */) /*: this */ {
+  fromRemote(remoteDoc /*: FullRemoteFile|RemoteDir */) /*: this */ {
     this.buildRemote = true
     this.doc = metadata.fromRemoteDoc(remoteDoc)
     this._consolidatePaths()
@@ -381,7 +377,7 @@ module.exports = class BaseMetadataBuilder {
       builder = builder.trashed()
     }
 
-    this.doc.remote = builder.build()
+    this.doc.remote = metadata.serializableRemote(builder.build())
     this.doc.remote.path = pathUtils.localToRemote(this.doc.path)
   }
 }

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -16,19 +16,18 @@ const dbBuilders = require('../db')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
-import type { RemoteDoc } from '../../../../core/remote/document'
-import type { MetadataRemoteInfo } from '../../../../core/metadata'
+import type { FullRemoteFile, RemoteDir, RemoteDoc } from '../../../../core/remote/document'
 
 type Ref = { _id: string, _type: string }
 */
 
-module.exports = class RemoteBaseBuilder /*:: <T: MetadataRemoteInfo> */ {
+module.exports = class RemoteBaseBuilder /*:: <T: FullRemoteFile|RemoteDir> */ {
   /*::
   cozy: ?Cozy
   remoteDoc: T & { referenced_by: Ref[] }
   */
 
-  constructor(cozy /*: ?Cozy */, old /*: ?(RemoteDoc|T) */) {
+  constructor(cozy /*: ?Cozy */, old /*: ?T */) {
     this.cozy = cozy
     if (old) {
       this.remoteDoc = _.cloneDeep(old)

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -16,25 +16,24 @@ const {
 /*::
 import type { Cozy } from 'cozy-client-js'
 import type { RemoteDir } from '../../../../core/remote/document'
-import type { MetadataRemoteDir } from '../../../../core/metadata'
 */
 
 // Used to generate readable unique dirnames
 var dirNumber = 1
 
-// Build a MetadataRemoteDir representing a remote Cozy directory:
+// Build a RemoteDir representing a remote Cozy directory:
 //
-//     const dir: MetadataRemoteDir = builders.remoteDir().inDir(...).build()
+//     const dir: RemoteDir = builders.remoteDir().inDir(...).build()
 //
 // To actually create the corresponding directory on the Cozy, use the async
 // #create() method instead:
 //
-//     const dir: MetadataRemoteDir = await builders.remoteDir().inDir(...).create()
+//     const dir: RemoteDir = await builders.remoteDir().inDir(...).create()
 //
 module.exports = class RemoteDirBuilder extends (
   RemoteBaseBuilder
-) /*:: <MetadataRemoteDir> */ {
-  constructor(cozy /*: ?Cozy */, old /*: ?(RemoteDir|MetadataRemoteDir) */) {
+) /*:: <RemoteDir> */ {
+  constructor(cozy /*: ?Cozy */, old /*: ?RemoteDir */) {
     super(cozy, old)
 
     if (!old) {
@@ -67,7 +66,7 @@ module.exports = class RemoteDirBuilder extends (
     })(cozy)
   }
 
-  async create() /*: Promise<MetadataRemoteDir> */ {
+  async create() /*: Promise<RemoteDir> */ {
     const cozy = this._ensureCozy()
 
     const json = await cozy.files.createDirectory({
@@ -97,7 +96,7 @@ module.exports = class RemoteDirBuilder extends (
     return _.clone(remoteJsonToRemoteDoc(json))
   }
 
-  async update() /*: Promise<MetadataRemoteDir> */ {
+  async update() /*: Promise<RemoteDir> */ {
     const cozy = this._ensureCozy()
 
     const json = inRemoteTrash(this.remoteDoc)

--- a/test/support/builders/remote/erased.js
+++ b/test/support/builders/remote/erased.js
@@ -10,8 +10,7 @@ const dbBuilders = require('../db')
 
 /*::
 import type { Cozy } from 'cozy-client-js'
-import type { RemoteFile, RemoteDir, CouchDBDeletion } from '../../../../core/remote/document'
-import type { MetadataRemoteFile, MetadataRemoteDir } from '../../../../core/metadata'
+import type { FullRemoteFile, RemoteDir, CouchDBDeletion } from '../../../../core/remote/document'
 */
 
 // Build a CouchDBDeletion representing a remote Cozy document that was
@@ -27,13 +26,10 @@ import type { MetadataRemoteFile, MetadataRemoteDir } from '../../../../core/met
 module.exports = class RemoteErasedBuilder {
   /*::
   cozy: ?Cozy
-  remoteDoc: ?RemoteFile|MetadataRemoteFile|RemoteDir|MetadataRemoteDir
+  remoteDoc: ?(FullRemoteFile|RemoteDir)
   */
 
-  constructor(
-    cozy /*: ?Cozy */,
-    old /*: ?(RemoteFile|MetadataRemoteFile|RemoteDir|MetadataRemoteDir) */
-  ) {
+  constructor(cozy /*: ?Cozy */, old /*: ?(FullRemoteFile|RemoteDir) */) {
     this.cozy = cozy
     if (old) {
       this.remoteDoc = {

--- a/test/support/builders/remote/file.js
+++ b/test/support/builders/remote/file.js
@@ -17,8 +17,7 @@ const { FILES_DOCTYPE } = require('../../../../core/remote/constants')
 /*::
 import type stream from 'stream'
 import type { Cozy } from 'cozy-client-js'
-import type { RemoteFile } from '../../../../core/remote/document'
-import type { MetadataRemoteFile } from '../../../../core/metadata'
+import type { FullRemoteFile, RemoteFile } from '../../../../core/remote/document'
 */
 
 // Used to generate readable unique filenames
@@ -41,23 +40,23 @@ const addReferencedBy = async (
 
 const baseData = `Content of remote file ${fileNumber}`
 
-// Build a MetadataRemoteFile representing a remote Cozy file:
+// Build a FullRemoteFile representing a remote Cozy file:
 //
-//     const file /*: MetadataRemoteFile */ = builders.remoteFile().inDir(...).build()
+//     const file /*: FullRemoteFile */ = builders.remoteFile().inDir(...).build()
 //
 // To actually create the corresponding file on the Cozy, use the async
 // #create() method instead:
 //
-//     const file /*: MetadataRemoteFile */ = await builders.remoteFile().inDir(...).create()
+//     const file /*: FullRemoteFile */ = await builders.remoteFile().inDir(...).create()
 //
 module.exports = class RemoteFileBuilder extends (
   RemoteBaseBuilder
-) /*:: <MetadataRemoteFile> */ {
+) /*:: <FullRemoteFile> */ {
   /*::
   _data: string | stream.Readable | Buffer
   */
 
-  constructor(cozy /*: ?Cozy */, old /*: ?(RemoteFile|MetadataRemoteFile) */) {
+  constructor(cozy /*: ?Cozy */, old /*: ?FullRemoteFile */) {
     super(cozy, old)
 
     if (!old) {
@@ -129,7 +128,7 @@ module.exports = class RemoteFileBuilder extends (
     return super.restored()
   }
 
-  async create() /*: Promise<MetadataRemoteFile> */ {
+  async create() /*: Promise<FullRemoteFile> */ {
     const cozy = this._ensureCozy()
 
     const remoteFile /*: RemoteFile */ = _.clone(
@@ -156,7 +155,7 @@ module.exports = class RemoteFileBuilder extends (
     }
 
     const parentDir = await cozy.files.statById(remoteFile.dir_id)
-    const doc /*: MetadataRemoteFile */ = {
+    const doc /*: FullRemoteFile */ = {
       ...remoteFile,
       path: posix.join(parentDir.attributes.path, remoteFile.name)
     }
@@ -164,7 +163,7 @@ module.exports = class RemoteFileBuilder extends (
     return doc
   }
 
-  async update() /*: Promise<MetadataRemoteFile> */ {
+  async update() /*: Promise<FullRemoteFile> */ {
     const cozy = this._ensureCozy()
 
     const parentDir = await cozy.files.statById(this.remoteDoc.dir_id)
@@ -188,7 +187,7 @@ module.exports = class RemoteFileBuilder extends (
           noSanitize: true
         })
     const remoteFile /*: RemoteFile */ = _.clone(remoteJsonToRemoteDoc(json))
-    const doc /*: MetadataRemoteFile */ = {
+    const doc /*: FullRemoteFile */ = {
       ...remoteFile,
       path: posix.join(parentDir.attributes.path, this.remoteDoc.name)
     }

--- a/test/support/builders/remote/note.js
+++ b/test/support/builders/remote/note.js
@@ -16,8 +16,7 @@ const {
 /*::
 import type stream from 'stream'
 import type { Cozy } from 'cozy-client'
-import type { RemoteFile } from '../../../../core/remote/document'
-import type { MetadataRemoteFile } from '../../../../core/metadata'
+import type { FullRemoteFile, RemoteFile } from '../../../../core/remote/document'
 */
 
 // Used to generate readable unique filenames
@@ -30,25 +29,25 @@ const baseMetadata = {
   version: 1
 }
 
-// Build a MetadataRemoteFile representing a remote Cozy Note:
+// Build a FullRemoteFile representing a remote Cozy Note:
 //
-//     const note /*: MetadataRemoteFile */ = builders.remoteNote().inDir(...).build()
+//     const note /*: FullRemoteFile */ = builders.remoteNote().inDir(...).build()
 //
 // To actually create the corresponding note on the Cozy, use the async
 // #create() method instead:
 //
-//     const note /*: MetadataRemoteFile */ = await builders.remoteNote().inDir(...).create()
+//     const note /*: FullRemoteFile */ = await builders.remoteNote().inDir(...).create()
 //
 module.exports = class RemoteNoteBuilder extends (
   RemoteBaseBuilder
-) /*:: <MetadataRemoteFile> */ {
+) /*:: <FullRemoteFile> */ {
   /*::
   _title: string
   _content: string
   _data: string
   */
 
-  constructor(cozy /*: Cozy */, old /*: ?(RemoteFile|MetadataRemoteFile) */) {
+  constructor(cozy /*: Cozy */, old /*: ?FullRemoteFile */) {
     super(cozy, old)
 
     if (!old) {
@@ -115,7 +114,7 @@ module.exports = class RemoteNoteBuilder extends (
     return super.build()
   }
 
-  async create() /*: Promise<MetadataRemoteFile> */ {
+  async create() /*: Promise<FullRemoteFile> */ {
     this._updateMetadata()
     this._updateExport()
 
@@ -136,7 +135,7 @@ module.exports = class RemoteNoteBuilder extends (
     remoteFile._rev = data.meta.rev
 
     const { data: parentDir } = await files.statById(remoteFile.dir_id)
-    const doc /*: MetadataRemoteFile */ = {
+    const doc /*: FullRemoteFile */ = {
       ...remoteFile,
       path: posix.join(parentDir.attributes.path, remoteFile.name)
     }
@@ -144,7 +143,7 @@ module.exports = class RemoteNoteBuilder extends (
     return doc
   }
 
-  async update() /*: Promise<MetadataRemoteFile> */ {
+  async update() /*: Promise<FullRemoteFile> */ {
     this._updateMetadata()
     this._updateExport()
 
@@ -165,7 +164,7 @@ module.exports = class RemoteNoteBuilder extends (
     )
 
     const parentDir = await cozy.files.statById(remoteFile.dir_id)
-    const doc /*: MetadataRemoteFile */ = {
+    const doc /*: FullRemoteFile */ = {
       ...remoteFile,
       path: posix.join(parentDir.attributes.path, remoteFile.name)
     }

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -853,7 +853,12 @@ describe('metadata', function () {
 
       const remote = builders.remoteFile().build()
       should(
-        buildFile('chat-mignon.jpg', stats, md5sum, remote).remote
+        buildFile(
+          'chat-mignon.jpg',
+          stats,
+          md5sum,
+          metadata.serializableRemote(remote)
+        ).remote
       ).deepEqual(remote)
     })
 
@@ -877,7 +882,12 @@ describe('metadata', function () {
 
       const remote = builders.remoteFile().build()
       should(
-        buildFile('chat-mignon.jpg', stats, md5sum, remote).remote
+        buildFile(
+          'chat-mignon.jpg',
+          stats,
+          md5sum,
+          metadata.serializableRemote(remote)
+        ).remote
       ).deepEqual(remote)
     })
 
@@ -907,7 +917,9 @@ describe('metadata', function () {
       should(doc).have.property('updated_at')
 
       const remote = builders.remoteDir().build()
-      should(buildDir('fixtures', stats, remote).remote).deepEqual(remote)
+      should(
+        buildDir('fixtures', stats, metadata.serializableRemote(remote)).remote
+      ).deepEqual(remote)
     })
 
     it('sets #updated_at with mtime', () => {
@@ -934,7 +946,7 @@ describe('metadata', function () {
       const doc = buildDir(
         path,
         builders.stats().ctime(ctime).mtime(ctime).ino(123).build(),
-        remote
+        metadata.serializableRemote(remote)
       )
       should(doc.remote).deepEqual(remote)
     })

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -1293,6 +1293,51 @@ describe('remote.Remote', function () {
       })
     })
   })
+
+  describe('fileContentWasVersioned', () => {
+    it('returns false if the given remote file has no old versions', async function () {
+      const file = await builders.remoteFile().data('original').create()
+      const { md5sum, size } = file
+
+      await should(
+        this.remote.fileContentWasVersioned(
+          { md5sum, size: Number(size) },
+          file
+        )
+      ).be.fulfilledWith(false)
+    })
+
+    it('returns true if the given remote file has an old version with the given content', async function () {
+      const original = await builders.remoteFile().data('original').create()
+      const modified = await builders
+        .remoteFile(original)
+        .data('modified')
+        .update()
+      const { md5sum, size } = original
+
+      await should(
+        this.remote.fileContentWasVersioned(
+          { md5sum, size: Number(size) },
+          modified
+        )
+      ).be.fulfilledWith(true)
+    })
+
+    it('returns false if the given remote file has no old versions with the given content', async function () {
+      const original = await builders.remoteFile().data('original').create()
+      const modified = await builders
+        .remoteFile(original)
+        .data('modified')
+        .update()
+
+      await should(
+        this.remote.fileContentWasVersioned(
+          { md5sum: builders.checksum('anything').build(), size: 8 },
+          modified
+        )
+      ).be.fulfilledWith(false)
+    })
+  })
 })
 
 describe('remote', function () {

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -1191,7 +1191,7 @@ describe('remote.Remote', function () {
 
     it('returns the directory metadata saved in PouchDB', async function () {
       await should(this.remote.findDirectoryByPath('dir')).be.fulfilledWith(
-        dir.remote
+        metadata.serializableRemote(dir.remote)
       )
       should(dir.remote).have.properties({
         _id: oldRemoteDir._id,

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -43,7 +43,7 @@ import type {
 import type {
   RemoteDoc,
   CouchDBDeletion,
-  RemoteFile,
+  FullRemoteFile,
   RemoteDir
 } from '../../../core/remote/document'
 import type {
@@ -52,7 +52,7 @@ import type {
   MetadataRemoteFile,
   MetadataRemoteDir
 } from '../../../core/metadata'
-import type { RemoteTree } from '../../support/builders'
+import type { RemoteTree } from '../../support/helpers/remote'
 */
 
 const saveTree = async (remoteTree, builders) => {
@@ -546,7 +546,7 @@ describe('RemoteWatcher', function () {
   })
 
   const validMetadata = (
-    remoteDoc /*: MetadataRemoteInfo */
+    remoteDoc /*: FullRemoteFile|RemoteDir */
   ) /*: Metadata */ => {
     const doc = metadata.fromRemoteDoc(remoteDoc)
     ensureValidPath(doc)
@@ -2120,13 +2120,15 @@ describe('RemoteWatcher', function () {
         []
       )
 
+      const serializable = metadata.serializableRemote(remoteDoc)
+
       should(change.type).equal('FileAddition')
       should(change.doc).have.properties({
         path: path.join('my-folder', 'file-5'),
         docType: 'file',
-        md5sum: remoteDoc.md5sum,
-        tags: remoteDoc.tags,
-        remote: remoteDoc
+        md5sum: serializable.md5sum,
+        tags: serializable.tags,
+        remote: serializable
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
     })
@@ -2148,16 +2150,18 @@ describe('RemoteWatcher', function () {
         []
       )
 
+      const serializable = metadata.serializableRemote(remoteDoc)
+
       should(change.type).equal('FileUpdate')
       should(change.doc).have.properties({
         path: path.join('my-folder', 'file-1'),
         docType: 'file',
-        md5sum: remoteDoc.md5sum,
-        tags: remoteDoc.tags,
+        md5sum: serializable.md5sum,
+        tags: serializable.tags,
         remote: {
-          ...remoteDoc,
-          created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
-          updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
+          ...serializable,
+          created_at: timestamp.roundedRemoteDate(serializable.created_at),
+          updated_at: timestamp.roundedRemoteDate(serializable.updated_at)
         }
       })
     })
@@ -2179,16 +2183,18 @@ describe('RemoteWatcher', function () {
         []
       )
 
+      const serializable = metadata.serializableRemote(remoteDoc)
+
       should(change.type).equal('FileUpdate')
       should(change.doc).have.properties({
         path: path.join('my-folder', 'file-1'),
         docType: 'file',
-        md5sum: remoteDoc.md5sum,
-        tags: remoteDoc.tags,
+        md5sum: serializable.md5sum,
+        tags: serializable.tags,
         remote: {
-          ...remoteDoc,
-          created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
-          updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
+          ...serializable,
+          created_at: timestamp.roundedRemoteDate(serializable.created_at),
+          updated_at: timestamp.roundedRemoteDate(serializable.updated_at)
         }
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
@@ -2211,17 +2217,19 @@ describe('RemoteWatcher', function () {
         []
       )
 
+      const serializable = metadata.serializableRemote(remoteDoc)
+
       should(change).have.property('update', false)
       should(change.type).equal('FileMove')
       should(change.doc).have.properties({
         path: path.join('my-folder', 'file-2-bis'),
         docType: 'file',
-        md5sum: remoteDoc.md5sum,
-        tags: remoteDoc.tags,
+        md5sum: serializable.md5sum,
+        tags: serializable.tags,
         remote: {
-          ...remoteDoc,
-          created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
-          updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
+          ...serializable,
+          created_at: timestamp.roundedRemoteDate(serializable.created_at),
+          updated_at: timestamp.roundedRemoteDate(serializable.updated_at)
         }
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])
@@ -2246,17 +2254,19 @@ describe('RemoteWatcher', function () {
         []
       )
 
+      const serializable = metadata.serializableRemote(remoteDoc)
+
       should(change).have.property('update', false)
       should(change.type).equal('FileMove')
       should(change.doc).have.properties({
         path: path.join('other-folder', 'file-2-ter'),
         docType: 'file',
-        md5sum: remoteDoc.md5sum,
-        tags: remoteDoc.tags,
+        md5sum: serializable.md5sum,
+        tags: serializable.tags,
         remote: {
-          ...remoteDoc,
-          created_at: timestamp.roundedRemoteDate(remoteDoc.created_at),
-          updated_at: timestamp.roundedRemoteDate(remoteDoc.updated_at)
+          ...serializable,
+          created_at: timestamp.roundedRemoteDate(serializable.created_at),
+          updated_at: timestamp.roundedRemoteDate(serializable.updated_at)
         }
       })
       should(change.doc).not.have.properties(['_rev', 'path', 'name'])

--- a/test/unit/utils/array.js
+++ b/test/unit/utils/array.js
@@ -1,0 +1,95 @@
+/* @flow */
+/* eslint-env mocha */
+
+const should = require('should')
+
+const { sortBy } = require('../../../core/utils/array')
+
+describe('utils/array', () => {
+  describe('sortBy', () => {
+    it('sorts elements in ascending order based on the given attribute', () => {
+      const elems = [
+        { id: 1, path: 'dir/subdir' },
+        { id: 2, path: 'other-dir' },
+        { id: 3, path: 'dir/subdir/file' },
+        { id: 4, path: 'dir' }
+      ]
+
+      elems.sort(sortBy({ path: 'asc' }))
+
+      should(elems.map(e => e.path)).deepEqual([
+        'dir',
+        'dir/subdir',
+        'dir/subdir/file',
+        'other-dir'
+      ])
+    })
+
+    it('sorts elements in descending order based on the given attribute', () => {
+      const elems = [
+        { id: 1, path: 'dir/subdir' },
+        { id: 2, path: 'other-dir' },
+        { id: 3, path: 'dir/subdir/file' },
+        { id: 4, path: 'dir' }
+      ]
+
+      elems.sort(sortBy({ path: 'desc' }))
+
+      should(elems.map(e => e.path)).deepEqual([
+        'other-dir',
+        'dir/subdir/file',
+        'dir/subdir',
+        'dir'
+      ])
+    })
+
+    it('sorts elements based on a deep attribute', () => {
+      const elems = [
+        { id: 1, attributes: { path: 'dir/subdir' } },
+        { id: 2, attributes: { path: 'other-dir' } },
+        { id: 3, attributes: { path: 'dir/subdir/file' } },
+        { id: 4, attributes: { path: 'dir' } }
+      ]
+
+      elems.sort(sortBy({ 'attributes.path': 'asc' }))
+
+      should(elems.map(e => e.attributes.path)).deepEqual([
+        'dir',
+        'dir/subdir',
+        'dir/subdir/file',
+        'other-dir'
+      ])
+    })
+
+    it('sorts elements based on non-string values', () => {
+      const elems = [
+        { id: 4, path: 'dir' },
+        { id: 1, path: 'dir/subdir' },
+        { id: 3, path: 'dir/subdir/file' },
+        { id: 2, path: 'other-dir' }
+      ]
+
+      elems.sort(sortBy({ id: 'asc' }))
+
+      should(elems.map(e => e.id)).deepEqual([1, 2, 3, 4])
+    })
+
+    it('sorts strings based on their included numbers if the numeric option is passed', () => {
+      const elems = [
+        { id: 1, path: 'dir/file 10' },
+        { id: 2, path: 'dir/annotation' },
+        { id: 3, path: 'dir/file 9' },
+        { id: 4, path: 'dir' }
+      ]
+
+      elems.sort(sortBy({ path: 'desc' }, { numeric: true }))
+
+      should(elems.map(e => e.path)).deepEqual([
+        'dir/file 10',
+        'dir/file 9',
+        'dir/annotation',
+        'dir'
+      ])
+    })
+  })
+})


### PR DESCRIPTION
We want to use old file versions stored in the remote Cozy to avoid as
many conflicts as possible and even "fix" existing ones. To do so,
whenever a situation would trigger the creation of a conflict we'll
fetch the conflict remote file's previous versions from the remote
Cozy and, if the local content can be found in one of them, we'll
write the remote content on the local filesystem instead of creating a
conflict.

This PR creates the few methods that we'll need to run these checks.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
