### PR TITLE
Update remote revision of directories affected by move bug

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -20,7 +20,7 @@ require('./globals')
 const pkg = require('../package.json')
 const config = require('./config')
 const { Pouch } = require('./pouch')
-const { migrations } = require('./pouch/migrations')
+const { migrations, runMigrations } = require('./migrations')
 const Ignore = require('./ignore')
 const { Merge } = require('./merge')
 const Prep = require('./prep')
@@ -393,7 +393,7 @@ class App {
     this.instanciate()
 
     await this.pouch.addAllViews()
-    await this.pouch.runMigrations(migrations)
+    await runMigrations(migrations, this.pouch)
 
     if (wasUpdated && this.remote) {
       try {

--- a/core/app.js
+++ b/core/app.js
@@ -393,7 +393,7 @@ class App {
     this.instanciate()
 
     await this.pouch.addAllViews()
-    await runMigrations(migrations, this.pouch)
+    await runMigrations(migrations, this)
 
     if (wasUpdated && this.remote) {
       try {

--- a/core/migrations/constants.js
+++ b/core/migrations/constants.js
@@ -1,0 +1,30 @@
+/**
+ * @module core/migrations/constants
+ * @flow
+ */
+
+/*::
+import type { Pouch } from '../pouch'
+import type { Remote } from '../remote'
+
+export type SchemaVersion = number
+*/
+
+const SCHEMA_DOC_ID = '_local/schema'
+const SCHEMA_INITIAL_VERSION = 0
+const INITIAL_SCHEMA = {
+  _id: SCHEMA_DOC_ID,
+  version: SCHEMA_INITIAL_VERSION
+}
+const MIGRATION_RESULT_NOOP = 'MigrationNoop'
+const MIGRATION_RESULT_COMPLETE = 'MigrationComplete'
+const MIGRATION_RESULT_FAILED = 'MigrationFailed'
+
+module.exports = {
+  SCHEMA_DOC_ID,
+  SCHEMA_INITIAL_VERSION,
+  INITIAL_SCHEMA,
+  MIGRATION_RESULT_NOOP,
+  MIGRATION_RESULT_COMPLETE,
+  MIGRATION_RESULT_FAILED
+}

--- a/core/migrations/constants.js
+++ b/core/migrations/constants.js
@@ -8,6 +8,11 @@ import type { Pouch } from '../pouch'
 import type { Remote } from '../remote'
 
 export type SchemaVersion = number
+
+export type InjectedDependencies = {
+  pouch: Pouch,
+  remote: Remote,
+}
 */
 
 const SCHEMA_DOC_ID = '_local/schema'

--- a/core/migrations/index.js
+++ b/core/migrations/index.js
@@ -1,0 +1,306 @@
+/**
+ * @module core/migrations
+ * @flow
+ */
+
+const PouchDB = require('pouchdb')
+const uuid = require('uuid').v4
+
+const logger = require('../utils/logger')
+const { PouchError } = require('../pouch/error')
+const migrations = require('./migrations')
+const {
+  INITIAL_SCHEMA,
+  MIGRATION_RESULT_COMPLETE,
+  MIGRATION_RESULT_FAILED,
+  MIGRATION_RESULT_NOOP,
+  SCHEMA_DOC_ID,
+  SCHEMA_INITIAL_VERSION
+} = require('./constants')
+
+/*::
+import type { SavedMetadata } from '../metadata'
+import type { Migration } from './migrations'
+import type { InjectedDependencies, SchemaVersion } from './constants'
+
+type PouchDBInfo = {
+  db_name: string,
+  doc_count: number,
+  update_seq: number
+}
+
+type MigrationData = {
+  errors: PouchError[]
+}
+type MigrationNoop = MigrationData & {
+  type: 'MigrationNoop'
+}
+type MigrationComplete = MigrationData & {
+  type: 'MigrationComplete',
+}
+type MigrationFailed = MigrationData & {
+  type: 'MigrationFailed',
+}
+type MigrationResult = MigrationNoop|MigrationComplete|MigrationFailed
+*/
+
+const log = logger({
+  component: 'Migrations'
+})
+
+async function runMigrations(
+  migrations /*: Migration[] */,
+  { pouch, remote } /*: InjectedDependencies */
+) {
+  log.info('Running migrations...')
+  for (const migration of migrations) {
+    // First attempt
+    const result = await migrate(migration, { pouch, remote })
+    log.info(migrationLog(migration, result))
+
+    if (result.type === MIGRATION_RESULT_FAILED) {
+      // Retry in case of failure
+      const result = await migrate(migration, { pouch, remote })
+
+      if (result.type === MIGRATION_RESULT_FAILED) {
+        // Error in case of second failure
+        const err = new MigrationFailedError(migration, result.errors)
+        log.fatal({ err, sentry: true }, migrationLog(migration, result))
+        throw err
+      } else {
+        log.info(migrationLog(migration, result))
+      }
+    }
+  }
+  log.info('Migrations done.')
+}
+
+async function migrate(
+  migration /*: Migration */,
+  { pouch, remote } /*: InjectedDependencies */
+) /*: Promise<MigrationResult> */ {
+  if ((await currentSchemaVersion(pouch.db)) !== migration.baseSchemaVersion) {
+    return migrationNoop()
+  } else {
+    const originalDBInfo = await pouch.db.info()
+    const migrationDB = createDB(
+      await migrationDBPath(migration, originalDBInfo)
+    )
+
+    let result /*: MigrationResult */
+    try {
+      // Keep track of docs that were not read from the changesfeed already
+      const unsyncedDocIds = await pouch.unsyncedDocIds()
+
+      const docs /*: SavedMetadata[] */ = await pouch.allDocs()
+      const affectedDocs = migration.affectedDocs(docs)
+      const migratedDocs = await migration.run(affectedDocs, { pouch, remote })
+
+      if (migratedDocs.length) {
+        await replicateDB(pouch.db, migrationDB)
+        result = await save(migratedDocs, migrationDB)
+      } else {
+        result = migrationNoop()
+      }
+
+      switch (result.type) {
+        case MIGRATION_RESULT_NOOP:
+          await updateSchemaVersion(migration.targetSchemaVersion, pouch.db)
+          break
+        case MIGRATION_RESULT_COMPLETE:
+          await updateSchemaVersion(migration.targetSchemaVersion, migrationDB)
+          await pouch.resetDatabase()
+          await replicateDB(migrationDB, pouch.db)
+          await pouch.touchDocs(unsyncedDocIds)
+          break
+      }
+    } catch (err) {
+      result = { type: MIGRATION_RESULT_FAILED, errors: [err.toString()] }
+    } finally {
+      migrationDB.destroy()
+    }
+
+    return result
+  }
+}
+
+class MigrationFailedError extends Error {
+  /*::
+  name: string
+  migration: string
+  errors: PouchError[]
+  sentry: true
+  */
+
+  constructor(migration /*: Migration */, errors /*: PouchError[] */) {
+    super(migration.description)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MigrationFailedError)
+    }
+
+    this.name = MIGRATION_RESULT_FAILED
+    this.errors = errors
+    this.sentry = true
+  }
+}
+
+function migrationNoop() /*: MigrationNoop */ {
+  return { type: MIGRATION_RESULT_NOOP, errors: [] }
+}
+
+async function currentSchemaVersion(
+  db /*: PouchDB */
+) /*: Promise<SchemaVersion> */ {
+  const schema = (await safeGet(db, SCHEMA_DOC_ID)) || INITIAL_SCHEMA
+  return schema.version || SCHEMA_INITIAL_VERSION
+}
+
+async function updateSchemaVersion(
+  version /*: SchemaVersion */,
+  db /*: PouchDB */
+) {
+  const schema = (await safeGet(db, SCHEMA_DOC_ID)) || INITIAL_SCHEMA
+  return await db.put({ ...schema, version })
+}
+
+function createDB(name /*: string */) /*: PouchDB */ {
+  return new PouchDB(name).on('error', err => {
+    throw err
+  })
+}
+
+async function migrationDBPath(
+  migration /*: Migration */,
+  originalDBInfo /*: PouchDBInfo */
+) /*: Promise<string> */ {
+  const date = new Date()
+  const dateString = `${date.getFullYear()}-${
+    date.getMonth() + 1
+  }-${date.getDate()}`
+  const safeUUID = uuid().replace(/-/g, '')
+  return `${originalDBInfo.db_name}-migration-${dateString}-${safeUUID}`
+}
+
+async function replicateDB(fromDB /*: PouchDB */, toDB /*: PouchDB */) {
+  return new Promise((resolve, reject) => {
+    fromDB.replicate
+      .to(toDB)
+      .on('complete', async () => {
+        try {
+          await safeReplicate(fromDB, toDB, '_local/remoteSeq')
+          await safeReplicate(fromDB, toDB, SCHEMA_DOC_ID)
+          const toDBInfo = await toDB.info()
+          const localSeq = {
+            _id: '_local/localSeq',
+            seq: toDBInfo.update_seq
+          }
+          await safePut(toDB, localSeq)
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      })
+      .on('denied', err => {
+        reject(err)
+      })
+      .on('error', err => {
+        reject(err)
+      })
+  })
+}
+
+async function safeGet(db /*: PouchDB */, id /*: string */) /*: Promise<*> */ {
+  let doc
+  try {
+    doc = await db.get(id)
+  } catch (err) {
+    if (err.status !== 404) throw err
+  }
+  return doc
+}
+
+async function safePut(
+  db /*: PouchDB */,
+  doc /*: { _id: string, _rev?: string } */
+) /*: Promise<*> */ {
+  const currentDoc = await safeGet(db, doc._id)
+  if (currentDoc) doc._rev = currentDoc._rev
+  return db.put(doc)
+}
+
+async function safeReplicate(
+  fromDB /*: PouchDB */,
+  toDB /*: PouchDB */,
+  id /*: string */
+) {
+  const fromValue = await safeGet(fromDB, id)
+  if (fromValue) {
+    const toValue = await safeGet(toDB, id)
+    if (toValue) fromValue._rev = toValue._rev
+    else delete fromValue._rev
+    await toDB.put(fromValue)
+  }
+}
+
+async function save(
+  docs /*: SavedMetadata[] */,
+  db /*: PouchDB */
+) /*: Promise<MigrationResult> */ {
+  if (docs.length) {
+    const pouchResults = await db.bulkDocs(docs)
+
+    const errors = []
+    for (const result of pouchResults) {
+      if (result.error) {
+        errors.push(new PouchError(result))
+      }
+    }
+
+    if (errors.length > 0) {
+      return {
+        type: MIGRATION_RESULT_FAILED,
+        errors
+      }
+    } else {
+      return {
+        type: MIGRATION_RESULT_COMPLETE,
+        errors
+      }
+    }
+  }
+
+  return migrationNoop()
+}
+
+function migrationLog(
+  migration /*: Migration */,
+  result /*: MigrationResult */
+) /*: string */ {
+  let globalResult
+
+  switch (result.type) {
+    case MIGRATION_RESULT_NOOP:
+      globalResult = 'NOOP'
+      break
+    case MIGRATION_RESULT_COMPLETE:
+      globalResult = 'Complete'
+      break
+    case MIGRATION_RESULT_FAILED:
+      globalResult = 'Failed'
+      break
+    default:
+      globalResult = 'Unexpected error'
+  }
+  return `--- ${migration.description} => ${globalResult}`
+}
+
+module.exports = {
+  MigrationFailedError,
+  currentSchemaVersion,
+  migrate,
+  migrations,
+  runMigrations,
+  save,
+  updateSchemaVersion
+}

--- a/core/migrations/migrations.js
+++ b/core/migrations/migrations.js
@@ -1,40 +1,16 @@
 /**
- * @module core/pouch/migrations
+ * @module core/migrations/migrations
  * @flow
  */
 
-const PouchDB = require('pouchdb')
-const uuid = require('uuid').v4
 const path = require('path')
 
-const { PouchError } = require('./error')
 const metadata = require('../metadata')
+const { SCHEMA_INITIAL_VERSION } = require('./constants')
 
 /*::
-import type { Pouch } from './'
 import type { SavedMetadata } from '../metadata'
-
-type PouchDBInfo = {
-  db_name: string,
-  doc_count: number,
-  update_seq: number
-}
-
-type SchemaVersion = number
-
-type MigrationData = {
-  errors: PouchError[]
-}
-type MigrationNoop = MigrationData & {
-  type: 'MigrationNoop'
-}
-type MigrationComplete = MigrationData & {
-  type: 'MigrationComplete',
-}
-type MigrationFailed = MigrationData & {
-  type: 'MigrationFailed',
-}
-type MigrationResult = MigrationNoop|MigrationComplete|MigrationFailed
+import type { SchemaVersion } from './constants'
 
 export type Migration = {
   baseSchemaVersion: SchemaVersion,
@@ -45,17 +21,7 @@ export type Migration = {
 }
 */
 
-const SCHEMA_DOC_ID = '_local/schema'
-const SCHEMA_INITIAL_VERSION = 0
-const INITIAL_SCHEMA = {
-  _id: SCHEMA_DOC_ID,
-  version: SCHEMA_INITIAL_VERSION
-}
-const MIGRATION_RESULT_NOOP = 'MigrationNoop'
-const MIGRATION_RESULT_COMPLETE = 'MigrationComplete'
-const MIGRATION_RESULT_FAILED = 'MigrationFailed'
-
-const migrations /*: Migration[] */ = [
+module.exports = ([
   {
     baseSchemaVersion: SCHEMA_INITIAL_VERSION,
     targetSchemaVersion: 1,
@@ -345,233 +311,4 @@ const migrations /*: Migration[] */ = [
       })
     }
   }
-]
-
-class MigrationFailedError extends Error {
-  /*::
-  name: string
-  migration: string
-  errors: PouchError[]
-  sentry: true
-  */
-
-  constructor(migration /*: Migration */, errors /*: PouchError[] */) {
-    super(migration.description)
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, MigrationFailedError)
-    }
-
-    this.name = MIGRATION_RESULT_FAILED
-    this.errors = errors
-    this.sentry = true
-  }
-}
-
-function migrationNoop() {
-  return { type: MIGRATION_RESULT_NOOP, errors: [] }
-}
-
-async function currentSchemaVersion(
-  db /*: PouchDB */
-) /*: Promise<SchemaVersion> */ {
-  const schema = (await safeGet(db, SCHEMA_DOC_ID)) || INITIAL_SCHEMA
-  return schema.version || SCHEMA_INITIAL_VERSION
-}
-
-async function updateSchemaVersion(
-  version /*: SchemaVersion */,
-  db /*: PouchDB */
-) {
-  const schema = (await safeGet(db, SCHEMA_DOC_ID)) || INITIAL_SCHEMA
-  return await db.put({ ...schema, version })
-}
-
-async function migrate(
-  migration /*: Migration */,
-  pouch /*: Pouch */
-) /*: Promise<MigrationResult> */ {
-  if ((await currentSchemaVersion(pouch.db)) !== migration.baseSchemaVersion) {
-    return migrationNoop()
-  } else {
-    const originalDBInfo = await pouch.db.info()
-    const migrationDB = createDB(
-      await migrationDBPath(migration, originalDBInfo)
-    )
-
-    let result /*: MigrationResult */
-    try {
-      // Keep track of docs that were not read from the changesfeed already
-      const unsyncedDocIds = await pouch.unsyncedDocIds()
-
-      const docs /*: SavedMetadata[] */ = await pouch.allDocs()
-      const affectedDocs = migration.affectedDocs(docs)
-      const migratedDocs = migration.run(affectedDocs)
-
-      if (migratedDocs.length) {
-        await replicateDB(pouch.db, migrationDB)
-        result = await save(migratedDocs, migrationDB)
-      } else {
-        result = migrationNoop()
-      }
-
-      switch (result.type) {
-        case MIGRATION_RESULT_NOOP:
-          await updateSchemaVersion(migration.targetSchemaVersion, pouch.db)
-          break
-        case MIGRATION_RESULT_COMPLETE:
-          await updateSchemaVersion(migration.targetSchemaVersion, migrationDB)
-          await pouch.resetDatabase()
-          await replicateDB(migrationDB, pouch.db)
-          await pouch.touchDocs(unsyncedDocIds)
-          break
-      }
-    } catch (err) {
-      result = { type: MIGRATION_RESULT_FAILED, errors: [err.toString()] }
-    } finally {
-      migrationDB.destroy()
-    }
-
-    return result
-  }
-}
-
-function createDB(name /*: string */) /*: PouchDB */ {
-  return new PouchDB(name).on('error', err => {
-    throw err
-  })
-}
-
-async function migrationDBPath(
-  migration /*: Migration */,
-  originalDBInfo /*: PouchDBInfo */
-) /*: Promise<string> */ {
-  const date = new Date()
-  const dateString = `${date.getFullYear()}-${
-    date.getMonth() + 1
-  }-${date.getDate()}`
-  const safeUUID = uuid().replace(/-/g, '')
-  return `${originalDBInfo.db_name}-migration-${dateString}-${safeUUID}`
-}
-
-async function replicateDB(fromDB /*: PouchDB */, toDB /*: PouchDB */) {
-  return new Promise((resolve, reject) => {
-    fromDB.replicate
-      .to(toDB)
-      .on('complete', async () => {
-        try {
-          await safeReplicate(fromDB, toDB, '_local/remoteSeq')
-          await safeReplicate(fromDB, toDB, SCHEMA_DOC_ID)
-          const toDBInfo = await toDB.info()
-          const localSeq = {
-            _id: '_local/localSeq',
-            seq: toDBInfo.update_seq
-          }
-          await safePut(toDB, localSeq)
-          resolve()
-        } catch (err) {
-          reject(err)
-        }
-      })
-      .on('denied', err => {
-        reject(err)
-      })
-      .on('error', err => {
-        reject(err)
-      })
-  })
-}
-
-async function safeGet(db /*: PouchDB */, id /*: string */) /*: Promise<*> */ {
-  let doc
-  try {
-    doc = await db.get(id)
-  } catch (err) {
-    if (err.status !== 404) throw err
-  }
-  return doc
-}
-
-async function safePut(
-  db /*: PouchDB */,
-  doc /*: { _id: string, _rev?: string } */
-) /*: Promise<*> */ {
-  const currentDoc = await safeGet(db, doc._id)
-  if (currentDoc) doc._rev = currentDoc._rev
-  return db.put(doc)
-}
-
-async function safeReplicate(
-  fromDB /*: PouchDB */,
-  toDB /*: PouchDB */,
-  id /*: string */
-) {
-  const fromValue = await safeGet(fromDB, id)
-  if (fromValue) {
-    const toValue = await safeGet(toDB, id)
-    if (toValue) fromValue._rev = toValue._rev
-    else delete fromValue._rev
-    await toDB.put(fromValue)
-  }
-}
-
-async function save(
-  docs /*: SavedMetadata[] */,
-  db /*: PouchDB */
-) /*: Promise<MigrationResult> */ {
-  const migrationResult /* MigrationResult */ = migrationNoop()
-
-  if (docs.length) {
-    const pouchResults = await db.bulkDocs(docs)
-
-    for (const result of pouchResults) {
-      if (result.error) {
-        migrationResult.errors = migrationResult.errors || []
-        migrationResult.errors.push(new PouchError(result))
-      }
-    }
-
-    migrationResult.type = migrationResult.errors.length
-      ? MIGRATION_RESULT_FAILED
-      : MIGRATION_RESULT_COMPLETE
-  }
-
-  return migrationResult
-}
-
-function migrationLog(
-  migration /*: Migration */,
-  result /*: MigrationResult */
-) /*: string */ {
-  let globalResult
-
-  switch (result.type) {
-    case MIGRATION_RESULT_NOOP:
-      globalResult = 'NOOP'
-      break
-    case MIGRATION_RESULT_COMPLETE:
-      globalResult = 'Complete'
-      break
-    case MIGRATION_RESULT_FAILED:
-      globalResult = 'Failed'
-      break
-    default:
-      globalResult = 'Unexpected error'
-  }
-  return `--- ${migration.description} => ${globalResult}`
-}
-
-module.exports = {
-  SCHEMA_DOC_ID,
-  SCHEMA_INITIAL_VERSION,
-  MIGRATION_RESULT_COMPLETE,
-  MIGRATION_RESULT_FAILED,
-  MIGRATION_RESULT_NOOP,
-  migrations,
-  MigrationFailedError,
-  currentSchemaVersion,
-  updateSchemaVersion,
-  migrate,
-  save,
-  migrationLog
-}
+] /*: Migration[] */)

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -15,19 +15,12 @@ const path = require('path')
 const metadata = require('../metadata')
 const logger = require('../utils/logger')
 const { PouchError } = require('./error')
-const {
-  MIGRATION_RESULT_FAILED,
-  MigrationFailedError,
-  migrate,
-  migrationLog
-} = require('./migrations')
 const remoteConstants = require('../remote/constants')
 
 /*::
 import type { Config } from '../config'
 import type { Metadata, SavedMetadata } from '../metadata'
 import type { Callback } from '../utils/func'
-import type { Migration } from './migrations'
 
 export type PouchRecord = { _id: string, _rev: string, _deleted?: true }
 */
@@ -100,30 +93,6 @@ class Pouch {
         _resolve()
       }
     })
-  }
-
-  async runMigrations(migrations /*: Migration[] */) {
-    log.info('Running migrations...')
-    for (const migration of migrations) {
-      // First attempt
-      const result = await migrate(migration, this)
-      log.info(migrationLog(migration, result))
-
-      if (result.type === MIGRATION_RESULT_FAILED) {
-        // Retry in case of failure
-        const result = await migrate(migration, this)
-
-        if (result.type === MIGRATION_RESULT_FAILED) {
-          // Error in case of second failure
-          const err = new MigrationFailedError(migration, result.errors)
-          log.fatal({ err, sentry: true }, migrationLog(migration, result))
-          throw err
-        } else {
-          log.info(migrationLog(migration, result))
-        }
-      }
-    }
-    log.info('Migrations done.')
   }
 
   /* Mini ODM */

--- a/gui/main.js
+++ b/gui/main.js
@@ -20,7 +20,7 @@ const {
   SYNC_DIR_EMPTY_MESSAGE,
   SYNC_DIR_UNLINKED_MESSAGE
 } = require('../core/local/errors')
-const migrations = require('../core/pouch/migrations')
+const { MigrationFailedError } = require('../core/migrations/migrations')
 const config = require('../core/config')
 const winRegistry = require('../core/utils/win_registry')
 
@@ -106,7 +106,7 @@ const setupDesktop = async () => {
 
     if (err instanceof config.InvalidConfigError) {
       await showInvalidConfigError()
-    } else if (err instanceof migrations.MigrationFailedError) {
+    } else if (err instanceof MigrationFailedError) {
       await showMigrationError(err)
     } else {
       await dialog.showMessageBox(null, {


### PR DESCRIPTION
Sub-directories of sub-directories of directories moved on the remote
Cozy would not see their new remote revision stored in PouchDB,
resulting in 412 errors when the user would modify them on their local
filesystem (i.e. since we don't have the latest revision, our
modifications are rejected by the remote Cozy).

This bug was fixed in #2216  but directories moved until now are still
affected by the issue.

We solve this problem here by fetching and updating in PouchDB the
latest remote revision of all directories if the remote metadata is
equivalent (we only compare a few attributes that we really care about
like the path, the tags…).

This is done via a migration and therefore these can now make use of
the `Remote` module to make calls to the remote Cozy.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
