### PR TITLE
gui: Open Cozy TOS in external browser

### DIFF
--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -1,5 +1,5 @@
 const { addFileManagerShortcut } = require('./shortcut')
-const { dialog, session, BrowserView } = require('electron')
+const { dialog, session, BrowserView, shell } = require('electron')
 const autoLaunch = require('./autolaunch')
 const defaults = require('./defaults')
 const { translate } = require('./i18n')
@@ -95,6 +95,13 @@ module.exports = class OnboardingWM extends WindowManager {
       })
       this.oauthView.setBounds({ ...bounds, x: 0, y: 0 })
       this.centerOnScreen(LOGIN_SCREEN_WIDTH, LOGIN_SCREEN_HEIGHT)
+
+      this.oauthView.webContents.on('will-navigate', (event, url) => {
+        if (url.endsWith('.pdf')) {
+          event.preventDefault()
+          shell.openExternal(url)
+        }
+      })
     } catch (err) {
       log.error({ err, url, sentry: true }, 'failed loading OAuth view')
     }


### PR DESCRIPTION
If the user decides to read our TOS during the on-boarding process,
opening them in the on-boarding window will prevent them to finish the
process as there is no way to go back to the OAuth dance.
Besides, these TOS are written in a PDF file rather than an HTML page
and does not seem to be readable within the OAuth webview.

To make sure the user can read the TOS and continue the on-boarding
process, we'll intercept navigation to PDF files and open the given
URLs in the external browser.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
