### PR TITLE
Handle network errors during file transfers

### DIFF
--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -188,7 +188,7 @@ const wrapError = (
   err /*: FetchError |  Error */,
   doc /*: ?SavedMetadata */
 ) /*: RemoteError */ => {
-  if (err.name === 'FetchError') {
+  if (isNetworkError(err)) {
     // $FlowFixMe FetchErrors missing status will fallback to the default case
     const { status } = err
 
@@ -379,6 +379,13 @@ function detail(err /*: FetchError */) /*: ?string */ {
   return detail
 }
 
+function isNetworkError(err /*: Error */) {
+  return (
+    err.name === 'FetchError' ||
+    (typeof err.message === 'string' && err.message.includes('net::'))
+  )
+}
+
 module.exports = {
   CozyDocumentMissingError,
   DirectoryNotFound,
@@ -405,5 +412,6 @@ module.exports = {
   UNKNOWN_REMOTE_ERROR_CODE,
   UNREACHABLE_COZY_CODE,
   USER_ACTION_REQUIRED_CODE,
+  isNetworkError,
   wrapError
 }

--- a/core/remote/errors.js
+++ b/core/remote/errors.js
@@ -386,6 +386,15 @@ function isNetworkError(err /*: Error */) {
   )
 }
 
+function isRetryableNetworkError(err /*: Error */) {
+  return (
+    typeof err.message === 'string' &&
+    err.message.includes('net::') &&
+    !err.message.includes('net::ERR_INTERNET_DISCONNECTED') &&
+    !err.message.includes('net::ERR_PROXY_CONNECTION_FAILED')
+  )
+}
+
 module.exports = {
   CozyDocumentMissingError,
   DirectoryNotFound,
@@ -413,5 +422,6 @@ module.exports = {
   UNREACHABLE_COZY_CODE,
   USER_ACTION_REQUIRED_CODE,
   isNetworkError,
+  isRetryableNetworkError,
   wrapError
 }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -169,6 +169,11 @@ class RemoteWatcher {
   async watch() /*: Promise<?RemoteError> */ {
     const release = await this.pouch.lock(this)
     try {
+      if (!this.running) {
+        log.debug('Watcher stopped: skipping remote watch')
+        return
+      }
+
       this.events.emit('buffering-start')
 
       const seq = await this.pouch.getRemoteSeq()

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -295,10 +295,10 @@ const wrapError = (
     return new SyncError({ sideName, err, code: INCOMPATIBLE_DOC_CODE, doc })
   } else if (err instanceof remoteErrors.ExcludedDirError) {
     return new SyncError({ sideName, err, code: EXCLUDED_DIR_CODE, doc })
-  } else if (sideName === 'remote' || err.name === 'FetchError') {
+  } else if (remoteErrors.isNetworkError(err)) {
     // FetchErrors can be raised from the LocalWriter when failing to download a
-    // file for example. In this case the sideName will be "local" but the error
-    // name will still be "FetchError".
+    // file for example. In this case the error name won't be "FetchError" but
+    // its message will still contain `net::`.
     // If err is a RemoteError, its code will be reused.
     return new SyncError({
       sideName,

--- a/core/utils/lifecycle.js
+++ b/core/utils/lifecycle.js
@@ -14,14 +14,14 @@ type State = 'done-stop' | 'will-start' | 'done-start' | 'will-stop'
 class LifeCycle extends EventEmitter {
   /*::
   currentState: State
-  blockedFor: Set<string>
+  blockedFor: ?string
   log: Logger
   */
 
   constructor(logger /*: Logger */) {
     super()
     this.currentState = 'done-stop'
-    this.blockedFor = new Set()
+    this.blockedFor = null
     this.log = logger
   }
 
@@ -89,18 +89,21 @@ class LifeCycle extends EventEmitter {
   }
 
   blockFor(reason /*: string */) {
-    this.blockedFor.add(reason)
+    this.log.debug(`blocking for ${reason}`)
+    this.blockedFor = reason
   }
 
   unblockFor(reason /*: string */) {
-    if (reason === 'all') this.blockedFor.clear()
-    else this.blockedFor.delete(reason)
-    if (this.blockedFor.size === 0) this.emit('ready')
+    this.log.debug(`unblocking for ${reason}`)
+    if (reason === 'all' || reason === this.blockedFor) {
+      this.blockedFor = null
+      this.emit('ready')
+    }
   }
 
   async ready() /*: Promise<void> */ {
     return new Promise(resolve => {
-      if (this.blockedFor.size === 0) resolve()
+      if (this.blockedFor == null) resolve()
       else this.once('ready', resolve)
     })
   }

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -51,7 +51,9 @@ class RemoteTestHelpers {
   }
 
   async pullChanges() {
+    this.side.watcher.running = true
     await this.side.watcher.watch()
+    this.side.watcher.running = false
   }
 
   async createDirectory(

--- a/test/unit/remote/errors.js
+++ b/test/unit/remote/errors.js
@@ -1,0 +1,18 @@
+/* eslint-env mocha */
+/* @flow */
+
+const should = require('should')
+
+const remoteErrors = require('../../../core/remote/errors')
+
+describe('Remote.wrapError', () => {
+  it('returns an UnreachableCozy error for net::ERR_NETWORKD_CHANGED errors', () => {
+    const netErr = new Error(
+      'Failed request, reason: net::ERR_NETWORKD_CHANGED'
+    )
+    should(remoteErrors.wrapError(netErr)).have.property(
+      'code',
+      remoteErrors.UNREACHABLE_COZY_CODE
+    )
+  })
+})

--- a/test/unit/sync/errors.js
+++ b/test/unit/sync/errors.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+/* @flow */
+
+const should = require('should')
+
+const remoteErrors = require('../../../core/remote/errors')
+const syncErrors = require('../../../core/sync/errors')
+
+describe('Sync.wrapError', () => {
+  it('returns an UnreachableCozy error for net::ERR_NETWORKD_CHANGED errors', () => {
+    const netErr = new Error(
+      'Failed request, reason: net::ERR_NETWORKD_CHANGED'
+    )
+    should(syncErrors.wrapError(netErr, 'local')).have.property(
+      'code',
+      remoteErrors.UNREACHABLE_COZY_CODE
+    )
+  })
+})


### PR DESCRIPTION
Network errors thrown while a file is being transferred to or from the
Cozy should be handled as `FetchError` errors so our error handling
mechanisms will work.
This includes showing proper error messages, retrying transfers and
avoiding blocking the client.

This PR solves multiple problems at once:
- `net::*` errors are handled as `FetchError` errors
- file transfers are retried as quickly as possible for a limited amount
  of network errors
- the remote watcher does not try to make calls to the remote Cozy when
  stopped
- the synchronization process does not get blocked for more than one
  reason at any given time (since it can only get unblocked for one
  reason)

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
