### PR TITLE
core/merge: Handle unsynced document moves

### DIFF
--- a/core/incompatibilities/platform.js
+++ b/core/incompatibilities/platform.js
@@ -28,7 +28,7 @@ export type ReservedCharsIncompatibility = {|
   type: 'reservedChars',
   name: string,
   platform: string,
-  reservedChars?: Set<SingleCharString>
+  reservedChars?: SingleCharString[]
 |}
 export type ReservedNameIncompatibility = {|
   type: 'reservedName',
@@ -241,7 +241,11 @@ const detectNameIncompatibilities = (
       type: 'reservedChars',
       name,
       platform,
-      reservedChars: new Set(reservedChars)
+      // XXX: We build a Set to make sure each reserved character is present
+      // only once but transform it back into an Array as Sets are not
+      // serializable (i.e. they're transformed into an empty Object when saved
+      // into PouchDB).
+      reservedChars: Array.from(new Set(reservedChars))
     })
   }
 

--- a/core/merge.js
+++ b/core/merge.js
@@ -547,40 +547,127 @@ class Merge {
 
     metadata.assignMaxDate(doc, was)
 
-    const folder /*: ?SavedMetadata */ = await this.pouch.bySyncedPath(doc.path)
-    if (folder) {
-      if (folder.trashed) {
-        doc.overwrite = folder.overwrite || folder
-      }
+    if (!metadata.wasSynced(was) || was.trashed) {
+      // The folder was moved on the local filesystem but does not exist on the
+      // remote Cozy so we cannot synchronize a move.
+      // We convert the local move into a creation at the move destination path
+      // instead.
+      move.convertToDestinationAddition(side, was, doc, { updateSide: true })
 
-      const idConflict /*: ?IdConflictInfo */ = IdConflict.detect(
-        { side, doc, was },
-        folder
+      const folder /*: ?SavedMetadata */ = await this.pouch.bySyncedPath(
+        doc.path
       )
-      if (idConflict) {
-        log.warn({ idConflict }, IdConflict.description(idConflict))
-        return this.resolveConflictAsync(side, doc)
-      }
+      if (folder) {
+        // The move overwrote an existing local document. To avoid having 2
+        // documents with the same path in PouchDB, the moved document's source
+        // record was erased in `moveFolderAsync()` and we'll merge its new
+        // metadata as an update of the overwritten document.
 
-      if (doc.overwrite || metadata.isAtLeastUpToDate(side, folder)) {
-        // On macOS and Windows, two documents can share the same id with a
-        // different path.
-        // This means we'll see moves with both `folder` and `doc` sharing the
-        // same id when changing the folder name's case or encoding and in this
-        // situation we're not actually doing an overwriting move so we
-        // shouldn't reuse the existing `folder`'s rev nor overwrite it.
-        if (folder.path === doc.path) {
-          doc.overwrite = folder.overwrite || folder
-          await this.pouch.eraseDocument(folder)
+        if (metadata.isAtLeastUpToDate(side, folder)) {
+          await this.pouch.eraseDocument(was)
+          metadata.markAsUnmerged(doc, side)
+          await this.putFolderRecursivelyAsync(side, doc, was)
+        } else {
+          const dst = await this.resolveConflictAsync(side, doc)
+          await this.putFolderRecursivelyAsync(side, dst, was)
         }
+      } else {
+        await this.putFolderRecursivelyAsync(side, doc, was)
+      }
+    } else {
+      const folder /*: ?SavedMetadata */ = await this.pouch.bySyncedPath(
+        doc.path
+      )
+      if (folder) {
+        if (folder.trashed) {
+          doc.overwrite = folder.overwrite || folder
+        }
+
+        const idConflict /*: ?IdConflictInfo */ = IdConflict.detect(
+          { side, doc, was },
+          folder
+        )
+        if (idConflict) {
+          log.warn({ idConflict }, IdConflict.description(idConflict))
+          return this.resolveConflictAsync(side, doc)
+        }
+
+        if (doc.overwrite || metadata.isAtLeastUpToDate(side, folder)) {
+          // On macOS and Windows, two documents can share the same id with a
+          // different path.
+          // This means we'll see moves with both `folder` and `doc` sharing the
+          // same id when changing the folder name's case or encoding and in this
+          // situation we're not actually doing an overwriting move so we
+          // shouldn't reuse the existing `folder`'s rev nor overwrite it.
+          if (folder.path === doc.path) {
+            doc.overwrite = folder.overwrite || folder
+            // XXX: Erasing the overwritten children's records is done in
+            // `moveFolderRecursivelyAsync()`.
+            await this.pouch.eraseDocument(folder)
+          }
+          return this.moveFolderRecursivelyAsync(side, doc, was, newRemoteRevs)
+        }
+
+        const dst = await this.resolveConflictAsync(side, doc)
+        return this.moveFolderRecursivelyAsync(side, dst, was, newRemoteRevs)
+      } else {
         return this.moveFolderRecursivelyAsync(side, doc, was, newRemoteRevs)
       }
+    }
+  }
 
-      //const dst = await this.resolveConflictAsync(side, doc)
-      const dst = await this.resolveConflictAsync(side, doc)
-      return this.moveFolderRecursivelyAsync(side, dst, was, newRemoteRevs)
-    } else {
-      return this.moveFolderRecursivelyAsync(side, doc, was, newRemoteRevs)
+  async putFolderRecursivelyAsync(
+    side /*: SideName */,
+    folder /*: Metadata  */,
+    was /*: SavedMetadata */
+  ) {
+    await this.putFolderAsync(side, folder)
+
+    const children = await this.pouch.byRecursivePath(was.path)
+    const dstChildren = await this.pouch.byRecursivePath(folder.path)
+    const makeDestinationPath = doc =>
+      metadata.newChildPath(doc.path, was.path, folder.path)
+
+    for (const child of children) {
+      const dstPath = makeDestinationPath(child)
+      const movedChild = { ...child, path: dstPath }
+
+      this.updateChildIncompatibilities(movedChild)
+
+      if (!metadata.wasSynced(child) || child.trashed) {
+        // The folder was moved on the local filesystem but does not exist on the
+        // remote Cozy so we cannot synchronize a move.
+        // We convert the local move into a creation at the move destination path
+        // instead.
+        move.convertToDestinationAddition(side, child, movedChild, {
+          updateSide: true
+        })
+
+        const overwrittenChild = dstChildren.find(
+          dst => metadata.id(dst.path) === metadata.id(movedChild.path)
+        )
+        if (overwrittenChild) {
+          // The move overwrote an existing local document. To avoid having 2
+          // documents with the same path in PouchDB, the moved document's source
+          // record was erased in `moveFolderAsync()` and we'll merge its new
+          // metadata as an update of the overwritten document.
+          await this.pouch.eraseDocument(child)
+          metadata.markAsUnmerged(movedChild, side)
+          if (movedChild.docType === 'file') {
+            await this.updateFileAsync(side, movedChild)
+          } else {
+            await this.putFolderAsync(side, movedChild)
+          }
+        } else {
+          if (movedChild.docType === 'file') {
+            await this.updateFileAsync(side, movedChild)
+          } else {
+            await this.putFolderAsync(side, movedChild)
+          }
+        }
+      } else {
+        await this.moveFileAsync(side, child, movedChild)
+      }
     }
   }
 
@@ -597,20 +684,13 @@ class Merge {
     )
     const docs = await this.pouch.byRecursivePath(was.path)
     const dstChildren = await this.pouch.byRecursivePath(folder.path)
-
-    const singleSide = metadata.detectSingleSide(was)
-    if (singleSide) {
-      move.convertToDestinationAddition(singleSide, was, folder, {
-        updateSide: true
-      })
-    } else {
-      move(side, was, folder)
-    }
-    let bulk = [folder]
-
     const makeDestinationPath = doc =>
       metadata.newChildPath(doc.path, was.path, folder.path)
 
+    move(side, was, folder)
+
+    // XXX: Store all changes to be merged in bulk at the end of the method call
+    let bulk = [folder]
     for (let doc of docs) {
       // Don't move children marked for deletion as we can simply propagate the
       // deletion at their original path.
@@ -663,18 +743,7 @@ class Merge {
         move.child(side, src, dst)
       }
 
-      // TODO: make sure that detecting an incompatibility on a child's
-      // destination path actually blocks the synchronization of the parent
-      // directory.
-      //
-      // FIXME: Find a cleaner way to pass the syncPath to the Merge
-      const incompatibilities = metadata.detectIncompatibilities(
-        dst,
-        this.pouch.config.syncPath
-      )
-      if (incompatibilities.length > 0)
-        dst.incompatibilities = incompatibilities
-      else delete dst.incompatibilities
+      this.updateChildIncompatibilities(dst)
 
       if (side === 'local' && dst.sides.local) {
         // Update the `local` attribute of children existing in the local folder
@@ -1049,6 +1118,21 @@ class Merge {
     delete folder.errors
 
     return this.pouch.bulkDocs(children.concat(folder))
+  }
+
+  updateChildIncompatibilities(child /*: SavedMetadata */) {
+    // TODO: make sure that detecting an incompatibility on a child's
+    // destination path actually blocks the synchronization of the parent
+    // directory.
+    //
+    // FIXME: Find a cleaner way to pass the syncPath to the Merge
+    const incompatibilities = metadata.detectIncompatibilities(
+      child,
+      this.pouch.config.syncPath
+    )
+    if (incompatibilities.length > 0)
+      child.incompatibilities = incompatibilities
+    else delete child.incompatibilities
   }
 }
 

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -435,6 +435,7 @@ function assignPlatformIncompatibilities(
 ) /*: void */ {
   const incompatibilities = detectIncompatibilities(doc, syncPath)
   if (incompatibilities.length > 0) doc.incompatibilities = incompatibilities
+  else if (doc.incompatibilities) delete doc.incompatibilities
 }
 
 // Return true if the checksum is invalid

--- a/core/move.js
+++ b/core/move.js
@@ -11,6 +11,7 @@
 const _ = require('lodash')
 
 const metadata = require('./metadata')
+const pathUtils = require('./utils/path')
 
 /*::
 import type { Metadata, SavedMetadata } from './metadata'
@@ -66,7 +67,8 @@ function child(
 function convertToDestinationAddition(
   side /*: SideName */,
   src /*: SavedMetadata */,
-  dst /*: Metadata */
+  dst /*: Metadata */,
+  { updateSide } /*: { updateSide: boolean } */
 ) {
   metadata.removeActionHints(src)
 
@@ -75,4 +77,15 @@ function convertToDestinationAddition(
   dst._id = src._id
   dst._rev = src._rev
   metadata.markSide(side, dst)
+
+  // Update side path
+  if (updateSide && dst[side] != null) {
+    if (side === 'local') {
+      metadata.updateLocal(dst, { ...dst.local, path: dst.path })
+    } else {
+      metadata.updateRemote(dst, {
+        path: pathUtils.localToRemote(dst.path)
+      })
+    }
+  }
 }

--- a/test/scenarios/move_overwriting_dir/with_unsynced_dir/atom/linux.json
+++ b/test/scenarios/move_overwriting_dir/with_unsynced_dir/atom/linux.json
@@ -1,0 +1,60 @@
+[
+  [
+    {
+      "action": "created",
+      "kind": "directory",
+      "path": "overwriting"
+    }
+  ],
+  [],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "overwriting/overwritten"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "overwriting/overwritten"
+    }
+  ],
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "overwriting/file"
+    }
+  ],
+  [
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "overwriting/file"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "file",
+      "path": "dir/overwritten"
+    }
+  ],
+  [
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "dir"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "directory",
+      "path": "dir",
+      "oldPath": "overwriting"
+    }
+  ]
+]

--- a/test/scenarios/move_overwriting_dir/with_unsynced_dir/scenario.js
+++ b/test/scenarios/move_overwriting_dir/with_unsynced_dir/scenario.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+/*:: import type { Scenario } from '../..' */
+
+module.exports = ({
+  side: 'local',
+  useCaptures: false,
+  init: [
+    { ino: 1, path: 'dir/' },
+    { ino: 2, path: 'dir/overwritten', content: 'overwritten content' }
+  ],
+  actions: [
+    {
+      type: 'mkdir',
+      path: 'overwriting/'
+    },
+    { type: 'wait', ms: 1000 },
+    {
+      type: 'create_file',
+      path: 'overwriting/overwritten',
+      content: 'overwriting content'
+    },
+    { type: 'create_file', path: 'overwriting/file', content: 'file content' },
+    { type: 'wait', ms: 1000 },
+    { type: 'mv', force: true, src: 'overwriting/', dst: 'dir/' },
+    { type: 'wait', ms: 1000 }
+  ],
+  expected: {
+    tree: ['dir/', 'dir/file', 'dir/overwritten'],
+    trash: [],
+    contents: {
+      'dir/file': 'file content',
+      'dir/overwritten': 'overwriting content'
+    }
+  }
+} /*: Scenario */)

--- a/test/scenarios/move_overwriting_file/with_unsynced_file/atom/linux.json
+++ b/test/scenarios/move_overwriting_file/with_unsynced_file/atom/linux.json
@@ -1,0 +1,22 @@
+[
+  [
+    {
+      "action": "created",
+      "kind": "file",
+      "path": "overwriting"
+    },
+    {
+      "action": "modified",
+      "kind": "file",
+      "path": "overwriting"
+    }
+  ],
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "path": "file",
+      "oldPath": "overwriting"
+    }
+  ]
+]

--- a/test/scenarios/move_overwriting_file/with_unsynced_file/scenario.js
+++ b/test/scenarios/move_overwriting_file/with_unsynced_file/scenario.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+/*:: import type { Scenario } from '../..' */
+
+module.exports = ({
+  side: 'local',
+  useCaptures: false,
+  init: [{ ino: 1, path: 'file', content: 'overwritten content' }],
+  actions: [
+    {
+      type: 'create_file',
+      path: 'overwriting',
+      content: 'overwriting content'
+    },
+    { type: 'wait', ms: 1000 },
+    { type: 'mv', src: 'overwriting', dst: 'file' },
+    { type: 'wait', ms: 1000 }
+  ],
+  expected: {
+    tree: ['file'],
+    trash: [],
+    contents: {
+      file: 'overwriting content'
+    }
+  }
+} /*: Scenario */)

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -130,12 +130,10 @@ module.exports = class BaseMetadataBuilder {
   incompatible() /*: this */ {
     const { platform } = process
 
-    if (platform === 'win32' || platform === 'darwin') {
-      // Colon is currently considered forbidden on both platforms by the app
-      // (although it probably shouldn't on macOS).
+    if (platform === 'win32') {
       return this.path('in:compatible')
     } else {
-      throw new Error(`Cannot build incompatible doc on ${platform}`)
+      return this.path(Array(256).fill('a').join(''))
     }
   }
 

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -338,11 +338,8 @@ module.exports = class BaseMetadataBuilder {
   _ensureRemote() /*: void */ {
     if (
       this.doc.remote != null &&
-      (!this.doc.sides ||
-        !this.doc.sides.local ||
-        (this.doc.sides.remote &&
-          (this.doc.sides.remote < this.doc.sides.local ||
-            remoteIsUpToDate(this.doc))))
+      (remoteIsUpToDate(this.doc) ||
+        _.get(this.doc, 'sides.remote') < _.get(this.doc, 'sides.local'))
     ) {
       return
     }

--- a/test/unit/incompatibilities/platform.js
+++ b/test/unit/incompatibilities/platform.js
@@ -19,7 +19,7 @@ describe('core/incompatibilities/platform', () => {
         {
           type: 'reservedChars',
           name,
-          reservedChars: new Set(reservedChars),
+          reservedChars,
           platform
         }
       ])
@@ -52,7 +52,7 @@ describe('core/incompatibilities/platform', () => {
               {
                 type: 'reservedChars',
                 name,
-                reservedChars: new Set(char),
+                reservedChars: [char],
                 platform
               }
             ]
@@ -104,7 +104,7 @@ describe('core/incompatibilities/platform', () => {
               {
                 type: 'reservedChars',
                 name,
-                reservedChars: new Set(char),
+                reservedChars: [char],
                 platform
               }
             ]
@@ -164,7 +164,7 @@ describe('core/incompatibilities/platform', () => {
               {
                 type: 'reservedChars',
                 name,
-                reservedChars: new Set(char),
+                reservedChars: [char],
                 platform
               }
             ]

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -266,7 +266,7 @@ describe('metadata', function () {
             name: 'q"ux',
             path: 'f?o:o\\ba|r\\baz\\q"ux',
             docType: 'file',
-            reservedChars: new Set('"'),
+            reservedChars: ['"'],
             platform
           },
           {
@@ -274,7 +274,7 @@ describe('metadata', function () {
             name: 'ba|r',
             path: 'f?o:o\\ba|r',
             docType: 'folder',
-            reservedChars: new Set('|'),
+            reservedChars: ['|'],
             platform
           },
           {
@@ -282,7 +282,7 @@ describe('metadata', function () {
             name: 'f?o:o',
             path: 'f?o:o',
             docType: 'folder',
-            reservedChars: new Set('?:'),
+            reservedChars: ['?', ':'],
             platform
           }
         ])

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -20,6 +20,7 @@ const {
   invalidPath,
   markSide,
   markAsUpToDate,
+  assignPlatformIncompatibilities,
   detectIncompatibilities,
   sameBinary,
   equivalent,
@@ -221,6 +222,30 @@ describe('metadata', function () {
 
     it('returns false if the checksum is OK', function () {
       should(invalidChecksum(builders.metafile().data('').build())).be.false()
+    })
+  })
+
+  describe('assignPlatformIncompatibilities', () => {
+    const syncPath = ';'
+
+    it('adds incompatibilities to given doc if any', () => {
+      const incompatible = builders.metafile().incompatible().build()
+      const doc = builders.metafile().path('foo/bar').build()
+
+      doc.path = incompatible.path
+      assignPlatformIncompatibilities(doc, syncPath)
+
+      should(doc).have.property('incompatibilities').and.not.be.empty()
+    })
+
+    it('removes incompatibilities from given doc if none', () => {
+      const incompatible = builders.metafile().incompatible().build()
+      const doc = builders.metafile().path('foo/bar').build()
+
+      incompatible.path = doc.path
+      assignPlatformIncompatibilities(incompatible, syncPath)
+
+      should(incompatible).not.have.property('incompatibilities')
     })
   })
 

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -3,11 +3,13 @@
 
 const _ = require('lodash')
 const should = require('should')
-const move = require('../../core/move')
 
 const configHelpers = require('../support/helpers/config')
 const pouchHelpers = require('../support/helpers/pouch')
 const Builders = require('../support/builders')
+const pathUtils = require('../../core/utils/path')
+const { otherSide } = require('../../core/side')
+const move = require('../../core/move')
 
 describe('move', () => {
   let builders
@@ -75,22 +77,39 @@ describe('move', () => {
 
     beforeEach(async () => {
       src = await builders.metadata().path('src').upToDate().create()
-      dst = builders.metadata(src).path('destination').build()
-
-      move(side, src, dst)
-      move.convertToDestinationAddition(side, src, dst)
+      dst = builders
+        .metadata()
+        .moveFrom(src)
+        .path('destination')
+        .changedSide(side)
+        .build()
     })
 
     it('updates the source document', () => {
+      move.convertToDestinationAddition(side, src, dst, { updateSide: false })
       should(dst._id).eql(src._id)
     })
 
     it('marks the document as newly added on `side`', () => {
+      move.convertToDestinationAddition(side, src, dst, { updateSide: false })
       should(dst.sides).deepEqual({ target: 1, [side]: 1 })
     })
 
     it('removes move hints', () => {
+      move.convertToDestinationAddition(side, src, dst, { updateSide: false })
       should(dst).not.have.property('moveFrom')
+    })
+
+    it('updates the given side path if requested', () => {
+      // XXX: we convert to an addition on the other side here because the move
+      // already updated `side` with the destination path and we wouldn't be
+      // testing much.
+      move.convertToDestinationAddition(otherSide(side), src, dst, {
+        updateSide: true
+      })
+      should(dst[otherSide(side)].path).deepEqual(
+        pathUtils.localToRemote(dst.path)
+      )
     })
   })
 })

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -2082,7 +2082,7 @@ describe('RemoteWatcher', function () {
             name: 'b<a>r',
             path: 'f:oo\\b<a>r',
             docType: 'file',
-            reservedChars: new Set('<>'),
+            reservedChars: ['<', '>'],
             platform
           },
           {
@@ -2090,7 +2090,7 @@ describe('RemoteWatcher', function () {
             name: 'f:oo',
             path: 'f:oo',
             docType: 'folder',
-            reservedChars: new Set(':'),
+            reservedChars: [':'],
             platform
           }
         ])


### PR DESCRIPTION
When a document existing only on side (i.e. not synchronized yet) is
moved, we convert the move into a creation at the move's destination
(because the move could not be synchronized since the document does not
exist on the remote Cozy).

Also, when we're dealing with an overwriting move, we transform it into
an update of the overwritten document instead (and make sure we don't
leave traces of the source of the move in PouchDB).

Failing to do so would result in:
- having 2 records with the same path in PouchDB which can lead to
  requests issues (they're based on the path and we're not sure which
  record would be returned)
- conflicts when trying to synchronize the creation of the local
  document on the remote Cozy since there is another document at the
  same path

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
