### PR TITLE
core/migrations: Handle revoked client errors

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -226,11 +226,13 @@ class App {
   }
 
   async removeConfig() {
+    log.info('Removing config...')
     await this.pouch.db.destroy()
     for (const name of await fse.readdir(this.basePath)) {
       if (name.startsWith(LOG_FILENAME)) continue
       await fse.remove(path.join(this.basePath, name))
     }
+    log.info('Config removed')
   }
 
   async uploadFileToSupport(

--- a/core/migrations/index.js
+++ b/core/migrations/index.js
@@ -115,7 +115,7 @@ async function migrate(
           break
       }
     } catch (err) {
-      result = { type: MIGRATION_RESULT_FAILED, errors: [err.toString()] }
+      result = { type: MIGRATION_RESULT_FAILED, errors: [err] }
     } finally {
       migrationDB.destroy()
     }

--- a/gui/js/actions.js
+++ b/gui/js/actions.js
@@ -1,0 +1,40 @@
+const { spawn } = require('child_process')
+const { app } = require('electron')
+const { Promise } = require('bluebird')
+
+const logger = require('../../core/utils/logger')
+
+const log = logger({
+  component: 'GUI:actions'
+})
+
+async function exit(code /*: number */) {
+  app.exit(code)
+  // XXX: Exiting is an asynchronous action that cannot be awaited so we give
+  // the process 1 second to actually exit.
+  await Promise.delay(1000)
+}
+
+async function restart() {
+  if (process.env.APPIMAGE) {
+    return new Promise(resolve => {
+      setImmediate(async () => {
+        log.info('Exiting old client...')
+        await exit(0)
+        resolve()
+      })
+      const args = process.argv.slice(1).filter(a => a !== '--isHidden')
+      log.info({ args, cmd: process.argv[0] }, 'Starting new client...')
+      spawn(process.argv[0], args, { detached: true })
+    })
+  } else {
+    app.relaunch()
+    log.info('Exiting old client...')
+    await exit(0)
+  }
+}
+
+module.exports = {
+  exit,
+  restart
+}

--- a/gui/js/tray.js
+++ b/gui/js/tray.js
@@ -42,45 +42,6 @@ const setImage = iconName => {
   lastIconName = iconName
 }
 
-module.exports.init = (app, listener) => {
-  tray = new Tray(nativeImage.createEmpty())
-  setImage('idle')
-
-  app.on('before-quit', () => tray.destroy())
-
-  let cachedBounds = null
-  const clicked = (e, bounds) => {
-    cachedBounds = bounds && bounds.y !== 0 ? bounds : cachedBounds
-    listener(tray.getBounds ? tray.getBounds() : cachedBounds)
-  }
-
-  // On Linux systems without libappindicator-gtk3 or other systems, clicks on
-  // the systray icon trigger events that can be caught to display the app
-  // window for example.
-  tray.on('click', clicked)
-  tray.on('right-click', clicked)
-  tray.on('double-click', clicked)
-  tray.setToolTip('loading')
-
-  if (!isMac) {
-    // When click events are not triggered, we need to display a context menu so
-    // users can open the app's window.
-    const cm = Menu.buildFromTemplate([
-      { label: translate('Tray Quit application'), click: app.quit }
-    ])
-    cm.insert(
-      0,
-      new MenuItem({
-        label: translate('Tray Show application'),
-        click: clicked
-      })
-    )
-    cm.insert(1, new MenuItem({ type: 'separator' }))
-    tray.setContextMenu(cm)
-  }
-  setStatus('idle')
-}
-
 // old tray menu
 /*
 const goToTab = (tab) => {
@@ -145,9 +106,58 @@ const systrayInfo = (status, label) => {
   }
 }
 
-const setStatus = (module.exports.setStatus = (status, label) => {
+const setStatus = (status, label) => {
   const [iconName, tooltip] = systrayInfo(status, label)
   tray.setToolTip(tooltip)
 
   if (lastIconName !== iconName) setImage(iconName)
-})
+}
+
+const init = (app, listener) => {
+  tray = new Tray(nativeImage.createEmpty())
+  setImage('idle')
+
+  app.on('before-quit', () => tray.destroy())
+
+  let cachedBounds = null
+  const clicked = (e, bounds) => {
+    cachedBounds = bounds && bounds.y !== 0 ? bounds : cachedBounds
+    listener(tray.getBounds ? tray.getBounds() : cachedBounds)
+  }
+
+  // On Linux systems without libappindicator-gtk3 or other systems, clicks on
+  // the systray icon trigger events that can be caught to display the app
+  // window for example.
+  tray.on('click', clicked)
+  tray.on('right-click', clicked)
+  tray.on('double-click', clicked)
+  tray.setToolTip('loading')
+
+  if (!isMac) {
+    // When click events are not triggered, we need to display a context menu so
+    // users can open the app's window.
+    const cm = Menu.buildFromTemplate([
+      { label: translate('Tray Quit application'), click: app.quit }
+    ])
+    cm.insert(
+      0,
+      new MenuItem({
+        label: translate('Tray Show application'),
+        click: clicked
+      })
+    )
+    cm.insert(1, new MenuItem({ type: 'separator' }))
+    tray.setContextMenu(cm)
+  }
+  setStatus('idle')
+}
+
+const wasInitiated = () => {
+  return tray != null
+}
+
+module.exports = {
+  init,
+  setStatus,
+  wasInitiated
+}

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -1,6 +1,5 @@
 const electron = require('electron')
 const { dialog, shell } = electron
-const { spawn } = require('child_process')
 const path = require('path')
 
 const { openNote } = require('../utils/notes')
@@ -10,6 +9,7 @@ const autoLaunch = require('./autolaunch')
 const DetailsWM = require('./details.window')
 const CozyWebWM = require('./cozy-web.window')
 const { translate } = require('./i18n')
+const { restart } = require('./actions')
 
 const log = require('../../core/app').logger({
   component: 'GUI'
@@ -241,7 +241,7 @@ module.exports = class TrayWM extends WindowManager {
           .stopSync()
           .then(() => this.desktop.removeRemote())
           .then(() => log.info('remote removed'))
-          .then(() => this.doRestart())
+          .then(() => restart())
           .catch(err =>
             log.error({ err, sentry: true }, 'failed disconnecting client')
           )
@@ -333,22 +333,6 @@ module.exports = class TrayWM extends WindowManager {
       openInWeb(path.dirname(pathToOpen), { desktop })
     } else {
       shell.showItemInFolder(pathToOpen)
-    }
-  }
-
-  doRestart() {
-    if (process.env.APPIMAGE) {
-      setTimeout(() => {
-        log.info('Exiting old client...')
-        this.app.exit(0)
-      }, 50)
-      const args = process.argv.slice(1).filter(a => a !== '--isHidden')
-      log.info({ args, cmd: process.argv[0] }, 'Starting new client...')
-      spawn(process.argv[0], args, { detached: true })
-    } else {
-      this.app.relaunch()
-      log.info('Exiting old client...')
-      this.app.exit(0)
     }
   }
 }

--- a/gui/main.js
+++ b/gui/main.js
@@ -188,7 +188,6 @@ const showInvalidConfigError = async () => {
   if (response === 0) {
     desktop
       .removeConfig()
-      .then(() => log.info('removed'))
       .catch(err =>
         log.error({ err, sentry: true }, 'failed disconnecting client')
       )
@@ -247,7 +246,6 @@ const sendErrorToMainWindow = async ({ msg, code }) => {
       desktop
         .stopSync()
         .then(() => desktop.removeConfig())
-        .then(() => log.info('removed'))
         .then(() => restart())
         .catch(err =>
           log.error({ err, sentry: true }, 'failed disconnecting client')


### PR DESCRIPTION
When migrations making requests to the remote Cozy encounter a revoked
OAuth client error, we should display this error to the user and allow
them to go through the on-boarding again instead of displaying the
failed migration error which will prevent them from running the client
until the configuration folder is deleted.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
