### PR TITLE
core/sync: Dir creation before moves from outside

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -182,10 +182,14 @@ const compareChanges = (
     if (opA.type === 'ADD' && opB.type === 'MOVE') {
       // Handle child addtion after parent move
       if (docA.path.startsWith(docB.path + sep)) return 1
+      // Handle move to dir after dir addition
+      if (docB.path.startsWith(docA.path + sep)) return -1
     }
     if (opB.type === 'ADD' && opA.type === 'MOVE') {
       // Handle child addtion after parent move
       if (docB.path.startsWith(docA.path + sep)) return -1
+      // Handle move to dir after dir addition
+      if (docA.path.startsWith(docB.path + sep)) return 1
     }
   }
 

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -1403,6 +1403,39 @@ describe('Sync', function () {
       }
     )
 
+    context('with a directory addition and a move into said directory', () => {
+      let addDir, moveFile
+      beforeEach(async function () {
+        const dir = await builders
+          .metadir()
+          .path('dir')
+          .sides({ remote: 1 })
+          .create()
+        const srcFile = await builders
+          .metafile()
+          .path('file')
+          .upToDate()
+          .create()
+        const dstFile = await builders
+          .metafile()
+          .moveFrom(srcFile)
+          .path('dir/file')
+          .changedSide('remote')
+          .create()
+
+        addDir = makeChange(dir, 'ADD', this)
+        moveFile = makeChange(dstFile, 'MOVE', this)
+      })
+
+      it('returns -1 if addDir is passed as first argument', () => {
+        should(compareChanges(addDir, moveFile)).eql(-1)
+      })
+
+      it('returns 1 if addDir is passed as second argument', () => {
+        should(compareChanges(moveFile, addDir)).eql(1)
+      })
+    })
+
     context(
       'with a directory deletion and a deletion within said directory',
       () => {


### PR DESCRIPTION
When content is moved to a directory that was just created (and not
synced yet), we would try to synchronize the move first.
This would raise synchronization errors as the directory would not
exist on the other side. It would eventually work after retrying
(since we would finally get to synchronize the directory creation) but
this slows down synchronization (especially if a lot of documents were
moved to the directory) and could be the source of more problems
(de-synchronized states is never good).

Simply adding a comparison rule between these changes forces the
synchronization of the directory's creation first and prevents retries
for the content move.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
