### PR TITLE
Release v3.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.35.0 - 2022-05-12
+
+Improvements for all users:
+
+- We fixed a few issues that were preventing the correct processing of movements
+  and renamings of documents that have never been synchronized and sometimes not
+  even been saved in our local database.
+  These should now be handled as creations at their new path and overwritten
+  documents trashed on the other side.
+- We've fixed yet another issue with data migrations making requests to the
+  remote Cozy when the Desktop's Oauth client has been revoked on the Cozy.
+  You will now be be informed of the issue and given the opportunity to
+  reconnect your client.
+- To prevent blocking the Desktop client to start and synchronize when an app
+  update is available but downloading it consistently fail, we've decided to
+  stop retrying the download after 5 failures. The client will still try to
+  download the update again 24 hours later.
+- We've updated the error message displayed when we fail to send a file to the
+  remote Cozy because it's size is either larger than the available space or the
+  maximum allowed. It should be easier to understand and the available action
+  less scary.
+- We've made changes to the dependency algorithm that decides which changes need
+  to be synchronized first in order for all changes to be synchronized correctly
+  (and without retry). When documents are moved to a freshly created directory,
+  we should always synchronize the creation of said directory before moving the
+  documents into it.
+  This would work with retries before but this was a waste of time and
+  resources.
+
+Improvements for Windows users:
+
+- The local database software could experience issues when trying to delete
+  temporary databases or the main database when disconnecting the client.
+  An update of said software should now handle them appropriately.
+
+Improvements for macOS users:
+
+- We fixed a few issues that were preventing the correct processing of movements
+  with case changes of documents that have never been been saved in our local
+  database.
+  These should now be handled as creations at their new path and overwritten
+  documents trashed on the other side.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.35.0-beta.2 - 2022-05-10
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.35.0-beta.2",
+  "version": "3.35.0",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- We fixed a few issues that were preventing the correct processing of
  movements and renamings of documents that have never been synchronized
  and sometimes not even been saved in our local database.
  These should now be handled as creations at their new path and
  overwritten documents trashed on the other side.
- We've fixed yet another issue with data migrations making requests to
  the remote Cozy when the Desktop's Oauth client has been revoked on
  the Cozy. You will now be be informed of the issue and given the
  opportunity to reconnect your client.
- To prevent blocking the Desktop client to start and synchronize when
  an app update is available but downloading it consistently fail, we've
  decided to stop retrying the download after 5 failures. The client
  will still try to download the update again 24 hours later.
- We've updated the error message displayed when we fail to send a file
  to the remote Cozy because it's size is either larger than the
  available space or the maximum allowed. It should be easier to
  understand and the available action less scary.
- We've made changes to the dependency algorithm that decides which
  changes need to be synchronized first in order for all changes to be
  synchronized correctly (and without retry). When documents are moved
  to a freshly created directory, we should always synchronize the
  creation of said directory before moving the documents into it.
  This would work with retries before but this was a waste of time and
  resources.

Improvements for Windows users:

- The local database software could experience issues when trying to
  delete temporary databases or the main database when disconnecting the
  client.
  An update of said software should now handle them appropriately.

Improvements for macOS users:

- We fixed a few issues that were preventing the correct processing of
  movements with case changes of documents that have never been been
  saved in our local database.
  These should now be handled as creations at their new path and
  overwritten documents trashed on the other side.
