### PR TITLE
core/remote/cozy: Use cozy-client queryAll method

### DIFF
--- a/core/remote/document.js
+++ b/core/remote/document.js
@@ -356,7 +356,10 @@ function jsonApiToRemoteJsonDoc(
       _deleted: true
     } /*: CouchDBDeletion */)
   } else if (!json.meta || !json.meta.rev) {
-    throw new Error('Missing meta.rev attribute in JsonAPI resource.')
+    const error = new Error('Missing meta.rev attribute in JsonAPI resource.')
+    // $FlowFixMe we add the `data` attribute on purpose
+    error.data = { json }
+    throw error
   } else {
     const { attributes, id, type, relationships } = json
 

--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -90,7 +90,8 @@ function errSerializer(err) {
       'errors',
       'doc',
       'incompatibilities',
-      'change'
+      'change',
+      'data'
     ])
   )
 

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -914,6 +914,33 @@ describe('RemoteCozy', function () {
       const dir = await builders.remoteDir().name('dir').create()
       await should(remoteCozy.getDirectoryContent(dir)).be.fulfilledWith([])
     })
+
+    it('does not fail when there are multiple result pages', async () => {
+      const tree = await builders.createRemoteTree([
+        'dir/',
+        'dir/subdir/',
+        'dir/subdir/subsubdir/',
+        'dir/subdir/file',
+        'dir/file',
+        'dir/other-subdir/',
+        'dir/other-subdir/next-level/',
+        'dir/other-subdir/next-level/last-level/',
+        'dir/other-subdir/next-level/last-level/content',
+        'dir/subdir/subsubdir/last',
+        'hello.txt',
+        'other-dir/',
+        'other-dir/content'
+      ])
+
+      const dirContent = await remoteCozy.getDirectoryContent(tree['dir/'], {
+        batchSize: 1
+      })
+      should(dirContent.map(metadata.serializableRemote)).deepEqual(
+        [tree['dir/file'], tree['dir/other-subdir/'], tree['dir/subdir/']].map(
+          metadata.serializableRemote
+        )
+      )
+    })
   })
 
   describe('#isExcludedDirectory', () => {


### PR DESCRIPTION
We added our own `RemoteCozy.queryAll()` method to fetch the content
of a directory from the remote Cozy but its implementation was flawed
and would result in errors when there were multiple pages of documents
to fetch (i.e. we use 3000 docs pages).

Instead of fixing this implementation, we will now use `cozy-client`'s
`queryAll()` method which is battle tested.
I don't understand why we didn't use it before.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
