### PR TITLE
build: Really unpack native modules

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,7 +26,7 @@ afterPack: './build/afterPackHook.js'
 afterSign: './build/afterSignHook.js'
 asarUnpack:
 - gui/scripts/**
-- '*.node' # see https://www.electronjs.org/docs/tutorial/application-packaging#adding-unpacked-files-to-asar-archives
+- '**/*.node' # see https://www.electronjs.org/docs/tutorial/application-packaging#adding-unpacked-files-to-asar-archives
 directories:
   buildResources: gui/assets
 fileAssociations:


### PR DESCRIPTION
*.node only matches files at the root.
**/*.node matches any file in the tree.

This should properly implement https://github.com/cozy-labs/cozy-desktop/pull/1846 (in addition to reasons mentioned
there, it should be noted that extracted files are not cleaned upon
exit, so this is yet another reason to have them unpacked from the
start).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
