### PR TITLE
test/helpers: Replace deprecated recursive rmdir

### DIFF
--- a/test/support/helpers/context_dir.js
+++ b/test/support/helpers/context_dir.js
@@ -155,7 +155,7 @@ class ContextDir {
   }
 
   async rmdir(target /*: string | {path: string} */) {
-    await fse.rmdirSync(this.abspath(target))
+    await fse.rm(this.abspath(target), { recursive: true })
   }
 
   async readFile(

--- a/test/support/helpers/scenarios.js
+++ b/test/support/helpers/scenarios.js
@@ -324,7 +324,7 @@ const merge = async (srcPath, dstPath) => {
     await fse.rename(srcPath, dstPath)
   } else if (srcStats && srcStats.isFile()) {
     debug('file is replacing dir', { srcPath, dstPath })
-    await fse.rmdir(dstPath, { recursive: true })
+    await fse.rm(dstPath, { recursive: true })
     await fse.rename(srcPath, dstPath)
   } else {
     for (const entry of await fse.readdir(srcPath)) {
@@ -333,7 +333,7 @@ const merge = async (srcPath, dstPath) => {
   }
   if (srcStats && srcStats.isDirectory()) {
     try {
-      await fse.rmdir(srcPath, { recursive: true })
+      await fse.rm(srcPath, { recursive: true })
     } catch (err) {
       debug('rmdir', { path: srcPath }, err)
     }


### PR DESCRIPTION
Recursive `fs.rmdir` calls have been deprecated in favor of recursive
calls to `fs.rm` and the deprecation warning is seen as an error by
AppVeyor thus failing the scenarios job.

Replacing these calls should get us a green CI again.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
