### PR TITLE
core/merge: Update remote metadata of trashed docs

### DIFF
--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -373,6 +373,15 @@ module.exports = class BaseMetadataBuilder {
     }
 
     this.doc.remote = metadata.serializableRemote(builder.build())
-    this.doc.remote.path = pathUtils.localToRemote(this.doc.path)
+
+    if (!this.doc.trashed) {
+      // when trashed, a document's path will start with the trash dir name
+      // instead of its old parent's path so we don't want to change the path in
+      // this case.
+      // FIXME: A better way to deal with this would be to use the remote
+      // builder's `inDir()` method but we don't necessarily have the directory
+      // 's _id on hand.
+      this.doc.remote.path = pathUtils.localToRemote(this.doc.path)
+    }
   }
 }


### PR DESCRIPTION
Since trashing a document on the remote Cozy changes its CouchDB
revision, we need to store this updated metadata in our local PouchDB.
This makes future changes on the remote doc and detecting that the
trashed remote document is up-to-date possible.

We were updating the remote revision only when the doc had previously
been moved and that move wasn't synchronized yet.
We're now saving the complete updated remote metadata whenever merging
a document trashing (this includes the `trashed` attribute).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
