### PR TITLE
core/remote: Move content before trashing parent

### DIFF
--- a/core/incompatibilities/platform.js
+++ b/core/incompatibilities/platform.js
@@ -229,7 +229,7 @@ const detectDirNameLengthIncompatibility = (
  */
 const detectNameIncompatibilities = (
   name /*: string */,
-  type /*: string */,
+  type /*: 'file'|'folder' */,
   platform /*: string */
 ) /*: NameIncompatibility[] */ => {
   const restrictions = restrictionsByPlatform(platform)
@@ -287,7 +287,7 @@ const detectNameIncompatibilities = (
  */
 const detectPathIncompatibilities = (
   path /*: string */,
-  type /*: string */
+  type /*: 'file'|'folder' */
 ) /*: Array<PlatformIncompatibility> */ => {
   const platform = process.platform
   const ancestorNames = path.split(sep)

--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -151,7 +151,7 @@ function analyseEvents(
     if (process.env.DEBUG) log.trace({ currentEvent: e, path: e.path })
     try {
       // chokidar make mistakes
-      if (e.type === 'unlinkDir' && e.old && e.old.docType === 'file') {
+      if (e.type === 'unlinkDir' && e.old && e.old.docType === metadata.FILE) {
         log.warn(
           { event: e, old: e.old, path: e.path },
           'chokidar miscategorized event (was file, event unlinkDir)'
@@ -160,7 +160,7 @@ function analyseEvents(
         e.type = 'unlink'
       }
 
-      if (e.type === 'unlink' && e.old && e.old.docType === 'folder') {
+      if (e.type === 'unlink' && e.old && e.old.docType === metadata.FOLDER) {
         log.warn(
           { event: e, old: e.old, path: e.path },
           'chokidar miscategorized event (was folder, event unlink)'

--- a/core/local/chokidar/event.js
+++ b/core/local/chokidar/event.js
@@ -15,6 +15,7 @@
  * @flow
  */
 
+const { FILE } = require('../../metadata')
 const stater = require('../stater')
 
 /*::
@@ -96,7 +97,7 @@ function eventType(type /*: string */, stats /*: ?fs.Stats */) /*: string */ {
 function pretendUnlinkFromMetadata(
   doc /*: SavedMetadata */
 ) /*: ChokidarUnlink|ChokidarUnlinkDir */ {
-  const type = doc.docType === 'file' ? 'unlink' : 'unlinkDir'
+  const type = doc.docType === FILE ? 'unlink' : 'unlinkDir'
   const path = doc.path
   // $FlowFixMe
   return { type, path, old: doc }

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -161,7 +161,7 @@ class Local /*:: implements Reader, Writer */ {
   ) /*: Promise<void> */ {
     let filePath = this.abspath(doc.path)
 
-    if (doc.docType === 'file') {
+    if (doc.docType === metadata.FILE) {
       // TODO: Honor existing read/write permissions
       await fse.chmod(filePath, doc.executable ? 0o755 : 0o644)
     }

--- a/core/merge.js
+++ b/core/merge.js
@@ -97,7 +97,7 @@ class Merge {
         return this.resolveConflictAsync(side, doc)
       }
 
-      if (file.docType === 'folder') {
+      if (file.docType === metadata.FOLDER) {
         return this.resolveConflictAsync(side, doc)
       }
 
@@ -120,7 +120,7 @@ class Merge {
       metadata.assignMaxDate(doc)
       return this.pouch.put(doc)
     } else {
-      if (file.docType === 'folder') {
+      if (file.docType === metadata.FOLDER) {
         throw new Error("Can't resolve this conflict!")
       }
 
@@ -317,7 +317,7 @@ class Merge {
       metadata.assignMaxDate(doc, folder)
       return this.pouch.put(doc)
     } else {
-      if (folder.docType === 'file') {
+      if (folder.docType === metadata.FILE) {
         return this.resolveConflictAsync(side, doc)
       }
 
@@ -653,13 +653,13 @@ class Merge {
           // metadata as an update of the overwritten document.
           await this.pouch.eraseDocument(child)
           metadata.markAsUnmerged(movedChild, side)
-          if (movedChild.docType === 'file') {
+          if (movedChild.docType === metadata.FILE) {
             await this.updateFileAsync(side, movedChild)
           } else {
             await this.putFolderAsync(side, movedChild)
           }
         } else {
-          if (movedChild.docType === 'file') {
+          if (movedChild.docType === metadata.FILE) {
             await this.updateFileAsync(side, movedChild)
           } else {
             await this.putFolderAsync(side, movedChild)
@@ -882,7 +882,7 @@ class Merge {
     if (!was) {
       log.debug({ path }, 'Nothing to trash')
       return
-    } else if (doc.docType !== was.docType || was.docType !== 'file') {
+    } else if (doc.docType !== was.docType || was.docType !== metadata.FILE) {
       log.error(
         { doc, was, sentry: true },
         'Mismatch on doctype for trashFileAsync'

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -77,6 +77,9 @@ const log = logger({
 
 const { platform } = process
 
+const FILE = 'file'
+const FOLDER = 'folder'
+
 const LOCAL_ATTRIBUTES = [
   'path',
   'docType',
@@ -947,6 +950,8 @@ function updateRemote(
 }
 
 module.exports = {
+  FILE,
+  FOLDER,
   LOCAL_ATTRIBUTES,
   REMOTE_ATTRIBUTES,
   assignMaxDate,

--- a/core/metadata.js
+++ b/core/metadata.js
@@ -232,9 +232,9 @@ function idNTFS(fpath /*: string */) {
 function localDocType(remoteDocType /*: string */) /*: string */ {
   switch (remoteDocType) {
     case REMOTE_FILE_TYPE:
-      return 'file'
+      return FILE
     case REMOTE_DIR_TYPE:
-      return 'folder'
+      return FOLDER
     default:
       throw new Error(`Unexpected Cozy Files type: ${remoteDocType}`)
   }
@@ -326,7 +326,7 @@ function isFile(
   doc /*: Metadata|MetadataLocalInfo|MetadataRemoteInfo */
 ) /*: boolean %checks */ {
   return doc.docType != null
-    ? doc.docType === 'file'
+    ? doc.docType === FILE
     : doc.type !== null
     ? doc.type === REMOTE_FILE_TYPE
     : false
@@ -336,18 +336,14 @@ function isFolder(
   doc /*: Metadata|MetadataLocalInfo|MetadataRemoteInfo */
 ) /*: boolean %checks */ {
   return doc.docType != null
-    ? doc.docType === 'folder'
+    ? doc.docType === FOLDER
     : doc.type !== null
     ? doc.type === REMOTE_DIR_TYPE
     : false
 }
 
 function kind(doc /*: Metadata */) /*: EventKind */ {
-  return doc.docType == null
-    ? 'file'
-    : doc.docType === 'folder'
-    ? 'directory'
-    : doc.docType
+  return doc.docType === FOLDER ? 'directory' : FILE
 }
 
 // Return true if the document has not a valid path
@@ -388,7 +384,7 @@ function invariants /*:: <T: Metadata|SavedMetadata> */(doc /*: T */) {
     err = new Error(`Metadata has 'sides.remote' but no remote`)
   } else if (doc.sides.local && !doc.local) {
     err = new Error(`Metadata has 'sides.local' but no local`)
-  } else if (doc.docType === 'file' && doc.md5sum == null) {
+  } else if (doc.docType === FILE && doc.md5sum == null) {
     err = new Error(`File metadata has no checksum`)
   }
 
@@ -425,7 +421,7 @@ function detectIncompatibilities(
   return incompatibilities.map(issue =>
     _.merge(
       {
-        docType: issue.path === metadata.path ? metadata.docType : 'folder'
+        docType: issue.path === metadata.path ? metadata.docType : FOLDER
       },
       issue
     )
@@ -446,7 +442,7 @@ function assignPlatformIncompatibilities(
 // MD5 has 16 bytes.
 // Base64 encoding must include padding.
 function invalidChecksum(doc /*: Metadata */) {
-  if (doc.md5sum == null) return doc.docType === 'file'
+  if (doc.md5sum == null) return doc.docType === FILE
 
   const buffer = Buffer.from(doc.md5sum, 'base64')
 
@@ -652,8 +648,8 @@ const makeComparator = (
       return [lhs || [], rhs || []]
     } else if (key === 'type' || key === 'docType') {
       return [
-        lhs === 'directory' ? 'folder' : lhs,
-        rhs === 'directory' ? 'folder' : rhs
+        lhs === REMOTE_DIR_TYPE ? FOLDER : lhs,
+        rhs === REMOTE_DIR_TYPE ? FOLDER : rhs
       ]
     } else if (Boolean(lhs) === lhs || Boolean(rhs) === rhs) {
       return [Boolean(lhs), Boolean(rhs)]
@@ -824,7 +820,7 @@ function buildDir(
 ) /*: Metadata */ {
   const doc /*: $Shape<Metadata> */ = {
     path: fpath,
-    docType: 'folder',
+    docType: FOLDER,
     updated_at: stats.mtime.toISOString(),
     ino: stats.ino,
     tags: [],
@@ -857,7 +853,7 @@ function buildFile(
 
   const doc /*: $Shape<Metadata> */ = {
     path: filePath,
-    docType: 'file',
+    docType: FILE,
     md5sum,
     ino,
     updated_at,
@@ -894,7 +890,7 @@ function shouldIgnore(
 ) /*: boolean */ {
   return ignoreRules.isIgnored({
     relativePath: id(doc.path),
-    isFolder: doc.docType === 'folder'
+    isFolder: doc.docType === FOLDER
   })
 }
 

--- a/core/prep.js
+++ b/core/prep.js
@@ -56,7 +56,7 @@ class Prep {
     metadata.ensureValidPath(doc)
     metadata.ensureValidChecksum(doc)
 
-    doc.docType = 'file'
+    doc.docType = metadata.FILE
     if (side === 'local' && metadata.shouldIgnore(doc, this.ignore)) {
       return
     }
@@ -71,7 +71,7 @@ class Prep {
     metadata.ensureValidPath(doc)
     metadata.ensureValidChecksum(doc)
 
-    doc.docType = 'file'
+    doc.docType = metadata.FILE
     if (side === 'local' && metadata.shouldIgnore(doc, this.ignore)) {
       return
     }
@@ -84,7 +84,7 @@ class Prep {
     log.debug({ path: doc.path }, 'putFolderAsync')
     metadata.ensureValidPath(doc)
 
-    doc.docType = 'folder'
+    doc.docType = metadata.FOLDER
     if (side === 'local' && metadata.shouldIgnore(doc, this.ignore)) {
       return
     }
@@ -117,7 +117,7 @@ class Prep {
       throw new Error(msg)
     }
 
-    doc.docType = 'file'
+    doc.docType = metadata.FILE
     let docIgnored = metadata.shouldIgnore(doc, this.ignore)
     let wasIgnored = metadata.shouldIgnore(was, this.ignore)
     if (side === 'local' && docIgnored && wasIgnored) {
@@ -157,7 +157,7 @@ class Prep {
       throw new Error(msg)
     }
 
-    doc.docType = 'folder'
+    doc.docType = metadata.FOLDER
     let docIgnored = metadata.shouldIgnore(doc, this.ignore)
     let wasIgnored = metadata.shouldIgnore(was, this.ignore)
     if (side === 'local' && docIgnored && wasIgnored) {
@@ -188,7 +188,7 @@ class Prep {
       return this.merge.trashFileAsync(side, was, was)
     } else {
       metadata.ensureValidPath(doc)
-      doc.docType = 'file'
+      doc.docType = metadata.FILE
 
       return this.merge.trashFileAsync(side, was, doc)
     }
@@ -210,7 +210,7 @@ class Prep {
       return this.merge.trashFolderAsync(side, was, was)
     } else {
       metadata.ensureValidPath(doc)
-      doc.docType = 'folder'
+      doc.docType = metadata.FOLDER
 
       return this.merge.trashFolderAsync(side, was, doc)
     }
@@ -222,7 +222,7 @@ class Prep {
     log.debug({ path: doc.path }, 'deleteFileAsync')
     metadata.ensureValidPath(doc)
 
-    doc.docType = 'file'
+    doc.docType = metadata.FILE
     if (side === 'local' && metadata.shouldIgnore(doc, this.ignore)) {
       return
     }
@@ -235,7 +235,7 @@ class Prep {
     log.debug({ path: doc.path }, 'deleteFolderAsync')
     metadata.ensureValidPath(doc)
 
-    doc.docType = 'folder'
+    doc.docType = metadata.FOLDER
     if (side === 'local' && metadata.shouldIgnore(doc, this.ignore)) {
       return
     }

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -359,6 +359,8 @@ const sortForDelete = (del, b, delFirst) => {
 
     return 0
   }
+  if (isMove(b) && areParentChild(deletedPath(del), deletedPath(b)))
+    return -delFirst
 
   return delFirst
 }

--- a/core/remote/change.js
+++ b/core/remote/change.js
@@ -306,9 +306,9 @@ const isDescendant = (a /*: RemoteChange */) /*: boolean %checks */ =>
 const isMove = (a /*: RemoteChange */) /*: boolean %checks */ =>
   isFileMove(a) || isFolderMove(a)
 const isFileMove = (a /*: RemoteChange */) /*: boolean %checks */ =>
-  a.type === 'FileMove' || (isDescendant(a) && a.doc.docType === 'File')
+  a.type === 'FileMove' || (isDescendant(a) && a.doc.docType === metadata.FILE)
 const isFolderMove = (a /*: RemoteChange */) /*: boolean %checks */ =>
-  a.type === 'DirMove' || (isDescendant(a) && a.doc.docType === 'Folder')
+  a.type === 'DirMove' || (isDescendant(a) && a.doc.docType === metadata.FOLDER)
 const isTrash = (a /*: RemoteChange */) /*: boolean %checks */ =>
   a.type === 'DirTrashing' || a.type === 'FileTrashing'
 const isRestore = (a /*: RemoteChange */) /*: boolean %checks */ =>
@@ -329,21 +329,15 @@ function includeDescendant(
 }
 
 const createdPath = (a /*: RemoteChange */) /*: ?string */ =>
-  isAdd(a) || isMove(a) || isDescendant(a) || isRestore(a) ? a.doc.path : null
+  isAdd(a) || isMove(a) || isRestore(a) ? a.doc.path : null
 const createdId = (a /*: RemoteChange */) /*: ?string */ =>
-  isAdd(a) || isMove(a) || isDescendant(a) || isRestore(a)
-    ? metadata.id(a.doc.path)
-    : null
+  isAdd(a) || isMove(a) || isRestore(a) ? metadata.id(a.doc.path) : null
 const deletedPath = (a /*: RemoteChange */) /*: ?string */ =>
-  isDelete(a)
-    ? a.doc.path
-    : isMove(a) || isDescendant(a) || isTrash(a)
-    ? a.was.path
-    : null
+  isDelete(a) ? a.doc.path : isMove(a) || isTrash(a) ? a.was.path : null
 const deletedId = (a /*: RemoteChange */) /*: ?string */ =>
   isDelete(a)
     ? metadata.id(a.doc.path)
-    : isMove(a) || isDescendant(a) || isTrash(a)
+    : isMove(a) || isTrash(a)
     ? metadata.id(a.was.path)
     : null
 const ignoredPath = (a /*: RemoteChange */) /*: ?string */ =>
@@ -383,7 +377,7 @@ const sortForDescendant = (desc, b, descFirst) => {
 }
 
 const sortForMove = (move, b, moveFirst) => {
-  if (isMove(b) || isDescendant(b)) {
+  if (isMove(b)) {
     if (isDescendant(move) && isDescendant(b)) {
       if (areParentChild(deletedPath(move), deletedPath(b))) return moveFirst
       if (areParentChild(deletedPath(b), deletedPath(move))) return -moveFirst
@@ -453,8 +447,8 @@ const sortChanges = (a, b) => {
   if (isDelete(a) || isTrash(a)) return sortForDelete(a, b, aFirst)
   if (isDelete(b) || isTrash(b)) return sortForDelete(b, a, bFirst)
 
-  if (isMove(a) || isDescendant(a)) return sortForMove(a, b, aFirst)
-  if (isMove(b) || isDescendant(b)) return sortForMove(b, a, bFirst)
+  if (isMove(a)) return sortForMove(a, b, aFirst)
+  if (isMove(b)) return sortForMove(b, a, bFirst)
 
   if (isRestore(a) || isAdd(a)) return sortForAdd(a, b, aFirst)
   if (isRestore(b) || isAdd(b)) return sortForAdd(b, a, bFirst)

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -423,7 +423,7 @@ class RemoteCozy {
 
   async findDirectoryByPath(path /*: string */) /*: Promise<RemoteDir> */ {
     const results = await this.search({ path })
-    if (results.length === 0 || results[0].type !== 'directory') {
+    if (results.length === 0 || results[0].type !== DIR_TYPE) {
       throw new DirectoryNotFound(path, this.url)
     }
 
@@ -471,7 +471,7 @@ class RemoteCozy {
       client: { clientID }
     } = this.config
     return (
-      doc.type === 'directory' &&
+      doc.type === DIR_TYPE &&
       doc.not_synchronized_on != null &&
       doc.not_synchronized_on.find(({ id }) => id === clientID) != null
     )
@@ -479,7 +479,7 @@ class RemoteCozy {
 
   async isEmpty(id /*: string */) /*: Promise<boolean> */ {
     const dir = await this.client.files.statById(id)
-    if (dir.attributes.type !== 'directory') {
+    if (dir.attributes.type !== DIR_TYPE) {
       throw new Error(
         `Cannot check emptiness of directory ${id}: ` +
           `wrong type: ${dir.attributes.type}`

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -452,7 +452,7 @@ class Remote /*:: implements Reader, Writer */ {
     // are changed but we'll need to review this when we start updating it only
     // after a move has been fully synchronzed.
     const dir = await this.pouch.bySyncedPath(pathUtils.remoteToLocal(path))
-    if (!dir || dir.deleted || !dir.remote || dir.docType !== 'folder') {
+    if (!dir || dir.deleted || !dir.remote || dir.docType !== metadata.FOLDER) {
       throw new DirectoryNotFound(path, this.config.cozyUrl)
     }
 
@@ -479,7 +479,7 @@ class Remote /*:: implements Reader, Writer */ {
   async includeInSync(doc /*: SavedMetadata */) /*: Promise<*> */ {
     const remoteDocs = await this.remoteCozy.search({ path: `/${doc.path}` })
     const remoteDoc = remoteDocs[0]
-    if (!remoteDoc || remoteDoc.type !== 'directory') return
+    if (!remoteDoc || remoteDoc.type !== DIR_TYPE) return
 
     await this.remoteCozy.includeInSync(remoteDoc)
   }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 
 const metadata = require('../../metadata')
 const remoteChange = require('../change')
-const { HEARTBEAT } = require('../constants')
+const { FILE_TYPE, DIR_TYPE, HEARTBEAT } = require('../constants')
 const remoteErrors = require('../errors')
 const { inRemoteTrash } = require('../document')
 const squashMoves = require('./squashMoves')
@@ -62,7 +62,7 @@ const needsContentFetching = (
   { isRecursiveFetch = false } /*: { isRecursiveFetch: boolean } */ = {}
 ) /*: boolean %checks */ => {
   return (
-    remoteDoc.type === 'directory' &&
+    remoteDoc.type === DIR_TYPE &&
     (folderMightHaveBeenExcluded(remoteDoc) || isRecursiveFetch)
   )
 }
@@ -352,7 +352,7 @@ class RemoteWatcher {
       }
       return remoteChange.deleted(was)
     } else {
-      if (remoteDoc.type !== 'directory' && remoteDoc.type !== 'file') {
+      if (remoteDoc.type !== DIR_TYPE && remoteDoc.type !== FILE_TYPE) {
         return {
           sideName,
           type: 'InvalidChange',
@@ -362,7 +362,7 @@ class RemoteWatcher {
           )
         }
       } else if (
-        remoteDoc.type === 'file' &&
+        remoteDoc.type === FILE_TYPE &&
         (remoteDoc.md5sum == null || remoteDoc.md5sum === '')
       ) {
         return {
@@ -416,7 +416,7 @@ class RemoteWatcher {
     }
     const { docType, path } = doc
 
-    if (doc.docType !== 'file' && doc.docType !== 'folder') {
+    if (doc.docType !== metadata.FILE && doc.docType !== metadata.FOLDER) {
       return {
         sideName,
         type: 'InvalidChange',
@@ -482,7 +482,7 @@ class RemoteWatcher {
       return remoteChange.added(doc)
     } else if (metadata.samePath(was, doc)) {
       if (
-        doc.docType === 'file' &&
+        doc.docType === metadata.FILE &&
         doc.md5sum === was.md5sum &&
         doc.size !== was.size
       ) {

--- a/core/remote/watcher/squashMoves.js
+++ b/core/remote/watcher/squashMoves.js
@@ -17,7 +17,7 @@ import type { RemoteChange, RemoteFileMove, RemoteDirMove, RemoteDescendantChang
 */
 
 const buildChange = (sideName, doc, was) => {
-  if (doc.docType === 'file') {
+  if (doc.docType === metadata.FILE) {
     return {
       sideName,
       type: 'FileMove',

--- a/core/utils/web.js
+++ b/core/utils/web.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const { generateWebLink } = require('cozy-client')
 
+const { DIR_TYPE } = require('../remote/constants')
 const capabilities = require('./capabilities')
 const logger = require('./logger')
 
@@ -36,7 +37,7 @@ async function findDocument(
 
   if (doc) {
     const hash = doc.remote
-      ? doc.remote.type === 'directory'
+      ? doc.remote.type === DIR_TYPE
         ? `folder/${doc.remote._id}`
         : `folder/${doc.remote.dir_id}/file/${doc.remote._id}`
       : ''

--- a/dev/remote/change-dir-exclusions.js
+++ b/dev/remote/change-dir-exclusions.js
@@ -9,6 +9,7 @@ const _ = require('lodash')
 
 const { Config } = require('../../core/config')
 const {
+  DIR_TYPE,
   FILES_DOCTYPE,
   OAUTH_CLIENTS_DOCTYPE,
   ROOT_DIR_ID,
@@ -85,7 +86,7 @@ async function getDirectoryContent(context) {
   while (resp && resp.next) {
     const queryDef = Q(FILES_DOCTYPE)
       .where({
-        type: 'directory',
+        type: DIR_TYPE,
         name: {
           $ne: ''
         },

--- a/test/integration/differential_sync.js
+++ b/test/integration/differential_sync.js
@@ -12,12 +12,13 @@ const TestHelpers = require('../support/helpers')
 const Builders = require('../support/builders')
 
 const {
+  DIR_TYPE,
   FILES_DOCTYPE,
   OAUTH_CLIENTS_DOCTYPE
 } = require('../../core/remote/constants')
 
 const path = remoteDoc =>
-  remoteDoc.type === 'directory'
+  remoteDoc.type === DIR_TYPE
     ? `${remoteDoc.path.slice(1)}/`
     : remoteDoc.path.slice(1)
 

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -8,6 +8,7 @@ const path = require('path')
 const metadata = require('../../core/metadata')
 const timestamp = require('../../core/utils/timestamp')
 const { INCOMPATIBLE_DOC_CODE } = require('../../core/sync/errors')
+const { DIR_TYPE } = require('../../core/remote/constants')
 
 const Builders = require('../support/builders')
 const configHelpers = require('../support/helpers/config')
@@ -362,7 +363,7 @@ describe('Platform incompatibilities', () => {
 
     // Simulate remote move
     helpers._sync.blockSyncFor.resetHistory()
-    if (remoteDocs['dir/'].type !== 'directory') {
+    if (remoteDocs['dir/'].type !== DIR_TYPE) {
       throw new Error('Unexpected remote file with dir/ path')
     }
     const remoteDoc = remoteDocs['dir/']

--- a/test/scenarios/move_dir_content_and_trash_dir/local/darwin.json
+++ b/test/scenarios/move_dir_content_and_trash_dir/local/darwin.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "unlinkDir",
+    "path": "dir"
+  },
+  {
+    "type": "unlink",
+    "path": "dir/file"
+  },
+  {
+    "type": "add",
+    "path": "file",
+    "stats": {
+      "dev": 16777222,
+      "mode": 33188,
+      "nlink": 1,
+      "uid": 501,
+      "gid": 20,
+      "rdev": 0,
+      "blksize": 4096,
+      "ino": 2,
+      "size": 3,
+      "blocks": 8,
+      "atimeMs": 1665588036348.5657,
+      "mtimeMs": 1665588035687.8835,
+      "ctimeMs": 1665588035707.0203,
+      "birthtimeMs": 1665588035687.0452,
+      "atime": "2022-10-12T15:20:36.349Z",
+      "mtime": "2022-10-12T15:20:35.688Z",
+      "ctime": "2022-10-12T15:20:35.707Z",
+      "birthtime": "2022-10-12T15:20:35.687Z"
+    }
+  }
+]

--- a/test/scenarios/move_dir_content_and_trash_dir/parcel/linux.json
+++ b/test/scenarios/move_dir_content_and_trash_dir/parcel/linux.json
@@ -1,0 +1,17 @@
+[
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "oldPath": "dir/file",
+      "path": "file",
+      "ino": 19843525
+    },
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "dir",
+      "deletedIno": 19915746
+    }
+  ]
+]

--- a/test/scenarios/move_dir_content_and_trash_dir/parcel/win32.json
+++ b/test/scenarios/move_dir_content_and_trash_dir/parcel/win32.json
@@ -1,0 +1,17 @@
+[
+  [
+    {
+      "action": "renamed",
+      "kind": "file",
+      "oldPath": "dir\\file",
+      "path": "file",
+      "ino": "0x001600000004F38F"
+    },
+    {
+      "action": "deleted",
+      "kind": "directory",
+      "path": "dir",
+      "deletedIno": "0x00270000000032CC"
+    }
+  ]
+]

--- a/test/scenarios/move_dir_content_and_trash_dir/remote/changes.json
+++ b/test/scenarios/move_dir_content_and_trash_dir/remote/changes.json
@@ -1,0 +1,72 @@
+[
+  {
+    "_id": "3283bd912c724cb28f185dc27d05516a",
+    "_rev": "2-1cb42eec6e9f81a68f8528627d8a4b9d",
+    "cozyMetadata": {
+      "createdAt": "2022-10-10T13:20:59.172240901+02:00",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.localhost:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2022-10-10T13:20:59.364513016+02:00",
+      "updatedByApps": [
+        {
+          "date": "2022-10-10T13:20:59.364513016+02:00",
+          "instance": "http://cozy.localhost:8080/",
+          "slug": "cozy-desktop"
+        }
+      ]
+    },
+    "created_at": "2022-10-10T11:20:59Z",
+    "dir_id": "io.cozy.files.trash-dir",
+    "name": "dir",
+    "path": "/.cozy_trash/dir",
+    "restore_path": "/",
+    "type": "directory",
+    "updated_at": "2022-10-10T11:20:59Z",
+    "tags": []
+  },
+  {
+    "_id": "3283bd912c724cb28f185dc27d055fd0",
+    "_rev": "2-082c0a9bacb2b92cb8df0316ba8005f1",
+    "class": "files",
+    "cozyMetadata": {
+      "createdAt": "2022-10-10T13:20:59.198873105+02:00",
+      "createdByApp": "cozy-desktop",
+      "createdOn": "http://cozy.localhost:8080/",
+      "doctypeVersion": "1",
+      "metadataVersion": 1,
+      "updatedAt": "2022-10-10T13:20:59.320520707+02:00",
+      "updatedByApps": [
+        {
+          "date": "2022-10-10T13:20:59.320520707+02:00",
+          "instance": "http://cozy.localhost:8080/",
+          "slug": "cozy-desktop"
+        }
+      ],
+      "uploadedAt": "2022-10-10T13:20:59.198873105+02:00",
+      "uploadedBy": {
+        "oauthClient": {
+          "id": "3283bd912c724cb28f185dc27d054227",
+          "kind": "",
+          "name": "test-2"
+        },
+        "slug": "cozy-desktop"
+      },
+      "uploadedOn": "http://cozy.localhost:8080/"
+    },
+    "created_at": "2022-10-10T11:20:59Z",
+    "dir_id": "io.cozy.files.root-dir",
+    "encrypted": false,
+    "executable": false,
+    "md5sum": "AIxZJsqGECPB0qNmU/2I4g==",
+    "mime": "application/octet-stream",
+    "name": "file",
+    "path": "/file",
+    "size": "8",
+    "trashed": false,
+    "type": "file",
+    "updated_at": "2022-10-10T11:20:59Z",
+    "tags": []
+  }
+]

--- a/test/scenarios/move_dir_content_and_trash_dir/scenario.js
+++ b/test/scenarios/move_dir_content_and_trash_dir/scenario.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+/*:: import type { Scenario } from '..' */
+
+module.exports = ({
+  useCaptures: false,
+  init: [
+    { ino: 1, path: 'dir/' },
+    { ino: 2, path: 'dir/file' }
+  ],
+  actions: [
+    { type: 'mv', src: 'dir/file', dst: 'file' },
+    { type: 'trash', path: 'dir' }
+  ],
+  expected: {
+    tree: ['file'],
+    trash: ['dir/']
+  }
+} /*: Scenario */)

--- a/test/support/builders/channel_event.js
+++ b/test/support/builders/channel_event.js
@@ -3,6 +3,7 @@
 const _ = require('lodash')
 const path = require('path')
 
+const { FILE, FOLDER } = require('../../../core/metadata')
 const events = require('../../../core/local/channel_watcher/event')
 
 const statsBuilder = require('./stats')
@@ -22,7 +23,7 @@ function randomPick /*:: <T> */(elements /*: Array<T> */) /*: T */ {
 }
 
 function kind(doc /*: Metadata */) /*: EventKind */ {
-  return doc.docType === 'folder' ? 'directory' : doc.docType
+  return doc.docType === FOLDER ? 'directory' : FILE
 }
 
 const defaultPath = 'foo'

--- a/test/support/builders/metadata/base.js
+++ b/test/support/builders/metadata/base.js
@@ -49,7 +49,7 @@ module.exports = class BaseMetadataBuilder {
       this.doc = _.cloneDeep(old)
     } else {
       this.doc = {
-        docType: 'folder', // To make flow happy (overridden by subclasses)
+        docType: metadata.FOLDER, // To make flow happy (overridden by subclasses)
         path: 'foo',
         tags: [],
         updated_at: new Date().toISOString(),

--- a/test/support/builders/metadata/dir.js
+++ b/test/support/builders/metadata/dir.js
@@ -1,5 +1,7 @@
 // @flow
 
+const { FOLDER } = require('../../../../core/metadata')
+
 const BaseMetadataBuilder = require('./base')
 
 /*::
@@ -10,6 +12,6 @@ import type { Pouch } from '../../../../core/pouch'
 module.exports = class DirMetadataBuilder extends BaseMetadataBuilder {
   constructor(pouch /*: ?Pouch */, old /*: ?Metadata */) {
     super(pouch, old)
-    this.doc.docType = 'folder'
+    this.doc.docType = FOLDER
   }
 }

--- a/test/support/builders/remote/base.js
+++ b/test/support/builders/remote/base.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 const { posix } = require('path')
 
 const {
+  DIR_TYPE,
   FILES_DOCTYPE,
   ROOT_DIR_ID,
   TRASH_DIR_ID,
@@ -39,7 +40,7 @@ module.exports = class RemoteBaseBuilder /*:: <T: FullRemoteFile|RemoteDir> */ {
         _id: dbBuilders.id(),
         _rev: dbBuilders.rev(1),
         _type: FILES_DOCTYPE,
-        type: 'directory',
+        type: DIR_TYPE,
         dir_id: ROOT_DIR_ID,
         name,
         path: posix.join(posix.sep, name),

--- a/test/support/builders/remote/dir.js
+++ b/test/support/builders/remote/dir.js
@@ -9,6 +9,7 @@ const {
   remoteJsonToRemoteDoc
 } = require('../../../../core/remote/document')
 const {
+  DIR_TYPE,
   FILES_DOCTYPE,
   OAUTH_CLIENTS_DOCTYPE
 } = require('../../../../core/remote/constants')
@@ -39,7 +40,7 @@ module.exports = class RemoteDirBuilder extends (
     if (!old) {
       this.name(`directory-${dirNumber++}`)
     }
-    this.remoteDoc.type = 'directory'
+    this.remoteDoc.type = DIR_TYPE
   }
 
   excludedFrom(clientIds /*: string[] */) /*: this */ {

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -11,6 +11,7 @@ const { Merge } = require('../../../core/merge')
 const Prep = require('../../../core/prep')
 const { Sync } = require('../../../core/sync')
 const SyncState = require('../../../core/syncstate')
+const { FOLDER } = require('../../../core/metadata')
 
 const conflictHelpers = require('./conflict')
 const { posixifyPath } = require('./context_dir')
@@ -203,7 +204,7 @@ class TestHelpers {
     return _.chain(await this.pouch.byRecursivePath(''))
       .map(
         ({ docType, path }) =>
-          posixifyPath(path) + (docType === 'folder' ? '/' : '')
+          posixifyPath(path) + (docType === FOLDER ? '/' : '')
       )
       .sort()
       .value()
@@ -214,7 +215,7 @@ class TestHelpers {
       .filter(doc => doc.incompatibilities)
       .map(
         ({ docType, path }) =>
-          posixifyPath(path) + (docType === 'folder' ? '/' : '')
+          posixifyPath(path) + (docType === FOLDER ? '/' : '')
       )
       .uniq()
       .sort()

--- a/test/support/helpers/pouch.js
+++ b/test/support/helpers/pouch.js
@@ -1,3 +1,4 @@
+const { FOLDER } = require('../../../core/metadata')
 const { Pouch } = require('../../../core/pouch')
 
 module.exports = {
@@ -17,7 +18,7 @@ module.exports = {
     const updated_at = new Date().toISOString()
     const doc = {
       path: 'my-folder',
-      docType: 'folder',
+      docType: FOLDER,
       updated_at,
       tags: [],
       local: {
@@ -40,7 +41,7 @@ module.exports = {
     const updated_at = new Date().toISOString()
     const doc = {
       path: folderPath,
-      docType: 'folder',
+      docType: FOLDER,
       updated_at,
       tags: [],
       local: {

--- a/test/support/helpers/remote.js
+++ b/test/support/helpers/remote.js
@@ -9,6 +9,7 @@ const cozyHelpers = require('./cozy')
 
 const { Remote, dirAndName } = require('../../../core/remote')
 const {
+  DIR_TYPE,
   ROOT_DIR_ID,
   TRASH_DIR_NAME
 } = require('../../../core/remote/constants')
@@ -141,7 +142,7 @@ class RemoteTestHelpers {
         const remotePath = path.posix.join(dirPath, name)
         let relPath = remotePath.slice(1)
 
-        if (type === 'directory') {
+        if (type === DIR_TYPE) {
           relPath += '/'
           pathsToScan.push(remotePath)
         }

--- a/test/unit/local/channel_watcher/initial_diff.js
+++ b/test/unit/local/channel_watcher/initial_diff.js
@@ -9,11 +9,12 @@ const Builders = require('../../../support/builders')
 const configHelpers = require('../../../support/helpers/config')
 const pouchHelpers = require('../../../support/helpers/pouch')
 
+const { FOLDER } = require('../../../../core/metadata')
 const { WINDOWS_DATE_MIGRATION_FLAG } = require('../../../../core/config')
 const Channel = require('../../../../core/local/channel_watcher/channel')
 const initialDiff = require('../../../../core/local/channel_watcher/initial_diff')
 
-const kind = doc => (doc.docType === 'folder' ? 'directory' : 'file')
+const kind = doc => (doc.docType === FOLDER ? 'directory' : 'file')
 
 const sameSecondDate = date => new Date(new Date(date).setMilliseconds(0))
 

--- a/test/unit/local/chokidar/watcher.js
+++ b/test/unit/local/chokidar/watcher.js
@@ -7,6 +7,7 @@ const sinon = require('sinon')
 const should = require('should')
 const EventEmitter = require('events')
 
+const { FOLDER } = require('../../../../core/metadata')
 const { TMP_DIR_NAME } = require('../../../../core/local/constants')
 const Watcher = require('../../../../core/local/chokidar/watcher')
 
@@ -291,7 +292,7 @@ onPlatform('darwin', () => {
             side.should.equal('local')
             doc.should.have.properties({
               path: 'aba',
-              docType: 'folder'
+              docType: FOLDER
             })
             doc.should.have.properties(['updated_at', 'ino'])
             return
@@ -309,7 +310,7 @@ onPlatform('darwin', () => {
               side.should.equal('local')
               doc.should.have.properties({
                 path: path.normalize('abb/abc'),
-                docType: 'folder'
+                docType: FOLDER
               })
               doc.should.have.properties(['updated_at'])
               return
@@ -479,7 +480,7 @@ onPlatform('darwin', () => {
                 side.should.equal('local')
                 doc.should.have.properties({
                   path: 'agb',
-                  docType: 'folder'
+                  docType: FOLDER
                 })
                 setTimeout(() => {
                   this.prep.addFileAsync.called.should.be.false()

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -3001,7 +3001,7 @@ describe('Merge', function () {
                 const { path: dstPath } = _.find(
                   sideEffects.savedDocs,
                   ({ path, docType }) =>
-                    docType === 'folder' && path.match(/conflict/)
+                    docType === metadata.FOLDER && path.match(/conflict/)
                 )
 
                 const folderAddition = _.defaultsDeep(
@@ -3313,7 +3313,7 @@ describe('Merge', function () {
                 const { path: dstPath } = _.find(
                   sideEffects.savedDocs,
                   ({ path, docType }) =>
-                    docType === 'folder' && path.match(/conflict/)
+                    docType === metadata.FOLDER && path.match(/conflict/)
                 )
                 const remoteDstPath = pathUtils.localToRemote(dstPath)
 

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -34,7 +34,7 @@ const {
 } = metadata
 const { Ignore } = require('../../core/ignore')
 const stater = require('../../core/local/stater')
-const { NOTE_MIME_TYPE } = require('../../core/remote/constants')
+const { DIR_TYPE, NOTE_MIME_TYPE } = require('../../core/remote/constants')
 const pathUtils = require('../../core/utils/path')
 const timestamp = require('../../core/utils/timestamp')
 
@@ -119,7 +119,7 @@ describe('metadata', function () {
         name: 'bar',
         path: '/foo/bar',
         tags: ['foo'],
-        type: 'directory',
+        type: DIR_TYPE,
         created_at: '2017-09-07T07:06:05Z',
         updated_at: '2017-09-08T07:06:05Z'
       }
@@ -127,7 +127,7 @@ describe('metadata', function () {
       const doc = metadata.fromRemoteDoc(remoteDoc)
 
       should(doc).deepEqual({
-        docType: 'folder',
+        docType: metadata.FOLDER,
         created_at: '2017-09-07T07:06:05.000Z',
         updated_at: '2017-09-08T07:06:05.000Z',
         path: pathUtils.remoteToLocal('foo/bar'),
@@ -273,7 +273,7 @@ describe('metadata', function () {
             type: 'reservedChars',
             name: 'ba|r',
             path: 'f?o:o\\ba|r',
-            docType: 'folder',
+            docType: metadata.FOLDER,
             reservedChars: ['|'],
             platform
           },
@@ -281,7 +281,7 @@ describe('metadata', function () {
             type: 'reservedChars',
             name: 'f?o:o',
             path: 'f?o:o',
-            docType: 'folder',
+            docType: metadata.FOLDER,
             reservedChars: ['?', ':'],
             platform
           }
@@ -935,7 +935,7 @@ describe('metadata', function () {
       const doc = buildDir('fixtures', stats)
       should(doc).have.properties({
         path: 'fixtures',
-        docType: 'folder',
+        docType: metadata.FOLDER,
         ino: stats.ino,
         tags: []
       })
@@ -1331,7 +1331,7 @@ describe('metadata', function () {
       metadata.updateLocal(dir)
 
       should(dir.local).have.properties({
-        docType: 'folder',
+        docType: metadata.FOLDER,
         ino: 2,
         updated_at: '2020-11-14T03:30:23.293Z'
       })

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -189,12 +189,12 @@ describe('Pouch', function () {
     describe('byIdMaybe', () => {
       it('resolves with a doc matching the given _id if any', async function () {
         const existing = await this.pouch.db.post({
-          docType: 'folder',
+          docType: metadata.FOLDER,
           path: 'my-folder'
         })
         const doc = await this.pouch.byIdMaybe(existing.id)
         should(doc).have.properties({
-          docType: 'folder',
+          docType: metadata.FOLDER,
           path: 'my-folder'
         })
       })
@@ -260,7 +260,7 @@ describe('Pouch', function () {
         docs.length.should.be.equal(1)
         docs[0].should.have.properties({
           path: 'my-folder',
-          docType: 'folder',
+          docType: metadata.FOLDER,
           tags: []
         })
       })
@@ -283,7 +283,7 @@ describe('Pouch', function () {
           })
           docs[i + 2].should.have.properties({
             path: path.join('my-folder', `folder-${i}`),
-            docType: 'folder',
+            docType: metadata.FOLDER,
             tags: []
           })
         }
@@ -294,7 +294,7 @@ describe('Pouch', function () {
         docs.length.should.be.equal(7)
         docs[0].should.have.properties({
           path: 'my-folder',
-          docType: 'folder',
+          docType: metadata.FOLDER,
           tags: []
         })
         for (let i = 1; i <= 3; i++) {
@@ -305,7 +305,7 @@ describe('Pouch', function () {
           })
           docs[i + 3].should.have.properties({
             path: path.join('my-folder', `folder-${i}`),
-            docType: 'folder',
+            docType: metadata.FOLDER,
             tags: []
           })
         }
@@ -552,7 +552,7 @@ describe('Pouch', function () {
     describe('removeDesignDoc', () => {
       it('removes given view', async function () {
         let query = `function (doc) {
-          if (doc.docType === 'folder') {
+          if (doc.docType === '${metadata.FOLDER}') {
             emit(doc._id);
           }
         }`

--- a/test/unit/prep.js
+++ b/test/unit/prep.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon')
 const should = require('should')
 
+const { FOLDER } = require('../../core/metadata')
 const { Ignore } = require('../../core/ignore')
 const Prep = require('../../core/prep')
 
@@ -139,7 +140,7 @@ describe('Prep', function () {
         let doc = { path: 'foo/folder-missing-fields' }
         await this.prep.putFolderAsync(this.side, doc)
         this.merge.putFolderAsync.calledWith(this.side, doc).should.be.true()
-        doc.docType.should.equal('folder')
+        doc.docType.should.equal(FOLDER)
         // FIXME: should.exist(doc.updated_at)
       })
 
@@ -262,11 +263,11 @@ describe('Prep', function () {
       it('expects a revision for was', async function () {
         let doc = {
           path: 'foo/bar',
-          docType: 'folder'
+          docType: FOLDER
         }
         let was = {
           path: 'foo/baz',
-          docType: 'folder'
+          docType: FOLDER
         }
         await should(
           this.prep.moveFolderAsync(this.side, doc, was)
@@ -278,11 +279,11 @@ describe('Prep', function () {
 
         let doc = {
           path: 'foo/bar',
-          docType: 'folder'
+          docType: FOLDER
         }
         let was = {
           path: 'foo/bar',
-          docType: 'folder'
+          docType: FOLDER
         }
         this.prep.moveFolderAsync(this.side, doc, was)
         should(this.prep.putFolderAsync).have.been.calledWith(this.side, doc)
@@ -296,7 +297,7 @@ describe('Prep', function () {
         let was = {
           _rev: '456',
           path: 'FOOBAR/OLD-MISSING-FIELDS',
-          docType: 'folder',
+          docType: FOLDER,
           updated_at: new Date(),
           tags: ['courge', 'quux']
         }
@@ -304,7 +305,7 @@ describe('Prep', function () {
         this.merge.moveFolderAsync
           .calledWith(this.side, doc, was)
           .should.be.true()
-        doc.docType.should.equal('folder')
+        doc.docType.should.equal(FOLDER)
         // FIXME: should.exist(doc.updated_at)
       })
     })
@@ -345,7 +346,7 @@ describe('Prep', function () {
         let doc = { path: 'kill/folder' }
         await this.prep.deleteFolderAsync(this.side, doc)
         this.merge.deleteFolderAsync.calledWith(this.side, doc).should.be.true()
-        doc.docType.should.equal('folder')
+        doc.docType.should.equal(FOLDER)
       })
 
       it('does nothing for ignored paths on local', async function () {

--- a/test/unit/remote/change.js
+++ b/test/unit/remote/change.js
@@ -35,6 +35,30 @@ describe('sorter()', () => {
     })
   })
 
+  describe('with two moves', () => {
+    it('sorts child move out of parent before parent move', () => {
+      const parentMove = {
+        type: 'DirMove',
+        doc: builders.metadir().path('moved').build(),
+        was: builders.metadir().path('dir').build()
+      }
+      const childMove = {
+        type: 'FileMove',
+        doc: builders.metafile().path('file').build(),
+        was: builders.metafile().path('dir/file').build()
+      }
+
+      should(remoteChange.sort([parentMove, childMove])).deepEqual([
+        childMove,
+        parentMove
+      ])
+      should(remoteChange.sort([childMove, parentMove])).deepEqual([
+        childMove,
+        parentMove
+      ])
+    })
+  })
+
   describe('with replacing move', () => {
     it('sorts move of replaced before move of replacing', () => {
       const moveReplacing = {
@@ -433,6 +457,101 @@ describe('sorter()', () => {
           emptySubsubdirMoveB
         ])
       })
+    })
+  })
+
+  describe('with deletion of parent', () => {
+    context('when file is trashed within parent', () => {
+      it('sorts parent deletion before child deletion', () => {
+        const dirTrashing = {
+          type: 'DirTrashing',
+          doc: builders.metadir().path('.cozy_trash/dir').build(),
+          was: builders.metadir().path('dir').build()
+        }
+        const fileTrashing = {
+          type: 'FileTrashing',
+          doc: builders.metafile().path('.cozy_trash/dir/file').build(),
+          was: builders.metafile().path('dir/file').build()
+        }
+        should(remoteChange.sort([dirTrashing, fileTrashing])).deepEqual([
+          dirTrashing,
+          fileTrashing
+        ])
+        should(remoteChange.sort([fileTrashing, dirTrashing])).deepEqual([
+          dirTrashing,
+          fileTrashing
+        ])
+      })
+    })
+
+    context('when file is trashed outside parent', () => {
+      it('sorts parent deletion before child deletion', () => {
+        const dirTrashing = {
+          type: 'DirTrashing',
+          doc: builders.metadir().path('.cozy_trash/dir').build(),
+          was: builders.metadir().path('dir').build()
+        }
+        const fileTrashing = {
+          type: 'FileTrashing',
+          doc: builders.metafile().path('.cozy_trash/file').build(),
+          was: builders.metafile().path('dir/file').build()
+        }
+        should(remoteChange.sort([dirTrashing, fileTrashing])).deepEqual([
+          dirTrashing,
+          fileTrashing
+        ])
+        should(remoteChange.sort([fileTrashing, dirTrashing])).deepEqual([
+          dirTrashing,
+          fileTrashing
+        ])
+      })
+    })
+
+    context('when file was moved into parent', () => {
+      // FIXME: this is not ideal as the child will be trashed outside of the
+      // parent.
+      // It would be best to sync the child move before its parent deletion.
+      it('sorts parent deletion before child deletion', () => {
+        const dirTrashing = {
+          type: 'DirTrashing',
+          doc: builders.metadir().path('.cozy_trash/dir').build(),
+          was: builders.metadir().path('dir').build()
+        }
+        const fileTrashing = {
+          type: 'FileTrashing',
+          doc: builders.metafile().path('.cozy_trash/dir/file').build(),
+          was: builders.metafile().path('dir/file').build()
+        }
+        should(remoteChange.sort([dirTrashing, fileTrashing])).deepEqual([
+          dirTrashing,
+          fileTrashing
+        ])
+        should(remoteChange.sort([fileTrashing, dirTrashing])).deepEqual([
+          dirTrashing,
+          fileTrashing
+        ])
+      })
+    })
+
+    it('sorts child move out of parent before parent deletion', () => {
+      const dirTrashing = {
+        type: 'DirTrashing',
+        doc: builders.metadir().path('.cozy_trash/dir').build(),
+        was: builders.metadir().path('dir').build()
+      }
+      const fileMove = {
+        type: 'FileMove',
+        doc: builders.metafile().path('file').build(),
+        was: builders.metafile().path('dir/file').build()
+      }
+      should(remoteChange.sort([dirTrashing, fileMove])).deepEqual([
+        fileMove,
+        dirTrashing
+      ])
+      should(remoteChange.sort([fileMove, dirTrashing])).deepEqual([
+        fileMove,
+        dirTrashing
+      ])
     })
   })
 })

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -11,6 +11,7 @@ const OldCozyClient = require('cozy-client-js').Client
 const CozyClient = require('cozy-client').default
 
 const {
+  DIR_TYPE,
   ROOT_DIR_ID,
   TRASH_DIR_ID,
   TRASH_DIR_NAME,
@@ -262,7 +263,7 @@ describe('RemoteCozy', function () {
             updatedAt: new Date().toISOString()
           })
         ).have.properties({
-          type: 'directory',
+          type: DIR_TYPE,
           name: ' foo '
         })
       })

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -13,7 +13,11 @@ const metadata = require('../../../core/metadata')
 const Prep = require('../../../core/prep')
 const remote = require('../../../core/remote')
 const { DirectoryNotFound } = require('../../../core/remote/errors')
-const { ROOT_DIR_ID, TRASH_DIR_ID } = require('../../../core/remote/constants')
+const {
+  DIR_TYPE,
+  ROOT_DIR_ID,
+  TRASH_DIR_ID
+} = require('../../../core/remote/constants')
 const { FetchError } = require('../../../core/remote/cozy')
 const { remoteJsonToRemoteDoc } = require('../../../core/remote/document')
 const timestamp = require('../../../core/utils/timestamp')
@@ -239,7 +243,7 @@ describe('remote.Remote', function () {
       should(folder.attributes).have.properties({
         path: '/folder-1',
         name: 'folder-1',
-        type: 'directory'
+        type: DIR_TYPE
       })
       should(timestamp.roundedRemoteDate(folder.attributes.updated_at)).equal(
         doc.updated_at
@@ -653,7 +657,7 @@ describe('remote.Remote', function () {
       )
       should(folder.attributes).have.properties({
         path: '/created',
-        type: 'directory',
+        type: DIR_TYPE,
         dir_id: ROOT_DIR_ID,
         updated_at: doc.updated_at
       })
@@ -783,7 +787,7 @@ describe('remote.Remote', function () {
         should(folder.attributes).have.properties({
           dir_id: couchdbFolder._id,
           name: 'folder-5',
-          type: 'directory'
+          type: DIR_TYPE
         })
         should(timestamp.roundedRemoteDate(folder.attributes.updated_at)).equal(
           doc.updated_at

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -58,7 +58,7 @@ import type { RemoteTree } from '../../support/helpers/remote'
 const saveTree = async (remoteTree, builders) => {
   for (const key in remoteTree) {
     const remoteDoc = remoteTree[key]
-    if (remoteDoc.type === 'folder') {
+    if (remoteDoc.type === DIR_TYPE) {
       await builders.metadir().fromRemote(remoteDoc).upToDate().create()
     } else {
       await builders.metafile().fromRemote(remoteDoc).upToDate().create()
@@ -2089,7 +2089,7 @@ describe('RemoteWatcher', function () {
             type: 'reservedChars',
             name: 'f:oo',
             path: 'f:oo',
-            docType: 'folder',
+            docType: metadata.FOLDER,
             reservedChars: [':'],
             platform
           }

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -445,7 +445,7 @@ describe('Sync', function () {
       await this.sync.apply(change)
       should(await this.pouch.bySyncedPath(change.doc.path)).have.properties({
         path: initial.path,
-        docType: 'folder',
+        docType: metadata.FOLDER,
         sides: {
           target: 4,
           local: 4,


### PR DESCRIPTION
When the content of a remote folder is moved out before the folder is
trashed or completely deleted, we should sync the move before syncing
the folder deletion even when fetching the two changes together.

While this is obvious when one is fetched after the other, syncing
both of them in the correct order requires sorting when fetched
together.

This is done by adding a new sorting rule in the remote change module,
responsible for sorting all fetched changes in an order that makes it
possible to sync all of them on the local filesystem.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
