### PR TITLE
dev: Build and publish zip target on macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -252,5 +252,6 @@ jobs:
             path: |
                 ${{ github.workspace }}/dist/latest-mac.yml
                 ${{ github.workspace }}/dist/Cozy[- ]Drive[- ]*.dmg
+                ${{ github.workspace }}/dist/Cozy[- ]Drive[- ]*-mac.zip
             retention-days: 5
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,6 +41,9 @@ mac:
   entitlements: './build/entitlements.mac.inherit.plist'
   category: public.app-category.productivity
   target:
+      - target: zip # this is required for the update to work (see https://github.com/electron-userland/electron-builder/issues/2199)
+        arch:
+            - x64
       - target: dmg
         arch:
             - x64


### PR DESCRIPTION
Although our users install Cozy Desktop via the `dmg` target on macOS,
the `zip` target is still required for the updater to work.
Indeed, if the generated zip file isn't published, the updater will
fail as it is looking for its presence.

The issue has been reported a long time ago in
https://github.com/electron-userland/electron-builder/issues/2199 but
there is no recent work on any potential solution.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
