### PR TITLE
fix: Avoid PouchDB conflicts when merging moves

### DIFF
--- a/core/local/chokidar/send_to_prep.js
+++ b/core/local/chokidar/send_to_prep.js
@@ -44,33 +44,30 @@ const onAddFile = (
   { path: filePath, stats, md5sum } /*: LocalFileAddition */,
   prep /*: Prep */
 ) => {
-  const logError = err => log.warn({ err, path: filePath })
   const doc = metadata.buildFile(filePath, stats, md5sum)
   log.info({ path: filePath }, 'FileAddition')
-  return prep.addFileAsync(SIDE, doc).catch(logError)
+  return prep.addFileAsync(SIDE, doc)
 }
 
 const onMoveFile = async (
   { path: filePath, stats, md5sum, old, overwrite } /*: LocalFileMove */,
   prep /*: Prep */
 ) => {
-  const logError = err => log.warn({ err, path: filePath })
   const doc = metadata.buildFile(filePath, stats, md5sum, old.remote)
   if (overwrite) doc.overwrite = overwrite
   log.info({ path: filePath, oldpath: old.path }, 'FileMove')
-  return prep.moveFileAsync(SIDE, doc, old).catch(logError)
+  return prep.moveFileAsync(SIDE, doc, old)
 }
 
 const onMoveFolder = (
   { path: folderPath, stats, old, overwrite } /*: LocalDirMove */,
   prep /*: Prep */
 ) => {
-  const logError = err => log.warn({ err, path: folderPath })
   const doc = metadata.buildDir(folderPath, stats, old.remote)
   // $FlowFixMe we set doc.overwrite to true, it will be replaced by metadata in merge
   if (overwrite) doc.overwrite = overwrite
   log.info({ path: folderPath, oldpath: old.path }, 'DirMove')
-  return prep.moveFolderAsync(SIDE, doc, old).catch(logError)
+  return prep.moveFolderAsync(SIDE, doc, old)
 }
 
 /** New directory detected */
@@ -80,9 +77,7 @@ const onAddDir = (
 ) => {
   const doc = metadata.buildDir(folderPath, stats)
   log.info({ path: folderPath }, 'DirAddition')
-  return prep
-    .putFolderAsync(SIDE, doc)
-    .catch(err => log.warn({ err, path: folderPath }))
+  return prep.putFolderAsync(SIDE, doc)
 }
 
 /** File deletion detected
@@ -99,9 +94,7 @@ const onUnlinkFile = (
     log.debug({ path: filePath }, 'Assuming file already removed')
     return
   }
-  return prep
-    .trashFileAsync(SIDE, old)
-    .catch(err => log.warn({ err, path: filePath }))
+  return prep.trashFileAsync(SIDE, old)
 }
 
 /** Folder deletion detected
@@ -118,9 +111,7 @@ const onUnlinkDir = (
     log.debug({ path: folderPath }, 'Assuming dir already removed')
     return
   }
-  return prep
-    .trashFolderAsync(SIDE, old)
-    .catch(err => log.warn({ err, path: folderPath }))
+  return prep.trashFolderAsync(SIDE, old)
 }
 
 /** File update detected */

--- a/core/merge.js
+++ b/core/merge.js
@@ -442,7 +442,23 @@ class Merge {
     doc /*: Metadata */,
     was /*: SavedMetadata */
   ) /*: Promise<*> */ {
-    log.debug({ path: doc.path, oldpath: was.path }, 'moveFileAsync')
+    const oldpath = was.path
+
+    was = await this.pouch.byIdMaybe(was._id)
+    if (!was) {
+      log.debug(
+        { path: oldpath },
+        'moved file missing from PouchDB. Adding at destination'
+      )
+      return this.addFileAsync(side, doc)
+    } else if (was.path !== oldpath) {
+      log.debug({ path: was.path, oldpath }, 'moved file original path changed')
+    }
+
+    log.debug(
+      { path: doc.path, oldpath: was ? was.path : oldpath },
+      'moveFileAsync'
+    )
 
     // If file is moved on Windows, it will never be executable so we keep the
     // existing value.
@@ -543,7 +559,26 @@ class Merge {
     was /*: SavedMetadata */,
     newRemoteRevs /*: ?RemoteRevisionsByID */
   ) {
-    log.debug({ path: doc.path, oldpath: was.path }, 'moveFolderAsync')
+    const oldpath = was.path
+
+    was = await this.pouch.byIdMaybe(was._id)
+    if (!was) {
+      log.debug(
+        { path: oldpath },
+        'moved folder missing from PouchDB. Adding at destination'
+      )
+      return this.putFolderAsync(side, doc)
+    } else if (was.path !== oldpath) {
+      log.debug(
+        { path: was.path, oldpath },
+        'moved folder original path changed'
+      )
+    }
+
+    log.debug(
+      { path: doc.path, oldpath: was ? was.path : oldpath },
+      'moveFolderAsync'
+    )
 
     metadata.assignMaxDate(doc, was)
 


### PR DESCRIPTION
When a document being synchronized with the remote Cozy is moved on
the local filesystem, we fail to merge the move in PouchDB because we
fetch the source record before it is updated by Sync (i.e. to add the
remote info) and get a conflict error since we don't have the new
revision.

Fetching the source record (again) right before merging the move, when
Merge has the PouchDB lock, solves this problem.

This should not create new issues as Merge should be able to handle
potential situations where changes to the source record are more
substantial than adding remote metadata.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
