### PR TITLE
feat: Restart Chokidar watcher on rescan request

### DIFF
--- a/core/local/channel_watcher/add_checksum.js
+++ b/core/local/channel_watcher/add_checksum.js
@@ -51,7 +51,7 @@ module.exports = {
  */
 function loop(
   channel /*: Channel */,
-  opts /*: { config: Config , checksumer: Checksumer } */
+  opts /*: { config: Config , checksumer: Checksumer, fatal: Error => any } */
 ) /*: Channel */ {
   const syncPath = opts.config.syncPath
 
@@ -75,7 +75,7 @@ function loop(
       }
     }
     return events
-  })
+  }, opts.fatal)
 }
 
 /** Return true when file is supposed to exist according to event data.

--- a/core/local/channel_watcher/add_infos.js
+++ b/core/local/channel_watcher/add_infos.js
@@ -42,7 +42,7 @@ module.exports = {
  */
 function loop(
   channel /*: Channel */,
-  opts /*: { config: Config, pouch: Pouch } */
+  opts /*: { config: Config, pouch: Pouch, fatal: Error => any } */
 ) /*: Channel */ {
   const syncPath = opts.config.syncPath
 
@@ -95,7 +95,7 @@ function loop(
       batch.push(event)
     }
     return batch
-  })
+  }, opts.fatal)
 }
 
 function needsStats(event /*: ChannelEvent */) /*: boolean %checks */ {

--- a/core/local/channel_watcher/channel.js
+++ b/core/local/channel_watcher/channel.js
@@ -48,36 +48,52 @@ class Channel {
 
   async doMap(
     fn /*: (ChannelBatch) => ChannelBatch */,
-    channel /*: Channel */
+    channel /*: Channel */,
+    notifyErr /*: Error => any */
   ) /*: Promise<void> */ {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const batch = fn(await this.pop())
-      channel.push(batch)
+      try {
+        const batch = fn(await this.pop())
+        channel.push(batch)
+      } catch (err) {
+        notifyErr(err)
+      }
     }
   }
 
-  map(fn /*: (ChannelBatch) => ChannelBatch */) /*: Channel */ {
+  map(
+    fn /*: (ChannelBatch) => ChannelBatch */,
+    notifyErr /*: Error => any */
+  ) /*: Channel */ {
     const channel = new Channel()
-    this.doMap(fn, channel)
+    this.doMap(fn, channel, notifyErr)
     return channel
   }
 
   async doAsyncMap(
     fn /*: (ChannelBatch) => Promise<ChannelBatch> */,
-    channel /*: Channel */
+    channel /*: Channel */,
+    notifyErr /*: Error => any */
   ) /*: Promise<void> */ {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const batch = await this.pop()
-      const after = await fn(batch)
-      channel.push(after)
+      try {
+        const batch = await this.pop()
+        const after = await fn(batch)
+        channel.push(after)
+      } catch (err) {
+        notifyErr(err)
+      }
     }
   }
 
-  asyncMap(fn /*: (ChannelBatch) => Promise<ChannelBatch> */) /*: Channel */ {
+  asyncMap(
+    fn /*: (ChannelBatch) => Promise<ChannelBatch> */,
+    notifyErr /*: Error => any */
+  ) /*: Channel */ {
     const channel = new Channel()
-    this.doAsyncMap(fn, channel)
+    this.doAsyncMap(fn, channel, notifyErr)
     return channel
   }
 }

--- a/core/local/channel_watcher/dispatch.js
+++ b/core/local/channel_watcher/dispatch.js
@@ -46,7 +46,8 @@ type DispatchOptions = {
   prep: Prep,
   pouch: Pouch,
   state: DispatchState,
-  onChannelEvents?: ChannelEventsDispatcher
+  onChannelEvents?: ChannelEventsDispatcher,
+  fatal: Error => any
 }
 */
 
@@ -73,7 +74,7 @@ function loop(
   channel /*: Channel */,
   opts /*: DispatchOptions */
 ) /*: Channel */ {
-  return channel.asyncMap(opts.onChannelEvents || step(opts))
+  return channel.asyncMap(opts.onChannelEvents || step(opts), opts.fatal)
 }
 
 function step(opts /*: DispatchOptions */) {

--- a/core/local/channel_watcher/filter_ignored.js
+++ b/core/local/channel_watcher/filter_ignored.js
@@ -32,7 +32,7 @@ module.exports = {
 
 function loop(
   channel /*: Channel */,
-  opts /*: { ignore: Ignore } */
+  opts /*: { ignore: Ignore, fatal: Error => any } */
 ) /*: Channel */ {
   const isIgnored = (path /*: string */, kind /*: EventKind */) =>
     opts.ignore.isIgnored({
@@ -54,7 +54,7 @@ function loop(
     }
 
     return batch
-  })
+  }, opts.fatal)
 }
 
 function notIgnoredEvent(

--- a/core/local/channel_watcher/fire_local_start_event.js
+++ b/core/local/channel_watcher/fire_local_start_event.js
@@ -26,10 +26,10 @@ module.exports = {
  */
 function loop(
   channel /*: Channel */,
-  opts /*: { events: EventEmitter } */
+  opts /*: { events: EventEmitter, fatal: Error => any } */
 ) /*: Channel */ {
   return channel.map(events => {
     opts.events.emit('local-start')
     return events
-  })
+  }, opts.fatal)
 }

--- a/core/local/channel_watcher/incomplete_fixer.js
+++ b/core/local/channel_watcher/incomplete_fixer.js
@@ -47,7 +47,8 @@ type IncompleteItem = {
 type IncompleteFixerOptions = {
   config: Config,
   checksumer: Checksumer,
-  pouch: Pouch
+  pouch: Pouch,
+  fatal: Error => any,
 }
 
 type Completion =
@@ -200,7 +201,7 @@ function loop(
   opts /*: IncompleteFixerOptions */
 ) /*: Channel */ {
   const incompletes = []
-  return channel.asyncMap(step({ incompletes }, opts))
+  return channel.asyncMap(step({ incompletes }, opts), opts.fatal)
 }
 
 function step(

--- a/core/local/channel_watcher/index.js
+++ b/core/local/channel_watcher/index.js
@@ -57,6 +57,13 @@ type ChannelWatcherOptions = {
   events: EventEmitter,
   ignore: Ignore
 }
+
+export type ChannelWatcherStepOptions = ChannelWatcherOptions & {
+  checksumer: Checksumer,
+  scan: Scanner,
+  state: Object,
+  fatal: Error => any
+}
 */
 
 const log = logger({
@@ -70,7 +77,7 @@ const log = logger({
 const only = (platform, step) => platform === process.platform && step
 
 /** The steps for the current platform. */
-const steps = _.compact([
+const STEPS = _.compact([
   addInfos,
   filterIgnored,
   fireLocatStartEvent,
@@ -98,7 +105,7 @@ const stepsInitialState = (
   opts /*: * */
 ) /*: Promise<Object> */ =>
   Promise.reduce(
-    steps,
+    STEPS,
     async (prevState, step) =>
       step.initialState
         ? _.assign(prevState, await step.initialState(opts))
@@ -124,16 +131,18 @@ class ChannelWatcher {
     this.producer = producer(opts)
     this.state = {}
 
-    const stepOptions = Object.assign(
-      ({
+    const stepOptions /* ChannelWatcherStepOptions */ = Object.assign(
+      {},
+      {
         checksumer: this.checksumer,
         scan: this.producer.scan,
-        state: this.state
-      } /*: Object */),
+        state: this.state,
+        fatal: this.fatal
+      },
       opts
     )
     // Here, we build the chain of steps.
-    steps.reduce(
+    STEPS.reduce(
       (chan, step) => step.loop(chan, stepOptions),
       this.producer.channel
     )

--- a/core/local/channel_watcher/scan_folder.js
+++ b/core/local/channel_watcher/scan_folder.js
@@ -28,7 +28,7 @@ module.exports = {
 
 function loop(
   channel /*: Channel */,
-  opts /*: { scan: Scanner } */
+  opts /*: { scan: Scanner, fatal: Error => any } */
 ) /*: Channel */ {
   return channel.asyncMap(async batch => {
     for (const event of batch) {
@@ -42,5 +42,5 @@ function loop(
       }
     }
     return batch
-  })
+  }, opts.fatal)
 }

--- a/core/local/chokidar/event_buffer.js
+++ b/core/local/chokidar/event_buffer.js
@@ -84,6 +84,11 @@ class EventBuffer /*:: <EventType> */ {
     this.flush()
     this.mode = mode
   }
+
+  clear() /*: void */ {
+    this.events = []
+    this.clearTimeout()
+  }
 }
 
 module.exports = EventBuffer

--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -54,9 +54,12 @@ log.chokidar = log.child({
   component: 'Chokidar'
 })
 
-function hasPath(event /*: ChokidarEvent */) /*: boolean %checks */ {
-  return event.path !== ''
-}
+const hasPath = (event /*: ChokidarEvent */) /*: boolean %checks */ =>
+  event.path !== ''
+
+// See https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags/kfseventstreameventflagmustscansubdirs
+const isRescanFlag = (flags /*: number */) /*: boolean %checks */ =>
+  (flags & 0x00000001) === 1
 
 /**
  * This file contains the filesystem watcher that will trigger operations when
@@ -175,9 +178,18 @@ class LocalWatcher {
 
       this.watcher
         .on('ready', () => this.buffer.switchMode('timeout'))
-        .on('raw', (event, path, details) =>
+        .on('raw', async (event, path, details) => {
           log.chokidar.debug({ event, path, details }, 'raw')
-        )
+
+          if (isRescanFlag(details.flags)) {
+            try {
+              await this.stop(true)
+              await this.start()
+            } catch (err) {
+              this.fatal(err)
+            }
+          }
+        })
         .on('error', err => {
           if (err.message === 'watch ENOSPC') {
             log.error(

--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -257,9 +257,15 @@ class LocalWatcher {
     }
   }
 
-  async stop(force /*: ?bool */) {
+  async stop(force /*: ?bool */ = false) {
     log.debug('Stopping watcher...')
-    if (this.watcher) {
+
+    if (!this.watcher) return
+
+    if (force) {
+      // Drop buffered events
+      this.buffer.clear()
+    } else {
       // XXX manually fire events for added file, because chokidar will cancel
       // them if they are still in the awaitWriteFinish period
       for (let relpath in this.watcher._pendingWrites) {
@@ -271,15 +277,20 @@ class LocalWatcher {
           log.warn({ err }, 'Could not fire remaining add events')
         }
       }
-      await this.watcher.close()
-      this.watcher = null
     }
+
+    // Stop underlying Chokidar watcher
+    await this.watcher.close()
+    this.watcher = null
+    // Stop accepting new events
     this.buffer.switchMode('idle')
-    if (force) return Promise.resolve()
-    // Give some time for awaitWriteFinish events to be managed
-    return new Promise(resolve => {
-      setTimeout(resolve, 1000)
-    })
+
+    if (!force) {
+      // Give some time for awaitWriteFinish events to be managed
+      return new Promise(resolve => {
+        setTimeout(resolve, 1000)
+      })
+    }
   }
 
   /* Helpers */

--- a/core/local/constants.js
+++ b/core/local/constants.js
@@ -8,5 +8,7 @@ module.exports = {
 
   // This constant is not made directly available through `fs` but comes from libuv.
   // See https://github.com/libuv/libuv/blob/30ff5bf2161257921f3a3ce5655804f7cb282aa9/include/uv/win.h#L685
-  UV_FS_O_EXLOCK: 0x10000000
+  UV_FS_O_EXLOCK: 0x10000000,
+
+  LOCAL_WATCHER_FATAL_EVENT: 'LocalWatcher:fatal'
 }

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -25,9 +25,10 @@ import type { Checksumer } from './checksumer'
 
 export interface Watcher {
   checksumer: Checksumer,
-  running: Promise<*>,
   start (): Promise<*>,
   stop (force: ?bool): Promise<*>,
+  onFatal (listener: Error => any): void,
+  fatal (err: Error): void,
 }
 
 export type LocalWatcherOptions = {

--- a/core/remote/constants.js
+++ b/core/remote/constants.js
@@ -36,6 +36,8 @@ module.exports = {
   // Remote watcher changes fetch interval
   HEARTBEAT: parseInt(process.env.COZY_DESKTOP_HEARTBEAT) || DEFAULT_HEARTBEAT,
 
+  REMOTE_WATCHER_FATAL_EVENT: 'RemoteWatcher:fatal',
+
   // ToS updated warning code
   TOS_UPDATED_WARNING_CODE: 'tos-updated',
 

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -9,7 +9,12 @@ const _ = require('lodash')
 
 const metadata = require('../../metadata')
 const remoteChange = require('../change')
-const { FILE_TYPE, DIR_TYPE, HEARTBEAT } = require('../constants')
+const {
+  FILE_TYPE,
+  DIR_TYPE,
+  HEARTBEAT,
+  REMOTE_WATCHER_FATAL_EVENT
+} = require('../constants')
 const remoteErrors = require('../errors')
 const { inRemoteTrash } = require('../document')
 const squashMoves = require('./squashMoves')
@@ -118,12 +123,13 @@ class RemoteWatcher {
   }
 
   onFatal(listener /*: Error => any */) {
-    this.events.on('RemoteWatcher:fatal', listener)
+    this.events.on(REMOTE_WATCHER_FATAL_EVENT, listener)
   }
 
   fatal(err /*: Error */) {
     log.error({ err, sentry: true }, `Remote watcher fatal: ${err.message}`)
-    this.events.emit('RemoteWatcher:fatal', err)
+    this.events.emit(REMOTE_WATCHER_FATAL_EVENT, err)
+    this.events.removeAllListeners(REMOTE_WATCHER_FATAL_EVENT)
     this.stop()
   }
 

--- a/core/utils/lifecycle.js
+++ b/core/utils/lifecycle.js
@@ -64,10 +64,10 @@ class LifeCycle extends EventEmitter {
   end(endState /*: 'start' | 'stop' */) {
     switch (endState) {
       case 'start':
-        this.transitionTo('done-start')
+        if (this.currentState === 'will-start') this.transitionTo('done-start')
         break
       case 'stop':
-        this.transitionTo('done-stop')
+        if (this.currentState === 'will-stop') this.transitionTo('done-stop')
         break
     }
   }

--- a/core/utils/lifecycle.js
+++ b/core/utils/lifecycle.js
@@ -103,8 +103,11 @@ class LifeCycle extends EventEmitter {
 
   async ready() /*: Promise<void> */ {
     return new Promise(resolve => {
-      if (this.blockedFor == null) resolve()
-      else this.once('ready', resolve)
+      this.once('ready', resolve)
+      if (this.blockedFor == null) {
+        resolve()
+        this.off('ready', resolve)
+      }
     })
   }
 }

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -283,7 +283,9 @@ describe('Update file', () => {
   })
 
   describe('M1, local merge M1, M2, remote sync M1, local merge M2', () => {
-    it('fails remote sync M1 & local merge M2', async () => {
+    it('fails remote sync M1 & local merge M2', async function () {
+      if (process.env.CI) this.timeout(60 * 1000)
+
       await cozy.files.create('Initial content', { name: 'file' })
       await helpers.pullAndSyncAll()
       await helpers.flushLocalAndSyncAll()

--- a/test/scenarios/change_unmerged_doc_case/scenario.js
+++ b/test/scenarios/change_unmerged_doc_case/scenario.js
@@ -4,6 +4,10 @@
 
 module.exports = ({
   useCaptures: false,
+  disabled: {
+    'local/darwin':
+      'cannot work as fsevents fires an add event for Dir/renamed-child last and we end up considrering this is yet another move. We need to figure out a way to get these events in order'
+  },
   init: [],
   actions: [
     { type: 'mkdir', path: 'dir' },
@@ -24,9 +28,9 @@ module.exports = ({
       path: 'moved-file',
       content: 'moved-file content'
     },
-    { type: 'wait', ms: 1000 },
+    { type: 'wait', ms: 500 },
     { type: 'mv', src: 'dir', dst: 'Dir' },
-    { type: 'wait', ms: 1000 },
+    { type: 'wait', ms: 500 },
     { type: 'mv', src: 'Dir/renamed-child', dst: 'Dir/Renamed-Child' },
     {
       type: 'mv',
@@ -35,7 +39,7 @@ module.exports = ({
     },
     { type: 'mv', src: 'file', dst: 'File' },
     { type: 'mv', src: 'moved-file', dst: 'Dir/moved-file' },
-    { type: 'wait', ms: 1000 }
+    { type: 'wait', ms: 500 }
   ],
   expected: {
     tree: [

--- a/test/scenarios/change_unmerged_doc_case_then_delete/scenario.js
+++ b/test/scenarios/change_unmerged_doc_case_then_delete/scenario.js
@@ -24,9 +24,9 @@ module.exports = ({
       path: 'moved-file',
       content: 'moved-file content'
     },
-    { type: 'wait', ms: 1000 },
+    { type: 'wait', ms: 500 },
     { type: 'mv', src: 'dir', dst: 'Dir' },
-    { type: 'wait', ms: 1000 },
+    { type: 'wait', ms: 500 },
     { type: 'mv', src: 'Dir/renamed-child', dst: 'Dir/Renamed-Child' },
     {
       type: 'mv',
@@ -35,11 +35,11 @@ module.exports = ({
     },
     { type: 'mv', src: 'file', dst: 'File' },
     { type: 'mv', src: 'moved-file', dst: 'Dir/moved-file' },
-    { type: 'wait', ms: 1000 },
+    { type: 'wait', ms: 500 },
     { type: 'trash', path: 'Dir' },
     { type: 'trash', path: 'File' },
     { type: 'trash', path: 'Moved-child' },
-    { type: 'wait', ms: 1000 }
+    { type: 'wait', ms: 500 }
   ],
   expected: {
     tree: [],

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -29,7 +29,10 @@ const TestHelpers = require('../support/helpers')
 const pouchHelpers = require('../support/helpers/pouch')
 const remoteCaptureHelpers = require('../../dev/capture/remote')
 
-const { platform } = process
+const {
+  env: { CI: isCI },
+  platform
+} = process
 
 const logger = require('../../core/utils/logger')
 const log = new logger({ component: 'TEST' })
@@ -126,6 +129,7 @@ describe('Scenario', function () {
           }
         } else {
           it(localTestName, async function () {
+            if (isCI) this.timeout(3 * 60 * 1000)
             await runLocalChokidarWithoutCaptures(
               scenario,
               _.cloneDeep(eventsFile),
@@ -141,7 +145,7 @@ describe('Scenario', function () {
         it.skip(`${stoppedTestName} (${stoppedTestSkipped})`, () => {})
       } else {
         it(stoppedTestName, async function () {
-          this.timeout(3 * 60 * 1000)
+          if (isCI) this.timeout(60 * 1000)
           await runLocalStopped(scenario, helpers)
         })
       }
@@ -156,6 +160,7 @@ describe('Scenario', function () {
     }
 
     it(remoteTestName, async function () {
+      if (isCI && platform === 'darwin') this.timeout(60 * 1000)
       await runRemote(scenario, helpers)
     })
   }

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -84,9 +84,11 @@ class TestHelpers {
   }
 
   async syncAll() {
-    this._sync.lifecycle.end('start')
+    this._sync.lifecycle.currentState = 'done-start'
     await this._sync.sync({ manualRun: true })
-    this._sync.lifecycle.end('stop')
+    // Wait until all potentially blocking changes have been handled
+    await this._sync.lifecycle.ready()
+    this._sync.lifecycle.currentState = 'done-stop'
   }
 
   async pullAndSyncAll() {

--- a/test/unit/local/channel_watcher/add_checksum.js
+++ b/test/unit/local/channel_watcher/add_checksum.js
@@ -2,6 +2,7 @@
 /* @flow */
 
 const should = require('should')
+const sinon = require('sinon')
 const path = require('path')
 
 const configHelpers = require('../../../support/helpers/config')
@@ -11,14 +12,15 @@ const addChecksum = require('../../../../core/local/channel_watcher/add_checksum
 const Channel = require('../../../../core/local/channel_watcher/channel')
 
 describe('core/local/channel_watcher/add_checksum.loop()', () => {
-  let config, dirpath, filepath
+  let dirpath, filepath, opts
   before(configHelpers.createConfig)
   before(function () {
-    config = this.config
-    config.syncPath = path.dirname(__dirname)
-
     dirpath = path.basename(__dirname)
     filepath = path.join(dirpath, path.basename(__filename))
+
+    const config = this.config
+    config.syncPath = path.dirname(__dirname)
+    opts = { config, checksumer: checksumer.init(), fatal: sinon.spy() }
   })
 
   it('should add checksum within a file event', async () => {
@@ -31,10 +33,7 @@ describe('core/local/channel_watcher/add_checksum.loop()', () => {
     ]
     const channel = new Channel()
     channel.push(batch)
-    const enhancedChannel = addChecksum.loop(channel, {
-      checksumer: checksumer.init(),
-      config
-    })
+    const enhancedChannel = addChecksum.loop(channel, opts)
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.an.Array().and.length(batch.length)
     should.exist(enhancedBatch[0].md5sum)
@@ -50,10 +49,7 @@ describe('core/local/channel_watcher/add_checksum.loop()', () => {
     ]
     const channel = new Channel()
     channel.push(batch)
-    const enhancedChannel = addChecksum.loop(channel, {
-      checksumer: checksumer.init(),
-      config
-    })
+    const enhancedChannel = addChecksum.loop(channel, opts)
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.an.Array().and.length(batch.length)
     should.not.exist(enhancedBatch[0].md5sum)
@@ -70,10 +66,7 @@ describe('core/local/channel_watcher/add_checksum.loop()', () => {
     ]
     const channel = new Channel()
     channel.push(batch)
-    const enhancedChannel = addChecksum.loop(channel, {
-      checksumer: checksumer.init(),
-      config
-    })
+    const enhancedChannel = addChecksum.loop(channel, opts)
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.an.Array().and.length(batch.length)
     should(enhancedBatch[0]).have.property('md5sum', 'checksum')
@@ -114,10 +107,7 @@ describe('core/local/channel_watcher/add_checksum.loop()', () => {
       renamedEvent,
       ignoredEvent
     ])
-    const enhancedChannel = addChecksum.loop(channel, {
-      checksumer: checksumer.init(),
-      config
-    })
+    const enhancedChannel = addChecksum.loop(channel, opts)
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).deepEqual([
       {

--- a/test/unit/local/channel_watcher/channel.js
+++ b/test/unit/local/channel_watcher/channel.js
@@ -158,13 +158,13 @@ describe('core/local/channel_watcher/Channel', function () {
      */
 
     const map = scenarioState => {
-      const { inputChannel, callback } = scenarioState
-      scenarioState.outputChannel = inputChannel.map(callback)
+      const { inputChannel, callback, notifyErr } = scenarioState
+      scenarioState.outputChannel = inputChannel.map(callback, notifyErr)
     }
 
     const asyncMap = scenarioState => {
-      const { inputChannel, callback } = scenarioState
-      scenarioState.outputChannel = inputChannel.asyncMap(callback)
+      const { inputChannel, callback, notifyErr } = scenarioState
+      scenarioState.outputChannel = inputChannel.asyncMap(callback, notifyErr)
     }
 
     const push = ({ inputChannel, inputBatches }) => {
@@ -245,7 +245,8 @@ describe('core/local/channel_watcher/Channel', function () {
             inputBatches: ChannelBatch[],
             inputChannel: Channel,
             outputChannel?: Channel,
-            outputBatchesPromise: Promise<ChannelBatch[]>
+            outputBatchesPromise: Promise<ChannelBatch[]>,
+            notifyErr: Error => any
           } */
 
           beforeEach('init scenarioState', () => {
@@ -253,7 +254,8 @@ describe('core/local/channel_watcher/Channel', function () {
               callback: sinon.spy(transform),
               inputBatches: [],
               inputChannel: new Channel(),
-              outputBatchesPromise: Promise.resolve([])
+              outputBatchesPromise: Promise.resolve([]),
+              notifyErr: sinon.spy()
             }
           })
 
@@ -319,7 +321,8 @@ describe('core/local/channel_watcher/Channel', function () {
             inputBatches: ChannelBatch[],
             inputChannel: Channel,
             outputChannel?: Channel,
-            outputBatchesPromise: Promise<ChannelBatch[]>
+            outputBatchesPromise: Promise<ChannelBatch[]>,
+            notifyErr: Error => any
           } */
 
           beforeEach('init scenarioState', () => {
@@ -327,7 +330,8 @@ describe('core/local/channel_watcher/Channel', function () {
               callback: sinon.spy(asyncTransform),
               inputBatches: [],
               inputChannel: new Channel(),
-              outputBatchesPromise: Promise.resolve([])
+              outputBatchesPromise: Promise.resolve([]),
+              notifyErr: sinon.spy()
             }
           })
 

--- a/test/unit/local/channel_watcher/dispatch.js
+++ b/test/unit/local/channel_watcher/dispatch.js
@@ -69,7 +69,8 @@ describe('core/local/channel_watcher/dispatch.loop()', function () {
       events,
       prep,
       pouch: this.pouch,
-      state: await dispatch.initialState()
+      state: await dispatch.initialState(),
+      fatal: sinon.spy()
     }
   })
   afterEach('clean pouch', pouchHelpers.cleanDatabase)

--- a/test/unit/local/channel_watcher/filter_ignored.js
+++ b/test/unit/local/channel_watcher/filter_ignored.js
@@ -2,6 +2,7 @@
 /* @flow */
 
 const should = require('should')
+const sinon = require('sinon')
 const _ = require('lodash')
 
 const { onPlatforms } = require('../../../support/helpers/platform')
@@ -18,19 +19,22 @@ onPlatforms(['linux', 'win32'], () => {
   describe('core/local/channel_watcher/filter_ignored.loop()', () => {
     const builders = new Builders()
 
-    let ignore
     let channel
+    let opts
 
     beforeEach(() => {
       channel = new Channel()
 
       const patterns = ['*.bck', 'tmp/', 'folder/']
-      ignore = new Ignore(patterns)
+      opts = {
+        ignore: new Ignore(patterns),
+        fatal: sinon.spy()
+      }
     })
 
     context('without any batches of events', () => {
       it('does not throw any errors', () => {
-        should(() => filterIgnored.loop(channel, { ignore })).not.throw()
+        should(() => filterIgnored.loop(channel, opts)).not.throw()
       })
     })
 
@@ -111,7 +115,7 @@ onPlatforms(['linux', 'win32'], () => {
       })
 
       it('keeps only the relevant events in order', async () => {
-        const filteredChannel = filterIgnored.loop(channel, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, opts)
 
         const renamedToCreatedEvent = {
           ...ignoredRenamedSrcEvent,
@@ -155,7 +159,7 @@ onPlatforms(['linux', 'win32'], () => {
       })
 
       it('returns a channel with only the relevant events in order', async () => {
-        const filteredChannel = filterIgnored.loop(channel, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, opts)
 
         const renamedToCreatedEvent = {
           ...ignoredRenamedSrcEvent,
@@ -206,7 +210,7 @@ onPlatforms(['linux', 'win32'], () => {
       })
 
       it('filters out folder events only', async () => {
-        const filteredChannel = filterIgnored.loop(channel, { ignore })
+        const filteredChannel = filterIgnored.loop(channel, opts)
 
         const relevantEvents = await filteredChannel.pop()
         should(relevantEvents).deepEqual([fileScanEvent])

--- a/test/unit/local/channel_watcher/scan_folder.js
+++ b/test/unit/local/channel_watcher/scan_folder.js
@@ -6,6 +6,15 @@ const sinon = require('sinon')
 const scanFolder = require('../../../../core/local/channel_watcher/scan_folder')
 const Channel = require('../../../../core/local/channel_watcher/channel')
 
+const setup = batch => {
+  const channel = new Channel()
+  channel.push(batch)
+  const scan = sinon.stub().resolves()
+  const fatal = sinon.spy()
+
+  return { channel, scan, fatal }
+}
+
 describe('core/local/channel_watcher/scan_folder.loop()', () => {
   it('should call the producer scan for action `created` only', async () => {
     const batch = [
@@ -45,10 +54,8 @@ describe('core/local/channel_watcher/scan_folder.loop()', () => {
         path: __dirname
       }
     ]
-    const channel = new Channel()
-    channel.push(batch)
-    const scan = sinon.stub().resolves()
-    const enhancedChannel = scanFolder.loop(channel, { scan })
+    const { channel, scan, fatal } = setup(batch)
+    const enhancedChannel = scanFolder.loop(channel, { scan, fatal })
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.length(batch.length)
     should(scan).be.calledOnce()
@@ -72,10 +79,8 @@ describe('core/local/channel_watcher/scan_folder.loop()', () => {
         path: __dirname
       }
     ]
-    const channel = new Channel()
-    channel.push(batch)
-    const scan = sinon.stub().resolves()
-    const enhancedChannel = scanFolder.loop(channel, { scan })
+    const { channel, scan, fatal } = setup(batch)
+    const enhancedChannel = scanFolder.loop(channel, { scan, fatal })
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.length(batch.length)
     should(scan).be.calledThrice()
@@ -99,10 +104,8 @@ describe('core/local/channel_watcher/scan_folder.loop()', () => {
         path: __dirname
       }
     ]
-    const channel = new Channel()
-    channel.push(batch)
-    const scan = sinon.stub().resolves()
-    const enhancedChannel = scanFolder.loop(channel, { scan })
+    const { channel, scan, fatal } = setup(batch)
+    const enhancedChannel = scanFolder.loop(channel, { scan, fatal })
     const enhancedBatch = await enhancedChannel.pop()
     should(enhancedBatch).be.length(batch.length)
     should(scan).be.calledTwice()

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -24,7 +24,8 @@ const remoteErrors = require('../../../core/remote/errors')
 const {
   FILE_TYPE,
   DIR_TYPE,
-  INITIAL_SEQ
+  INITIAL_SEQ,
+  REMOTE_WATCHER_FATAL_EVENT
 } = require('../../../core/remote/constants')
 const { RemoteWatcher } = require('../../../core/remote/watcher')
 const timestamp = require('../../../core/utils/timestamp')
@@ -145,17 +146,17 @@ describe('RemoteWatcher', function () {
       should(this.watcher.watchTimeout.ref()).eql(timeoutID)
     })
 
-    it('emits a RemoteWatcher:fatal event on fatal error during first watch()', async function () {
+    it('emits a REMOTE_WATCHER_FATAL_EVENT event on fatal error during first watch()', async function () {
       this.watcher.watch.resolves(fatalError)
 
       await this.watcher.start()
       should(this.events.emit).have.been.calledWith(
-        'RemoteWatcher:fatal',
+        REMOTE_WATCHER_FATAL_EVENT,
         fatalError
       )
     })
 
-    it('emits a RemoteWatcher:fatal event on fatal error during second watch()', async function () {
+    it('emits a REMOTE_WATCHER_FATAL_EVENT event on fatal error during second watch()', async function () {
       this.watcher.watch
         .onFirstCall()
         .resolves()
@@ -165,7 +166,7 @@ describe('RemoteWatcher', function () {
       await this.watcher.start()
       await this.watcher.resetTimeout()
       should(this.events.emit).have.been.calledWith(
-        'RemoteWatcher:fatal',
+        REMOTE_WATCHER_FATAL_EVENT,
         fatalError
       )
     })
@@ -306,10 +307,10 @@ describe('RemoteWatcher', function () {
         })
 
         context('during a scheduled run', () => {
-          it('emits a RemoteWatcher:fatal event', async function () {
+          it('emits a REMOTE_WATCHER_FATAL_EVENT event', async function () {
             await this.watcher.resetTimeout()
             await should(this.events.emit).have.been.calledWith(
-              'RemoteWatcher:fatal',
+              REMOTE_WATCHER_FATAL_EVENT,
               err
             )
           })

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -201,12 +201,12 @@ describe('Sync', function () {
   describe('sync', function () {
     beforeEach('stub lifecycle', function () {
       this.sync.events = new EventEmitter()
-      this.sync.lifecycle.end('start')
+      this.sync.lifecycle.currentState = 'done-start'
     })
     afterEach('restore lifecycle', function () {
       this.sync.events.emit('stopped')
       delete this.sync.events
-      this.sync.lifecycle.end('stop')
+      this.sync.lifecycle.currentState = 'done-stop'
     })
 
     it('waits for and applies available changes', async function () {
@@ -526,11 +526,11 @@ describe('Sync', function () {
       describe('when apply throws a NEEDS_REMOTE_MERGE_CODE error', () => {
         beforeEach(function () {
           sinon.stub(this.sync, 'blockSyncFor').callsFake(() => {
-            this.sync.lifecycle.end('stop')
+            this.sync.lifecycle.currentState = 'done-stop'
           })
         })
         beforeEach('simulate error', async function () {
-          this.sync.lifecycle.end('start')
+          this.sync.lifecycle.currentState = 'done-start'
           sinon.stub(this.sync, 'apply').rejects(
             new syncErrors.SyncError({
               code: remoteErrors.NEEDS_REMOTE_MERGE_CODE,


### PR DESCRIPTION
On macOS, we rely on events sent by `fsevents` to detect what changes
have been made to files and folders on the local filesystem.
It turns out that `fsevents` can be overwhelmed when too many changes
are made on the whole filesystem at any given time and drops events in
this case.
It will then emit a special event indicating when the content of a
watched directory should be re-scanned entirely to make sure we get
the latest state of every file and folder (see
https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags/kfseventstreameventflagmustscansubdirs).

We found out that following this event, `fsevents` will emit `delete`
and `create` events for every file and folder at the root of the
watched directory, causing Desktop to delete and re-upload every
synchronized documents.

To avoid this painful situation, we now detect the special event, drop
any buffered event as they might not be up-to-date and restart the
watcher to do a full scan of the local directory once again.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
