### PR TITLE
chore: Migrate transifex config from v2 to v3

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,8 @@
 [main]
 host = https://www.transifex.com
 
-[cozy-desktop.enjson]
+[o:cozy:p:cozy-desktop:r:enjson]
 file_filter = gui/locales/<lang>.json
 source_file = gui/locales/en.json
 source_lang = en
-type = KEYVALUEJSON
+type        = KEYVALUEJSON


### PR DESCRIPTION
Transifex stops February 12 their API v2. Therefore, we are migrating the configuration to v3. If you were using a [transifex-client](https://github.com/transifex/transifex-client), you also must move to [Transifex CLI](https://developers.transifex.com/docs/cli) to be compatible with the v3 API.