### PR TITLE
ci: Use older linux GA runner image

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -30,14 +30,14 @@ env:
 jobs:
   cancel:
     name: 'Cancel Previous Runs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 3
     steps:
       - uses: styfle/cancel-workflow-action@5df4e62aed82ea1f787d2a02ab3dbfcaa49ffdd1
 
   unit:
     needs: cancel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Lint & Unit tests
     steps:
       - uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
 
   integration:
     needs: cancel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Integration tests
     steps:
       - uses: actions/checkout@v3
@@ -145,7 +145,7 @@ jobs:
 
   scenarios:
     needs: cancel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Scenarios
     strategy:
       matrix:
@@ -201,7 +201,7 @@ jobs:
 
   build:
     needs: cancel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Build packages
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #2283 

The symbol used to compile our native addons depend on the version of
the OS on which they're compiled.
We've lost compatibility with some LTS OS versions like Debian stable
and Ubuntu 20.04 because of an upgrade of the runner image so we're
switching to a specific version, ubuntu-20.04.
