### PR TITLE
Release v3.38.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.38.0-beta.1 - 2023-03-13
+
+Improvements for linux users:
+
+- We reverted our build machine Ubuntu version back to v20.04 as newer versions
+  make our native addons such as the Linux local watcher incompatible with some
+  current LTS versions of popular distributions like Ubuntu and Debian.
+  This change does not have short term drawbacks.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.37.0 - 2023-03-09
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.37.0",
+  "version": "3.38.0-beta.1",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for linux users:

- We reverted our build machine Ubuntu version back to v20.04 as newer
  versions make our native addons such as the Linux local watcher
  incompatible with some current LTS versions of popular distributions
  like Ubuntu and Debian.
  This change does not have short term drawbacks.