### PR TITLE
feat: Enable partial synchronization by default

### DIFF
--- a/gui/ports.js
+++ b/gui/ports.js
@@ -99,7 +99,7 @@ ipcRenderer.on(
       },
       flags: {
         partialSyncEnabled:
-          partialSyncEnabled != null ? partialSyncEnabled : false
+          partialSyncEnabled != null ? partialSyncEnabled : true
       }
     })
   }


### PR DESCRIPTION
Until now, partial synchronization was hidden behind a feature flag.
Although this flag was enabled on all `mycozy.cloud` instances, this
requires self-hosted administrators to think about activating it.

The feature is mature and can be enabled everywhere (unless the flag
is present and disabled).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
