### PR TITLE
Release v3.38.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.38.0-beta.2 - 2023-03-13
+
+Improvements for all users:
+
+- We've activated the partial synchronization feature by default. It can still
+  be disabled by setting the
+  `settings.partial-desktop-sync.show-synced-folders-selection` flag to `false`
+  either in the client's config or on the Cozy itself.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.38.0-beta.1 - 2023-03-13
 
 Improvements for linux users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.38.0-beta.1",
+  "version": "3.38.0-beta.2",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- We've activated the partial synchronization feature by default. It can
  still be disabled by setting the
  `settings.partial-desktop-sync.show-synced-folders-selection` flag to
  `false` either in the client's config or on the Cozy itself.