### PR TITLE
ci: Use official CouchDB docker image

### DIFF
--- a/.github/actions/setup-couchdb/action.yaml
+++ b/.github/actions/setup-couchdb/action.yaml
@@ -93,11 +93,11 @@ runs:
         podman-machine ssh box -L ${{ inputs.couchdb-port }}:localhost:5984 -N &
 
         echo "Downloading CouchDB docker image..."
-        _=$(podman-machine ssh box -- sudo podman pull apache/couchdb:${{ inputs.couchdb-version }}) # assign result to var to avoid exiting if the command errors out
+        _=$(podman-machine ssh box -- sudo podman pull couchdb:${{ inputs.couchdb-version }}) # assign result to var to avoid exiting if the command errors out
         until [[ $? -eq 0 ]]
         do
           echo "Retrying CouchDB docker image download..."
-          _=$(podman-machine ssh box -- sudo podman pull apache/couchdb:${{ inputs.couchdb-version }})
+          _=$(podman-machine ssh box -- sudo podman pull couchdb:${{ inputs.couchdb-version }})
         done
 
         echo "Starting CouchDB..."
@@ -107,7 +107,7 @@ runs:
           -e "COUCHDB_USER=${{ inputs.couchdb-user }}" \
           -e "COUCHDB_PASSWORD=${{ inputs.couchdb-password }}" \
           --name couch \
-          apache/couchdb:${{ inputs.couchdb-version }}
+          couchdb:${{ inputs.couchdb-version }}
 
         echo "Waiting for CouchDB server to be ready..."
         sleep 5


### PR DESCRIPTION
The official image on the Docker hub seems to be
https://hub.docker.com/_/couchdb rather than
https://hub.docker.com/r/apache/couchdb.

We try to use this image as the previous cannot be downloaded anymore
by `podman-machine` which fails with this error:

```bash
Error: error pulling image "apache/couchdb:3.2.2": unable to pull apache/couchdb:3.2.2: 5 errors occurred:
	* Error initializing source docker://apache/couchdb:3.2.2: Error reading manifest 3.2.2 in docker.io/apache/couchdb: manifest unknown: OCI index found, but accept header does not support OCI indexes
	* Error initializing source docker://registry.fedoraproject.org/apache/couchdb:3.2.2: Error reading manifest 3.2.2 in registry.fedoraproject.org/apache/couchdb: manifest unknown: manifest unknown
	* Error initializing source docker://quay.io/apache/couchdb:3.2.2: Error reading manifest 3.2.2 in quay.io/apache/couchdb: unauthorized: access to the requested resource is not authorized
	* Error initializing source docker://registry.access.redhat.com/apache/couchdb:3.2.2: Error reading manifest 3.2.2 in registry.access.redhat.com/apache/couchdb: name unknown: Repo not found
	* Error initializing source docker://registry.centos.org/apache/couchdb:3.2.2: Error reading manifest 3.2.2 in registry.centos.org/apache/couchdb: manifest unknown: manifest unknown
```

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
