### PR TITLE
fix: Use Sync lifecycle state transitions in tests

### DIFF
--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -84,11 +84,11 @@ class TestHelpers {
   }
 
   async syncAll() {
-    this._sync.lifecycle.currentState = 'done-start'
+    this._sync.lifecycle.transitionTo('done-start')
     await this._sync.sync({ manualRun: true })
     // Wait until all potentially blocking changes have been handled
     await this._sync.lifecycle.ready()
-    this._sync.lifecycle.currentState = 'done-stop'
+    this._sync.lifecycle.transitionTo('done-stop')
   }
 
   async pullAndSyncAll() {

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -201,12 +201,12 @@ describe('Sync', function () {
   describe('sync', function () {
     beforeEach('stub lifecycle', function () {
       this.sync.events = new EventEmitter()
-      this.sync.lifecycle.currentState = 'done-start'
+      this.sync.lifecycle.transitionTo('done-start')
     })
     afterEach('restore lifecycle', function () {
       this.sync.events.emit('stopped')
       delete this.sync.events
-      this.sync.lifecycle.currentState = 'done-stop'
+      this.sync.lifecycle.transitionTo('done-stop')
     })
 
     it('waits for and applies available changes', async function () {
@@ -526,11 +526,11 @@ describe('Sync', function () {
       describe('when apply throws a NEEDS_REMOTE_MERGE_CODE error', () => {
         beforeEach(function () {
           sinon.stub(this.sync, 'blockSyncFor').callsFake(() => {
-            this.sync.lifecycle.currentState = 'done-stop'
+            this.sync.lifecycle.transitionTo('done-stop')
           })
         })
         beforeEach('simulate error', async function () {
-          this.sync.lifecycle.currentState = 'done-start'
+          this.sync.lifecycle.transitionTo('done-start')
           sinon.stub(this.sync, 'apply').rejects(
             new syncErrors.SyncError({
               code: remoteErrors.NEEDS_REMOTE_MERGE_CODE,


### PR DESCRIPTION
We use the Sync lifecycle module to follow state changes and take
actions upon them. This is done via async methods which return
Promises resolving when a specific state is transitioned to.

However, in tests, we were modifying the state by hand so the
associated events would not be fired and the Promises waiting for them
would never resolve. This resulted in tests failing from time to time,
especially in the Windows and macOS CI builds.

We replaced all the manual state changes with the appropriate
transitions.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
