### PR TITLE
fix: Handle send to trash errors

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -476,12 +476,22 @@ class Local /*:: implements Reader, Writer */ {
           `Cannot trash locally deleted ${doc.docType}.`
         )
         return
-      } else {
-        log.error(
-          { path: doc.path, err, sentry: true },
-          'Could not trash local document'
-        )
       }
+
+      log.error(
+        { path: doc.path, err, sentry: true },
+        'Could not trash local document'
+      )
+    }
+
+    log.info({ path: doc.path }, 'Permanently deleting...')
+    try {
+      await fse.remove(fullpath)
+    } catch (err) {
+      log.error(
+        { path: fullpath, err, sentry: true },
+        'Could not permanently delete document'
+      )
       throw err
     }
   }

--- a/core/utils/fs.js
+++ b/core/utils/fs.js
@@ -38,6 +38,18 @@ function validName(name /*: string */) {
   return name.replace(ILLEGAL_CHARACTERS_REGEXP, REPLACEMENT_CHARACTER)
 }
 
+class MissingFileError extends Error {
+  constructor(path) {
+    super()
+
+    this.errno = -2
+    this.code = 'ENOENT'
+    this.syscall = 'lstat'
+    this.path = path
+    this.message = `ENOENT: no such file or directory, lstat '${path}'`
+  }
+}
+
 async function sendToTrash(fullpath /*: string */) {
   try {
     await shell.trashItem(fullpath)
@@ -45,16 +57,13 @@ async function sendToTrash(fullpath /*: string */) {
     if (await fse.exists(fullpath)) {
       throw err
     } else {
-      const error = new Error()
-      error.code = 'ENOENT'
-      error.path = fullpath
-      error.message = `${error.code}: No such file or directory, sendToTrash '${error.path}'`
-      throw error
+      throw new MissingFileError(fullpath)
     }
   }
 }
 
 module.exports = {
+  MissingFileError,
   hideOnWindows,
   sendToTrash,
   validName

--- a/test/support/doubles/fs.js
+++ b/test/support/doubles/fs.js
@@ -1,0 +1,37 @@
+const sinon = require('sinon')
+const fse = require('fs-extra')
+
+const { MissingFileError } = require('../../../core/utils/fs')
+
+const createTrashMock = () => {
+  const sendToTrash = sinon.stub()
+
+  const reset = () => {
+    sendToTrash.callsFake(async fullpath => {
+      const docExists = await fse.exists(fullpath)
+      if (!docExists) {
+        throw new MissingFileError(fullpath)
+      }
+
+      await fse.remove(fullpath)
+    })
+  }
+
+  const withFailingTrash = () => {
+    sendToTrash.callsFake(async fullpath => {
+      throw new Error(`Could not trash ${fullpath}`)
+    })
+  }
+
+  reset()
+
+  return {
+    reset,
+    sendToTrash,
+    withFailingTrash
+  }
+}
+
+module.exports = {
+  createTrashMock
+}


### PR DESCRIPTION
Sending a document to the trash can fail for various reasons, one of
them being the absence of a trash (e.g. on Windows network shares).

In this case the document would remain in the user's local
synchronization directory while it's been deleted on their Cozy.
To prevent this state, we'll catch trash errors and try to permanently
delete the document.

In a second time, we might want to mark the trashed document on the
remote Cozy to alert the user that document might not be recoverable
from a local trash (if all connected Desktops's OSes don't have a
working trash for example).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
