### PR TITLE
fix: Await full sync stop before closing the app

### DIFF
--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -275,9 +275,13 @@ module.exports = class TrayWM extends WindowManager {
       },
       'auto-launcher': (event /*: ElectronEvent */, enabled /*: boolean */) =>
         autoLaunch.setEnabled(enabled),
-      'close-app': () => {
-        this.desktop.stopSync()
-        this.app.quit()
+      'close-app': async () => {
+        try {
+          await this.desktop.stopSync()
+          await this.app.quit()
+        } catch (err) {
+          log.error({ err, sentry: true }, 'error while quitting client')
+        }
       },
       'unlink-cozy': () => {
         if (!this.desktop.config.isValid()) {


### PR DESCRIPTION
When closing the application from a user request (via the "Quit"
button for example), we first stop the synchronization to avoid
corrupting data.

However, we were not waiting for the synchronization to be fully
stopped (i.e. it is an asynchronous process) before closing the
application.
We believe this might be the source of crashes on Windows.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
