### PR TITLE
Revert "fix: Await full sync stop before closing the app (#2300)"

### DIFF
--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -275,13 +275,9 @@ module.exports = class TrayWM extends WindowManager {
       },
       'auto-launcher': (event /*: ElectronEvent */, enabled /*: boolean */) =>
         autoLaunch.setEnabled(enabled),
-      'close-app': async () => {
-        try {
-          await this.desktop.stopSync()
-          await this.app.quit()
-        } catch (err) {
-          log.error({ err, sentry: true }, 'error while quitting client')
-        }
+      'close-app': () => {
+        this.desktop.stopSync()
+        this.app.quit()
       },
       'unlink-cozy': () => {
         if (!this.desktop.config.isValid()) {


### PR DESCRIPTION
This reverts commit 0901d11ead767a16e3ae3dfe6048f248e4f5a1fb.

By awaiting the full sync stop, we prevent quitting the app during a
synchronisation or a watcher run while these can take a very long time
(especially the first scan of local and remote changes).

We'll bring back this behavior once we have a way to cancel the
on-going sync and watch runs.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
