### PR TITLE
fix: Replace default http Agent with ProxyAgent

### DIFF
--- a/core/remote/watcher/realtime_manager.js
+++ b/core/remote/watcher/realtime_manager.js
@@ -3,11 +3,9 @@
  * @flow
  */
 
-const http = require('http')
 const _ = require('lodash')
 const autoBind = require('auto-bind')
 const { RealtimePlugin } = require('cozy-realtime')
-const { WebSocket } = require('ws')
 
 const logger = require('../../utils/logger')
 const { MILLISECONDS, SECONDS } = require('../../utils/time')
@@ -68,11 +66,6 @@ class RealtimeManager {
 
     try {
       client.registerPlugin(RealtimePlugin, {
-        createWebSocket: (url, doctype) => {
-          // XXX: If using `RemoteCozy` behind a proxy, `http.globalAgent` needs
-          // to be configured first by calling `network.setup()`.
-          return new WebSocket(url, doctype, { agent: http.globalAgent })
-        },
         logger: logger({ component: 'RemoteWatcher:CozyRealtime' })
       })
 

--- a/gui/js/network/index.js
+++ b/gui/js/network/index.js
@@ -161,7 +161,7 @@ const setupProxy = async (
       : {}) // XXX: we need the key not to be present for our unit tests to pass
   })
   // $FlowFixMe
-  http.globalAgent = https.globalAgent = agent
+  http.Agent.globalAgent = http.globalAgent = https.globalAgent = agent
 
   electronApp.on('login', (event, webContents, request, authInfo, callback) => {
     log.debug({ request: request.method + ' ' + request.url }, 'Login event')
@@ -281,6 +281,11 @@ const reset = async (
   // $FlowFixMe
   https.request = originalHttpsRequest
 
+  // $FlowFixMe
+  http.Agent.globalAgent = http.globalAgent = new http.Agent({})
+  // $FlowFixMe
+  https.globalAgent = new https.Agent({})
+
   for (const event of [
     'select-client-certificate',
     'certificate-error',
@@ -288,11 +293,6 @@ const reset = async (
   ]) {
     electronApp.removeAllListeners(event)
   }
-
-  // $FlowFixMe
-  http.globalAgent = new http.Agent()
-  // $FlowFixMe
-  https.globalAgent = new https.Agent()
 
   const syncSession = session.fromPartition(SESSION_PARTITION_NAME)
   syncSession.setCertificateVerifyProc(null)


### PR DESCRIPTION
When replacing `electron-proxy-agent` with our custom implementation
of a proxy agent, we replaced the `globalAgent` of both `http` and
`https` modules but left `http.Agent.globalAgent` untouched.

Unfortunately, this prevented our `WebSocket`s to connect when the
Sentry SDK was setup as its wrapper over `http.request` would make
changes to the protocol being used to make the connection.

It seems that the protocol used was the one of
`http.Agent.globalAgent` so replacing this agent again fixes the
issue.
This also allows us to stop passing a custom agent to the `WebSocket`
constructor and thus simplify the use of `cozy-realtime`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
