### PR TITLE
feat: Send same Sentry event at most once per 24h

### DIFF
--- a/core/utils/time.js
+++ b/core/utils/time.js
@@ -6,9 +6,11 @@
 const MILLISECONDS = 1
 const SECONDS = 1000 * MILLISECONDS
 const MINUTES = 60 * SECONDS
+const HOURS = 60 * MINUTES
 
 module.exports = {
   MILLISECONDS,
   SECONDS,
-  MINUTES
+  MINUTES,
+  HOURS
 }


### PR DESCRIPTION
Desktop was not filtering events sent to our Sentry server which could
result in a lot of events being sent at once when facing an issue
which is not resolved quickly during an operation which is retried or
done repeatedly (e.g. errors raised while trying to access PouchDB
while the db is corrupted).

We will now keep track of all events sent in the past 24 hours (or
since the app was last started, whichever is the most recent) and will
only send events that were not sent already in this timespan.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
