### PR TITLE
fix: Close OAuth BrowserView only if present

### DIFF
--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -115,7 +115,9 @@ module.exports = class OnboardingWM extends WindowManager {
   }
 
   closeOAuthView() {
-    this.win.removeBrowserView(this.oauthView)
+    if (this.oauthView) {
+      this.win.removeBrowserView(this.oauthView)
+    }
   }
 
   async create() {


### PR DESCRIPTION
It seems our OAuth `BrowserView` can be undefined when it's time to
close it.
Although we're uncertain why, it could be Electron closes it already
when loading the redirect URL.

Anyway, we can check for its presence before trying to close it and
avoid errors.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
