### PR TITLE
feat: Open _blank target links in defaut browser

### DIFF
--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -111,6 +111,19 @@ module.exports = class OnboardingWM extends WindowManager {
         this.oauthView.webContents.openDevTools({ mode: 'detach' })
       }
 
+      this.oauthView.webContents.setWindowOpenHandler(
+        ({ url, disposition }) => {
+          switch (disposition) {
+            case 'foreground-tab':
+            case 'background-tab':
+            case 'new-window':
+              shell.openExternal(url)
+              return { action: 'deny' }
+            default:
+              return { action: 'allow' }
+          }
+        }
+      )
       this.oauthView.webContents.on('will-navigate', (event, url) => {
         if (url.endsWith('.pdf')) {
           event.preventDefault()

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -103,6 +103,14 @@ module.exports = class OnboardingWM extends WindowManager {
       this.oauthView.setBounds({ ...bounds, x: 0, y: 0 })
       this.centerOnScreen(LOGIN_SCREEN_WIDTH, LOGIN_SCREEN_HEIGHT)
 
+      if (this.devtools) {
+        // Switch devtools to current view
+        this.oauthView.webContents.setDevToolsWebContents(
+          this.devtools.webContents
+        )
+        this.oauthView.webContents.openDevTools({ mode: 'detach' })
+      }
+
       this.oauthView.webContents.on('will-navigate', (event, url) => {
         if (url.endsWith('.pdf')) {
           event.preventDefault()
@@ -115,6 +123,10 @@ module.exports = class OnboardingWM extends WindowManager {
   }
 
   closeOAuthView() {
+    if (this.devtools) {
+      this.win.webContents.openDevTools()
+    }
+
     if (this.oauthView) {
       this.win.removeBrowserView(this.oauthView)
     }


### PR DESCRIPTION
By default when links have a `_blank` target, Desktop will open the
targeted page in a new window.

However, we'd like these to be opened in the user's default browser
instead as a mechanism to control where links rendered by `cozy-stack`
should be opened.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
