### PR TITLE
Release v3.39.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Cozy Drive for Desktop: Changelog
 
+## 3.39.0-beta.4 - 2023-09-01
+
+Improvements for all users:
+
+- OpenOffice lock files won't be synchronized anymore.
+- The onboarding window will now honor `_blank` link targets during the
+  onboarding process by opening the targeted URL in a default browser tab
+  rather than a new Cozy Desktop window.
+
+See also [known issues](https://github.com/cozy-labs/cozy-desktop/blob/master/KNOWN_ISSUES.md).
+
+Happy syncing!
+
 ## 3.39.0-beta.3 - 2023-06-20
 
 Improvements for all users:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.39.0-beta.3",
+  "version": "3.39.0-beta.4",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Improvements for all users:

- OpenOffice lock files won't be synchronized anymore.
- The onboarding window will now honor `_blank` link targets during the
  onboarding process by opening the targeted URL in a default browser
  tab rather than a new Cozy Desktop window.