### PR TITLE
feat: React to power being suspended/resumed

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -161,6 +161,7 @@ class RemoteWatcher {
 
   startClock() {
     if (this.watchInterval == null) {
+      log.info('starting watch clock')
       this.watchInterval = setInterval(() => {
         if (this.queue.empty) {
           this.requestRun()
@@ -170,6 +171,7 @@ class RemoteWatcher {
   }
 
   stopClock() {
+    log.info('stopping watch clock')
     clearInterval(this.watchInterval)
   }
 
@@ -180,6 +182,7 @@ class RemoteWatcher {
     }
 
     try {
+      log.info('requesting watch run')
       this.queue.remove(() => true)
       return await this.queue.pushAsync()
     } catch (err) {

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -84,7 +84,7 @@ class RemoteWatcher {
   remoteCozy: RemoteCozy
   events: EventEmitter
   running: boolean
-  watchInterval: IntervalID
+  watchInterval: ?IntervalID
   queue: QueueObject
   realtimeManager: RealtimeManager
   */
@@ -173,6 +173,7 @@ class RemoteWatcher {
   stopClock() {
     log.info('stopping watch clock')
     clearInterval(this.watchInterval)
+    this.watchInterval = null
   }
 
   async requestRun() {

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -326,6 +326,7 @@ class Sync {
     this.local.stop()
     this.remote.stop()
     clearInterval(this.retryInterval)
+    this.retryInterval = null
     this.lifecycle.unblockFor('all')
     this.lifecycle.end('stop')
   }
@@ -363,6 +364,7 @@ class Sync {
 
     await Promise.all([this.local.stop(), this.remote.stop()])
     clearInterval(this.retryInterval)
+    this.retryInterval = null
     this.lifecycle.unblockFor('all')
     this.lifecycle.end('stop')
   }

--- a/gui/main.js
+++ b/gui/main.js
@@ -10,6 +10,7 @@ const {
   Notification,
   ipcMain,
   dialog,
+  powerMonitor,
   session
 } = require('electron')
 
@@ -109,6 +110,15 @@ const setupDesktop = async () => {
     // a cozy-note)?
     await desktop.setup()
     desktopIsReady()
+
+    powerMonitor.on('suspend', () => {
+      log.info('power suspended')
+      desktop.events.emit('power-suspend')
+    })
+    powerMonitor.on('resume', () => {
+      log.info('power resumed')
+      desktop.events.emit('power-resume')
+    })
 
     // We do it here since Sentry's setup happens in `desktop.setup()`
     if (process.platform === 'win32') {

--- a/test/unit/remote/watcher.js
+++ b/test/unit/remote/watcher.js
@@ -220,7 +220,7 @@ describe('RemoteWatcher', function () {
       await this.watcher.start()
       await this.watcher.stop()
       should(this.watcher.running).be.false()
-      should(this.watcher.watchInterval._destroyed).be.true()
+      should(this.watcher.watchInterval).be.null()
     })
 
     it('can be called multiple times', async function () {
@@ -228,7 +228,7 @@ describe('RemoteWatcher', function () {
       await this.watcher.stop()
       await this.watcher.stop()
       should(this.watcher.running).be.false()
-      should(this.watcher.watchInterval._destroyed).be.true()
+      should(this.watcher.watchInterval).be.null()
     })
   })
 


### PR DESCRIPTION
Using Electron's power monitoring, we can make sure the watchers and
the synchronization are stopped when the power is suspended and
started again when the power is resumed.

This has 2 benefits:
  1. avoid delays to the power suspension (OSs try not to stop active
     processes)
  2. make sure event loops are reactivated when power is resumed as this
     seems to be an issue with Electron (see
     https://github.com/electron/electron/issues/4465)

The second point seems to be particularly true on macOS where we see
the remote watcher stop working completely sometimes after a long
suspension time.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
