### PR TITLE
ci: Sign Windows binaries using Digicert Keylocker

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2022
 platform: x64
 
 clone_depth: 10

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,9 @@ test_script:
   - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:integration --timeout $env:MOCHA_TIMEOUT }
   - ps: if ($env:BUILD_JOB -eq "scenarios") { yarn test:scenarios --timeout $env:MOCHA_TIMEOUT }
 
+before_build:
+  - ps: if ($env:BUILD_JOB -eq "build") { pwsh -NoProfile -ExecutionPolicy Unrestricted -Command .\build\windows\setup-keylocker.ps1 }
+
 build_script:
   - ps: if ($env:BUILD_JOB -eq "build") { yarn dist }
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,8 @@ environment:
   NO_BREAKPOINTS: "1"
   matrix:
       - BUILD_JOB: "short_tests"
-      - BUILD_JOB: "scenarios_build"
+      - BUILD_JOB: "scenarios"
+      - BUILD_JOB: "build"
 
 cache:
   - node_modules -> yarn.lock
@@ -18,27 +19,24 @@ install:
   - cmd: appveyor-retry yarn install
   - cmd: appveyor-retry node node_modules/electron/install.js
   - cmd: appveyor-retry yarn install:electron
-  - cmd: appveyor-retry yarn bootstrap:remote
-
-build: off
+  - ps: yarn build:css; yarn build:elm
 
 test_script:
-  - ps: yarn build:css; yarn build:elm
+  - ps: if ($env:BUILD_JOB -ne "build") { yarn bootstrap:remote }
   - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:elm }
   - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:world --timeout $env:MOCHA_TIMEOUT }
   - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:unit --timeout $env:MOCHA_TIMEOUT }
   - ps: if ($env:BUILD_JOB -eq "short_tests") { yarn test:integration --timeout $env:MOCHA_TIMEOUT }
-  - ps: if ($env:BUILD_JOB -eq "scenarios_build") { yarn test:scenarios --timeout $env:MOCHA_TIMEOUT }
+  - ps: if ($env:BUILD_JOB -eq "scenarios") { yarn test:scenarios --timeout $env:MOCHA_TIMEOUT }
+
+build_script:
+  - ps: if ($env:BUILD_JOB -eq "build") { yarn dist }
+
+artifacts:
+  - path: "dist\\latest.yml"
+  - path: "dist\\Cozy*Drive*Setup*.exe*"
 
 on_failure:
   - node --version
   - npm --version
   - yarn --version
-
-on_finish:
-  - ps: |
-      if ($env:BUILD_JOB -eq "scenarios_build") {
-        yarn dist
-        Push-AppveyorArtifact dist\latest.yml
-        Resolve-Path -Path "dist\Cozy[ -]Drive[ -]Setup[ -]*.exe" -Relative | % { Push-AppveyorArtifact $_ }
-      }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,9 +10,12 @@ environment:
       - BUILD_JOB: "short_tests"
       - BUILD_JOB: "scenarios_build"
 
+cache:
+  - node_modules -> yarn.lock
+
 install:
   - ps: Update-NodeJsInstallation 18.12.1 x64
-  - cmd: appveyor-retry yarn install --verbose
+  - cmd: appveyor-retry yarn install
   - cmd: appveyor-retry node node_modules/electron/install.js
   - cmd: appveyor-retry yarn install:electron
   - cmd: appveyor-retry yarn bootstrap:remote

--- a/build/windows/customSign.js
+++ b/build/windows/customSign.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-useless-escape */
+'use strict'
+
+exports.default = async function (configuration) {
+  const { execSync } = require('child_process')
+
+  const whoami = 'customSign.js'
+
+  if (!process.env.SM_INSTALL_DIR) {
+    throw `Unable to sign files because the path to smctl.exe is not set in the environment.`
+  }
+  if (!process.env.SIGNTOOL_DIR) {
+    throw `Unable to sign files because the path to signtool.exe is not set in the environment.`
+  }
+
+  // Common
+  const filePath = `"${configuration.path.replace(/\\/g, '/')}"`
+  const smctlDir = `"${process.env.SM_INSTALL_DIR}"`
+  const signToolDir = `"${process.env.SIGNTOOL_DIR}"`
+
+  try {
+    const signCommand = `.\\build\\windows\\sign.ps1`
+    const keyPairAlias = `"${process.env.KEYPAIR_ALIAS}"`
+    const sign = [
+      `pwsh`,
+      `-NoProfile`,
+      `-ExecutionPolicy Unrestricted`,
+      `-Command \"$Input | ${signCommand}`,
+      `-FilePath '${filePath}'`,
+      `-KeyPairAlias '${keyPairAlias}'`,
+      `-SmctlDir '${smctlDir}'`,
+      `-SignToolDir '${signToolDir}'\"`
+    ]
+    const signStdout = execSync(sign.join(' ')).toString()
+    if (signStdout.match(/FAILED/)) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[${whoami}] Error detected in ${signCommand}: [${signStdout}]`
+      )
+      throw `Error detected in ${signCommand}: [${signStdout}]`
+    }
+  } catch (e) {
+    throw `Exception thrown during code signing: ${e.message}`
+  }
+
+  // Verify the signature
+  try {
+    const verifyCommand = `.\\build\\windows\\verify.ps1`
+    const fingerprint = `"${process.env.SM_CERTIFICATE_FINGERPRINT}"`
+    const verify = [
+      `pwsh`,
+      `-NoProfile`,
+      `-ExecutionPolicy Unrestricted`,
+      `-Command \"$Input | ${verifyCommand}`,
+      `-FilePath '${filePath}'`,
+      `-Fingerprint '${fingerprint}'`,
+      `-SmctlDir '${smctlDir}'`,
+      `-SignToolDir '${signToolDir}'\"`
+    ]
+    const verifyStdout = execSync(verify.join(' ')).toString()
+    if (verifyStdout.match(/FAILED/)) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[${whoami}] Error detected in ${verifyCommand}: [${verifyStdout}]`
+      )
+      throw `Error detected in ${verifyCommand}: [${verifyStdout}]`
+    }
+  } catch (e) {
+    throw `Exception thrown during signature verification: ${e.message}`
+  }
+}

--- a/build/windows/setup-keylocker.ps1
+++ b/build/windows/setup-keylocker.ps1
@@ -1,0 +1,59 @@
+try {
+  $whoami = $MyInvocation.MyCommand
+
+  # Verify that all required environment variables are set
+  $required = @(
+    'SM_API_KEY',
+    'SM_KEYPAIR_ALIAS',
+    'SM_CERTIFICATE_FINGERPRINT',
+    'SM_CLIENT_CERT_FILE_B64',
+    'SM_CLIENT_CERT_FILE',
+    'SM_CLIENT_CERT_PASSWORD',
+    'SM_HOST',
+    'SM_TOOLS_URI',
+    'SM_INSTALL_DIR',
+    'SIGNTOOL_DIR'
+  )
+  foreach ($variable in $required) {
+    if (!$(Test-Path "env:$variable")) {
+      throw "Unable to sign files because $variable is not set in the environment."
+    }
+  }
+
+  # Download SM Tools
+  Write-Host "[$whoami] Downloading SM Tools..."
+  $params = @{
+    Method  = 'Get'
+    Headers = @{
+      'x-api-key' = $env:SM_API_KEY
+    }
+    Uri     = $env:SM_TOOLS_URI
+    OutFile = 'smtools.msi'
+  }
+  Invoke-WebRequest @params
+
+  # Install SM Tools
+  Write-Host "[$whoami] Installing SM Tools..."
+  msiexec.exe /i smtools.msi /quiet /qn | Wait-Process
+
+  # Decode client certificate
+  Write-Host "[$whoami] Creating certificate file holder..."
+  New-Item C:\Certificate.p12.b64
+  Write-Host "[$whoami] Setting certificate file content..."
+  Set-Content -Path "${env:SM_CLIENT_CERT_FILE}.b64" -Value $env:SM_CLIENT_CERT_FILE_B64
+  Write-Host "[$whoami] Decoding certificate file content..."
+  certutil -decode "${env:SM_CLIENT_CERT_FILE}.b64" $env:SM_CLIENT_CERT_FILE
+
+  # Get the smctl.exe executable
+  $smctl = "${env:SM_INSTALL_DIR}\smctl.exe"
+
+  # XXX: Uncomment to debug tools installation
+  # Write-Host "[$whoami] Verifying SM Tools install..."
+  # & "$smctl" healthcheck --all
+
+  # Sync certificate
+  Write-Host "[$whoami] Synchronizing certificate..."
+  & "$smctl" windows certsync --keypair-alias="${env:SM_KEYPAIR_ALIAS}"
+} catch {
+  throw $PSItem
+}

--- a/build/windows/sign.ps1
+++ b/build/windows/sign.ps1
@@ -1,0 +1,30 @@
+[OutputType([Void])]
+Param(
+  [Parameter(Mandatory)]
+  [String]
+  $FilePath,
+
+  [Parameter(Mandatory)]
+  [String]
+  $KeyPairAlias,
+
+  [Parameter(Mandatory)]
+  [String]
+  $SmctlDir,
+
+  [Parameter(Mandatory)]
+  [String]
+  $SignToolDir
+)
+
+# Set the path
+$env:Path = @(
+  [System.Environment]::GetEnvironmentVariable('Path', 'Machine'),
+  [System.Environment]::GetEnvironmentVariable('Path', 'User'),
+  $SignToolDir
+) -join ';'
+
+# Get the smctl.exe executable
+$smctl = "$SmctlDir\smctl.exe"
+
+& "$smctl" sign --input="$FilePath" --keypair-alias="$KeyPairAlias" --verbose

--- a/build/windows/verify.ps1
+++ b/build/windows/verify.ps1
@@ -1,0 +1,30 @@
+[OutputType([Void])]
+Param(
+  [Parameter(Mandatory)]
+  [String]
+  $FilePath,
+
+  [Parameter(Mandatory)]
+  [String]
+  $Fingerprint,
+
+  [Parameter(Mandatory)]
+  [String]
+  $SmctlDir,
+
+  [Parameter(Mandatory)]
+  [String]
+  $SignToolDir
+)
+
+# Set the path
+$env:Path = @(
+  [System.Environment]::GetEnvironmentVariable('Path', 'Machine'),
+  [System.Environment]::GetEnvironmentVariable('Path', 'User'),
+  $SignToolDir
+) -join ';'
+
+# Get the smctl.exe executable
+$smctl = "$SmctlDir\smctl.exe"
+
+& "$smctl" sign verify --input="$FilePath" --fingerprint="$Fingerprint"

--- a/dev/remote/generate-test-env.js
+++ b/dev/remote/generate-test-env.js
@@ -15,7 +15,7 @@ const passphrase = process.env.COZY_PASSPHRASE || 'cozy'
 const storage = new cozy.MemoryStorage()
 
 function chooseCozyUrl(buildJob) {
-  return buildJob === 'scenarios_build'
+  return buildJob === 'scenarios'
     ? process.env.COZY_URL_2
     : process.env.COZY_URL_1
 }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,7 +64,10 @@ win:
             - ia32
   # Comment out the following line if the Digicert server starts failing.
   # Electron-Builder will then swtich back to the default Comodoca server.
-  rfc3161TimeStampServer: 'http://timestamp.digicert.com/'
+  rfc3161TimeStampServer: 'http://timestamp.digicert.com'
+  sign: 'build/windows/customSign.js'
+  signDlls: true
+  signingHashAlgorithms: ['sha256']
 
 linux:
   target:


### PR DESCRIPTION
Following changes to the internation recommandations regarding code
signing certificates issuance and storage, DigiCert does not allow
simply downloading a certificate and use it to sign binaries.
Instead, we need to store it in a HSM or, as we chose, in a
cloud-based HSM such as DigiCert Keylocker.

This means we need to install tools to fetch the certificate from the
HSM prior to signing our software and also use a custom signing script
as `electron-builder` does not support Keylocker out of the box.

The process is split into 3 phases:
1. download the DigiCert client and the certificate
2. sign our binaries
3. verify the signature

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
