### PR TITLE
fix: Process Chokidar events batches sequentially

### DIFF
--- a/.github/actions/setup-dnsmasq/action.yaml
+++ b/.github/actions/setup-dnsmasq/action.yaml
@@ -1,0 +1,23 @@
+name: Setup cozy-stack
+author: Erwan Guyader
+description: Setup dnsmasq for .localhost domains on macOS
+runs:
+  using: composite
+  steps:
+    - name: Install dnsmasq
+      shell: bash
+      run: brew install dnsmasq
+
+    - name: Add address entry to point .localhost to 127.0.0.1
+      shell: bash
+      run: echo "address=/.localhost/127.0.0.1" >> "$(brew --prefix)"/etc/dnsmasq.conf
+
+    - name: Start dnsmasq
+      shell: bash
+      run: sudo brew services start dnsmasq
+
+    - name: Create resolver configuration
+      shell: bash
+      run: |
+        sudo mkdir -p /etc/resolver
+        echo "nameserver 127.0.0.1" | sudo tee /etc/resolver/localhost

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -94,6 +94,8 @@ jobs:
         uses: ./.github/actions/setup-cozy-stack
         with:
           couchdb-url: ${{ steps.setup-couchdb.outputs.couchdb-url }}
+      - name: Setup DNS resolution for .localhost
+        uses: ./.github/actions/setup-dnsmasq
       - name: Setup local env
         env:
           COZY_DESKTOP_FS: ${{ matrix.fs }}
@@ -151,6 +153,8 @@ jobs:
         uses: ./.github/actions/setup-cozy-stack
         with:
           couchdb-url: ${{ steps.setup-couchdb.outputs.couchdb-url }}
+      - name: Setup DNS resolution for .localhost
+        uses: ./.github/actions/setup-dnsmasq
       - name: Setup local env
         env:
           COZY_DESKTOP_FS: ${{ matrix.fs }}
@@ -209,6 +213,8 @@ jobs:
         uses: ./.github/actions/setup-cozy-stack
         with:
           couchdb-url: ${{ steps.setup-couchdb.outputs.couchdb-url }}
+      - name: Setup DNS resolution for .localhost
+        uses: ./.github/actions/setup-dnsmasq
       - name: Setup local env
         env:
           COZY_DESKTOP_FS: ${{ matrix.fs }}

--- a/core/local/chokidar/event_buffer.js
+++ b/core/local/chokidar/event_buffer.js
@@ -49,25 +49,29 @@ class EventBuffer /*:: <EventType> */ {
 
   push(event /*: EventType */) /*: void */ {
     this.events.push(event)
-    this.shiftTimeout()
+    this.resetTimeout()
   }
 
   unflush(events /*: Array<EventType> */) /*: void */ {
     this.events = events.concat(this.events)
-    this.shiftTimeout()
+    this.resetTimeout()
   }
 
-  shiftTimeout() /*: void */ {
-    if (this.mode === 'timeout') {
-      this.clearTimeout()
+  setTimeout() /*: void */ {
+    if (this.mode === 'timeout' && this.timeout == null) {
       this.timeout = setTimeout(this.flush, this.timeoutInMs)
     }
   }
 
   clearTimeout() /*: void */ {
-    if (this.timeout != null) {
-      clearTimeout(this.timeout)
-      delete this.timeout
+    clearTimeout(this.timeout)
+    delete this.timeout
+  }
+
+  resetTimeout() /*: void */ {
+    if (this.mode === 'timeout') {
+      this.clearTimeout()
+      this.setTimeout()
     }
   }
 
@@ -81,8 +85,11 @@ class EventBuffer /*:: <EventType> */ {
   }
 
   switchMode(mode /*: EventBufferMode */) /*: void */ {
-    this.flush()
     this.mode = mode
+    this.clearTimeout()
+    if (this.events.length > 0) {
+      this.setTimeout()
+    }
   }
 
   clear() /*: void */ {


### PR DESCRIPTION
We buffer events emitted by Chokidar as the underlying FSEvents API,
on macOS, can add delay between events relating to the same document
and processing the first events without the latter ones can lead to
wrong assumptions about what changes were actually made.

Buffered events are then flushed 10 seconds after the last event was
buffered (i.e. each buffered event resets the 10 seconds delay).

Since this process is asynchronous and is only time-based, we can end
up flushing buffered events while some previous batch is still being
processed, creating situations where unexpected behavior can happen.

To prevent this, we now prevent any buffer flushes while a batch is
being processed and restore the flushing timeout once finished.
This can add a small delay to the next batch processing but since we
don't know if already buffered events could be flushed at that point
it seems safer.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
