### PR TITLE
deps: Upgrade `cozy-client-js` to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "bunyan": "2.0.5",
     "chokidar": "^3.5.0",
     "cozy-client": "^38.2.0",
-    "cozy-client-js": "^0.20.0",
+    "cozy-client-js": "^0.21.0",
     "cozy-flags": "^3.0.1",
     "cozy-realtime": "^4.6.0",
     "cozy-stack-client": "^38.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3069,10 +3069,10 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cozy-client-js@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.20.0.tgz#a507ef9ccbeb340aacd58ca1f1d0cdc9d000e853"
-  integrity sha512-ppguq9hkmtGpS2y+3pE4Pw0CcNOB25Lb82/q0I5r2k+pxCgrbI+6HB85TWQH8OEt/qJVoCCCa9dWE5WSZBUDYw==
+cozy-client-js@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.21.0.tgz#7d4d4aa01b65065aae44263d1f84fbee46f7916c"
+  integrity sha512-ShOwe/sf7bW2alNieB6RbwEEtPUMEAOIP+TZtDwweKyLKFtrW1pn21H2GS5zpJ+4ofuue3T6gyFNXAgNF3O9yw==
   dependencies:
     core-js "^3.6.5"
     cross-fetch "^3.0.6"


### PR DESCRIPTION
Necessary to catch Invalid Token errors returned by `cozy-stack` with
a 401 HTTP status (instead of the 400 status used historically).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
