### PR TITLE
deps: Upgrade @electron/notarize to v2.1.0

### DIFF
--- a/.github/actions/build-and-publish/action.yaml
+++ b/.github/actions/build-and-publish/action.yaml
@@ -17,6 +17,9 @@ inputs:
   apple-id-password:
     description: 'The Apple notarization account password.'
     required: false
+  apple-team-id:
+    description: 'Id of the team the Apple notarization account if part of.'
+    required: false
 runs:
   using: composite
   steps:
@@ -28,6 +31,7 @@ runs:
         CSC_KEY_PASSWORD: "${{ inputs.mac-cert-password }}"
         APPLE_ID: "${{ inputs.apple-id }}"
         APPLE_ID_PASSWORD: "${{ inputs.apple-id-password }}"
+        APPLE_TEAM_ID: "${{ inputs.apple-team-id }}"
       run: |
         if [ "${{ runner.os }}" == "Linux" ]; then
           # Install build dependencies:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -273,6 +273,7 @@ jobs:
           mac-cert-password: "${{ secrets.mac_cert_password }}"
           apple-id: "${{ secrets.apple_id }}"
           apple-id-password: "${{ secrets.apple_id_password }}"
+          apple-team-id: "${{ secrets.apple_team_id }}"
       - name: Save artifacts
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v3
@@ -283,4 +284,3 @@ jobs:
                 ${{ github.workspace }}/dist/Cozy[- ]Drive[- ]*.dmg
                 ${{ github.workspace }}/dist/Cozy[- ]Drive[- ]*-mac.zip
             retention-days: 5
-

--- a/build/afterSignHook.js
+++ b/build/afterSignHook.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 // eslint-disable-next-line node/no-unpublished-require
-const electron_notarize = require('electron-notarize')
+const electron_notarize = require('@electron/notarize')
 
 module.exports = async function (params) {
   // Only notarize the app on Mac OS only.
@@ -28,10 +28,10 @@ module.exports = async function (params) {
   console.log(`Notarizing ${appId} found at ${appPath}`)
 
   await electron_notarize.notarize({
-    appBundleId: appId,
     appPath: appPath,
     appleId: process.env.APPLE_ID,
-    appleIdPassword: process.env.APPLE_ID_PASSWORD
+    appleIdPassword: process.env.APPLE_ID_PASSWORD,
+    teamId: process.env.APPLE_TEAM_ID
   })
 
   // eslint-disable-next-line no-console

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.16.7",
+    "@electron/notarize": "^2.1.0",
     "@sentry/cli": "^2.3.0",
     "babel-preset-cozy-app": "^2.0.1",
     "chai": "4.3.4",
@@ -151,7 +152,6 @@
     "electron-builder": "^23.6.0",
     "electron-download": "^4.1.1",
     "electron-mocha": "11.0.2",
-    "electron-notarize": "^0.1.1",
     "elm": "^0.19.1",
     "elm-format": "0.8.5",
     "elm-test": "^0.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,6 +1070,15 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
+"@electron/notarize@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@electron/notarize/-/notarize-2.1.0.tgz#76aaec10c8687225e8d0a427cc9df67611c46ff3"
+  integrity sha512-Q02xem1D0sg4v437xHgmBLxI2iz/fc0D4K7fiVWHa/AnW8o7D751xyKNXgziA6HrTOme9ul1JfWN5ark8WH1xA==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+    promise-retry "^2.0.1"
+
 "@electron/remote@2.0.8":
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.8.tgz#85ff321f0490222993207106e2f720273bb1a5c3"
@@ -3753,14 +3762,6 @@ electron-mocha@11.0.2:
     which "^2.0.2"
     yargs "^16.2.0"
 
-electron-notarize@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.1.1.tgz#c3563d70c5e7b3315f44e8495b30050a8c408b91"
-  integrity sha512-TpKfJcz4LXl5jiGvZTs5fbEx+wUFXV5u8voeG5WCHWfY/cdgdD8lDZIZRqLVOtR3VO+drgJ9aiSHIO9TYn/fKg==
-  dependencies:
-    debug "^4.1.1"
-    fs-extra "^8.0.1"
-
 electron-osx-sign@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz#9b69c191d471d9458ef5b1e4fdd52baa059f1bb8"
@@ -4604,7 +4605,7 @@ fs-extra@10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@8.1.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
+fs-extra@8.1.0, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==


### PR DESCRIPTION
This package replaces the older `electron-notarize`.
This version uses Apple's `notarytool` executable by default to sign
code which we'll need as the legacy executable will stop working by
Nov. 1 2023.
