### PR TITLE
ci: Stringify automated registration errors

### DIFF
--- a/dev/remote/automated_registration.js
+++ b/dev/remote/automated_registration.js
@@ -131,7 +131,9 @@ const authorize = async authorizeUrl => {
   if (redirectUrl) {
     return redirectUrl
   } else {
-    throw new Error(`Authorization failed (code ${res.status}):\n  ${body}`)
+    throw new Error(
+      `Authorization failed (code ${res.status}):\n  ${JSON.stringify(body)}`
+    )
   }
 }
 


### PR DESCRIPTION
When `cozy-stack` returns an error response to an OAuth authorization
request, we throw a Javascript error with the response body.

However, when the body is a JSON object, we only get its type in the
error message rather than the content itself.
By stringifying the body, we make sure its content will be included in
the error message and thus displayed in the logs or console.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
