### PR TITLE
ci: Sign Windows binary on master only

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,7 @@ before_build:
   - ps: if ($env:BUILD_JOB -eq "build") { pwsh -NoProfile -ExecutionPolicy Unrestricted -Command .\build\windows\setup-keylocker.ps1 }
 
 build_script:
+  - ps: $env:SKIP_CODE_SIGNING=($env:APPVEYOR_REPO_BRANCH -ne "master")
   - ps: if ($env:BUILD_JOB -eq "build") { yarn dist }
 
 artifacts:

--- a/build/windows/customSign.js
+++ b/build/windows/customSign.js
@@ -2,6 +2,12 @@
 'use strict'
 
 exports.default = async function (configuration) {
+  if (process.env.SKIP_CODE_SIGNING === 'True') {
+    // eslint-disable-next-line no-console
+    console.log('Skipping code signing')
+    return
+  }
+
   const { execSync } = require('child_process')
 
   const whoami = 'customSign.js'


### PR DESCRIPTION
Since we switched to using DigiCert's cloud HSM for code signing
certificate storage (the other option being using a hardware token),
we have been limited to 1000 code signatures per year.

We could increase the number of allowed signatures at a cost.

We choose to stop signing binaries generated by Pull Requests as
they're not published.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
