### PR TITLE
feat: Disabling popover mode

### DIFF
--- a/doc/usage/linux.md
+++ b/doc/usage/linux.md
@@ -154,7 +154,8 @@ effects so you need to do a right-click on the icon then select the
 >
 > By default, the window behaves like a system tray / popover menu that appears
 > below the Cozy icon / app indicator, same as Windows & macOS. But it doesn't
-> work so well with recent GNOME versions or with tiling Window managers.
+> work so well with the GNOME appindicator extension (see above) or with tiling
+> window managers.
 >
 > You can set `"gui": {"popoverMode": false}` in your
 > `~/.cozy-desktop/config.json` to force the window to behave like a normal one

--- a/doc/usage/linux.md
+++ b/doc/usage/linux.md
@@ -150,11 +150,15 @@ effects so you need to do a right-click on the icon then select the
 > extension providing support for appindicator. You can find and install one
 > from https://extensions.gnome.org/ by searching for `appindicator`.
 
-> **Note for i3wm Users**
+> **Disabling the "popover" mode**
 >
-> You can set `"gui": {"visibleOnBlur": true}` in your
-> `~/.cozy-desktop/config.json` so the popover doesn't hide when focusing
-> another window.
+> By default, the window behaves like a system tray / popover menu that appears
+> below the Cozy icon / app indicator, same as Windows & macOS. But it doesn't
+> work so well with recent GNOME versions or with tiling Window managers.
+>
+> You can set `"gui": {"popoverMode": false}` in your
+> `~/.cozy-desktop/config.json` to force the window to behave like a normal one
+> (that is movable, resizable & has a close button).
 
 ## Uninstall
 

--- a/gui/main.js
+++ b/gui/main.js
@@ -700,6 +700,11 @@ app.on('window-all-closed', () => {
   log.debug('All windows closed. Keep running in tray...')
 })
 
+app.on('before-quit', () => {
+  // Indicate the tray window that it should not prevent closing.
+  app.quitting = true
+})
+
 ipcMain.on('show-help', () => {
   helpWindow.show()
 })


### PR DESCRIPTION
Recent GNOME versions don't have a systray anymore.

Users can use this extension to bring the systray icon back: https://extensions.gnome.org/extension/615/appindicator-support/

But instead of showing the Cozy tray window on click, the extension shows an intermediate menu with 2 entries instead:
- Show application (which actually toggles its visibility somehow?)
- Quit application (app gets a SIGSEGV signal)

Thus the current tray window behavior feels neither as a proper popover (needs 2 clicks to show up) nor as a proper window (no decorations / resizing / moving / mazimizing).

Here we introduce a new GUI configuration option named `popoverMode`, which is assumed to be enabled by default, unless explicitly disabled (i.e. set to false).

When disabled:
- The window has proper decorations, allowing it to be moved, resized, maximized & closed.
- The windows is hidden on close, same as on blur when the option is disabled, unless the application is actually exiting.

The new option replaces & improves the old visibleOnBlur option that was requested by some tiling window manager user(s).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes => there were no unit tests for this part of the code, I manually checked that I could show/hide/quit the app multiple time, with & without the option, but please note I didn't test it myself on Windows nor macOS.
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
