### PR TITLE
fix: Require `flags` in GUI via Electron remote

### DIFF
--- a/gui/ports.js
+++ b/gui/ports.js
@@ -5,7 +5,6 @@
 const electron = require('electron')
 const { ipcRenderer } = electron
 const remote = require('@electron/remote')
-const { SHOW_SYNCED_FOLDERS_FLAG } = require('../core/utils/flags')
 
 /*::
 import type { SyncStatus, UserAlert, SyncError } from '../core/syncstate'
@@ -17,6 +16,7 @@ window.onerror = (message, url, line, column, err) => {
 
 const pkg = remote.require('../package.json')
 const defaults = remote.require('./js/defaults')
+const { SHOW_SYNCED_FOLDERS_FLAG } = remote.require('../core/utils/flags')
 
 const container = document.getElementById('container')
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CozyDrive",
   "productName": "Cozy Drive",
   "private": true,
-  "version": "3.40.0",
+  "version": "3.41.0-alpha.1",
   "description": "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.",
   "homepage": "https://github.com/cozy-labs/cozy-desktop",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozycloud.cc/)",


### PR DESCRIPTION
Modules can only be required in renderer scripts via
`@electron/remote`.
Doing otherwise will throw an error and prevent the script from
executing properly.

This would manifest itself in an empty GUI.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
