### PR TITLE
tech: Reduce amount of logs written to disk

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -27,7 +27,7 @@ const { Remote } = require('./remote')
 const { Sync } = require('./sync')
 const SyncState = require('./syncstate')
 const Registration = require('./remote/registration')
-const { logger, LOG_BASENAME } = require('./utils/logger')
+const { defaultTransport, logger, LOG_BASENAME } = require('./utils/logger')
 const { sendToTrash } = require('./utils/fs')
 const notes = require('./utils/notes')
 const web = require('./utils/web')
@@ -428,11 +428,13 @@ class App {
     }
 
     const allFlags = await flags.all(this.config)
+
     const measurePerfFlag = allFlags[flags.MEASURE_PERF_FLAG]
-
     process.env.MEASURE_PERF = process.env.MEASURE_PERF || measurePerfFlag
-
     if (measurePerfFlag) process.env.PRINT_PERF_MEASURES = '1'
+
+    const debugFlag = allFlags[flags.DEBUG_FLAG]
+    if (debugFlag) defaultTransport.level = 'trace'
   }
 
   clientInfo() /*: ClientInfo */ {

--- a/core/local/channel_watcher/add_infos.js
+++ b/core/local/channel_watcher/add_infos.js
@@ -92,7 +92,7 @@ function loop(
           }
         }
       } catch (err) {
-        log.debug('Cannot get infos', { err, event })
+        log.error('Cannot get infos', { err, event })
         _.set(event, ['incomplete', STEP_NAME], err.message)
       }
       batch.push(event)

--- a/core/local/channel_watcher/await_write_finish.js
+++ b/core/local/channel_watcher/await_write_finish.js
@@ -270,7 +270,7 @@ async function awaitWriteFinish(channel /*: Channel */, out /*: Channel */) {
 function loop(channel /*: Channel */, opts /*: {} */) /*: Channel */ {
   const out = new Channel()
   awaitWriteFinish(channel, out).catch(err => {
-    log.warn({ err })
+    log.error({ err })
   })
   return out
 }

--- a/core/local/channel_watcher/dispatch.js
+++ b/core/local/channel_watcher/dispatch.js
@@ -91,7 +91,7 @@ function step(opts /*: DispatchOptions */) {
       try {
         await dispatchEvent(event, opts)
       } catch (err) {
-        log.warn('could not dispatch local event', { err, event })
+        log.error('could not dispatch local event', { err, event })
       }
     }
 
@@ -127,7 +127,7 @@ async function dispatchEvent(
         ).last_seq
         opts.events.emit('sync-target', target)
       } catch (err) {
-        log.warn({ err })
+        log.error({ err })
         /* ignore err */
       }
     } finally {
@@ -156,25 +156,25 @@ actions = {
     actions.createddirectory(event, opts, 'Dir found'),
 
   createdfile: async (event, { prep }, description = 'File added') => {
-    log.info(description, { event })
+    log.debug(description, { event })
     const doc = buildFile(event.path, event.stats, event.md5sum)
     await prep.addFileAsync(SIDE, doc)
   },
 
   createddirectory: async (event, { prep }, description = 'Dir added') => {
-    log.info(description, { event })
+    log.debug(description, { event })
     const doc = buildDir(event.path, event.stats)
     await prep.putFolderAsync(SIDE, doc)
   },
 
   modifiedfile: async (event, { prep }) => {
-    log.info('File modified', { event })
+    log.debug('File modified', { event })
     const doc = buildFile(event.path, event.stats, event.md5sum)
     await prep.updateFileAsync(SIDE, doc)
   },
 
   modifieddirectory: async (event, { prep }) => {
-    log.info('Dir modified', { event })
+    log.debug('Dir modified', { event })
     const doc = buildDir(event.path, event.stats)
     await prep.putFolderAsync(SIDE, doc)
   },
@@ -200,7 +200,7 @@ actions = {
       log.warn('File move source has been replaced in Pouch', { event })
       return
     }
-    log.info('File moved', { event })
+    log.debug('File moved', { event })
 
     const doc = buildFile(event.path, event.stats, event.md5sum)
     if (event.overwrite) {
@@ -236,7 +236,7 @@ actions = {
       log.warn('Dir move source has been replaced in Pouch', { event })
       return
     }
-    log.info('Dir moved', { event })
+    log.debug('Dir moved', { event })
 
     const doc = buildDir(event.path, event.stats)
     if (event.overwrite) {
@@ -255,7 +255,7 @@ actions = {
       // => we can ignore safely this event
       return
     }
-    log.info('File removed', { event })
+    log.debug('File removed', { event })
     await prep.trashFileAsync(SIDE, was)
   },
 
@@ -267,7 +267,7 @@ actions = {
       // => we can ignore safely this event
       return
     }
-    log.info('Dir removed', { event })
+    log.debug('Dir removed', { event })
     await prep.trashFolderAsync(SIDE, was)
   }
 }

--- a/core/local/channel_watcher/incomplete_fixer.js
+++ b/core/local/channel_watcher/incomplete_fixer.js
@@ -310,7 +310,7 @@ function step(
             state.incompletes.splice(i, 1)
           }
         } catch (err) {
-          log.warn('Error while rebuilding incomplete event', {
+          log.error('Error while rebuilding incomplete event', {
             err,
             event,
             item

--- a/core/local/channel_watcher/index.js
+++ b/core/local/channel_watcher/index.js
@@ -156,7 +156,7 @@ class ChannelWatcher {
   }
 
   async start() {
-    log.debug('starting...')
+    log.info('Starting watcher...')
 
     await stepsInitialState(this.state, this)
     const scanDone = new Promise(resolve => {
@@ -167,7 +167,7 @@ class ChannelWatcher {
   }
 
   async stop() /*: Promise<*> */ {
-    log.debug('stopping...')
+    log.info('Stopping watcher...')
 
     await this.producer.stop()
   }
@@ -177,7 +177,7 @@ class ChannelWatcher {
   }
 
   fatal(err /*: Error */) /*: void */ {
-    log.error(`Local watcher fatal: ${err.message}`, { err, sentry: true })
+    log.fatal(`Local watcher fatal: ${err.message}`, { err, sentry: true })
     this.events.emit(LOCAL_WATCHER_FATAL_EVENT, err)
     this.events.removeAllListeners(LOCAL_WATCHER_FATAL_EVENT)
     this.stop()

--- a/core/local/channel_watcher/initial_diff.js
+++ b/core/local/channel_watcher/initial_diff.js
@@ -75,7 +75,7 @@ function loop(
 ) /*: Channel */ {
   const out = new Channel()
   initialDiff(channel, out, opts).catch(err => {
-    log.warn({ err })
+    log.error({ err })
   })
   return out
 }

--- a/core/local/channel_watcher/overwrite.js
+++ b/core/local/channel_watcher/overwrite.js
@@ -179,7 +179,7 @@ const loop = (channel /*: Channel */, opts /*: OverwriteOptions */) => {
   const out = new Channel()
 
   _loop(channel, out, opts).catch(err => {
-    log.warn({ err })
+    log.error({ err })
   })
 
   return out

--- a/core/local/channel_watcher/parcel_producer.js
+++ b/core/local/channel_watcher/parcel_producer.js
@@ -99,6 +99,8 @@ class Producer {
    *   events for its content in that case).
    */
   async start() {
+    log.info('Starting producer...')
+
     this.watcher = await parcel.subscribe(
       this.config.syncPath,
       async (err, events) => {
@@ -115,7 +117,7 @@ class Producer {
 
     this.channel.push([INITIAL_SCAN_DONE])
     this.initialScanDone = true
-    log.trace('Scan done')
+    log.info('Folder scan done')
 
     this.events.emit('buffering-end')
   }
@@ -186,7 +188,8 @@ class Producer {
   }
 
   async stop() {
-    log.trace('Stop')
+    log.info('Stopping producer...')
+
     if (this.watcher) {
       await this.watcher.unsubscribe()
       // XXX: unsubscribe() resolves before it was actually finished

--- a/core/local/channel_watcher/scan_folder.js
+++ b/core/local/channel_watcher/scan_folder.js
@@ -40,7 +40,7 @@ function loop(
       }
       if (event.action === 'created' && event.kind === 'directory') {
         opts.scan(event.path).catch(err => {
-          log.warn('Error on folder scan', { err, event })
+          log.error('Error on folder scan', { err, event })
         })
       }
     }

--- a/core/local/channel_watcher/win_identical_renaming.js
+++ b/core/local/channel_watcher/win_identical_renaming.js
@@ -178,7 +178,7 @@ const loop = (
   const out = new Channel()
 
   _loop(channel, out, opts).catch(err => {
-    log.warn({ err })
+    log.error({ err })
   })
 
   return out

--- a/core/local/chokidar/analysis.js
+++ b/core/local/chokidar/analysis.js
@@ -146,7 +146,7 @@ function analyseEvents(
   const changesFound = new LocalChangeMap()
 
   if (pendingChanges.length > 0) {
-    log.warn(`Prepend ${pendingChanges.length} pending change(s)`, {
+    log.debug(`Prepend ${pendingChanges.length} pending change(s)`, {
       changes: pendingChanges
     })
     for (const a of pendingChanges) {

--- a/core/local/chokidar/normalize_paths.js
+++ b/core/local/chokidar/normalize_paths.js
@@ -45,7 +45,7 @@ const step = async (
         normalizedPaths.push(normalized)
 
         if (c.path !== normalized) {
-          log.info(
+          log.debug(
             'normalizing local path to match existing doc and parent norms',
             { path: c.path, normalized }
           )

--- a/core/local/chokidar/send_to_prep.js
+++ b/core/local/chokidar/send_to_prep.js
@@ -45,7 +45,7 @@ const onAddFile = (
   prep /*: Prep */
 ) => {
   const doc = metadata.buildFile(filePath, stats, md5sum)
-  log.info('FileAddition', { path: filePath })
+  log.debug('FileAddition', { path: filePath })
   return prep.addFileAsync(SIDE, doc)
 }
 
@@ -55,7 +55,7 @@ const onMoveFile = async (
 ) => {
   const doc = metadata.buildFile(filePath, stats, md5sum, old.remote)
   if (overwrite) doc.overwrite = overwrite
-  log.info('FileMove', { path: filePath, oldpath: old.path })
+  log.debug('FileMove', { path: filePath, oldpath: old.path })
   return prep.moveFileAsync(SIDE, doc, old)
 }
 
@@ -66,7 +66,7 @@ const onMoveFolder = (
   const doc = metadata.buildDir(folderPath, stats, old.remote)
   // $FlowFixMe we set doc.overwrite to true, it will be replaced by metadata in merge
   if (overwrite) doc.overwrite = overwrite
-  log.info('DirMove', { path: folderPath, oldpath: old.path })
+  log.debug('DirMove', { path: folderPath, oldpath: old.path })
   return prep.moveFolderAsync(SIDE, doc, old)
 }
 
@@ -76,7 +76,7 @@ const onAddDir = (
   prep /*: Prep */
 ) => {
   const doc = metadata.buildDir(folderPath, stats)
-  log.info('DirAddition', { path: folderPath })
+  log.debug('DirAddition', { path: folderPath })
   return prep.putFolderAsync(SIDE, doc)
 }
 
@@ -89,7 +89,7 @@ const onUnlinkFile = (
   { path: filePath, old } /*: LocalFileDeletion */,
   prep /*: Prep */
 ) => {
-  log.info('FileDeletion', { path: filePath })
+  log.debug('FileDeletion', { path: filePath })
   if (!old) {
     log.debug('Assuming file already removed', { path: filePath })
     return
@@ -106,7 +106,7 @@ const onUnlinkDir = (
   { path: folderPath, old } /*: LocalDirDeletion */,
   prep /*: Prep */
 ) => {
-  log.info('DirDeletion', { path: folderPath })
+  log.debug('DirDeletion', { path: folderPath })
   if (!old) {
     log.debug('Assuming dir already removed', { path: folderPath })
     return
@@ -123,7 +123,7 @@ const onChange = (
   } /*: LocalFileUpdate|LocalFileAdded|LocalFileUpdated */,
   prep /*: Prep */
 ) => {
-  log.info('FileUpdate', { path: filePath })
+  log.debug('FileUpdate', { path: filePath })
   const doc = metadata.buildFile(filePath, stats, md5sum)
   return prep.updateFileAsync(SIDE, doc)
 }

--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -124,7 +124,7 @@ class LocalWatcher {
    * @see https://github.com/paulmillr/chokidar
    */
   start() {
-    log.debug('Starting...')
+    log.info('Starting watcher...')
 
     this.resetInitialScanParams()
 
@@ -175,7 +175,7 @@ class LocalWatcher {
             log.chokidar.debug(eventType, { path, stats, isInitialScan })
             const newEvent = chokidarEvent.build(eventType, path, stats)
             if (newEvent.type !== eventType) {
-              log.info('fixed wrong fsevents event type', {
+              log.debug('fixed wrong fsevents event type', {
                 eventType,
                 event: newEvent
               })
@@ -189,10 +189,11 @@ class LocalWatcher {
       this.watcher
         .on('ready', () => {
           stopChokidarScanMeasure()
+          log.info('Folder scan done')
           this.buffer.switchMode('timeout')
         })
         .on('raw', async (event, path, details) => {
-          log.chokidar.debug('raw', { event, path, details })
+          log.chokidar.trace('raw', { event, path, details })
 
           if (isRescanFlag(details.flags)) {
             try {
@@ -225,7 +226,7 @@ class LocalWatcher {
   // TODO: Start checksuming as soon as an add/change event is buffered
   // TODO: Put flushed event batches in a queue
   async onFlush(rawEvents /*: ChokidarEvent[] */) {
-    log.debug(`Flushed ${rawEvents.length} events`)
+    log.info(`Flushed ${rawEvents.length} events`)
 
     this.events.emit('buffering-end')
     syncDir.ensureExistsSync(this)
@@ -283,7 +284,7 @@ class LocalWatcher {
   }
 
   async stop(force /*: ?bool */ = false) {
-    log.debug('Stopping watcher...')
+    log.info('Stopping watcher...')
 
     if (!this.watcher) return
 
@@ -345,7 +346,7 @@ class LocalWatcher {
   }
 
   fatal(err /*: Error */) /*: void */ {
-    log.error(`Local watcher fatal: ${err.message}`, { err, sentry: true })
+    log.fatal(`Local watcher fatal: ${err.message}`, { err, sentry: true })
     this.events.emit(LOCAL_WATCHER_FATAL_EVENT, err)
     this.events.removeAllListeners(LOCAL_WATCHER_FATAL_EVENT)
     this.stop()

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -504,7 +504,7 @@ class Local /*:: implements Reader, Writer */ {
   ) /*: Promise<T> */ {
     const conflict = metadata.createConflictingDoc(newMetadata)
 
-    log.warn('Resolving local conflict', {
+    log.info('Resolving local conflict', {
       path: conflict.path,
       oldpath: newMetadata.path
     })

--- a/core/pouch/index.js
+++ b/core/pouch/index.js
@@ -53,7 +53,7 @@ class Pouch {
     this._lock = { id: this.nextLockId++, promise: Promise.resolve(null) }
     this.db = new PouchDB(this.config.dbPath)
     this.db.setMaxListeners(100)
-    this.db.on('error', err => log.warn(err))
+    this.db.on('error', err => log.error(err))
     this.updater = async.queue(async task => {
       const taskDoc = await this.byIdMaybe(task._id)
       if (taskDoc) return this.db.put({ ...task, _rev: taskDoc._rev })
@@ -69,7 +69,7 @@ class Pouch {
     await fse.ensureDir(this.config.dbPath)
     this.db = new PouchDB(this.config.dbPath)
     this.db.setMaxListeners(100)
-    this.db.on('error', err => log.warn(err))
+    this.db.on('error', err => log.error(err))
     return this.addAllViews()
   }
 
@@ -153,7 +153,7 @@ class Pouch {
     { checkInvariants = true } /*: { checkInvariants: boolean } */ = {}
   ) /*: Promise<SavedMetadata> */ {
     if (checkInvariants) metadata.invariants(doc)
-    log.debug('Saving metadata...', {
+    log.info('Saving metadata...', {
       path: doc.path,
       _id: doc._id,
       _deleted: doc._deleted,
@@ -176,7 +176,7 @@ class Pouch {
   }
 
   remove(doc /*: SavedMetadata */) /*: Promise<SavedMetadata> */ {
-    log.debug('Removing record', { path: doc.path, _id: doc._id, doc })
+    log.info('Removing record', { path: doc.path, _id: doc._id, doc })
     return this.put(_.defaults({ _deleted: true }, doc))
   }
 
@@ -186,7 +186,7 @@ class Pouch {
   // result in an attempt to take action.
   // This method also does not care about invariants like `remove()` does.
   eraseDocument({ _id, _rev, path } /*: SavedMetadata */) {
-    log.debug('Erasing record', { path, _id, _rev })
+    log.info('Erasing record', { path, _id, _rev })
     return this.db.put({ _id, _rev, _deleted: true })
   }
 
@@ -197,7 +197,7 @@ class Pouch {
     const docsToErase = []
     docs.forEach(doc => {
       const { path, _id, _rev } = _.clone(doc)
-      log.debug('Erasing bulk record...', { path, _id, _rev })
+      log.info('Erasing bulk record...', { path, _id, _rev })
       docsToErase.push({ _id, _rev, _deleted: true })
     })
 
@@ -226,7 +226,7 @@ class Pouch {
       metadata.invariants(doc)
       const { path, _id } = doc
       const { local, remote } = doc.sides || {}
-      log.debug('Saving bulk metadata...', {
+      log.info('Saving bulk metadata...', {
         path,
         _id,
         local,
@@ -541,7 +541,7 @@ class Pouch {
       return
     } else {
       await this.db.put(doc)
-      log.debug(`Design document created: ${name}`)
+      log.trace(`Design document created: ${name}`)
     }
   }
 
@@ -573,7 +573,7 @@ class Pouch {
     try {
       return await this.db.get(id, { rev })
     } catch (err) {
-      log.debug('could fetch fetch previous revision', {
+      log.error('could not fetch previous revision', {
         path: doc.path,
         _id: doc._id,
         rev,

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -301,7 +301,7 @@ class Remote /*:: implements Reader, Writer */ {
     if (!doc.remote) {
       return this.addFolderAsync(doc)
     }
-    log.info('Updating metadata...', { path })
+    log.info('Updating folder metadata...', { path })
 
     const attrs = {
       updated_at: mostRecentUpdatedAt(doc)
@@ -426,7 +426,7 @@ class Remote /*:: implements Reader, Writer */ {
       await this.diskUsage()
       return true
     } catch (err) {
-      log.debug('Could not reach remote Cozy', { err })
+      log.warn('Could not reach remote Cozy', { err })
       return false
     }
   }
@@ -467,7 +467,7 @@ class Remote /*:: implements Reader, Writer */ {
   ) /*: Promise<?T> */ {
     const conflict = metadata.createConflictingDoc(newMetadata)
 
-    log.warn('Resolving remote conflict', {
+    log.info('Resolving remote conflict', {
       path: conflict.path,
       oldpath: newMetadata.path
     })

--- a/core/remote/warning_poller.js
+++ b/core/remote/warning_poller.js
@@ -67,7 +67,7 @@ class RemoteWarningPoller {
 
   async poll() {
     if (this.polling) {
-      log.warn('Skipping polling (already in progress)')
+      log.debug('Skipping polling (already in progress)')
       this.scheduleNext(this.ticks)
       return
     }
@@ -77,7 +77,7 @@ class RemoteWarningPoller {
       this.polling = this.remoteCozy.warnings()
       const warnings /*: Warning[] */ = await this.polling
 
-      log.info(`${warnings.length} warnings`)
+      log.debug(`${warnings.length} warnings`)
       if (warnings.length > 0) log.trace({ warnings })
 
       for (const warning of warnings) {

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -110,7 +110,7 @@ class RemoteWatcher {
 
   async start() {
     if (!this.running) {
-      log.debug('Starting watcher')
+      log.info('Starting watcher')
       this.running = true
       this.startClock()
 
@@ -129,7 +129,7 @@ class RemoteWatcher {
 
   async stop() {
     if (this.running) {
-      log.debug('Stopping watcher')
+      log.info('Stopping watcher')
 
       if (this.realtimeManager) {
         this.realtimeManager.stop()
@@ -146,7 +146,7 @@ class RemoteWatcher {
   }
 
   error(err /*: RemoteError */) {
-    log.warn(`Remote watcher error: ${err.message}`, { err })
+    log.error(`Remote watcher error: ${err.message}`, { err })
     this.events.emit(REMOTE_WATCHER_ERROR_EVENT, err)
   }
 
@@ -155,7 +155,7 @@ class RemoteWatcher {
   }
 
   async fatal(err /*: Error */) {
-    log.error(`Remote watcher fatal: ${err.message}`, { err, sentry: true })
+    log.fatal(`Remote watcher fatal: ${err.message}`, { err, sentry: true })
     this.events.emit(REMOTE_WATCHER_FATAL_EVENT, err)
     this.events.removeAllListeners(REMOTE_WATCHER_FATAL_EVENT)
     await this.stop()
@@ -173,7 +173,7 @@ class RemoteWatcher {
 
   startClock() {
     if (this.watchInterval == null) {
-      log.info('starting watch clock')
+      log.debug('starting watch clock')
       this.watchInterval = setInterval(() => {
         if (this.queue.idle()) {
           // Enqueue a scheduled run only if there weren't any running on
@@ -185,7 +185,7 @@ class RemoteWatcher {
   }
 
   stopClock() {
-    log.info('stopping watch clock')
+    log.debug('stopping watch clock')
     clearInterval(this.watchInterval)
     this.watchInterval = null
   }
@@ -197,7 +197,7 @@ class RemoteWatcher {
     }
 
     try {
-      log.info('requesting watch run')
+      log.debug('requesting watch run')
 
       if (this.queue.idle()) {
         // If there aren't any requests running, enqueue one and wait until
@@ -230,7 +230,7 @@ class RemoteWatcher {
     const release = await this.pouch.lock(this)
     try {
       if (!this.running) {
-        log.debug('Watcher stopped: skipping remote watch')
+        log.info('Watcher stopped: skipping remote watch')
         return
       }
 
@@ -243,7 +243,7 @@ class RemoteWatcher {
       this.events.emit('online')
 
       if (docs.length === 0) {
-        log.debug('No remote changes for now')
+        log.info('No remote changes for now')
         await this.fetchReincludedContent()
         return
       }
@@ -264,7 +264,7 @@ class RemoteWatcher {
       this.events.emit('sync-target', target)
 
       await this.pouch.setRemoteSeq(last_seq)
-      log.debug('No more remote changes for now')
+      log.info('No more remote changes for now')
     } catch (err) {
       // TODO: Maybe wrap remote errors more closely to remote calls to avoid
       // wrapping other kinds of errors? PouchDB errors for example.
@@ -281,7 +281,7 @@ class RemoteWatcher {
 
     while (dirs.length) {
       for (const dir of dirs) {
-        log.trace('Fetching content of unknown folder...', { path: dir.path })
+        log.info('Fetching content of unknown folder...', { path: dir.path })
         const children = await this.remoteCozy.getDirectoryContent(dir.remote)
 
         await this.processRemoteChanges(children, { isRecursiveFetch: true })
@@ -394,7 +394,7 @@ class RemoteWatcher {
     } /*: { isInitialFetch?: boolean, isRecursiveFetch?: boolean } */ = {}
   ) /*: RemoteChange */ {
     const oldpath /*: ?string */ = was ? was.path : undefined
-    log.debug('change received', {
+    log.info('change received', {
       path: remoteDoc.path || oldpath,
       oldpath,
       remoteDoc,
@@ -498,7 +498,7 @@ class RemoteWatcher {
       metadata.assignPlatformIncompatibilities(doc, this.config.syncPath)
       const { incompatibilities } = doc
       if (incompatibilities) {
-        log.debug({ path, oldpath: was && was.path, incompatibilities })
+        log.info({ path, oldpath: was && was.path, incompatibilities })
       }
     } else {
       if (!was) {
@@ -607,39 +607,39 @@ class RemoteWatcher {
           })
           break
         case 'FileTrashing':
-          log.info('file was trashed remotely', { path })
+          log.debug('file was trashed remotely', { path })
           await this.prep.trashFileAsync(sideName, change.was, change.doc)
           break
         case 'DirTrashing':
-          log.info('folder was trashed remotely', { path })
+          log.debug('folder was trashed remotely', { path })
           await this.prep.trashFolderAsync(sideName, change.was, change.doc)
           break
         case 'FileDeletion':
-          log.info('file was deleted permanently', { path })
+          log.debug('file was deleted permanently', { path })
           await this.prep.deleteFileAsync(sideName, change.doc)
           break
         case 'DirDeletion':
-          log.info('folder was deleted permanently', { path })
+          log.debug('folder was deleted permanently', { path })
           await this.prep.deleteFolderAsync(sideName, change.doc)
           break
         case 'FileAddition':
-          log.info('file was added remotely', { path })
+          log.debug('file was added remotely', { path })
           await this.prep.addFileAsync(sideName, change.doc)
           break
         case 'DirAddition':
-          log.info('folder was added remotely', { path })
+          log.debug('folder was added remotely', { path })
           await this.prep.putFolderAsync(sideName, change.doc)
           break
         case 'FileUpdate':
-          log.info('file was updated remotely', { path })
+          log.debug('file was updated remotely', { path })
           await this.prep.updateFileAsync(sideName, change.doc)
           break
         case 'DirUpdate':
-          log.info('folder was updated remotely', { path })
+          log.debug('folder was updated remotely', { path })
           await this.prep.putFolderAsync(sideName, change.doc)
           break
         case 'FileMove':
-          log.info('file was moved or renamed remotely', {
+          log.debug('file was moved or renamed remotely', {
             path,
             oldpath: change.was.path
           })
@@ -654,7 +654,7 @@ class RemoteWatcher {
           break
         case 'DirMove':
           {
-            log.info('folder was moved or renamed remotely', {
+            log.debug('folder was moved or renamed remotely', {
               path,
               oldpath: change.was.path
             })
@@ -685,13 +685,13 @@ class RemoteWatcher {
           }
           break
         case 'UpToDate':
-          log.info(`${docType} is up-to-date`, { path })
+          log.debug(`${docType} is up-to-date`, { path })
           break
         default:
           throw new Error(`Unexpected change type: ${change.type}`)
       } // switch
     } catch (err) {
-      log.debug('could not apply change', {
+      log.error('could not apply change', {
         err,
         path: change.doc.path,
         change

--- a/core/remote/watcher/normalizePaths.js
+++ b/core/remote/watcher/normalizePaths.js
@@ -53,7 +53,7 @@ const normalizePaths = async (
         normalizedPaths.push(normalized)
 
         if (c.doc.path !== normalized) {
-          log.info('normalizing path to match existing doc and parent norms', {
+          log.trace('normalizing path to match existing doc and parent norms', {
             path: normalized,
             oldpath: c.doc.path
           })

--- a/core/remote/watcher/realtime_manager.js
+++ b/core/remote/watcher/realtime_manager.js
@@ -79,7 +79,7 @@ class RealtimeManager {
       // Add logs to `disconnected` event as `cozy-realtime` doesn't log anything
       // when emitting this event.
       this.realtime.on('disconnected', () =>
-        log.debug('realtime websocket disconnected')
+        log.info('realtime websocket disconnected')
       )
       this.realtime.on('error', this.onError)
 
@@ -90,7 +90,7 @@ class RealtimeManager {
   }
 
   async start() {
-    log.debug('Starting realtime manager...')
+    log.info('Starting realtime manager...')
 
     if (this.realtime == null) {
       log.warn(
@@ -111,7 +111,7 @@ class RealtimeManager {
       this.onError(err)
 
       const delay = this.options.reconnectionDelay
-      log.debug(`Will retry starting realtime in ${delay} ms`)
+      log.trace(`Will retry starting realtime in ${delay} ms`)
       this.reconnectTimeout = setTimeout(this.start, delay)
 
       return
@@ -121,6 +121,8 @@ class RealtimeManager {
   }
 
   async stop() {
+    log.info('Stopping realtime manager...')
+
     clearTimeout(this.reconnectTimeout)
 
     if (this.realtime == null) {

--- a/core/utils/flags.js
+++ b/core/utils/flags.js
@@ -9,7 +9,8 @@ const { RemoteCozy } = require('../remote/cozy')
 import type { Config } from '../config'
 */
 
-const MEASURE_PERF_FLAG = 'desktop.measure-perf'
+const DEBUG_FLAG = 'desktop.debug.enabled'
+const MEASURE_PERF_FLAG = 'desktop.measure-perf.enabled'
 const SHOW_SYNCED_FOLDERS_FLAG =
   'settings.partial-desktop-sync.show-synced-folders-selection'
 
@@ -25,6 +26,7 @@ const all = async (config /*: Config */) => {
 }
 
 module.exports = {
+  DEBUG_FLAG,
   MEASURE_PERF_FLAG,
   SHOW_SYNCED_FOLDERS_FLAG,
   all

--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -138,7 +138,7 @@ const defaultFormatter = combine(
 )
 
 const defaultTransport = new DailyRotateFile({
-  level: 'trace',
+  level: 'info',
   dirname: LOG_DIR,
   filename: LOG_BASENAME,
   datePattern: 'YYYY-MM-DD', // XXX: rotate every day

--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -138,7 +138,7 @@ const defaultFormatter = combine(
 )
 
 const defaultTransport = new DailyRotateFile({
-  level: 'info',
+  level: process.env.DEBUG ? 'trace' : 'info',
   dirname: LOG_DIR,
   filename: LOG_BASENAME,
   datePattern: 'YYYY-MM-DD', // XXX: rotate every day
@@ -217,6 +217,7 @@ module.exports = {
   LOG_BASENAME,
   defaultFormatter,
   defaultLogger,
+  defaultTransport,
   dropTimestamp,
   logger,
   messageToMsg

--- a/gui/js/autolaunch.js
+++ b/gui/js/autolaunch.js
@@ -45,7 +45,7 @@ if (process.env.APPIMAGE) {
       return
     })
     .catch(err =>
-      log.warn('could not check autolaunch or replace old one', { err })
+      log.error('could not check autolaunch or replace old one', { err })
     )
 }
 
@@ -66,5 +66,5 @@ module.exports.setEnabled = enabled => {
       }
       return was
     })
-    .catch(err => log.warn('could not set autolaunch', { err }))
+    .catch(err => log.error('could not set autolaunch', { err }))
 }

--- a/gui/js/cozy-web.window.js
+++ b/gui/js/cozy-web.window.js
@@ -29,7 +29,7 @@ module.exports = class CozyWebWM extends WindowManager {
   }
 
   create() {
-    this.log.debug('create')
+    this.log.trace('create')
     const opts = {
       ...this.windowOptions(),
       autoHideMenuBar: true,
@@ -47,10 +47,10 @@ module.exports = class CozyWebWM extends WindowManager {
       this.win = null
     })
     this.win.on('unresponsive', () => {
-      this.log.warn('Web page becomes unresponsive')
+      this.log.warn('Web page is unresponsive')
     })
     this.win.on('responsive', () => {
-      this.log.warn('Web page becomes responsive again')
+      this.log.warn('Web page is responsive again')
     })
     this.centerOnScreen(opts.width, opts.height)
 

--- a/gui/js/network/agent.js
+++ b/gui/js/network/agent.js
@@ -129,7 +129,7 @@ class ProxyAgent extends Agent {
 
   constructor(opts /*:: ?: AgentConnectOpts */ = {}) {
     super(opts)
-    log.debug('Creating new ProxyAgent instance', { opts })
+    log.info('Creating new ProxyAgent instance', { opts })
     this.cache = new LRUCache({ max: 20 })
     this.proxyHeaders = opts && opts.headers ? opts.headers : {}
     this.connectOpts = _.omit(opts, 'headers')
@@ -178,8 +178,8 @@ class ProxyAgent extends Agent {
       return secureEndpoint ? this.httpsAgent : this.httpAgent
     }
 
-    log.debug('Request URL: %o', url)
-    log.debug('Proxy URL: %o', proxy)
+    log.trace('Request URL: %o', url)
+    log.trace('Proxy URL: %o', proxy)
 
     // attempt to get a cached `http.Agent` instance first
     const cacheKey = `${protocol}+${proxy}`
@@ -195,7 +195,7 @@ class ProxyAgent extends Agent {
       agent = new ctor(proxy, this.connectOpts)
       this.cache.set(cacheKey, agent)
     } else {
-      log.debug('Cache hit for proxy URL: %o', proxy)
+      log.trace('Cache hit for proxy URL: %o', proxy)
     }
 
     return agent
@@ -214,7 +214,7 @@ class ProxyAgent extends Agent {
 // It is meant to be used with `ProxyAgent`.
 const getProxyForUrl =
   (session /*: Session */) => async (reqUrl /*: string */) => {
-    log.info('getProxyForUrl', { reqUrl })
+    log.debug('getProxyForUrl', { reqUrl })
     const proxy = await session.resolveProxy(reqUrl)
     if (!proxy) {
       return ''

--- a/gui/js/network/index.js
+++ b/gui/js/network/index.js
@@ -74,7 +74,7 @@ const networkConfig = (argv /*: Array<*> */ = process.argv) => {
     .help('help')
     .parse(argv)
 
-  log.debug('argv', { networkConfig })
+  log.info('argv', { networkConfig })
   return networkConfig
 }
 
@@ -93,7 +93,7 @@ const getSession = (
   syncSession.setCertificateVerifyProc((request, callback) => {
     const { hostname, certificate, verificationResult, errorCode } = request
     if (verificationResult < 0) {
-      log.warn('Certificate Verification Error', {
+      log.error('Certificate Verification Error', {
         hostname,
         certificate: formatCertificate(certificate),
         verificationResult,

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -155,7 +155,7 @@ module.exports = class OnboardingWM extends WindowManager {
         await this.jumpToSyncPath()
       }
     } catch (err) {
-      log.warn('could not create Onboarding window', { err })
+      log.error('could not create Onboarding window', { err })
     }
   }
 
@@ -226,7 +226,10 @@ module.exports = class OnboardingWM extends WindowManager {
         return
       },
       err => {
-        log.warn('failed registering device with remote Cozy', { err, cozyUrl })
+        log.error('failed registering device with remote Cozy', {
+          err,
+          cozyUrl
+        })
         if (err.code && err.code.match(/PROXY/)) {
           syncSession.resolveProxy(cozyUrl, p => {
             event.sender.send(
@@ -268,12 +271,12 @@ module.exports = class OnboardingWM extends WindowManager {
   onStartSync(event /*: ElectronEvent */, syncPath /*: string */) {
     const { error } = this.checkSyncPath(syncPath, event.sender)
     if (error) {
-      log.warn({ err: error })
+      log.error({ err: error })
       return
     }
     let desktop = this.desktop
     if (!desktop.config.isValid()) {
-      log.warn('Cannot start desktop client. No valid config found!')
+      log.error('Cannot start desktop client. No valid config found!')
       return
     }
     try {
@@ -281,11 +284,11 @@ module.exports = class OnboardingWM extends WindowManager {
       try {
         addFileManagerShortcut(desktop.config)
       } catch (err) {
-        log.warn('failed adding shortcuts in file manager', { err })
+        log.error('failed adding shortcuts in file manager', { err })
       }
       this.afterOnboarding()
     } catch (err) {
-      log.warn('failed starting sync', { err })
+      log.error('failed starting sync', { err })
       event.sender.send('folder-error', translate('Error Invalid path'))
     }
   }

--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -145,7 +145,7 @@ module.exports = class TrayWM extends WindowManager {
   }
 
   show(trayPos /*: Bounds */) {
-    this.log.debug('show')
+    this.log.trace('show')
     super.show()
     this.placeWithTray(DASHBOARD_SCREEN_WIDTH, DASHBOARD_SCREEN_HEIGHT, trayPos)
     return Promise.resolve(this.win)
@@ -204,7 +204,7 @@ module.exports = class TrayWM extends WindowManager {
 
   hide() {
     if (this.win) {
-      this.log.debug('hide')
+      this.log.trace('hide')
       this.win.hide()
     }
   }

--- a/gui/js/updater.window.js
+++ b/gui/js/updater.window.js
@@ -113,7 +113,7 @@ module.exports = class UpdaterWM extends WindowManager {
       }
     })
     autoUpdater.on('download-progress', progressObj => {
-      log.trace('Downloading...', { progress: progressObj })
+      log.info('Downloading...', { progress: progressObj })
       this.send('update-downloading', progressObj)
     })
     autoUpdater.on('update-downloaded', info => {

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -67,7 +67,7 @@ module.exports = class WindowManager {
 
   async show() {
     if (!this.win) await this.create()
-    this.log.debug('show')
+    this.log.trace('show')
 
     // devTools
     if (process.env.WATCH === 'true' || process.env.DEBUG === 'true') {
@@ -108,7 +108,7 @@ module.exports = class WindowManager {
 
   hide() {
     if (this.win) {
-      this.log.debug('hide')
+      this.log.trace('hide')
       this.win.close()
     }
     this.win = null
@@ -124,7 +124,7 @@ module.exports = class WindowManager {
 
   reload() {
     if (this.win) {
-      this.log.debug('reload')
+      this.log.trace('reload')
       this.win.reload()
     }
   }
@@ -167,7 +167,7 @@ module.exports = class WindowManager {
   }
 
   create() {
-    this.log.debug('create')
+    this.log.trace('create')
     const opts = {
       indexPath: path.resolve(__dirname, '..', 'index.html'),
       ...this.windowOptions()
@@ -188,10 +188,10 @@ module.exports = class WindowManager {
       ...opts
     })
     this.win.on('unresponsive', () => {
-      this.log.warn('Web page becomes unresponsive')
+      this.log.warn('Web page is unresponsive')
     })
     this.win.on('responsive', () => {
-      this.log.warn('Web page becomes responsive again')
+      this.log.warn('Web page is responsive again')
     })
     this.win.webContents.on(
       'did-fail-load',

--- a/gui/main.js
+++ b/gui/main.js
@@ -200,7 +200,7 @@ const showWindow = async bounds => {
       const hasAutolaunch = await autoLaunch.isEnabled()
       trayWindow.send('auto-launch', hasAutolaunch)
     } catch (err) {
-      log.warn('could not show tray window or recent files', { err })
+      log.error('could not show tray window or recent files', { err })
     }
   }
 }
@@ -697,7 +697,7 @@ app.on('ready', async () => {
 // Don't quit the app when all windows are closed, keep the tray icon
 // See http://electron.atom.io/docs/api/app/#event-window-all-closed
 app.on('window-all-closed', () => {
-  log.debug('All windows closed. Keep running in tray...')
+  log.trace('All windows closed. Keep running in tray...')
 })
 
 ipcMain.on('show-help', () => {


### PR DESCRIPTION
Since logging often decreases app performance, we reduce the amount of
lines we write in normal conditions by changing the level of logging
statement called often to `debug` or `trace` and changing the level of
written lines to `info`.
We also make sure important information is logged with the `info`
level at the minimum so they get written.

Since we decrease the amount of logs written to disk, we might miss some
important information to help debug user issues and thus add the
possibility to re-enable `trace` level logging via a (remote) flag.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
