### PR TITLE
fix: Setup Sentry fingerprint for errors only

### DIFF
--- a/core/utils/sentry.js
+++ b/core/utils/sentry.js
@@ -195,9 +195,9 @@ class SentryTransport extends winston.Transport {
       Sentry.withScope(scope => {
         scope.setLevel(sentryLevel)
         scope.setContext('msgDetails', extra)
-        scope.setFingerprint([component, err.name, err.message])
 
         if (err) {
+          scope.setFingerprint([component, err.name, err.message])
           Sentry.captureException(formatError(err))
         } else {
           Sentry.captureMessage(msg)


### PR DESCRIPTION
To help Sentry group similar errors together, we set the message
fingerprint ourselves with the error's name and message and the
originating logger name.

However, if we trying to send a message to Sentry without an error
(i.e. we logged a message with the `sentry: true` option), trying to
get its name or message will throw an error for trying to get
attributes of `undefined`.

Therefore, we'll set the fingerprint manually only when sending a
message related to an error.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
