### PR TITLE
feat: Add suspend and resume actions to watchers

### DIFF
--- a/core/local/channel_watcher/index.js
+++ b/core/local/channel_watcher/index.js
@@ -165,6 +165,18 @@ class ChannelWatcher {
     await scanDone
   }
 
+  resume() {
+    log.info('Resuming watcher...')
+
+    return this.producer.resume()
+  }
+
+  suspend() {
+    log.info('Suspending watcher...')
+
+    return this.producer.suspend()
+  }
+
   async stop() /*: Promise<*> */ {
     log.info('Stopping watcher...')
 

--- a/core/local/chokidar/event_buffer.js
+++ b/core/local/chokidar/event_buffer.js
@@ -106,7 +106,7 @@ class EventBuffer /*:: <EventType> */ {
   }
 
   switchMode(mode /*: EventBufferMode */) /*: void */ {
-    this.flush()
+    this.clearTimeout()
     this.mode = mode
   }
 

--- a/core/local/index.js
+++ b/core/local/index.js
@@ -115,6 +115,17 @@ class Local /*:: implements Reader, Writer */ {
     return this.watcher.start()
   }
 
+  resume() {
+    syncDir.ensureExistsSync(this)
+    this.syncDirCheckInterval = syncDir.startIntervalCheck(this)
+    return this.watcher.resume()
+  }
+
+  suspend() {
+    clearInterval(this.syncDirCheckInterval)
+    return this.watcher.suspend()
+  }
+
   /** Stop watching the file system */
   stop() {
     clearInterval(this.syncDirCheckInterval)

--- a/core/local/watcher.js
+++ b/core/local/watcher.js
@@ -26,6 +26,8 @@ import type { Checksumer } from './checksumer'
 export interface Watcher {
   checksumer: Checksumer,
   start (): Promise<*>,
+  resume (): Promise<*>,
+  suspend (): Promise<*>,
   stop (force: ?bool): Promise<*>,
   onFatal (listener: Error => any): void,
   fatal (err: Error): void,

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -117,6 +117,15 @@ class Remote /*:: implements Reader, Writer */ {
     return this.warningsPoller.start()
   }
 
+  async resume() {
+    await this.watcher.resume()
+    return this.warningsPoller.start()
+  }
+
+  async suspend() {
+    await Promise.all([this.watcher.suspend(), this.warningsPoller.stop()])
+  }
+
   async stop() {
     await Promise.all([this.watcher.stop(), this.warningsPoller.stop()])
   }

--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -110,7 +110,8 @@ class RemoteWatcher {
 
   async start() {
     if (!this.running) {
-      log.info('Starting watcher')
+      log.info('Starting watcher...')
+
       this.running = true
       this.startClock()
 
@@ -127,9 +128,21 @@ class RemoteWatcher {
     }
   }
 
+  resume() {
+    log.info('Resuming watcher...')
+
+    return this.start()
+  }
+
+  suspend() {
+    log.info('Suspending watcher...')
+
+    return this.stop()
+  }
+
   async stop() {
     if (this.running) {
-      log.info('Stopping watcher')
+      log.info('Stopping watcher...')
 
       if (this.realtimeManager) {
         this.realtimeManager.stop()

--- a/test/unit/local/chokidar/event_buffer.js
+++ b/test/unit/local/chokidar/event_buffer.js
@@ -83,7 +83,7 @@ onPlatform('darwin', () => {
 
       it('can be switched to timeout mode', () => {
         buffer.switchMode('timeout')
-        should(flushed).have.been.calledWith([event1, event2])
+        should(flushed).not.have.been.called()
       })
     })
 
@@ -96,7 +96,7 @@ onPlatform('darwin', () => {
         buffer.push(event1)
         buffer.switchMode('idle')
         clock.tick(TIMEOUT_IN_MS)
-        should(flushed).have.been.calledWith([event1])
+        should(flushed).not.have.been.called()
       })
 
       it('does not flush without events', () => {


### PR DESCRIPTION
When we started reacting to OS's suspend and resume events, we took
the simple route of stopping and restarting both the remote and local
watchers each time.

However, this is time consuming, especially with the local watcher
since it does a full scan of the local synchronization directory on
start, and quite unnecessary since there little change we missed a
local event while the computer was suspended.

This is why we now introduce suspend and resume actions which, for the
local watcher at least, only take care of stopping and restarting
their event subscriptions.
This should improve performance when resuming a suspended computer.

For now the remote watcher still does a complete stop and restart as
it does not trigger expensive computing.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
