### PR TITLE
test: Prevent excessive errors during tests

### DIFF
--- a/core/local/channel_watcher/dispatch.js
+++ b/core/local/channel_watcher/dispatch.js
@@ -117,7 +117,17 @@ async function dispatchEvent(
     // Lock to prevent Merge/Sync conflicts
     const release = await opts.pouch.lock(component)
     try {
-      await actions[event.action + event.kind](event, opts)
+      switch (event.action) {
+        case 'scan':
+        case 'created':
+        case 'modified':
+        case 'renamed':
+        case 'deleted':
+          await actions[event.action + event.kind](event, opts)
+          break
+        default:
+          log.warn('could not dispatch event with invalid action', { event })
+      }
       try {
         const target = (
           await opts.pouch.db.changes({

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -38,6 +38,9 @@ describe('Add', () => {
 
     helpers.spyPouch()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   afterEach(() => helpers.local.clean())
   afterEach(pouchHelpers.cleanDatabase)

--- a/test/integration/case_or_encoding_change.js
+++ b/test/integration/case_or_encoding_change.js
@@ -27,6 +27,9 @@ describe('Case or encoding change', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   describe('directory', () => {
     let dir, dir2

--- a/test/integration/conflict_resolution.js
+++ b/test/integration/conflict_resolution.js
@@ -37,6 +37,9 @@ describe('Conflict resolution', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   describe('local', () => {
     beforeEach('create and merge conflicting remote file', async () => {

--- a/test/integration/differential_sync.js
+++ b/test/integration/differential_sync.js
@@ -45,6 +45,9 @@ describe('Differential synchronization', () => {
 
     builders = new Builders({ cozy })
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   let remoteDir, remoteFile
   beforeEach(async function () {

--- a/test/integration/executable.js
+++ b/test/integration/executable.js
@@ -33,6 +33,9 @@ describe('Executable handling', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   const executableStatus = async relpath => {
     const mode = await syncDir.octalMode(relpath)

--- a/test/integration/full_loop.js
+++ b/test/integration/full_loop.js
@@ -32,6 +32,9 @@ describe('Full watch/merge/sync/repeat loop', () => {
 
     helpers.spyPouch()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   it('remote -> local add file', async () => {
     await helpers._local.watcher.start()

--- a/test/integration/id_conflict.js
+++ b/test/integration/id_conflict.js
@@ -35,6 +35,9 @@ describe('Identity conflict', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   describe('between two dirs', () => {
     describe('both remote', () => {

--- a/test/integration/interrupted_sync.js
+++ b/test/integration/interrupted_sync.js
@@ -33,6 +33,9 @@ describe('Sync gets interrupted, initialScan occurs', () => {
 
     helpers.spyPouch()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   it('move Folder', async () => {
     const docs = await helpers.remote.createTree(['/a/', '/b/'])

--- a/test/integration/move.js
+++ b/test/integration/move.js
@@ -55,6 +55,9 @@ describe('Move', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   afterEach(() => helpers.local.clean())
   afterEach(pouchHelpers.cleanDatabase)

--- a/test/integration/mtime-update.js
+++ b/test/integration/mtime-update.js
@@ -26,6 +26,9 @@ describe('Update only mtime', () => {
     helpers = TestHelpers.init(this)
     helpers.local.setupTrash()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   afterEach(() => helpers.local.clean())
   afterEach(pouchHelpers.cleanDatabase)

--- a/test/integration/notes.js
+++ b/test/integration/notes.js
@@ -33,6 +33,9 @@ describe('Update', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   describe('Cozy Note', () => {
     let note

--- a/test/integration/permanent_deletion.js
+++ b/test/integration/permanent_deletion.js
@@ -27,6 +27,9 @@ describe('Permanent deletion remote', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   it('file', async () => {
     const file = await cozy.files.create('File content', { name: 'file' })

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -54,6 +54,9 @@ describe('Platform incompatibilities', () => {
         helpers._sync.lifecycle.unblockFor(err.code)
       })
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   const shouldHaveBlockedFor = dpath =>
     Array.isArray(dpath)

--- a/test/integration/sync_state.js
+++ b/test/integration/sync_state.js
@@ -31,6 +31,9 @@ describe('Sync state', () => {
 
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   it('1 sync error (missing remote file)', async () => {
     // XXX: Get current PouchDB sequence (it's not 0 since we have design docs)

--- a/test/integration/trash.js
+++ b/test/integration/trash.js
@@ -39,6 +39,9 @@ describe('Trash', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   describe('file', () => {
     let parent, file

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -43,6 +43,9 @@ describe('Update file', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
   })
+  afterEach(async function () {
+    await helpers.stop()
+  })
 
   describe('local offline change with unsynced previous local change', () => {
     beforeEach(async () => {

--- a/test/unit/remote/offline.js
+++ b/test/unit/remote/offline.js
@@ -48,18 +48,23 @@ describe('Remote', function () {
       sinon.spy(this.events, 'emit')
 
       await this.remote.start()
-      should(this.events.emit).have.been.calledWithMatch(
-        'RemoteWatcher:error',
-        { code: remoteErrors.UNREACHABLE_COZY_CODE }
-      )
 
-      fetchStub.restore()
-      this.events.emit.resetHistory()
+      try {
+        should(this.events.emit).have.been.calledWithMatch(
+          'RemoteWatcher:error',
+          { code: remoteErrors.UNREACHABLE_COZY_CODE }
+        )
 
-      await this.remote.watcher.watch()
-      should(this.events.emit).not.have.been.calledWith('RemoteWatcher:error')
+        fetchStub.restore()
+        this.events.emit.resetHistory()
 
-      this.events.emit.restore()
+        await this.remote.watcher.watch()
+        should(this.events.emit).not.have.been.calledWith('RemoteWatcher:error')
+
+        this.events.emit.restore()
+      } finally {
+        await this.remote.stop()
+      }
     }).timeout(120000)
   })
 })

--- a/test/unit/remote/realtime_manager.js
+++ b/test/unit/remote/realtime_manager.js
@@ -22,7 +22,8 @@ const setup = async () => {
   return {
     eventHandler,
     realtime: realtimeManager.realtime,
-    realtimeManager
+    realtimeManager,
+    teardown: client.logout
   }
 }
 
@@ -33,7 +34,7 @@ describe('RealtimeManager', function () {
 
   describe('start', () => {
     it('subscribes to all io.cozy.files realtime events', async function () {
-      const { realtime, realtimeManager } = await setup()
+      const { teardown, realtime, realtimeManager } = await setup()
 
       const subscribeSpy = sinon.spy(realtime, 'subscribe')
 
@@ -57,13 +58,14 @@ describe('RealtimeManager', function () {
         )
       } finally {
         subscribeSpy.restore()
+        await teardown()
       }
     })
   })
 
   describe('stop', () => {
     it('removes all subscriptions', async function () {
-      const { realtime, realtimeManager } = await setup()
+      const { teardown, realtime, realtimeManager } = await setup()
 
       const unsubscribeSpy = sinon.spy(realtime, 'unsubscribe')
 
@@ -87,40 +89,53 @@ describe('RealtimeManager', function () {
         )
       } finally {
         unsubscribeSpy.restore()
+        await teardown()
       }
     })
   })
 
   describe('onCreated', () => {
     it('calls event handler for a created realtime event', async function () {
-      const { eventHandler, realtimeManager } = await setup()
+      const { teardown, eventHandler, realtimeManager } = await setup()
 
-      // $FlowFixMe we don't care about the type of doc passed here
-      realtimeManager.onCreated({})
+      try {
+        // $FlowFixMe we don't care about the type of doc passed here
+        realtimeManager.onCreated({})
 
-      should(eventHandler).have.been.calledOnce()
+        should(eventHandler).have.been.calledOnce()
+      } finally {
+        await teardown()
+      }
     })
   })
 
   describe('onUpdated', () => {
     it('calls event handler for an updated realtime event', async function () {
-      const { eventHandler, realtimeManager } = await setup()
+      const { teardown, eventHandler, realtimeManager } = await setup()
 
-      // $FlowFixMe we don't care about the type of doc passed here
-      realtimeManager.onUpdated({})
+      try {
+        // $FlowFixMe we don't care about the type of doc passed here
+        realtimeManager.onUpdated({})
 
-      should(eventHandler).have.been.calledOnce()
+        should(eventHandler).have.been.calledOnce()
+      } finally {
+        await teardown()
+      }
     })
   })
 
   describe('onDeleted', () => {
     it('calls event handler for a deleted realtime event', async function () {
-      const { eventHandler, realtimeManager } = await setup()
+      const { teardown, eventHandler, realtimeManager } = await setup()
 
-      // $FlowFixMe we don't care about the type of doc passed here
-      realtimeManager.onDeleted({})
+      try {
+        // $FlowFixMe we don't care about the type of doc passed here
+        realtimeManager.onDeleted({})
 
-      should(eventHandler).have.been.calledOnce()
+        should(eventHandler).have.been.calledOnce()
+      } finally {
+        await teardown()
+      }
     })
   })
 })


### PR DESCRIPTION
Some tests are the cause of errors (while not turning red) as they
start background processings which are not stopped at the end of the
tests and end up trying to access a destroyed database.

Stopping these processings will prevent those errors and might improve
test performance.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
