### PR TITLE
tech: Remove remote change log

### DIFF
--- a/core/remote/watcher/index.js
+++ b/core/remote/watcher/index.js
@@ -394,7 +394,7 @@ class RemoteWatcher {
     } /*: { isInitialFetch?: boolean, isRecursiveFetch?: boolean } */ = {}
   ) /*: RemoteChange */ {
     const oldpath /*: ?string */ = was ? was.path : undefined
-    log.info('change received', {
+    log.debug('change received', {
       path: remoteDoc.path || oldpath,
       oldpath,
       remoteDoc,


### PR DESCRIPTION
Keep reducing logs to decrease IO pressure and RAM usage when
  receiving numerous changes from the remote Cozy.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
