### PR TITLE
fix: Break down large PouchDB.bulkDocs calls

### DIFF
--- a/.jq
+++ b/.jq
@@ -145,12 +145,24 @@ def issues: clean | select(is_issue);
 def path(pattern):
   clean | select(
     (
-      try (.path // (.doc | .path) // (.change | .doc | .path) // (.idConflict | .newDoc | .path) // (.event | .path)),
-      try (.oldpath // (.was | .path) // (.idConflict | .existingDoc | .path) // (.event | .oldPath)),
+      try (
+        .path //
+        (.doc | .path) //
+        (.idConflict | .newDoc | .path) //
+        (.event | .path) //
+        (.docs | arrays | .[].path) //
+        (.batch | arrays | .[].path)
+      ),
+      try (
+        .oldpath //
+        (.was | .path) //
+        (.idConflict | .existingDoc | .path) //
+        (.event | .oldPath)
+      ),
       ""
     )
-      | strings
-      | test(pattern)
+    | strings
+    | test(pattern)
   );
 
 def shortPath:

--- a/test/unit/pouch/index.js
+++ b/test/unit/pouch/index.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 const { REV_CONFLICT } = require('pouchdb')
 
 const metadata = require('../../../core/metadata')
-const { sortByPath } = require('../../../core/pouch')
+const { sortByPath, createBatches } = require('../../../core/pouch')
 
 const Builders = require('../../support/builders')
 const configHelpers = require('../../support/helpers/config')
@@ -724,5 +724,53 @@ describe('Pouch', function () {
       ).map(({ _rev, ...rest }) => ({ shortRev: shortRev(_rev), ...rest }))
       should(touchedDocs).deepEqual(expected)
     })
+  })
+})
+
+describe('createBatches', () => {
+  it('creates batches of at most the given size from the given documents', () => {
+    const builders = new Builders()
+
+    const docs = [
+      builders.metafile().build(),
+      builders.metafile().build(),
+      builders.metafile().build(),
+      builders.metafile().build(),
+      builders.metafile().build()
+    ]
+
+    should(createBatches(docs, 1)).deepEqual([
+      [docs[0]],
+      [docs[1]],
+      [docs[2]],
+      [docs[3]],
+      [docs[4]]
+    ])
+
+    should(createBatches(docs, 2)).deepEqual([
+      [docs[0], docs[1]],
+      [docs[2], docs[3]],
+      [docs[4]]
+    ])
+
+    should(createBatches(docs, 3)).deepEqual([
+      [docs[0], docs[1], docs[2]],
+      [docs[3], docs[4]]
+    ])
+
+    should(createBatches(docs, 5)).deepEqual([
+      [docs[0], docs[1], docs[2], docs[3], docs[4]]
+    ])
+
+    should(createBatches(docs, 6)).deepEqual([
+      [docs[0], docs[1], docs[2], docs[3], docs[4]]
+    ])
+
+    should(createBatches(docs, 0)).deepEqual([
+      [docs[0], docs[1], docs[2], docs[3], docs[4]]
+    ])
+    should(createBatches(docs, -1)).deepEqual([
+      [docs[0], docs[1], docs[2], docs[3], docs[4]]
+    ])
   })
 })


### PR DESCRIPTION
Large `bulkDocs` calls (i.e. with thousands of documents to save at
once) can be the source of crashes.

We're not sure if this comes from PouchDB or the logger calls with
each document but we've figured that creating smaller batches of
documents, logging them all at once and then saving the batch in
PouchDB prevents crashes.

It should also result in less I/O since we're making a lot less logger
calls.
To accommodate for these logging changes, we update our `jq` `path`
filter so it looks into batches for documents with the expected path.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
