### PR TITLE
fix: Pass message to log calls as first argument

### DIFF
--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -155,7 +155,7 @@ const retry = async (
   cause /*: {| err: RemoteError |} | {| err: SyncError, change: Change |} */,
   sync /*: Sync */
 ) => {
-  log.debug(cause, 'retrying after blocking error')
+  log.debug('retrying after blocking error', cause)
 
   const { err } = cause
   if (err.code === remoteErrors.UNREACHABLE_COZY_CODE) {
@@ -195,7 +195,7 @@ const skip = async (
   cause /*: {| err: RemoteError |} | {| err: SyncError, change: Change |} */,
   sync /*: Sync */
 ) => {
-  log.debug(cause, 'user skipped required action')
+  log.debug('user skipped required action', cause)
 
   clearInterval(sync.retryInterval)
 
@@ -212,7 +212,7 @@ const createConflict = async (
   cause /*: {| err: RemoteError |} | {| err: SyncError, change: Change |} */,
   sync /*: Sync */
 ) => {
-  log.debug(cause, 'user requested conflict creation')
+  log.debug('user requested conflict creation', cause)
 
   clearInterval(sync.retryInterval)
 

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -1010,7 +1010,7 @@ class Sync {
     cause
     /*: {| err: RemoteError |} | {| err: SyncError, change: Change |} */
   ) {
-    log.info(cause, 'blocking sync for error')
+    log.info('blocking sync for error', cause)
 
     const { err } = cause
 


### PR DESCRIPTION
Winston loggers expect the message to be the first argument and extra
options as the other ones.

Failing to do that results in messages to be interpreted as options
and transformed into objects and finally not being properly displayed
(or filterable) when debugging.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
