### PR TITLE
fix: Vertically center updater progress spinner

### DIFF
--- a/gui/styles/_updater.styl
+++ b/gui/styles/_updater.styl
@@ -26,7 +26,6 @@
     background-color: var(--primaryColor)
     width: 4em
     height: 4em
-    translate: 0 50%
 
   p
     box-sizing border-box


### PR DESCRIPTION
The spinner was slightly off, being pushed down 50% of its height.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
