### PR TITLE
fix: Setup Desktop before opening notes on macOS

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -522,11 +522,12 @@ app.on('second-instance', async (event, argv) => {
     log.info('second instance invoked with arguments', { filePath })
 
     // If we found a note to open, stop here. Otherwise, show main window.
-    if (
-      filePath.endsWith('.cozy-note') &&
-      (await openNote(filePath, { desktop }))
-    )
+    if (filePath.endsWith('.cozy-note')) {
+      await openNote(filePath, { desktop })
       return
+    } else {
+      log.warn('file path argument does not have valid Cozy note extension')
+    }
   }
 
   // Make sure the main window exists before trying to show it
@@ -633,19 +634,18 @@ app.on('ready', async () => {
     // We need a valid config to start the App and open the requested note.
     // We assume users won't have notes they want to open without a connected
     // client.
-    if (!desktop.config.syncPath) {
-      await exit(0)
-      return
+    if (desktop.config.syncPath) {
+      if (filePath.endsWith('.cozy-note')) {
+        await openNote(filePath, { desktop })
+      } else {
+        log.warn('file path argument does not have valid Cozy note extension')
+      }
+    } else {
+      log.warn('no valid config')
     }
 
-    // If we found a note to open, stop here. Otherwise, start sync app.
-    if (
-      filePath.endsWith('.cozy-note') &&
-      (await openNote(filePath, { desktop }))
-    ) {
-      await exit(0)
-      return
-    }
+    await exit(0)
+    return
   }
 
   if (shouldStartSync) {

--- a/gui/utils/notes.js
+++ b/gui/utils/notes.js
@@ -47,7 +47,7 @@ const openMarkdownViewer = async (
   }
 }
 
-const showGenericError = (filePath, err) => {
+const showGenericError = async (filePath, err) => {
   log.error('Could not display markdown content of note', {
     err,
     path: filePath,
@@ -55,10 +55,10 @@ const showGenericError = (filePath, err) => {
     sentry: true
   })
 
-  dialog.showMessageBoxSync(null, {
+  await dialog.showMessageBox(null, {
     type: 'error',
     message: translate('Error Unexpected error'),
-    details: `${err.name}: ${err.message}`,
+    detail: `${err.name}: ${err.message}`,
     buttons: [translate('AppMenu Close')]
   })
 }
@@ -119,11 +119,11 @@ const openNote = async (
         )
         return true
       } catch (err) {
-        showGenericError(filePath, err)
+        await showGenericError(filePath, err)
         return false
       }
     } else {
-      showGenericError(filePath, err)
+      await showGenericError(filePath, err)
       return false
     }
   }


### PR DESCRIPTION
Desktop registers with the OS as being able to open Cozy Note
documents. Thus, when a user opens a local `.cozy-note` file Desktop
opens the associated note in the default browser.

On Linux and Windows we receive one of two events depending on the
state of the application when the file is opened:
- `second-instance` when Desktop was already running
- `ready` when Desktop was not running

In both cases the file path is found in the execution arguments.

On macOS however, the file path will be made available via a dedicated
`open-file` event in both situations.
When the application is not running though, we'll also receive a
`ready` event **after** the `open-file` event.

This is where we encountered a deadlock situation:
- when receiving the `ready` event, we setup the application and start
  the synchronization unless asked not to (e.g. when opening a note
  while Desktop was not already running)
- when receiving the `open-file` event, we request not to start the
  synchronization if the application was not already running but need
  to wait for the setup to complete to open the note

The setup process was only run if the synchronization should be
started or a note file path was passed as argument which only occurs
on Linux and Windows.
Therefore, the app was stuck, ever waiting for the setup process to
complete.

We now make sure the setup process is run as long as we have a valid
config.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
