### PR TITLE
fix: Do not mark undefined remote as trashed

### DIFF
--- a/core/metadata.js
+++ b/core/metadata.js
@@ -517,13 +517,15 @@ function dissociateLocal(doc /*: Metadata */) {
 
 function markAsTrashed(doc /*: Metadata */, sideName /*: SideName */) {
   if (sideName === 'remote') {
-    if (doc.remote && doc.remote.type === REMOTE_DIR_TYPE) {
-      // FIXME: Remote directories have no `trashed` attribute so we know
-      // they're trashed when their path is within the remote trashbin. We
-      // should find a way to reconstruct that path or stop relying on this
-      // function altogether.
-    } else {
-      doc.remote.trashed = true
+    if (doc.remote) {
+      if (doc.remote.type === REMOTE_DIR_TYPE) {
+        // FIXME: Remote directories have no `trashed` attribute so we know
+        // they're trashed when their path is within the remote trashbin. We
+        // should find a way to reconstruct that path or stop relying on this
+        // function altogether.
+      } else {
+        doc.remote.trashed = true
+      }
     }
   } else if (doc.local) {
     doc.local.trashed = true


### PR DESCRIPTION
When merging the trashing of a document, we add a `trashed` marker in
its metadata for the side on which it was trashed (e.g. in the
`remote` attribute if the document was trashed on the Cozy) as well as
its global metadata.

However, when a directory is trashed, we also mark all its children
and these might not have been synchronized yet and the trashed side
metadata can be missing.

e.g. given we have the synchronized directory `dir/` and a local only
file `dir/file`, when merging the trashing of `dir/` on the Cozy we:

  1. mark `dir/` as trashed and its `remote` attribute
  2. try to do the same for `dir/file` but it has no `remote` attribute, only a `local` one

We were not checking for the presence of the `remote` attribute and in
this case we would end up with an error while trying to mark
`dir/file` as we'd try to add a `trashed` attribute on `undefined`
(i.e. the missing `remote` attribute).

By checking for the presence of the `remote` attribute we make sure we
don't get this error and don't block the synchronization of the
parent directory trashing.
The child will still be removed with its parent.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
