### PR TITLE
fix: Keep watching local changes after suspension

### DIFF
--- a/core/local/chokidar/watcher.js
+++ b/core/local/chokidar/watcher.js
@@ -227,10 +227,6 @@ class LocalWatcher {
   async resume() {
     log.info('Resuming watcher...')
 
-    if (this.watcher && this.watcher.getWatched().length === 0) {
-      this.watcher.add('.')
-    }
-
     // Flush previously buffered events
     this.buffer.flush()
     // Restart flushes loop
@@ -242,11 +238,6 @@ class LocalWatcher {
 
     // Stop flushes loop but keep buffered events
     this.buffer.switchMode('idle')
-
-    // Stop underlying Chokidar watcher
-    if (this.watcher) {
-      this.watcher.unwatch('.')
-    }
   }
 
   async stop(force /*: ?bool */ = false) {


### PR DESCRIPTION
We wanted to stop watching local changes with Chokidar when macOS goes
to sleep and restart when resuming but it appears the `unwatch`/`add`
duo of Chokidar methods does not work as expected (i.e. they at least
don't seem to be recursive).

This was preventing the local watcher from doing its job after macOS
resumed from sleep so we'll try not to stop watching the local changes
when going to sleep.
If this has advert effects on the suspension we'll try to find another
way.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
