### PR TITLE
feat: Remove version from linux binary name

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -87,7 +87,7 @@ linux:
     friends and colleagues. You can host your own Cozy Cloud, and or use the hosting
     services. Your freedom to chose is why you can trust us.
 appImage:
-  artifactName: 'Cozy-Drive-${version}-${arch}.${ext}'
+  artifactName: 'Cozy-Drive-${arch}.${ext}'
   executableArgs: [" "] # do not use --no-sandbox by default (see build/launcher-script.sh for details on when it should be used)
 
 extraResources:


### PR DESCRIPTION
Since the release of Ubuntu 24.04, AppArmor profiles are required for
user applications to run (maybe only when started automatically).
As the profile contains the fullpath to the binary that needs to be
allowed to run, we need Desktop to have a stable binary name to allow
our users to add a profile and not change it every time they update
the app.

Therefore, we're removing the version from the AppImage binary name.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
