### PR TITLE
deps: Upgrade `elm-explorations/test` to v2.2.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,10 +8,10 @@
     "dependencies": {
         "direct": {
             "cuducos/elm-format-number": "9.0.1",
-            "elm/browser": "1.0.1",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
@@ -20,13 +20,13 @@
             "mpizenberg/elm-pointer-events": "3.1.0"
         },
         "indirect": {
-            "elm/virtual-dom": "1.0.2",
-            "myrho/elm-round": "1.0.4"
+            "elm/virtual-dom": "1.0.3",
+            "myrho/elm-round": "1.0.5"
         }
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.0"
+            "elm-explorations/test": "1.2.2"
         },
         "indirect": {
             "elm/random": "1.0.0"

--- a/elm.json
+++ b/elm.json
@@ -26,9 +26,10 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2"
+            "elm-explorations/test": "2.2.0"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/random": "1.0.0"
         }
     }


### PR DESCRIPTION
`elm-explorations/test` < v2.0.0 is not compatible with the new
`elm-test` version we recently upgraded to thus preventing us from
running elm tests.