### PR TITLE
test: Fix flaky merge unit test

### DIFF
--- a/core/merge.js
+++ b/core/merge.js
@@ -493,6 +493,11 @@ class Merge {
         // the overwritten document.
         await this.pouch.eraseDocument(was)
         metadata.markAsUnmerged(doc, side)
+        // XXX: this call to updateFileAsync will ignore the file modification
+        // and thus not save it in PouchDB if this is a local move and it
+        // happens that `doc` and `file` have the exact same modification date.
+        // Although this should be very rare in production, this has happened
+        // in tests.
         return this.updateFileAsync(side, doc)
       } else {
         return this.addFileAsync(side, doc)

--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -2661,6 +2661,7 @@ describe('Merge', function() {
           .data('content')
           .tags('courge', 'quux')
           .sides({ local: 1 })
+          .updatedAt(existing.updated_at + 1) // XXX: make sure the replacing file has a different (and more recent) modification date than the existing file
           .create()
         const doc = builders
           .metafile()


### PR DESCRIPTION
When a local file move to a destination where a file already exists is
converted into an update of the existing file, if the existing and
moved files have the exact same modification date then the
modification will be ignored and not saved in PouchDB.

This choice was made on purpose to avoid merging intermediary file
changes in some situations like the propagation of a remote change to
the local filesystem.

Although having the exact same modification date for 2 files should be
almost impossible in production, it can quite easily happen in tests
where documents and their metadata are generated very closely.
This was the case in the unit test for this specific situation which
was failing from time to time (more often on the CI).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
