### PR TITLE
feat: Always detect complete local folder deletion

### DIFF
--- a/core/local/index.js
+++ b/core/local/index.js
@@ -217,6 +217,10 @@ class Local /*:: implements Reader, Writer */ {
     return false
   }
 
+  async exists(relpath /*: string */) /*: Promise<boolean> */ {
+    return fse.exists(this.abspath(relpath))
+  }
+
   /* Write operations */
 
   /**

--- a/core/reader.js
+++ b/core/reader.js
@@ -13,5 +13,6 @@ import type { SavedMetadata } from './metadata'
 
 export interface Reader {
   createReadStreamAsync (SavedMetadata): Promise<ReadableWithSize>;
+  exists (string): Promise<boolean>;
 }
 */

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -443,6 +443,11 @@ class Remote /*:: implements Reader, Writer */ {
     }
   }
 
+  async exists(fullpath /*: string */) /*: Promise<boolean> */ {
+    const remoteDoc = await this.remoteCozy.findMaybeByPath(fullpath)
+    return remoteDoc != null
+  }
+
   async findDocByPath(fpath /*: string */) /*: Promise<?MetadataRemoteInfo> */ {
     const [parentPath, name] = dirAndName(fpath)
     const { _id: dir_id } = await this.findDirectoryByPath(parentPath)

--- a/test/unit/remote/index.js
+++ b/test/unit/remote/index.js
@@ -1211,6 +1211,28 @@ describe('remote.Remote', function() {
     })
   })
 
+  describe('exists', () => {
+    it('checks for file existence on the remote Cozy', async function() {
+      const filepath = '/folder/testfile'
+
+      await should(this.remote.exists(filepath)).be.fulfilledWith(false)
+
+      await remoteHelpers.createFileByPath(filepath)
+
+      await should(this.remote.exists(filepath)).be.fulfilledWith(true)
+    })
+
+    it('checks for dir existence on the remote Cozy', async function() {
+      const dirpath = '/folder/testdir'
+
+      await should(this.remote.exists(dirpath)).be.fulfilledWith(false)
+
+      await remoteHelpers.createDirectoryByPath(dirpath)
+
+      await should(this.remote.exists(dirpath)).be.fulfilledWith(true)
+    })
+  })
+
   describe('findDirectoryByPath', () => {
     let oldRemoteDir, newRemoteDir, oldDir, dir
     beforeEach(async function() {


### PR DESCRIPTION
  To make finding trashed documents and their restoration easy for
  users, we want to keep a folder's hierarchy when trashing it rather
  than trashing each element separately which would put them all at the
  trash's root.

  However, when deleting a folder with content on the local filesystem, we
  receive events for the deletion of each document and the event for the
  folder itself can be received last (e.g. on linux).
  When there's no delay in the processing of these events (e.g. on macOS
  we buffer events for 10 seconds before processing them), we can end up
  propagating the deletion of the folder's content before we even got
  the chance to merge the folder's deletion.
  In this situation, we'll end up trashing each document separately.

  Rather than adding delay on all platforms, we add a new check during
  the propagation of deletions. If the parent folder is not marked as
  trashed in PouchDB, we check if it's still present on the local
  filesystem. If it's not, we assume we haven't merged its deletion yet
  and don't propagate the document deletion as we should propagate its
  parent's deletion later.

  We haven't seen advert effects on performances but if we ever do, we
  could always some kind of cache of these checks.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
