### PR TITLE
test: Fix flaky merge unit tests

### DIFF
--- a/test/unit/merge.js
+++ b/test/unit/merge.js
@@ -2663,7 +2663,7 @@ describe('Merge', function() {
           .data('content')
           .tags('courge', 'quux')
           .sides({ local: 1 })
-          .updatedAt(existing.updated_at + 1) // XXX: make sure the replacing file has a different (and more recent) modification date than the existing file
+          .updatedAt(timestamp.after(existing.updated_at)) // XXX: make sure the replacing file has a different (and more recent) modification date than the existing file
           .create()
         const doc = builders
           .metafile()

--- a/test/unit/remote/cozy.js
+++ b/test/unit/remote/cozy.js
@@ -21,6 +21,7 @@ const {
 } = require('../../../core/remote/constants')
 const { FetchError, RemoteCozy } = require('../../../core/remote/cozy')
 const { DirectoryNotFound } = require('../../../core/remote/errors')
+const timestamp = require('../../../core/utils/timestamp')
 const CozyStackDouble = require('../../support/doubles/cozy_stack')
 const configHelpers = require('../../support/helpers/config')
 const { COZY_URL } = require('../../support/helpers/cozy')
@@ -363,11 +364,13 @@ describe('RemoteCozy', function() {
   describe('updateAttributesById', () => {
     context('when the name starts or ends with a space', () => {
       it('updates the file with the given name', async () => {
+        const origDate = new Date()
         const remoteFile = await builders
           .remoteFile()
           .inRootDir()
           .name(' foo')
           .data('initial content')
+          .updatedAt(...timestamp.spread(origDate))
           .create()
 
         should(
@@ -375,7 +378,7 @@ describe('RemoteCozy', function() {
             remoteFile._id,
             {
               name: 'bar ',
-              updated_at: new Date().toISOString()
+              updated_at: timestamp.after(origDate).toISOString()
             },
             { ifMatch: remoteFile._rev }
           )


### PR DESCRIPTION
  Some actions on `io.cozy.files` documents require them to have an
  `updated_at` date attribute more recent than their `created_at`
  attribute.

  Although having the exact same modification date for 2 files should be
  almost impossible in production, it can quite easily happen in tests
  where documents and their metadata are generated very closely.

  This is why we sometimes need to make sure the modification date is
  increased between two versions of a document in unit tests.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
