### PR TITLE
ci: Separate node modules caches by arch on macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -79,7 +79,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup Docker
         uses: douglascamata/setup-docker-macos-action@v1-alpha
       - name: Install Bash for docker-cache
@@ -148,7 +148,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup Docker
         uses: douglascamata/setup-docker-macos-action@v1-alpha
       - name: Install Bash for docker-cache
@@ -218,7 +218,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup Docker
         uses: douglascamata/setup-docker-macos-action@v1-alpha
       - name: Install Bash for docker-cache
@@ -290,7 +290,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: ${{ runner.os }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-v${{ env.NODE_VERSION }}-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
  We need to cache node modules not only by OS name and node version but
  also by Github Actions runner arch as some dependencies are compiled
  and thus not compatible with both arm64 and x86-64 versions of macOS.

  # Context

  Our macOS workflow has been running two different versions of macOS
  for a little while now as we need an arm64 runner to create a arm64
  binary (this runner still allows us to create an x86-64 binary).
  Besides, the job responsible for creating binaries is one of the first
  to run (because its name is `build` and jobs are run in alphabetical
  order) and thus would update the shared node modules cache when it is
  required (e.g. when upgrading a dependency).

  We recently removed `cozy-client-js` from our dependencies so the
  cache was updated by the arm64 job and all jobs running on a x86-64
  version of macOS started to fail.

  Using separate caches for the different runner architectures will
  solve this problem.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
