### PR TITLE
ci: Upgrade linux jobs' Ubuntu image

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -32,14 +32,14 @@ env:
 jobs:
   cancel:
     name: 'Cancel Previous Runs'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:
       - uses: styfle/cancel-workflow-action@5df4e62aed82ea1f787d2a02ab3dbfcaa49ffdd1
 
   unit:
     needs: cancel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Lint & Unit tests
     steps:
       - uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
 
   integration:
     needs: cancel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Integration tests
     steps:
       - uses: actions/checkout@v3
@@ -151,7 +151,7 @@ jobs:
 
   scenarios:
     needs: cancel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Scenarios
     strategy:
       matrix:
@@ -209,7 +209,7 @@ jobs:
 
   build:
     needs: cancel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build packages
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
  The `ubuntu-20.04` image has been deprecated since 2025-04-15 and jobs
  still using it are automatically cancelled by Github Actions.
  See https://github.com/actions/runner-images/issues/11101

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
