### PR TITLE
fix: Change references to internal binary on linux

### DIFF
--- a/build/afterPackHook.js
+++ b/build/afterPackHook.js
@@ -1,5 +1,5 @@
-const path = require('path')
 const fs = require('fs')
+const path = require('path')
 const util = require('util')
 
 const renameAsync = util.promisify(fs.rename)
@@ -24,10 +24,10 @@ module.exports = async function(context) {
   const chromeSandbox = path.join(context.appOutDir, 'chrome-sandbox')
 
   return Promise.all([
-    // rename cozydrive to cozydrive-bin
+    // rename twakedesktop to twakedesktop-bin
     renameAsync(sourceExecutable, targetExecutable),
 
-    // rename launcher script to cozydrive
+    // rename launcher script to twakedesktop
     renameAsync(launcherScript, sourceExecutable),
 
     // remove the chrome-sandbox file since we explicitly disable it

--- a/build/launcher-script.sh
+++ b/build/launcher-script.sh
@@ -61,4 +61,4 @@ UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/
 # distributions using its custom kernel.
 # This prevents the app from starting and so the only way for our users to use
 # Cozy Desktop is for us to manually disable the Chromium sandbox at runtime.
-exec "$APP_DIR/cozydrive-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"
+exec "$APP_DIR/twakedesktop-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"

--- a/doc/usage/build.md
+++ b/doc/usage/build.md
@@ -37,10 +37,10 @@ yarn dist
 
 ## Run it
 ```bash
-mkdir /opt/cozydrive # you can change this path
-cp ./dist/CozyDrive-*.AppImage /opts/cozydrive/CozyDrive.AppImage
-chmod +x /opt/cozydrive/CozyDrive.AppImage
-/opt/cozydrive/CozyDrive.AppImage
+mkdir /opt/twakedesktop # you can change this path
+cp ./dist/Twake-Desktop-*.AppImage /opts/twakedesktop/Twake-Desktop.AppImage
+chmod +x /opt/twakedesktop/Twake-Desktop.AppImage
+/opt/twakedesktop/Twake-Desktop.AppImage
 ```
 
 **Note:** When a new version gets out, the application will attempt to update itself but it will fail, simply repeat the steps above to make it works again.

--- a/doc/usage/linux.md
+++ b/doc/usage/linux.md
@@ -125,8 +125,8 @@ on system start.
 Almost everything is in the `*.AppImage` file however, if you have installed
 `appimaged`, the following additional files are created:
 
-- Launcher file in `~/.local/share/applications/appimagekit_<unique identifier>-Cozy_Drive.desktop`
-- Icons in `~/.local/share/icons/hicolor/*/apps/appimagekit<same unique identifier>-cozydrive.png`
+- Launcher file in `~/.local/share/applications/appimagekit_<unique identifier>-Twake_Desktop.desktop`
+- Icons in `~/.local/share/icons/hicolor/*/apps/appimagekit<same unique identifier>-twakedesktop.png`
 
 Everything else works the same as Windows or macOS: your synchronized files are
 in `~/Twake/` or the folder you choose on first run, and the hidden


### PR DESCRIPTION
  AppImage binaries are in fact composed of multiple files including the
  actual binary that will be executed to run the app.

  We have references to this internal binary in our codebase because we
  replace it with a custom launcher script to disable Electron's chrome
  sandbox (we use another kind of sandbox).

  However, when we renamed Cozy Desktop into Twake Desktop, we forgot to
  change these references and the resulting AppImage did not run.

  It's all good now.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
