### PR TITLE
fix: Remove cookies before starting registration

### DIFF
--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -171,6 +171,8 @@ module.exports = class OnboardingWM extends WindowManager {
     let cozyUrl
     try {
       cozyUrl = await desktop.checkCozyUrl(arg.cozyUrl)
+      // XXX: remove potential auth cookies set when checking the cozyUrl
+      syncSession.clearStorageData()
     } catch (err) {
       return event.sender.send(
         'registration-error',


### PR DESCRIPTION
  To check if the given instance URL is a valid one and get its root
  form (i.e. the instance domain), we use a `cozy-client` helper
  (`rootCozyUrl`) that makes calls to the `/.well-known/change-password`
  route on the server.
  This route redirects requests to the Settings app and in fine to the
  OIDC start route and the SSO since we're not logged in.

  It turns out that some SSO can store a cookie when reaching the login
  page which prevents overwriting the successful login redirection if
  another call to the login page with a different redirection URL is
  made.

  In this case, the requested OAuth registration redirection is not
  acknowledged and the user gets redirected to the Settings app instead
  of the OAuth permissions page thus preventing the completion of the
  process.

  By clearing out cookies after the instance URL check, we make sure we
  drop this SSO cookie and start fresh when doing the OAuth
  registration.

  /!\ This solution could have unanticipated repercutions on proxy users
  so this should only be a temporary solution until we change the
  `rootCozyUrl` helper to make use of `/public/prelogin` instead of
  `/.well-known/change-password`.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
