### PR TITLE
feat: Block upgrade for existing users

### DIFF
--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -44,6 +44,10 @@
 
   "AppUpgrade App upgrade failed": "Cozy Desktop upgrade failed",
   "AppUpgrade An error happened during the upgrade of Cozy Desktop. Please contact support at contact@cozycloud.cc.": "An error happened after we tried upgrading your Cozy Desktop version. Please contact support at contact@cozycloud.cc.",
+  "AppUpgrade A new version of the application is available": "A new version of the application is available",
+  "AppUpgrade We are thrilled to announce the launch of our new Twake application": "We are thrilled to announce the launch of our new Twake application.\nTo use it, you'll need to uninstall your current application and install the new one by clicking on the \"Go to download\" button.\nThank you for your trust and see you soon on Twake!",
+  "AppUpgrade Go to download": "Go to download",
+  "AppUpgrade Later": "Later",
 
   "Bar GoToCozy": "Open Cozy",
   "Bar GoToFolder": "Open Folder",

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -44,6 +44,10 @@
 
   "AppUpgrade App upgrade failed": "Cozy Desktop upgrade failed",
   "AppUpgrade An error happened during the upgrade of Cozy Desktop. Please contact support at contact@cozycloud.cc.": "An error happened after we tried upgrading your Cozy Desktop version. Please contact support at contact@cozycloud.cc.",
+  "AppUpgrade A new version of the application is available": "A new version of the application is available",
+  "AppUpgrade We are thrilled to announce the launch of our new Twake application": "We are thrilled to announce the launch of our new Twake application.\nTo use it, you'll need to uninstall your current application and install the new one by clicking on the \"Go to download\" button.\nThank you for your trust and see you soon on Twake!",
+  "AppUpgrade Go to download": "Go to download",
+  "AppUpgrade Later": "Later",
 
   "Bar GoToCozy": "Abrir Cozy",
   "Bar GoToFolder": "Abrir Folder",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -44,6 +44,10 @@
 
   "AppUpgrade App upgrade failed": "Échec de la mise à jour",
   "AppUpgrade An error happened during the upgrade of Cozy Desktop. Please contact support at contact@cozycloud.cc.": "Une erreur est survenue pendant la mise à jour de Cozy Desktop. Merci de contacter l'assistance sur contact@cozycloud.cc.",
+  "AppUpgrade A new version of the application is available": "Une nouvelle version de l’application est disponible !",
+  "AppUpgrade We are thrilled to announce the launch of our new Twake application": "Nous sommes heureux de vous annoncer le lancement de notre nouvelle application Twake.\nPour en profiter, vous devez désinstaller votre application actuelle, puis installer la nouvelle version en cliquant sur le bouton « Aller au téléchargement ».\nMerci pour votre confiance et à très vite sur Twake !",
+  "AppUpgrade Go to download": "Aller au téléchargement",
+  "AppUpgrade Later": "Plus tard",
 
   "Bar GoToCozy": "Ouvrir Cozy",
   "Bar GoToFolder": "Ouvrir le dossier",


### PR DESCRIPTION
  The Twake Desktop rebranding cannot be properly achieved for current
  users as some Cozy icons and texts would remain or old executables
  even.

  To prevent this unideal situation, we prefer to block upgrades for
  current Cozy Desktop users and invite them to install Twake Desktop in
  its stead.

  /!\ This will need to be reverted for the Twake Desktop launch.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
