### PR TITLE
feat: Drop Windows ia32 build

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -63,7 +63,7 @@ const config = {
   },
 
   win: {
-    target: [{ target: 'nsis', arch: ['x64', 'ia32'] }],
+    target: [{ target: 'nsis', arch: ['x64'] }],
     // Comment out the following line if the Digicert server starts failing.
     // Electron-Builder will then swtich back to the default Comodoca server.
     rfc3161TimeStampServer: 'http://timestamp.digicert.com',


### PR DESCRIPTION
  We've stopped officially supporting 32 bits versions of Windows a long
  time ago but we kept building a 32 bits version of Cozy Desktop
  anyway.

  However, one of our dependencies, `@gyselroth/windows-node-fsstat`
  does not compile for ia32 anymore.
  Since we don't support 32 bits Windows we won't try to fix the
  dependency and stop building our 32 bits version instead.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
