### PR TITLE
ci: Allow forcing code signing on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ before_build:
   - ps: if ($env:BUILD_JOB -eq "build") { pwsh -NoProfile -ExecutionPolicy Unrestricted -Command .\build\windows\setup-keylocker.ps1 }
 
 build_script:
-  - ps: $env:SIGN_CODE=( ($env:APPVEYOR_REPO_BRANCH -eq "master" ) -and ($env:APPVEYOR_REPO_TAG -eq 'true') )
+  - ps: $env:SIGN_CODE=( ($env:FORCE_CODE_SIGNING -eq "true") -or (($env:APPVEYOR_REPO_BRANCH -eq "master" ) -and ($env:APPVEYOR_REPO_TAG -eq 'true')) )
   - ps: if ($env:BUILD_JOB -eq "build") { yarn dist }
 
 artifacts:


### PR DESCRIPTION
  We avoid signing code for builds other than tags on the master branch
  as we have a limited number of signatures included with our
  certificate purchase.

  However, we might want to sign our executables in other situations so
  allowing to force code signing would be helpful (e.g. creating
  hot fix releases from version branches).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
