### PR TITLE
fix: Remove newlines from AppImage description

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -81,7 +81,7 @@ const config = {
     synopsis:
       'Twake Desktop is a synchronization tool for your Twake Workplace files and folders.',
     description:
-      'Save them safely in your open source personal cloud, access them anywhere,\nanytime with the mobile application and share them with the world or just your\nfriends and colleagues. You can host your own Twake Workplace or use hosted\nservices. Your freedom to chose is why you can trust us.'
+      'Save them safely in your open source personal cloud, access them anywhere, anytime with the mobile application and share them with the world or just your friends and colleagues. You can host your own Twake Workplace or use hosted services. Your freedom to chose is why you can trust us.'
   },
   appImage: {
     artifactName: 'Twake-Desktop-${arch}.${ext}',


### PR DESCRIPTION
  `electron-builder` does not quote the AppImage description so newlines
  will create new lines in the output `.desktop` file making it invalid
  and thus breaking the integration with the OS.

  We added these newlines in the javascript version of our
  `electron-builder` config file as the description was on multiple
  lines in the yaml version but apparently the description was written
  in one line in the output before.
  Since we don't really care about the format of the description we
  simply removed the newlines.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
