### PR TITLE
fix: Use native APIs to manage auto-launch

### DIFF
--- a/gui/js/autolaunch.js
+++ b/gui/js/autolaunch.js
@@ -4,67 +4,141 @@
  */
 
 const AutoLaunch = require('auto-launch')
+const { app } = require('electron')
 
 const log = require('../../core/app').logger({
   component: 'GUI'
 })
 
 const APP_NAME = 'Twake-Desktop'
-const opts = {
-  name: APP_NAME,
-  isHidden: true
+const NATIVE_PLATFORMS = new Set(['darwin', 'win32'])
+
+class LinuxAutoLauncher {
+  constructor({ AutoLaunchClass, appImagePath, logger }) {
+    const opts = {
+      name: APP_NAME,
+      isHidden: true
+    }
+
+    if (appImagePath) opts.path = appImagePath
+
+    this.autoLauncher = new AutoLaunchClass(opts)
+
+    if (appImagePath) {
+      // `auto-launch` replaces the configured name with the AppImage file name
+      // when a path is provided. Keep a stable name so updates do not change
+      // the autolaunch entry.
+      this.autoLauncher.opts.appName = APP_NAME
+
+      // Refresh the desktop entry so its Exec path follows the current
+      // AppImage after an update or move.
+      this.ready = this.refresh().catch(err =>
+        logger.error('could not refresh AppImage autolaunch entry', { err })
+      )
+    } else {
+      this.ready = Promise.resolve()
+    }
+  }
+
+  async refresh() {
+    if (await this.autoLauncher.isEnabled()) {
+      await this.autoLauncher.disable()
+      await this.autoLauncher.enable()
+    }
+  }
+
+  async isEnabled() {
+    await this.ready
+    return this.autoLauncher.isEnabled()
+  }
+
+  async setEnabled(enabled) {
+    await this.ready
+
+    if (enabled) {
+      await this.autoLauncher.enable()
+    } else {
+      await this.autoLauncher.disable()
+    }
+
+    return enabled
+  }
 }
 
-if (process.env.APPIMAGE) {
-  opts.path = process.env.APPIMAGE
-}
+class NativeAutoLauncher {
+  constructor({ electronApp, logger, platform }) {
+    this.app = electronApp
+    this.log = logger
+    this.platform = platform
+  }
 
-const autoLauncher = new AutoLaunch(opts)
+  async isEnabled() {
+    const settings = this.app.getLoginItemSettings()
 
-if (process.env.APPIMAGE) {
-  // Fix issue with `auto-launch` that uses the path instead of the app name
-  // when defining the autolaunch entry leading to autolaunch to stop working
-  // after an app update.
-  // See https://github.com/Teamwork/node-auto-launch/issues/92
+    if (this.platform === 'darwin' && settings.status) {
+      this.log.debug('macOS autolaunch status', {
+        enabled: settings.openAtLogin,
+        status: settings.status
+      })
 
-  // Make sure the autolaunch entry will use the app's name.
-  autoLauncher.opts.appName = APP_NAME
-
-  // Check if there is an autolaunch entry with the app's path.
-  autoLauncher
-    .isEnabled()
-    .then(pathAutoLaunchEnabled => {
-      if (pathAutoLaunchEnabled) {
-        // Remove it to avoid having multiple entries.
-        autoLauncher.disable()
-
-        // Create an autolaunch entry with the app's name if there was an entry
-        // with the app's path.
-        autoLauncher.enable()
+      if (settings.status === 'requires-approval') {
+        this.log.warn('macOS autolaunch requires user approval')
       }
-      return
-    })
-    .catch(err =>
-      log.error('could not check autolaunch or replace old one', { err })
-    )
+    }
+
+    return settings.openAtLogin
+  }
+
+  async setEnabled(enabled) {
+    this.app.setLoginItemSettings({ openAtLogin: enabled })
+    return this.isEnabled()
+  }
 }
 
-module.exports.isEnabled = () => autoLauncher.isEnabled()
+class AutoLaunchManager {
+  constructor({ autoLauncher, logger }) {
+    this.autoLauncher = autoLauncher
+    this.log = logger
+  }
 
-module.exports.setEnabled = enabled => {
-  autoLauncher
-    .isEnabled()
-    .then(was => {
-      if (was !== enabled) {
-        if (enabled) {
-          autoLauncher.enable()
-          return true
-        } else {
-          autoLauncher.disable()
-          return false
-        }
-      }
-      return was
-    })
-    .catch(err => log.error('could not set autolaunch', { err }))
+  async isEnabled() {
+    try {
+      return await this.autoLauncher.isEnabled()
+    } catch (err) {
+      this.log.error('could not check autolaunch status', { err })
+      return false
+    }
+  }
+
+  async setEnabled(enabled) {
+    try {
+      const wasEnabled = await this.autoLauncher.isEnabled()
+
+      if (wasEnabled === enabled) return wasEnabled
+
+      const isEnabled = await this.autoLauncher.setEnabled(enabled)
+      this.log.debug(`${isEnabled ? 'Enabled' : 'Disabled'} autolaunch`)
+      return isEnabled
+    } catch (err) {
+      this.log.error('could not set autolaunch', { err })
+      return false
+    }
+  }
 }
+
+const createAutoLauncher = ({
+  AutoLaunchClass = AutoLaunch,
+  appImagePath = process.env.APPIMAGE,
+  electronApp = app,
+  logger = log,
+  platform = process.platform
+} = {}) => {
+  const autoLauncher = NATIVE_PLATFORMS.has(platform)
+    ? new NativeAutoLauncher({ electronApp, logger, platform })
+    : new LinuxAutoLauncher({ AutoLaunchClass, appImagePath, logger })
+
+  return new AutoLaunchManager({ autoLauncher, logger })
+}
+
+module.exports = createAutoLauncher()
+module.exports.createAutoLauncher = createAutoLauncher

--- a/test/unit/gui/autolaunch.js
+++ b/test/unit/gui/autolaunch.js
@@ -1,0 +1,246 @@
+const should = require('should')
+const sinon = require('sinon')
+
+const { createAutoLauncher } = require('../../../gui/js/autolaunch')
+
+describe('autolaunch', () => {
+  const sandbox = sinon.createSandbox()
+  let logger
+
+  beforeEach(() => {
+    logger = {
+      debug: sandbox.spy(),
+      error: sandbox.spy(),
+      warn: sandbox.spy()
+    }
+  })
+
+  afterEach(() => sandbox.restore())
+
+  describe('macOS and Windows', () => {
+    let electronApp
+
+    beforeEach(() => {
+      electronApp = {
+        getLoginItemSettings: sandbox.stub(),
+        setLoginItemSettings: sandbox.stub()
+      }
+    })
+
+    it('reads the native login item status', async () => {
+      electronApp.getLoginItemSettings.returns({
+        openAtLogin: true,
+        status: 'enabled'
+      })
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'darwin'
+      })
+
+      should(await autoLauncher.isEnabled()).be.true()
+
+      sinon.assert.calledOnceWithExactly(electronApp.getLoginItemSettings)
+      sinon.assert.notCalled(logger.warn)
+    })
+
+    it('logs when macOS requires user approval', async () => {
+      electronApp.getLoginItemSettings.returns({
+        openAtLogin: false,
+        status: 'requires-approval'
+      })
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'darwin'
+      })
+
+      should(await autoLauncher.isEnabled()).be.false()
+
+      sinon.assert.calledOnceWithExactly(
+        logger.warn,
+        'macOS autolaunch requires user approval'
+      )
+    })
+
+    it('enables the native login item', async () => {
+      electronApp.getLoginItemSettings.onFirstCall().returns({
+        openAtLogin: false,
+        status: 'not-registered'
+      })
+      electronApp.getLoginItemSettings.onSecondCall().returns({
+        openAtLogin: true,
+        status: 'enabled'
+      })
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'darwin'
+      })
+
+      should(await autoLauncher.setEnabled(true)).be.true()
+
+      sinon.assert.calledOnceWithExactly(electronApp.setLoginItemSettings, {
+        openAtLogin: true
+      })
+    })
+
+    it('disables the native login item', async () => {
+      electronApp.getLoginItemSettings.onFirstCall().returns({
+        openAtLogin: true
+      })
+      electronApp.getLoginItemSettings.onSecondCall().returns({
+        openAtLogin: false
+      })
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'win32'
+      })
+
+      should(await autoLauncher.setEnabled(false)).be.false()
+
+      sinon.assert.calledOnceWithExactly(electronApp.setLoginItemSettings, {
+        openAtLogin: false
+      })
+    })
+
+    it('does not update an unchanged native login item', async () => {
+      electronApp.getLoginItemSettings.returns({ openAtLogin: true })
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'win32'
+      })
+
+      should(await autoLauncher.setEnabled(true)).be.true()
+
+      sinon.assert.notCalled(electronApp.setLoginItemSettings)
+    })
+
+    it('returns false and logs native API errors', async () => {
+      const err = new Error('could not read login item')
+      electronApp.getLoginItemSettings.throws(err)
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'darwin'
+      })
+
+      should(await autoLauncher.isEnabled()).be.false()
+
+      sinon.assert.calledOnceWithExactly(
+        logger.error,
+        'could not check autolaunch status',
+        { err }
+      )
+    })
+
+    it('returns false and logs native update errors', async () => {
+      const err = new Error('could not update login item')
+      electronApp.getLoginItemSettings.returns({ openAtLogin: false })
+      electronApp.setLoginItemSettings.throws(err)
+      const autoLauncher = createAutoLauncher({
+        electronApp,
+        logger,
+        platform: 'win32'
+      })
+
+      should(await autoLauncher.setEnabled(true)).be.false()
+
+      sinon.assert.calledOnceWithExactly(
+        logger.error,
+        'could not set autolaunch',
+        { err }
+      )
+    })
+  })
+
+  describe('Linux', () => {
+    let autoLaunchBackend
+    let AutoLaunchClass
+
+    beforeEach(() => {
+      autoLaunchBackend = {
+        opts: { appName: 'Twake-Desktop-x86_64.AppImage' },
+        disable: sandbox.stub().resolves(),
+        enable: sandbox.stub().resolves(),
+        isEnabled: sandbox.stub()
+      }
+      AutoLaunchClass = sandbox.stub().returns(autoLaunchBackend)
+    })
+
+    it('keeps the AppImage launcher name and path stable', async () => {
+      autoLaunchBackend.isEnabled.onFirstCall().resolves(true)
+      autoLaunchBackend.isEnabled.onSecondCall().resolves(true)
+
+      const autoLauncher = createAutoLauncher({
+        AutoLaunchClass,
+        appImagePath: '/opt/Twake-Desktop.AppImage',
+        logger,
+        platform: 'linux'
+      })
+
+      should(await autoLauncher.isEnabled()).be.true()
+
+      sinon.assert.calledOnceWithExactly(AutoLaunchClass, {
+        name: 'Twake-Desktop',
+        isHidden: true,
+        path: '/opt/Twake-Desktop.AppImage'
+      })
+      should(autoLaunchBackend.opts.appName).equal('Twake-Desktop')
+      sinon.assert.calledOnce(autoLaunchBackend.disable)
+      sinon.assert.calledOnce(autoLaunchBackend.enable)
+    })
+
+    it('enables autolaunch through the Linux backend', async () => {
+      autoLaunchBackend.isEnabled.resolves(false)
+      const autoLauncher = createAutoLauncher({
+        AutoLaunchClass,
+        logger,
+        platform: 'linux'
+      })
+
+      should(await autoLauncher.setEnabled(true)).be.true()
+
+      sinon.assert.calledOnceWithExactly(AutoLaunchClass, {
+        name: 'Twake-Desktop',
+        isHidden: true
+      })
+      sinon.assert.calledOnce(autoLaunchBackend.enable)
+      sinon.assert.notCalled(autoLaunchBackend.disable)
+    })
+
+    it('disables autolaunch through the Linux backend', async () => {
+      autoLaunchBackend.isEnabled.resolves(true)
+      const autoLauncher = createAutoLauncher({
+        AutoLaunchClass,
+        logger,
+        platform: 'linux'
+      })
+
+      should(await autoLauncher.setEnabled(false)).be.false()
+
+      sinon.assert.calledOnce(autoLaunchBackend.disable)
+      sinon.assert.notCalled(autoLaunchBackend.enable)
+    })
+
+    it('returns false and logs Linux backend errors', async () => {
+      const err = new Error('could not read desktop entry')
+      autoLaunchBackend.isEnabled.rejects(err)
+      const autoLauncher = createAutoLauncher({
+        AutoLaunchClass,
+        logger,
+        platform: 'linux'
+      })
+
+      should(await autoLauncher.isEnabled()).be.false()
+
+      sinon.assert.calledOnceWithExactly(
+        logger.error,
+        'could not check autolaunch status',
+        { err }
+      )
+    })
+  })
+})

--- a/test/unit/gui/onboarding.window.js
+++ b/test/unit/gui/onboarding.window.js
@@ -1,3 +1,5 @@
+const { session } = require('electron')
+const should = require('should')
 const sinon = require('sinon')
 
 const autoLaunch = require('../../../gui/js/autolaunch')
@@ -28,7 +30,8 @@ describe('onboarding.window', () => {
       sinon.assert.callOrder(
         onboardingWindow.focus,
         onboardingWindow.desktop.registerWithDelegationCode,
-        onboardingWindow.sendSyncConfig
+        onboardingWindow.sendSyncConfig,
+        autoLaunch.setEnabled
       )
       sinon.assert.calledWithExactly(
         onboardingWindow.desktop.registerWithDelegationCode,
@@ -36,6 +39,64 @@ describe('onboarding.window', () => {
         'delegation-code'
       )
       sinon.assert.calledOnce(onboardingWindow.sendSyncConfig)
+      sinon.assert.calledOnceWithExactly(autoLaunch.setEnabled, true)
+    })
+  })
+
+  describe('onRegisterWithURL', () => {
+    const sandbox = sinon.createSandbox()
+    let event
+    let onboardingWindow
+    let syncSession
+
+    beforeEach(() => {
+      syncSession = {
+        clearStorageData: sandbox.stub().resolves(),
+        webRequest: {
+          onBeforeRedirect: sandbox.stub(),
+          onBeforeRequest: sandbox.stub()
+        }
+      }
+      sandbox.stub(session, 'fromPartition').returns(syncSession)
+      sandbox.stub(autoLaunch, 'setEnabled')
+
+      onboardingWindow = Object.create(OnboardingWM.prototype)
+      onboardingWindow.closeOAuthView = sandbox.spy()
+      onboardingWindow.desktop = {
+        checkCozyUrl: sandbox.stub().resolves('https://example.mycozy.cloud'),
+        config: {},
+        registerWithURL: sandbox.stub().resolves('file:///registered')
+      }
+      onboardingWindow.win = {
+        loadURL: sandbox.spy(),
+        webContents: { once: sandbox.spy() }
+      }
+      event = { sender: {} }
+    })
+
+    afterEach(() => sandbox.restore())
+
+    it('enables autolaunch after registering with a Cozy URL', async () => {
+      await onboardingWindow.onRegisterWithURL(event, {
+        cozyUrl: 'example.mycozy.cloud',
+        location: 'Paris'
+      })
+
+      should(onboardingWindow.desktop.config.cozyUrl).equal(
+        'https://example.mycozy.cloud'
+      )
+      sinon.assert.calledWith(
+        onboardingWindow.desktop.registerWithURL,
+        'https://example.mycozy.cloud',
+        'Paris',
+        sinon.match.func
+      )
+      sinon.assert.callOrder(
+        onboardingWindow.win.loadURL,
+        onboardingWindow.closeOAuthView,
+        autoLaunch.setEnabled
+      )
+      sinon.assert.calledOnceWithExactly(autoLaunch.setEnabled, true)
     })
   })
 })


### PR DESCRIPTION
## Summary

- manage auto-launch with Electron's native login-item APIs on macOS and Windows
- keep the existing `auto-launch` backend for Linux and AppImage packages
- preserve the public `isEnabled()` / `setEnabled()` contract used by onboarding and tray code
- retain the stable AppImage launcher name, hidden start, and desktop-entry path refresh
- add unit coverage for native status, approval, updates, failures, Linux/AppImage behavior, and both onboarding registration paths

## Root cause

The legacy `auto-launch` package manages macOS login items through AppleScript. This is no longer reliable on recent macOS versions, while the Electron version used by Desktop already exposes the native login-item APIs backed by macOS Service Management.


Fixes #2460
