### PR TITLE
feat: Cleanup onboarding when closing its window

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -90,7 +90,6 @@ class App {
     basePath = path.resolve(basePath)
     this.basePath = findBasePath(basePath)
     this.config = config.load(this.basePath)
-    this.pouch = new Pouch(this.config)
     this.events = new SyncState()
 
     autoBind(this)
@@ -187,7 +186,9 @@ class App {
 
   async removeConfig() {
     log.info('Removing config...')
-    await this.pouch.db.destroy()
+    if (this.pouch) {
+      await this.pouch.db.destroy()
+    }
     for (const name of await fse.readdir(this.basePath)) {
       if (name.startsWith(LOG_BASENAME)) continue
       await fse.remove(path.join(this.basePath, name))
@@ -265,9 +266,15 @@ class App {
     }
 
     const sendPouchDBTree = async () => {
+      if (!this.pouch) {
+        log.warn('no PouchDB so no tree to send')
+        return
+      }
+
       const pouchdbTree = await this.pouch.localTree()
 
       if (!pouchdbTree) {
+        log.warn('no PouchDB tree to send')
         return
       } else {
         return this.uploadFileToSupport(
@@ -302,6 +309,7 @@ class App {
 
   // Instanciate some objects before sync
   instanciate() {
+    this.pouch = new Pouch(this.config)
     this.ignore = Ignore.loadSync(this.config.ignoreRulesPath)
     this.merge = new Merge(this.pouch)
     this.prep = new Prep(this.merge, this.ignore, this.config)

--- a/core/app.js
+++ b/core/app.js
@@ -32,7 +32,12 @@ const { Sync } = require('./sync')
 const SyncState = require('./syncstate')
 const flags = require('./utils/flags')
 const { sendToTrash } = require('./utils/fs')
-const { baseLogger, logger, LOG_BASENAME } = require('./utils/logger')
+const {
+  addDefaultTransport,
+  baseLogger,
+  logger,
+  LOG_BASENAME
+} = require('./utils/logger')
 const notes = require('./utils/notes')
 const web = require('./utils/web')
 
@@ -345,6 +350,8 @@ class App {
     if (!this.config.isValid()) {
       throw new config.InvalidConfigError()
     }
+
+    addDefaultTransport()
 
     let wasUpdated = clientInfo.configVersion !== clientInfo.appVersion
     if (wasUpdated) {

--- a/core/app.js
+++ b/core/app.js
@@ -154,9 +154,8 @@ class App {
   }
 
   // Save the config with all the informations for synchonization
-  saveConfig(cozyUrl /*: string */, syncPath /*: string */) {
+  saveConfig(syncPath /*: string */) {
     fse.ensureDirSync(syncPath)
-    this.config.cozyUrl = cozyUrl
     this.config.syncPath = syncPath
     this.config.persist()
     log.info(

--- a/core/app.js
+++ b/core/app.js
@@ -367,6 +367,8 @@ class App {
           sentry: true
         })
       }
+
+      this.config.persist()
     }
 
     this.instanciate()

--- a/core/config.js
+++ b/core/config.js
@@ -7,6 +7,7 @@
 const fs = require('fs')
 const path = require('path')
 
+const autoBind = require('auto-bind')
 const fse = require('fs-extra')
 const _ = require('lodash')
 
@@ -76,12 +77,11 @@ class Config {
   constructor(basePath /*: string */) {
     this.basePath = basePath
     this.configPath = path.join(basePath, 'config.json')
-    fse.ensureFileSync(this.configPath)
     this.dbPath = path.join(basePath, 'db')
-    fse.ensureDirSync(this.dbPath)
-    hideOnWindows(basePath)
 
     this.fileConfig = this.read()
+
+    autoBind(this)
   }
 
   // Read the configuration from disk
@@ -107,6 +107,8 @@ class Config {
 
   // Save configuration to file system.
   persist() {
+    hideOnWindows(this.basePath)
+
     this._writeTmpConfig(this.toJSON())
     this._moveTmpConfig()
   }
@@ -193,7 +195,6 @@ class Config {
   set client(options /*: OAuthClient */) {
     const { creds } = this.fileConfig
     this.fileConfig.creds = _.merge(creds, { client: options })
-    this.persist()
   }
 
   get version() /*: string */ {
@@ -202,7 +203,6 @@ class Config {
 
   set version(newVersion /*: string */) /*: * */ {
     _.set(this.fileConfig, 'creds.client.softwareVersion', newVersion)
-    this.persist()
   }
 
   get permissions() /*: string[] */ {
@@ -217,7 +217,6 @@ class Config {
   set permissions(scope /*: string */) {
     const { creds } = this.fileConfig
     this.fileConfig.creds = _.merge(creds, { scope })
-    this.persist()
   }
 
   // Return the id of the registered OAuth client
@@ -240,11 +239,11 @@ class Config {
   set oauthTokens(token /*: OAuthTokens */) {
     const { creds } = this.fileConfig
     this.fileConfig.creds = _.merge(creds, { token })
-    this.persist()
   }
 
   onTokenRefresh(newToken /*: OAuthTokens */) {
     this.oauthTokens = newToken
+    this.persist() // XXX: automatically persist as onTokenRefresh is called by CozyClient
   }
 
   // Flags are options that can be activated by the user via the config file.
@@ -268,7 +267,6 @@ class Config {
       )
     }
     _.set(this.fileConfig, `flags.${flag}`, isActive)
-    this.persist()
   }
 
   get watcherType() /*: WatcherType */ {
@@ -298,6 +296,9 @@ function loadOrDeleteFile(configPath /*: string */) /*: FileConfig */ {
     if (e instanceof SyntaxError) {
       log.error(`Could not read config file at ${configPath}`, { err: e })
       fse.unlinkSync(configPath)
+      return {}
+    } else if (e.code === 'ENOENT') {
+      log.warn(`Config file does not exist at ${configPath}`, { err: e })
       return {}
     } else {
       throw e

--- a/core/utils/logger.js
+++ b/core/utils/logger.js
@@ -21,8 +21,6 @@ export type Logger = winston.Logger
 const LOG_DIR = findBasePath(process.env.COZY_DESKTOP_DIR || os.homedir())
 const LOG_BASENAME = 'logs.txt'
 
-fse.ensureDirSync(LOG_DIR)
-
 // Remove the `timestamp` field as we use the `time` alias (for backwards
 // compatibility with our jq filters.
 //
@@ -136,15 +134,6 @@ const defaultFormatter = combine(
   levelToInt()
 )
 
-const defaultTransport = new DailyRotateFile({
-  dirname: LOG_DIR,
-  filename: LOG_BASENAME,
-  datePattern: 'YYYY-MM-DD', // XXX: rotate every day
-  maxFiles: 7,
-  zippedArchive: true, // XXX: gzip archived log files
-  format: combine(defaultFormatter, json())
-})
-
 const baseLogger = winston.createLogger({
   levels: {
     fatal: 0,
@@ -155,7 +144,7 @@ const baseLogger = winston.createLogger({
     trace: 5
   },
   level: process.env.DEBUG ? 'trace' : 'info',
-  transports: [defaultTransport]
+  transports: []
 })
 baseLogger.on('error', err => {
   // eslint-disable-next-line no-console
@@ -204,6 +193,23 @@ function logger(options) {
   return baseLogger.child(options)
 }
 
+let defaultTransportAdded = false
+function addDefaultTransport() {
+  if (defaultTransportAdded) return
+
+  baseLogger.add(
+    new DailyRotateFile({
+      dirname: LOG_DIR,
+      filename: LOG_BASENAME,
+      datePattern: 'YYYY-MM-DD', // XXX: rotate every day
+      maxFiles: 7,
+      zippedArchive: true, // XXX: gzip archived log files
+      format: combine(defaultFormatter, json())
+    })
+  )
+  defaultTransportAdded = true
+}
+
 module.exports = {
   FATAL_LVL,
   ERROR_LVL,
@@ -215,7 +221,7 @@ module.exports = {
   LOG_BASENAME,
   defaultFormatter,
   baseLogger,
-  defaultTransport,
+  addDefaultTransport,
   dropTimestamp,
   logger,
   messageToMsg

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 const { enable: enableRemoteModule } = require('@electron/remote/main')
-const { dialog, session, BrowserView, shell } = require('electron')
+const { app, dialog, session, BrowserView, shell } = require('electron')
 
 const autoLaunch = require('./autolaunch')
 const { translate } = require('./i18n')
@@ -149,6 +149,8 @@ module.exports = class OnboardingWM extends WindowManager {
 
       enableRemoteModule(this.win.webContents)
 
+      this.win.on('closed', app.quit)
+
       if (this.shouldJumpToSyncPath) {
         await this.jumpToSyncPath()
       }
@@ -288,6 +290,8 @@ module.exports = class OnboardingWM extends WindowManager {
       } catch (err) {
         log.error('failed adding shortcuts in file manager', { err })
       }
+
+      this.win.off('closed', app.quit)
       this.afterOnboarding()
     } catch (err) {
       log.error('failed starting sync', { err })

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -274,21 +274,24 @@ module.exports = class OnboardingWM extends WindowManager {
       log.error({ err: error })
       return
     }
-    let desktop = this.desktop
-    if (!desktop.config.isValid()) {
+
+    if (!this.desktop.config.isValid()) {
       log.error('Cannot start desktop client. No valid config found!')
       return
     }
+
     try {
-      desktop.saveConfig(desktop.config.cozyUrl, syncPath)
+      this.desktop.saveConfig(syncPath)
+
       try {
-        addFileManagerShortcut(desktop.config)
+        addFileManagerShortcut(syncPath)
       } catch (err) {
         log.error('failed adding shortcuts in file manager', { err })
       }
       this.afterOnboarding()
     } catch (err) {
       log.error('failed starting sync', { err })
+      // TODO: figure if this is still relevant; seems not
       event.sender.send('folder-error', translate('Error Invalid path'))
     }
   }

--- a/gui/js/shortcut.js
+++ b/gui/js/shortcut.js
@@ -55,13 +55,13 @@ const macosAddFavorite = path => {
 // For Windows <=> NT kernel version mapping, see:
 //   https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
 //   https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
-module.exports.addFileManagerShortcut = config => {
+module.exports.addFileManagerShortcut = syncPath => {
   if (platform === 'win32' && major >= 10) {
-    win10PinToHome(config.syncPath)
+    win10PinToHome(syncPath)
   } else if (platform === 'win32' && major >= 6) {
-    winAddLink(config.syncPath)
+    winAddLink(syncPath)
   } else if (platform === 'darwin') {
-    macosAddFavorite(config.syncPath)
+    macosAddFavorite(syncPath)
   } else {
     throw new Error(`Not registering shortcut on ${platform} ${major}`)
   }

--- a/gui/main.js
+++ b/gui/main.js
@@ -74,7 +74,6 @@ sentry.setup(desktop.clientInfo())
 
 let diskTimeout = null
 let onboardingWindow = null
-let helpWindow = null
 let updaterWindow = null
 let trayWindow = null
 
@@ -196,6 +195,15 @@ const showWindow = async bounds => {
   }
 }
 
+const showHelp = async () => {
+  log.trace('Setting up help WM...')
+  const helpWindow = new HelpWM(desktop)
+  const win = await helpWindow.show()
+  await new Promise(resolve => {
+    win.on('closed', resolve)
+  })
+}
+
 const showInvalidConfigError = async () => {
   const options = {
     type: 'warning',
@@ -217,8 +225,7 @@ const showInvalidConfigError = async () => {
         log.error('failed disconnecting client', { err, sentry: true })
       )
   } else {
-    helpWindow = new HelpWM(desktop)
-    helpWindow.show()
+    await showHelp()
   }
 }
 
@@ -239,8 +246,7 @@ const showMigrationError = async (err /*: Error */) => {
   }
   const { response } = await dialog.showMessageBox(null, options)
   if (response === 0) {
-    helpWindow = new HelpWM(desktop)
-    helpWindow.show()
+    await showHelp()
   }
 }
 
@@ -684,7 +690,7 @@ app.on('window-all-closed', () => {
 })
 
 ipcMain.on('show-help', () => {
-  helpWindow.show()
+  showHelp()
 })
 
 // On watch mode, automatically reload the window when sources are updated

--- a/gui/main.js
+++ b/gui/main.js
@@ -15,7 +15,8 @@ const {
   ipcMain,
   dialog,
   powerMonitor,
-  session
+  session,
+  shell
 } = require('electron')
 
 if (process.env.INSECURE_SSL) {
@@ -225,7 +226,7 @@ const showInvalidConfigError = async () => {
         log.error('failed disconnecting client', { err, sentry: true })
       )
   } else {
-    await showHelp()
+    await shell.openExternal('mailto:support@twake.app')
   }
 }
 

--- a/gui/main.js
+++ b/gui/main.js
@@ -96,11 +96,6 @@ const notificationsState = {
   notifiedMsg: ''
 }
 
-const toggleWindow = bounds => {
-  if (trayWindow.shown()) trayWindow.hide()
-  else showWindow(bounds)
-}
-
 const setupDesktop = async () => {
   try {
     // TODO: allow setting desktop up without running migrations (when opening
@@ -166,39 +161,38 @@ const startApp = async () => {
   }
 }
 
+const toggleWindow = bounds => {
+  if (trayWindow.shown()) trayWindow.hide()
+  else showWindow(bounds)
+}
+
 const showWindow = async bounds => {
   if (
     notificationsState.revokedAlertShown ||
     notificationsState.syncDirUnlinkedShown
   )
     return
+
   if (updaterWindow && updaterWindow.shown()) return updaterWindow.focus()
-  if (!desktop.config.syncPath) {
-    onboardingWindow.show(bounds)
-    // registration is done, but we need a syncPath
-    if (desktop.config.isValid()) {
-      onboardingWindow.jumpToSyncPath()
+
+  if (desktop.sync) {
+    sendDiskUsage()
+  }
+
+  try {
+    await trayWindow.show(bounds)
+
+    trayWindow.sendSyncConfig()
+
+    const files = await lastFiles.list()
+    for (const file of files) {
+      trayWindow.send('transfer', { ...file, transferred: file.size })
     }
-  } else {
-    if (desktop.sync) {
-      sendDiskUsage()
-    }
 
-    try {
-      await trayWindow.show(bounds)
-
-      trayWindow.sendSyncConfig()
-
-      const files = await lastFiles.list()
-      for (const file of files) {
-        trayWindow.send('transfer', { ...file, transferred: file.size })
-      }
-
-      const hasAutolaunch = await autoLaunch.isEnabled()
-      trayWindow.send('auto-launch', hasAutolaunch)
-    } catch (err) {
-      log.error('could not show tray window or recent files', { err })
-    }
+    const hasAutolaunch = await autoLaunch.isEnabled()
+    trayWindow.send('auto-launch', hasAutolaunch)
+  } catch (err) {
+    log.error('could not show tray window or recent files', { err })
   }
 }
 

--- a/gui/main.js
+++ b/gui/main.js
@@ -74,9 +74,9 @@ let desktop = new Desktop.App(process.env.COZY_DESKTOP_DIR)
 sentry.setup(desktop.clientInfo())
 
 let diskTimeout = null
-let onboardingWindow = null
 let updaterWindow = null
 let trayWindow = null
+let windowsCreated = false
 
 let desktopIsReady, desktopIsKO
 const whenDesktopReady = new Promise((resolve, reject) => {
@@ -146,18 +146,6 @@ const setupDesktop = async () => {
     }
     await exit(0)
     return
-  }
-}
-
-const startApp = async () => {
-  if (!desktop.config.syncPath) {
-    onboardingWindow.show()
-    // registration is done, but we need a syncPath
-    if (desktop.config.isValid()) {
-      onboardingWindow.jumpToSyncPath()
-    }
-  } else {
-    startSync()
   }
 }
 
@@ -495,6 +483,18 @@ const startSync = async () => {
   sendDiskUsage()
 }
 
+const setupWindows = () => {
+  tray.init(toggleWindow)
+  lastFiles.init(desktop)
+  log.trace('Setting up tray WM...')
+  trayWindow = new TrayWM(desktop, lastFiles)
+
+  // Os X wants all application to have a menu
+  Menu.setApplicationMenu(buildAppMenu())
+
+  windowsCreated = true
+}
+
 const dumbhash = k =>
   k
     .split('')
@@ -619,68 +619,78 @@ app.on('ready', async () => {
   log.info('Loading CLI...')
   i18n.init(app)
 
-  if (desktop.config.syncPath) {
-    await setupDesktop()
-  }
-
-  if (process.platform !== 'darwin' && argv && argv.length > 2) {
-    const filePath = argv[argv.length - 1]
+  // Note opening on Windows and Linux
+  const filePath = argv && argv.length > 1 ? argv[argv.length - 1] : null
+  if (filePath && filePath.endsWith('.cozy-note')) {
     log.info('main instance invoked with arguments', { filePath, argv })
 
     // We need a valid config to start the App and open the requested note.
     // We assume users won't have notes they want to open without a connected
     // client.
     if (desktop.config.syncPath) {
-      if (filePath.endsWith('.cozy-note')) {
-        await openNote(filePath, { desktop })
-      } else {
-        log.warn('file path argument does not have valid Cozy note extension')
-      }
+      await setupDesktop()
+      await openNote(filePath, { desktop })
     } else {
       log.warn('no valid config')
+      await showInvalidConfigError()
     }
 
     await exit(0)
     return
   }
 
-  if (shouldStartSync) {
-    tray.init(toggleWindow)
-    lastFiles.init(desktop)
-    log.trace('Setting up tray WM...')
-    trayWindow = new TrayWM(desktop, lastFiles)
-    log.trace('Setting up help WM...')
-    helpWindow = new HelpWM(desktop)
-    log.trace('Setting up onboarding WM...')
-    onboardingWindow = new OnboardingWM(desktop)
-    onboardingWindow.onOnboardingDone(async () => {
+  // Note opening on macOS
+  if (!shouldStartSync) {
+    log.info('main instance invoked for open-file')
+
+    // We need a valid config to start the App and open the requested note.
+    // We assume users won't have notes they want to open without a connected
+    // client.
+    if (desktop.config.syncPath) {
       await setupDesktop()
-      onboardingWindow.hide()
-      await trayWindow.show()
-      await startSync()
-    })
-
-    // Os X wants all application to have a menu
-    Menu.setApplicationMenu(buildAppMenu())
-
-    // On OS X it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    app.on('activate', showWindow)
-
-    if (app.isPackaged) {
-      log.trace('Setting up updater WM...')
-      updaterWindow = new UpdaterWM(desktop)
-      updaterWindow.onUpToDate(() => {
-        updaterWindow.hide()
-        startApp()
-      })
-      updaterWindow.checkForUpdates()
-      setInterval(() => {
-        updaterWindow.checkForUpdates()
-      }, DAILY)
     } else {
-      startApp()
+      log.warn('no valid config')
+      await showInvalidConfigError()
     }
+
+    return
+  }
+
+  if (!desktop.config.syncPath) {
+    log.trace('Setting up onboarding WM...')
+    const onboardingWindow = new OnboardingWM(desktop)
+    await new Promise(resolve => {
+      onboardingWindow.onOnboardingDone(resolve)
+      onboardingWindow.show()
+    })
+    onboardingWindow.hide()
+    setupWindows()
+    await trayWindow.show()
+  }
+
+  await setupDesktop()
+
+  if (!windowsCreated) {
+    setupWindows()
+  }
+
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  app.on('activate', showWindow)
+
+  if (app.isPackaged) {
+    log.trace('Setting up updater WM...')
+    updaterWindow = new UpdaterWM(desktop)
+    updaterWindow.onUpToDate(() => {
+      updaterWindow.hide()
+      startSync()
+    })
+    updaterWindow.checkForUpdates()
+    setInterval(() => {
+      updaterWindow.checkForUpdates()
+    }, DAILY)
+  } else {
+    startSync()
   }
 })
 

--- a/test/support/helpers/config.js
+++ b/test/support/helpers/config.js
@@ -19,6 +19,7 @@ module.exports = {
     this.config = config.load(findBasePath(this.basePath))
     this.config.syncPath = path.join(this.basePath, DEFAULT_SYNC_DIR_NAME)
     this.config.cozyUrl = COZY_URL
+    this.config.persist()
 
     this.syncPath = this.config.syncPath
     fse.ensureDirSync(this.syncPath)

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -115,10 +115,8 @@ describe('core/config', function() {
           }
         })
 
-        it('throws an error', function() {
-          ;(() => {
-            config.loadOrDeleteFile(this.config.configPath)
-          }).should.throw()
+        it('returns an empty object', function() {
+          should(config.loadOrDeleteFile(this.config.configPath)).deepEqual({})
         })
       })
 


### PR DESCRIPTION
  Avoid starting the synchronization with an invalid configuration when
  the onboarding hasn't been completed by writing the configuration on
  disk only at the end of the onboarding and quitting the app when
  closing the onboarding window.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
