### PR TITLE
fix: Registration re-throws cozy-client errors

### DIFF
--- a/core/remote/registration.js
+++ b/core/remote/registration.js
@@ -129,7 +129,10 @@ module.exports = class Registration {
       return redirectURI
     } catch (err) {
       log.error('could not register OAuth client', { err })
+
       this.config.clear()
+
+      throw err
     }
   }
 }


### PR DESCRIPTION
  If creating a `CozyClient` instance fails during the registration and
  throws an error, we should let it bubble up after cleaning the
  configuration so the UI is notified and can display a message to the
  user.

  This is how we display an error when the given instance URL is invalid
  for example.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
