### PR TITLE
fix: Prevent 'Client already registered' on onboarding over a leftover config

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -194,7 +194,7 @@ class Config {
   // Set the remote configuration
   set client(options /*: OAuthClient */) {
     const { creds } = this.fileConfig
-    this.fileConfig.creds = _.merge(creds, { client: options })
+    this.fileConfig.creds = { ...creds, client: options }
   }
 
   get version() /*: string */ {

--- a/core/config.js
+++ b/core/config.js
@@ -243,7 +243,14 @@ class Config {
 
   onTokenRefresh(newToken /*: OAuthTokens */) {
     this.oauthTokens = newToken
-    this.persist() // XXX: automatically persist as onTokenRefresh is called by CozyClient
+    // Only persist once the onboarding is complete (i.e. a sync path
+    // has been chosen). Otherwise the first `client.login()` performed
+    // during onboarding would write partial credentials to disk, which
+    // survives across app restarts and breaks the next onboarding
+    // attempt with a local "Client already registered" error.
+    if (this.syncPath) {
+      this.persist()
+    }
   }
 
   // Flags are options that can be activated by the user via the config file.

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -194,6 +194,60 @@ describe('core/config', function() {
       })
     })
 
+    describe('onTokenRefresh', function() {
+      const newToken = {
+        tokenType: 'Bearer',
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        scope: 'io.cozy.files'
+      }
+
+      beforeEach('set initial credentials', function() {
+        this.config.fileConfig.creds = {
+          client: { clientID: 'x', clientName: 'test' },
+          token: {
+            tokenType: 'Bearer',
+            accessToken: 'old',
+            refreshToken: 'old',
+            scope: ''
+          }
+        }
+      })
+
+      context('when a sync path has been chosen', function() {
+        it('updates the token in memory', function() {
+          this.config.onTokenRefresh(newToken)
+          should(this.config.oauthTokens.accessToken).equal('new-access')
+        })
+
+        it('persists the refreshed token to disk', function() {
+          this.config.onTokenRefresh(newToken)
+
+          const persisted = config.loadOrDeleteFile(this.config.configPath)
+          should(persisted.creds.token.accessToken).equal('new-access')
+        })
+      })
+
+      context('when no sync path has been chosen yet', function() {
+        beforeEach('simulate onboarding in progress', function() {
+          // The config helper sets a syncPath and persists; an ongoing
+          // onboarding is in the opposite state.
+          delete this.config.fileConfig.path
+          fse.removeSync(this.config.configPath)
+        })
+
+        it('updates the token in memory', function() {
+          this.config.onTokenRefresh(newToken)
+          should(this.config.oauthTokens.accessToken).equal('new-access')
+        })
+
+        it('does not persist the config to disk', function() {
+          this.config.onTokenRefresh(newToken)
+          should(fse.existsSync(this.config.configPath)).be.false()
+        })
+      })
+    })
+
     describe('Client', function() {
       it('can set a client', function() {
         this.config.client = { clientName: 'test' }

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -205,6 +205,29 @@ describe('core/config', function() {
         this.config.reset()
         should(this.config.isValid()).be.false()
       })
+
+      it('replaces previous client fields when set to new options', function() {
+        // Mimic a fully registered client left over from a previous
+        // session (e.g. after an interrupted onboarding).
+        this.config.client = {
+          clientID: 'stale-id',
+          clientSecret: 'stale-secret',
+          registrationAccessToken: 'stale-token',
+          clientName: 'test',
+          redirectURI: 'http://localhost:3344/callback'
+        }
+
+        // Registration.process reassigns the client with fresh options
+        // from `oauthClient()`, which never carries a `clientID`.
+        this.config.client = {
+          clientName: 'test',
+          redirectURI: 'http://localhost:3344/callback'
+        }
+
+        should(this.config.client.clientID).be.undefined()
+        should(this.config.client.clientSecret).be.undefined()
+        should(this.config.client.registrationAccessToken).be.undefined()
+      })
     })
 
     describe('flags', () => {


### PR DESCRIPTION
## Summary

On Windows, re-running the onboarding over a config that already contains OAuth credentials (e.g. after an interrupted onboarding, a manual edit, or an upgrade) fails on the first click on "Next" with the generic "No Twake Workplace at this address!" error. The logs show `Client already registered` thrown locally by `cozy-stack-client`. A second click works but leaves orphaned OAuth clients on the server, and the issue reappears on every app restart.

Two root causes:

- **`set client` in `core/config.js`** deep-merged new options via `_.merge`, silently preserving any stale `clientID` left on disk. `CozyClient.isRegistered()` then returned `true` and `stackClient.register()` threw before any HTTP call. Fixed by replacing the client configuration atomically with a shallow spread — the OAuth client is atomic by nature and both callers always assign a complete object.
- **`Config.onTokenRefresh`** unconditionally persisted the config to disk, which happens on the very first `client.login()` during onboarding — long before the user chooses a sync folder. An abandoned onboarding therefore left half-written credentials on disk, triggering the bug on the next launch. Fixed by gating persistence on `syncPath` being set, which closes the last unsealed persistence path left open by #2414 (`25ce2ced`), `3ee12035` and `ddd09f98`. Tokens obtained during onboarding stay in memory and are persisted atomically by `saveConfig()` when the user picks a sync folder.

Each commit body explains the why, and the first commit contains a PowerShell snippet to reproduce the failure from an existing install.

## Test plan

- [x] `yarn mocha test/unit/config.js` — 44 passing, including 5 new tests in `core/config`:
  - `Client > replaces previous client fields when set to new options`
  - `onTokenRefresh > when a sync path has been chosen > updates the token in memory`
  - `onTokenRefresh > when a sync path has been chosen > persists the refreshed token to disk`
  - `onTokenRefresh > when no sync path has been chosen yet > updates the token in memory`
  - `onTokenRefresh > when no sync path has been chosen yet > does not persist the config to disk`
- [x] Verified each test fails on the pre-fix implementation (`expected 'stale-id' to be undefined` and `expected true to be false` respectively).
- [ ] Manual Windows reproduction from the install described in the first commit's message: the UI opens the SSO webview on the first click of "Next" instead of showing "No Twake Workplace at this address!".
- [ ] Regression check on the happy path: complete a fresh onboarding end to end and confirm `config.json` contains the full credentials + `path` after the user clicks "Start sync", and that token refreshes during normal sync still write the new token to disk.

## Notes

Out of scope for this PR: on abandoned onboardings, the OAuth client registered server-side is still not cleaned up (no `remote.unregister()` call on window close). This PR only removes the local leak that was breaking re-registration; a separate change would be needed to clean up orphaned server clients.
=> But we have a jobs to remove unused Oauth client, so it shoud be ok 