### PR TITLE
fix: Prevent 'Client already registered' on onboarding over a leftover config

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -194,7 +194,7 @@ class Config {
   // Set the remote configuration
   set client(options /*: OAuthClient */) {
     const { creds } = this.fileConfig
-    this.fileConfig.creds = _.merge(creds, { client: options })
+    this.fileConfig.creds = { ...creds, client: options }
   }
 
   get version() /*: string */ {

--- a/core/config.js
+++ b/core/config.js
@@ -243,7 +243,14 @@ class Config {
 
   onTokenRefresh(newToken /*: OAuthTokens */) {
     this.oauthTokens = newToken
-    this.persist() // XXX: automatically persist as onTokenRefresh is called by CozyClient
+    // Only persist once the onboarding is complete (i.e. a sync path
+    // has been chosen). Otherwise the first `client.login()` performed
+    // during onboarding would write partial credentials to disk, which
+    // survives across app restarts and breaks the next onboarding
+    // attempt with a local "Client already registered" error.
+    if (this.syncPath) {
+      this.persist()
+    }
   }
 
   // Flags are options that can be activated by the user via the config file.

--- a/core/remote/registration.js
+++ b/core/remote/registration.js
@@ -130,7 +130,12 @@ module.exports = class Registration {
     } catch (err) {
       log.error('could not register OAuth client', { err })
 
+      // Persist the cleanup so a leftover `clientID` or token on disk
+      // does not survive a failed registration and break the next
+      // onboarding attempt (locally with "Client already registered"
+      // or remotely with an "Invalid token" on a revoked client).
       this.config.clear()
+      this.config.persist()
 
       throw err
     }

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -194,6 +194,60 @@ describe('core/config', function() {
       })
     })
 
+    describe('onTokenRefresh', function() {
+      const newToken = {
+        tokenType: 'Bearer',
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        scope: 'io.cozy.files'
+      }
+
+      beforeEach('set initial credentials', function() {
+        this.config.fileConfig.creds = {
+          client: { clientID: 'x', clientName: 'test' },
+          token: {
+            tokenType: 'Bearer',
+            accessToken: 'old',
+            refreshToken: 'old',
+            scope: ''
+          }
+        }
+      })
+
+      context('when a sync path has been chosen', function() {
+        it('updates the token in memory', function() {
+          this.config.onTokenRefresh(newToken)
+          should(this.config.oauthTokens.accessToken).equal('new-access')
+        })
+
+        it('persists the refreshed token to disk', function() {
+          this.config.onTokenRefresh(newToken)
+
+          const persisted = config.loadOrDeleteFile(this.config.configPath)
+          should(persisted.creds.token.accessToken).equal('new-access')
+        })
+      })
+
+      context('when no sync path has been chosen yet', function() {
+        beforeEach('simulate onboarding in progress', function() {
+          // The config helper sets a syncPath and persists; an ongoing
+          // onboarding is in the opposite state.
+          delete this.config.fileConfig.path
+          fse.removeSync(this.config.configPath)
+        })
+
+        it('updates the token in memory', function() {
+          this.config.onTokenRefresh(newToken)
+          should(this.config.oauthTokens.accessToken).equal('new-access')
+        })
+
+        it('does not persist the config to disk', function() {
+          this.config.onTokenRefresh(newToken)
+          should(fse.existsSync(this.config.configPath)).be.false()
+        })
+      })
+    })
+
     describe('Client', function() {
       it('can set a client', function() {
         this.config.client = { clientName: 'test' }

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -205,6 +205,29 @@ describe('core/config', function() {
         this.config.reset()
         should(this.config.isValid()).be.false()
       })
+
+      it('replaces previous client fields when set to new options', function() {
+        // Mimic a fully registered client left over from a previous
+        // session (e.g. after an interrupted onboarding).
+        this.config.client = {
+          clientID: 'stale-id',
+          clientSecret: 'stale-secret',
+          registrationAccessToken: 'stale-token',
+          clientName: 'test',
+          redirectURI: 'http://localhost:3344/callback'
+        }
+
+        // Registration.process reassigns the client with fresh options
+        // from `oauthClient()`, which never carries a `clientID`.
+        this.config.client = {
+          clientName: 'test',
+          redirectURI: 'http://localhost:3344/callback'
+        }
+
+        should(this.config.client.clientID).be.undefined()
+        should(this.config.client.clientSecret).be.undefined()
+        should(this.config.client.registrationAccessToken).be.undefined()
+      })
     })
 
     describe('flags', () => {

--- a/test/unit/remote/registration.js
+++ b/test/unit/remote/registration.js
@@ -3,7 +3,9 @@
 const os = require('os')
 
 const should = require('should')
+const sinon = require('sinon')
 
+const config = require('../../../core/config')
 const Registration = require('../../../core/remote/registration')
 const configHelpers = require('../../support/helpers/config')
 
@@ -35,6 +37,37 @@ describe('Registration', function() {
       should(params.clientKind).equal('desktop')
       should(params.clientURI).equal(pkg.homepage)
       should(params.logoURI).equal(pkg.logo)
+    })
+  })
+
+  describe('process', function() {
+    context('when registration fails', function() {
+      beforeEach('persist stale credentials on disk', function() {
+        this.config.client = {
+          clientID: 'stale-client-id',
+          clientSecret: 'stale-secret',
+          clientName: 'test',
+          redirectURI: 'http://localhost:3344/callback'
+        }
+        this.config.persist()
+      })
+
+      afterEach(function() {
+        sinon.restore()
+      })
+
+      it('clears the stale credentials from disk', async function() {
+        sinon
+          .stub(this.registration, 'oauthClient')
+          .throws(new Error('registration failure'))
+
+        await should(this.registration.process({})).be.rejectedWith(
+          'registration failure'
+        )
+
+        const persisted = config.loadOrDeleteFile(this.config.configPath)
+        should(persisted.creds).be.undefined()
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

On Windows, re-running the onboarding over a config that already contains OAuth credentials (after an interrupted onboarding, a server-side revocation of the client, or some upgrade scenarios that leave `syncPath` unset while `creds.client` is still on disk) fails on the first click on "Suivant" with the generic "No Twake Workplace at this address!" error. Logs show `Client already registered` thrown locally by `cozy-stack-client`, sometimes accompanied by a `FetchError: Invalid token` from a parallel `io.cozy.settings` query. A second click on "Suivant" works (in-memory `creds` was cleared) but the issue comes back on every app restart because the disk copy was never cleaned.

Three root causes, each fixed by one commit:

- **`set client` in `core/config.js`** deep-merged new options via `_.merge`, silently preserving any stale `clientID` left on disk. `CozyClient.isRegistered()` then returned `true` and `stackClient.register()` threw before any HTTP call. Fixed by replacing the client configuration atomically with a shallow spread — both callers always assign a complete OAuth client object.
- **`Config.onTokenRefresh`** unconditionally persisted the config to disk, which happens on the very first `client.login()` during onboarding — before the user has picked a sync folder. An abandoned onboarding therefore left half-written credentials on disk. Fixed by gating persistence on `syncPath` being set, which closes the last unsealed persistence path left open by #2414 (`25ce2ced`), `3ee12035` and `ddd09f98`.
- **`Registration.process` catch block** only cleared `creds` from memory, never from disk. Any failure — local `Client already registered`, server-side revocation, network hiccup — therefore left a disk/memory divergence that broke the next app start. Fixed by calling `config.persist()` after `config.clear()` so the cleanup reaches the file.

The three fixes are layered: the first makes the happy path succeed on the first click, the second prevents the stale state from ever being written during onboarding, and the third guarantees that *any* failure in the registration flow cleans up after itself.

Each commit body explains the why; the first commit also contains a PowerShell snippet to reproduce the failure from an existing install.

## Test plan

- [x] `yarn mocha test/unit/config.js test/unit/remote/registration.js` — 47 passing, including 6 new tests:
  - `core/config > Client > replaces previous client fields when set to new options`
  - `core/config > onTokenRefresh > when a sync path has been chosen > updates the token in memory`
  - `core/config > onTokenRefresh > when a sync path has been chosen > persists the refreshed token to disk`
  - `core/config > onTokenRefresh > when no sync path has been chosen yet > updates the token in memory`
  - `core/config > onTokenRefresh > when no sync path has been chosen yet > does not persist the config to disk`
  - `Registration > process > when registration fails > clears the stale credentials from disk`
- [x] Verified each test fails on the pre-fix implementation (`expected 'stale-id' to be undefined`, `expected true to be false`, and `expected Object { client: { clientID: 'stale-client-id', ... } } to be undefined` respectively).
- [ ] Manual Windows reproduction from the install described in the first commit's message: the UI opens the SSO webview on the first click of "Suivant" instead of showing "No Twake Workplace at this address!".
- [ ] Regression check on the happy path: complete a fresh onboarding end to end and confirm `config.json` contains the full credentials + `path` after the user clicks "Démarrer la synchronisation", and that token refreshes during normal sync still write the new token to disk.
- [ ] Abandoned-onboarding scenario: start an onboarding, complete SSO, close the window before choosing a sync folder. With the fix, `config.json` does not exist (or contains no `creds`) after the app quits, and the next launch starts a clean onboarding.

## Notes

Out of scope: orphaned OAuth clients left on the Cozy server after abandoned onboardings. `Registration.process` does not call `remote.unregister()` on failure, so the server may accumulate never-used clients. That would require a separate change and involves round-tripping through the server, which is risky on an already-revoked client.

Closes #2418 (same branch, opened from my fork before I had push access here).