### PR TITLE
ci: Fix Windows code signing trigger

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,8 +34,13 @@ before_build:
   - pwsh: if ($env:BUILD_JOB -eq "build") { pwsh -NoProfile -ExecutionPolicy Unrestricted -Command .\build\windows\setup-keylocker.ps1 }
 
 build_script:
-  - pwsh: $env:SIGN_CODE=( ($env:FORCE_CODE_SIGNING -eq "true") -or (($env:APPVEYOR_REPO_BRANCH -eq "master" ) -and ($env:APPVEYOR_REPO_TAG -eq 'true')) )
-  - pwsh: if ($env:BUILD_JOB -eq "build") { yarn dist }
+  - pwsh: |
+      if ($env:BUILD_JOB -eq "build") {
+          $env:SIGN_CODE=(
+            ($env:FORCE_CODE_SIGNING -eq "true") -or (($env:APPVEYOR_REPO_BRANCH -eq "master" ) -and ($env:APPVEYOR_REPO_TAG -eq 'true'))
+          )
+          yarn dist
+      }
 
 artifacts:
   - path: "dist\\latest.yml"


### PR DESCRIPTION
  Since we switched from PowerShell to PowerShell Core commands on
  AppVeyor, the assignment of the `SIGN_CODE` env variable does not
  survive across multiple commands so its value would be empty in the
  command that launches `yarn dist` and checks it to decide whether to
  sign the generated binaries or not.

  We couldn't figure how to make this work with PowerShell Core so we
  move the variable assignment to the command that uses it.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
