### PR TITLE
feat: Add registration via Twake Signup

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -39,6 +39,7 @@ const {
   LOG_BASENAME
 } = require('./utils/logger')
 const notes = require('./utils/notes')
+const { getInstanceFromFqdn } = require('./utils/twake')
 const web = require('./utils/web')
 
 /*::
@@ -143,14 +144,24 @@ class App {
   }
 
   // Return a promise for registering a device on the Twake Workplace
-  async registerRemote(
+  async registerWithURL(
     cozyUrl /*: string */,
     redirectURI /*: ?string */,
     onRegistered /*: ?Function */,
-    deviceName /*: string */
+    deviceName /*: ?string */
   ) {
     const registration = new Registration(cozyUrl, this.config)
     return registration.process(pkg, redirectURI, onRegistered, deviceName)
+  }
+
+  async registerWithDelegationCode(
+    fqdn /*: string */,
+    code /*: string */,
+    deviceName /*: ?string */
+  ) {
+    const cozyUrl = getInstanceFromFqdn(fqdn)
+    const registration = new Registration(cozyUrl, this.config)
+    return registration.registerWithDelegationCode(pkg, code, deviceName)
   }
 
   // Save the config with all the informations for synchonization

--- a/core/remote/client.js
+++ b/core/remote/client.js
@@ -2,6 +2,8 @@
 
 const { default: CozyClient } = require('cozy-client')
 
+const { logger } = require('../utils/logger')
+
 /*::
 export type OAuthClient = {
   clientID: string,
@@ -33,7 +35,19 @@ export type ClientOptions = $ReadOnly<{
   oauthTokens: ?OAuthTokens,
   onTokenRefresh: ?(OAuthTokens) => any,
 }>
+
+type AccessToken = {
+  token_type: string,
+  access_token: string,
+  accessToken?: string,
+  refresh_token: string,
+  scope: string,
+}
 */
+
+const log = logger({
+  component: 'Remote/client'
+})
 
 function createClient(
   { cozyUrl, client, oauthTokens, onTokenRefresh } /*: ClientOptions */
@@ -65,6 +79,47 @@ async function registerClient(
   return client.authorize({ openURLCallback })
 }
 
+async function connectOIDCClient(client /*: CozyClient */, code /*: string */) {
+  log.debug('connectOIDCClient', { client, code })
+  const result = await loginWithOIDC(client, code)
+  log.debug('connectOIDCClient', { result })
+
+  const stackClient = client.getStackClient()
+  stackClient.setToken(result)
+}
+
+async function loginWithOIDC(
+  client /*: CozyClient */,
+  code /*: string */
+) /*: Promise<AccessToken> */ {
+  log.debug('loginWithOIDC', { client, code })
+  const stackClient = client.getStackClient()
+  await stackClient.register()
+  log.debug('loginWithOIDC', { oauthOptions: stackClient.oauthOptions })
+
+  const { scope: scopes } = client.options
+  const {
+    clientID: client_id,
+    clientSecret: client_secret
+  } = stackClient.oauthOptions
+  const data = {
+    code,
+    client_id,
+    client_secret,
+    scope: scopes.join(' ')
+  }
+  log.debug('loginWithOIDC', { data })
+
+  const loginResult = await stackClient.fetchJSON(
+    'POST',
+    '/oidc/access_token',
+    data
+  )
+  log.debug('loginWithOIDC', { loginResult })
+
+  return loginResult
+}
+
 async function loginAndSaveClient(
   client /*: CozyClient */,
   storage /*: { -client: OAuthClient, -oauthTokens: OAuthTokens } */
@@ -86,5 +141,6 @@ function saveOauthClient(
 module.exports = {
   createClient,
   registerClient,
+  connectOIDCClient,
   loginAndSaveClient
 }

--- a/core/remote/registration.js
+++ b/core/remote/registration.js
@@ -11,7 +11,12 @@ const url = require('url')
 const autoBind = require('auto-bind')
 const open = require('open')
 
-const { createClient, loginAndSaveClient, registerClient } = require('./client')
+const {
+  createClient,
+  loginAndSaveClient,
+  registerClient,
+  connectOIDCClient
+} = require('./client')
 const { logger } = require('../utils/logger')
 
 const PORT_NUMBER = 3344
@@ -107,6 +112,31 @@ module.exports = class Registration {
       clientURI: pkg.homepage,
       logoURI: pkg.logo,
       policyURI: 'https://files.cozycloud.cc/cgu.pdf'
+    }
+  }
+
+  async registerWithDelegationCode(
+    pkg /*: Object */,
+    code /*: string */,
+    deviceName /*: ?string */,
+    redirectURI /*: ?string */
+  ) {
+    this.config.cozyUrl = this.cozyUrl
+    this.config.client = this.oauthClient(pkg, redirectURI, deviceName)
+
+    try {
+      const client = createClient(this.config)
+      await connectOIDCClient(client, code)
+      await loginAndSaveClient(client, this.config)
+    } catch (err) {
+      log.error('could not register OAuth client with delegation code', {
+        err,
+        code
+      })
+
+      this.config.clear()
+
+      throw err
     }
   }
 

--- a/core/utils/twake.js
+++ b/core/utils/twake.js
@@ -1,0 +1,102 @@
+/**
+ * @module core/utils/twake
+ * @flow
+ */
+
+/*::
+export type TwakeConfiguration = {
+  'twake-flagship-login-uri': string,
+}
+*/
+
+const COZY_SCHEME = 'cozy'
+const UNSECURE_DOMAINS = ['cozy.tools', 'localhost', 'nip.io']
+
+const managerEnv = () /*: string */ => process.env.MANAGER_ENV || 'prod'
+
+const managerURL = () /*: string */ => {
+  switch (managerEnv()) {
+    case 'local':
+      return 'http://cloudery.localhost:3000'
+    case 'dev':
+      return 'https://manager-int.cozycloud.cc'
+    case 'int':
+      return 'https://manager-int.cozycloud.cc'
+    case 'prod':
+      return 'https://manager.cozycloud.cc'
+    default:
+      return 'https://manager.cozycloud.cc'
+  }
+}
+
+const oidcRoute = () /*: string */ => {
+  // XXX: Allow connecting to LNG instance using 'default' offer
+  const offer = process.env.MANAGER_OFFER
+
+  switch (managerEnv()) {
+    case 'local':
+      return offer || 'twake_prod'
+    case 'dev':
+      return offer || 'twake'
+    case 'int':
+      return offer || 'twake_stg'
+    case 'prod':
+      return offer || 'twake_prod'
+    default:
+      return offer || 'twake_prod'
+  }
+}
+
+const oidcLoginURL = () /*: string */ => {
+  return `${managerURL()}/linagora/${oidcRoute()}`
+}
+
+/**
+ * Get Cozy Instance from FQDN
+ *
+ * Instance is computed from FQDN by adding a protocol to it
+ *
+ * 'cozy.tools', 'localhost', 'nip.io' URLs are enforced with
+ * unsecure HTTP protocol
+ *
+ * @param fqdn - Cozy's FQDN
+ * @returns the computed Instance URL as string
+ */
+const getInstanceFromFqdn = (fqdn /*: string */) /*: string */ => {
+  const instance = getURLWithEnforcedProtocol(fqdn)
+
+  return removeTrailingSlash(instance.toString())
+}
+
+const getURLWithEnforcedProtocol = (uri /*: string */) /*: URL */ => {
+  const uriWithProtocol = hasProtocol(uri) ? uri : `https://${uri}`
+  const url = new URL(uriWithProtocol)
+
+  if (isUnsecureDomain(url.hostname)) {
+    url.protocol = 'http'
+  }
+
+  return url
+}
+
+const hasProtocol = (url /*: string */) /*: boolean */ => {
+  return url.includes('://')
+}
+
+const isUnsecureDomain = (domain /*: string */) /*: boolean */ => {
+  return UNSECURE_DOMAINS.some(d => domain.endsWith(d))
+}
+
+const removeTrailingSlash = (value /*: string */) /*: string */ => {
+  return value.replace(/\/$/, '')
+}
+
+module.exports = {
+  COZY_SCHEME,
+  managerEnv,
+  managerURL,
+  oidcRoute,
+  oidcLoginURL,
+  getInstanceFromFqdn,
+  isUnsecureDomain
+}

--- a/gui/elm/Ports.elm
+++ b/gui/elm/Ports.elm
@@ -21,7 +21,6 @@ port module Ports exposing
     , newRelease
     , openFile
     , quitAndInstall
-    , registerRemote
     , registrationError
     , reinitialization
     , reinitializeSynchronization
@@ -81,9 +80,6 @@ port showInParent : ( String, Bool ) -> Cmd msg
 
 
 port quitAndInstall : () -> Cmd msg
-
-
-port registerRemote : String -> Cmd msg
 
 
 port registrationError : (String -> msg) -> Sub msg

--- a/gui/elm/Window/Onboarding.elm
+++ b/gui/elm/Window/Onboarding.elm
@@ -1,4 +1,4 @@
-module Window.Onboarding exposing
+port module Window.Onboarding exposing
     ( Model
     , Msg(..)
     , Page(..)
@@ -60,7 +60,10 @@ update msg model =
             case
                 subMsg
             of
-                Welcome.NextPage ->
+                Welcome.LoginWithTwake ->
+                    ( model, registerWithTwake () )
+
+                Welcome.LoginWithAddress ->
                     ( { model | page = AddressPage }
                     , Ports.focus ".wizard__address"
                     )
@@ -86,6 +89,9 @@ update msg model =
                     Folder.update subMsg model.context
             in
             ( { model | context = context }, cmd )
+
+
+port registerWithTwake : () -> Cmd msg
 
 
 

--- a/gui/elm/Window/Onboarding/Address.elm
+++ b/gui/elm/Window/Onboarding/Address.elm
@@ -1,4 +1,4 @@
-module Window.Onboarding.Address exposing
+port module Window.Onboarding.Address exposing
     ( Msg(..)
     , correctAddress
     , dropAppName
@@ -26,7 +26,7 @@ import Window.Onboarding.Context as Context exposing (Context)
 
 type Msg
     = FillAddress String
-    | RegisterRemote
+    | RegisterWithURL
     | RegistrationError String
 
 
@@ -133,7 +133,7 @@ update msg context =
         FillAddress address ->
             ( Context.setAddressConfig context { address = address, error = "", busy = False }, Cmd.none )
 
-        RegisterRemote ->
+        RegisterWithURL ->
             let
                 addressConfig =
                     context.addressConfig
@@ -149,11 +149,14 @@ update msg context =
 
             else
                 ( Context.setAddressConfig context { addressConfig | busy = True }
-                , Ports.registerRemote addressConfig.address
+                , registerWithURL addressConfig.address
                 )
 
         RegistrationError error ->
             setError context error
+
+
+port registerWithURL : String -> Cmd msg
 
 
 
@@ -207,7 +210,7 @@ view helpers context =
                         , value context.addressConfig.address
                         , disabled context.addressConfig.busy
                         , onInput FillAddress
-                        , Keyboard.onEnter RegisterRemote
+                        , Keyboard.onEnter RegisterWithURL
                         ]
                         []
                     ]
@@ -227,7 +230,7 @@ view helpers context =
                     attribute "aria-busy" "true"
 
                   else
-                    onClick RegisterRemote
+                    onClick RegisterWithURL
                 ]
                 [ span [] [ text (helpers.t "Address Next") ] ]
             ]

--- a/gui/elm/Window/Onboarding/Welcome.elm
+++ b/gui/elm/Window/Onboarding/Welcome.elm
@@ -16,7 +16,8 @@ import Window.Onboarding.Context as Context exposing (Context)
 
 
 type Msg
-    = NextPage
+    = LoginWithTwake
+    | LoginWithAddress
 
 
 
@@ -38,13 +39,19 @@ view helpers context =
             , a
                 [ class "c-btn c-btn--full"
                 , href "#"
-                , onClick NextPage
+                , onClick LoginWithTwake
                 ]
-                [ span [] [ text (helpers.t "Welcome Sign in to my Twake Workplace") ] ]
+                [ span [] [ text (helpers.t "Welcome Sign in") ] ]
             , a
-                [ href "https://sign-up.twake.app?register"
-                , class "more-info"
+                [ class "c-btn c-btn--secondary c-btn--full"
+                , href "https://sign-up.twake.app?register"
                 ]
-                [ text (helpers.t "Address Don't have an account? Request one here") ]
+                [ span [] [ text (helpers.t "Welcome Create account") ] ]
+            , a
+                [ class "more-info"
+                , href "#"
+                , onClick LoginWithAddress
+                ]
+                [ text (helpers.t "Welcome Enter my Twake URL") ]
             ]
         ]

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -11,6 +11,7 @@ const WindowManager = require('./window_manager')
 const log = require('../../core/app').logger({
   component: 'GUI/Onboarding'
 })
+const { COZY_SCHEME, oidcLoginURL } = require('../../core/utils/twake')
 
 /*::
 import type { Event as ElectronEvent } from 'electron'
@@ -34,7 +35,8 @@ module.exports = class OnboardingWM extends WindowManager {
 
   ipcEvents() {
     return {
-      'register-remote': this.onRegisterRemote,
+      'register-with-url': this.onRegisterWithURL,
+      'register-with-twake': this.onRegisterWithTwake,
       'choose-folder': this.onChooseFolder,
       'start-sync': this.onStartSync
     }
@@ -163,7 +165,7 @@ module.exports = class OnboardingWM extends WindowManager {
     this.afterOnboarding = handler
   }
 
-  async onRegisterRemote(
+  async onRegisterWithURL(
     event /*: ElectronEvent */,
     arg /*: { cozyUrl: string, location: string } */
   ) {
@@ -211,7 +213,7 @@ module.exports = class OnboardingWM extends WindowManager {
       this.openOAuthView(url)
       return promise
     }
-    return desktop.registerRemote(cozyUrl, arg.location, onRegistered).then(
+    return desktop.registerWithURL(cozyUrl, arg.location, onRegistered).then(
       redirectURI => {
         syncSession.clearStorageData()
         this.win.webContents.once('dom-ready', () => {
@@ -248,6 +250,62 @@ module.exports = class OnboardingWM extends WindowManager {
         throw err
       }
     )
+  }
+
+  async onRegisterWithTwake() {
+    const syncSession = session.fromPartition(SESSION_PARTITION_NAME)
+
+    const registrationDone = new Promise((resolve, reject) => {
+      syncSession.protocol.handle(COZY_SCHEME, async request => {
+        log.debug(`received cozy:// request; starting OIDC registration`, {
+          request
+        })
+
+        try {
+          syncSession.protocol.unhandle(COZY_SCHEME)
+        } catch (err) {
+          log.error(`failed to unhandle ${COZY_SCHEME} protocol`, {
+            err,
+            sentry: true
+          })
+        }
+
+        const redirectURI = new URL(request.url)
+        const code = redirectURI.searchParams.get('code')
+        const fqdn = redirectURI.searchParams.get('fqdn')
+
+        try {
+          await this.desktop.registerWithDelegationCode(fqdn, code)
+
+          resolve()
+
+          // XXX: protocol.handle is expecting a Response to be returned.
+          // Even though we don't care about it we return an empty response to
+          // avoid errors on stderr.
+          return new Response()
+        } catch (err) {
+          log.error('failed registering device with Twake instance', {
+            err,
+            fqdn,
+            code
+          })
+          reject(err)
+        }
+      })
+    })
+
+    this.openOAuthView(
+      `${oidcLoginURL()}?redirect_after_oidc=${COZY_SCHEME}://`
+    )
+
+    await registrationDone
+    await this.sendSyncConfig()
+
+    this.closeOAuthView()
+
+    if (!process.env.DEBUG) {
+      autoLaunch.setEnabled(true)
+    }
   }
 
   onChooseFolder(event /*: ElectronEvent */) {

--- a/gui/locales/de.json
+++ b/gui/locales/de.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Bei meinem Twake Workplace anmelden",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Willkommen zur Twake Desktop!"
 }

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Sign in to my Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Welcome to Twake Desktop!"
 }

--- a/gui/locales/eo.json
+++ b/gui/locales/eo.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Sign in to my Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Welcome to Twake Desktop!"
 }

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -291,6 +291,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Iniciar sesión en mi Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "¡Bienvenido a Twake Desktop!"
 }

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Détails",
   "UserAlert Got it": "J'ai compris",
 
-  "Welcome Sign in to my Twake Workplace": "Me connecter à ma Twake Workplace",
+  "Welcome Sign in": "Me connecter",
+  "Welcome Create account": "Créer un compte",
+  "Welcome Enter my Twake URL": "Entrer l'URL de mon Twake",
   "Welcome Your own private cloud": "Bienvenue sur Twake Desktop !"
 }

--- a/gui/locales/it_IT.json
+++ b/gui/locales/it_IT.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Entra nel mio Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Benvenuto su Twake Desktop !"
 }

--- a/gui/locales/ja.json
+++ b/gui/locales/ja.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Twake Workplace にサインイン",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Twake Desktop へようこそ !"
 }

--- a/gui/locales/nl.json
+++ b/gui/locales/nl.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Inloggen op mijn Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Welkom by Twake Desktop!"
 }

--- a/gui/locales/nl_NL.json
+++ b/gui/locales/nl_NL.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Details tonen",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Inloggen op mijn Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Welkom bij Twake Desktop!"
 }

--- a/gui/locales/pl.json
+++ b/gui/locales/pl.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Zaloguj się do mojego Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Witaj w Twake Desktop!"
 }

--- a/gui/locales/sq.json
+++ b/gui/locales/sq.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Sign in to my Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Welcome to Twake Desktop!"
 }

--- a/gui/locales/zh_CN.json
+++ b/gui/locales/zh_CN.json
@@ -300,6 +300,8 @@
   "UserAlert Show details": "Show details",
   "UserAlert Got it": "Got it",
 
-  "Welcome Sign in to my Twake Workplace": "Sign in to my Twake Workplace",
+  "Welcome Sign in": "Sign in",
+  "Welcome Create account": "Create account",
+  "Welcome Enter my Twake URL": "Enter my Twake URL",
   "Welcome Your own private cloud": "Welcome to Twake Desktop!"
 }

--- a/gui/ports.js
+++ b/gui/ports.js
@@ -68,11 +68,14 @@ ipcRenderer.on('registration-error', (event, err) => {
   err = errMessage(err)
   elmectron.ports.registrationError.send(err)
 })
-elmectron.ports.registerRemote.subscribe(url => {
-  ipcRenderer.send('register-remote', {
+elmectron.ports.registerWithURL.subscribe(url => {
+  ipcRenderer.send('register-with-url', {
     cozyUrl: url,
     location: window.location.toString().replace('#', '')
   })
+})
+elmectron.ports.registerWithTwake.subscribe(() => {
+  ipcRenderer.send('register-with-twake')
 })
 
 ipcRenderer.on('folder-chosen', (event, result) => {


### PR DESCRIPTION
  The main way to connect Desktop to a Twake Workplace will now be
  directly via Twake Signup allowing users to connect via their
  registered phone number or Twake e-mail instead of their workplace's
  URL.

  Connecting with the URL is still possible for old Cozy instances.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
