### PR TITLE
fix: Send clientKind when updating OAuth client

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -51,7 +51,7 @@ import type stream from 'stream'
 import type { Metadata } from './metadata'
 
 export type ClientInfo = {
-  appVersion: string,
+  clientURI: string,
   configPath: string,
   configVersion: ?string,
   cozyUrl: string,
@@ -60,6 +60,7 @@ export type ClientInfo = {
   osRelease: string,
   osArch: string,
   permissions: string[],
+  softwareVersion: string,
   syncPath: string
 }
 */
@@ -398,10 +399,10 @@ class App {
 
     addDefaultTransport()
 
-    let wasUpdated = clientInfo.configVersion !== clientInfo.appVersion
+    let wasUpdated = clientInfo.configVersion !== clientInfo.softwareVersion
     if (wasUpdated) {
       try {
-        this.config.version = clientInfo.appVersion
+        this.config.version = clientInfo.softwareVersion
       } catch (err) {
         log.error('could not update config version after app update', {
           err,
@@ -440,7 +441,7 @@ class App {
 
     if (wasUpdated && this.remote) {
       try {
-        this.remote.update()
+        this.remote.update(clientInfo)
       } catch (err) {
         log.error('could not update OAuth client after app update', {
           err,
@@ -470,7 +471,7 @@ class App {
     const config = this.config || {}
 
     return {
-      appVersion: pkg.version,
+      clientURI: pkg.homepage,
       configPath: config.configPath,
       configVersion: config.version,
       cozyUrl: config.cozyUrl,
@@ -479,6 +480,7 @@ class App {
       osRelease: os.release(),
       osArch: os.arch(),
       permissions: config.permissions,
+      softwareVersion: pkg.version,
       syncPath: config.syncPath
     }
   }

--- a/core/remote/cozy.js
+++ b/core/remote/cozy.js
@@ -115,8 +115,18 @@ class RemoteCozy {
     return this.client.logout()
   }
 
-  async update() /*: Promise<void> */ {
-    return this.client.stackClient.updateInformation()
+  async update(
+    {
+      clientURI,
+      softwareVersion
+    } /*: { clientURI: string, softwareVersion: string } */
+  ) /*: Promise<void> */ {
+    return this.client.stackClient.updateInformation({
+      softwareVersion,
+      clientKind: this.config.client.clientKind,
+      clientURI,
+      policyURI: this.config.client.policyURI
+    })
   }
 
   async diskUsage() /* Promise<{ quota: number, used: number }> */ {

--- a/core/remote/index.js
+++ b/core/remote/index.js
@@ -138,8 +138,13 @@ class Remote /*:: implements Reader, Writer */ {
     return this.remoteCozy.unregister()
   }
 
-  update() {
-    return this.remoteCozy.update()
+  update(
+    {
+      clientURI,
+      softwareVersion
+    } /*: { clientURI: string, softwareVersion: string } */
+  ) {
+    return this.remoteCozy.update({ clientURI, softwareVersion })
   }
 
   updateLastSynced() {

--- a/core/utils/sentry.js
+++ b/core/utils/sentry.js
@@ -94,11 +94,11 @@ function setup(clientInfos /*: ClientInfo */) {
     return
   }
   try {
-    const { appVersion, cozyUrl } = clientInfos
+    const { softwareVersion, cozyUrl } = clientInfos
     const { domain, instance, environment } = toSentryContext(cozyUrl)
     Sentry.init({
       dsn: SENTRY_DSN,
-      release: appVersion,
+      release: softwareVersion,
       environment,
       // Inject preload script into all used sessions
       getSessions: () => [

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -290,7 +290,7 @@ describe('App', function() {
       const info = app.clientInfo()
 
       should(info).deepEqual({
-        appVersion: version,
+        clientURI: 'https://github.com/cozy-labs/cozy-desktop',
         configPath: path.join(basePath, BASE_DIR_NAME, 'config.json'),
         configVersion: '',
         cozyUrl: undefined,
@@ -299,6 +299,7 @@ describe('App', function() {
         osType: os.type(),
         osArch: os.arch(),
         permissions: [],
+        softwareVersion: version,
         syncPath: undefined
       })
     })
@@ -311,7 +312,6 @@ describe('App', function() {
       const app = new App(this.basePath)
       const info = app.clientInfo()
 
-      should(info.appVersion).equal(version)
       should(info.configPath).startWith(this.basePath)
       should(info.configVersion).equal(this.config.version)
       should(info.cozyUrl).equal(this.config.cozyUrl)
@@ -319,6 +319,7 @@ describe('App', function() {
       should.exist(info.osRelease)
       should.exist(info.osType)
       should(info.permissions).deepEqual(this.config.permissions)
+      should(info.softwareVersion).equal(version)
       should(info.syncPath).equal(this.syncPath)
     })
   })


### PR DESCRIPTION
  The `clientKind` OAuth client attribute is not part of the mandatory
  ones so `cozy-client` does not send it by default when updating a
  client and we need to explicitely send it.

  Without this the `clientKind` is removed from the
  `io.cozy.oauth.clients` doc on the remote Cozy and it's not listed in
  the Settings app anymore.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
