### PR TITLE
fix: Properly order replacement after move events

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -148,6 +148,9 @@ const detectOperation = async (
 // - a positive value when the second Change should be propagated before the
 //   first one
 // - 0 when the order of the Changes should be kept
+const A_FIRST = -1
+const B_FIRST = 1
+const KEEP_ORDER = 0
 const compareChanges = (
   { operation: opA, doc: docA } /*: Change */,
   { operation: opB, doc: docB } /*: Change */
@@ -159,8 +162,8 @@ const compareChanges = (
   if (opA.side != null && opB.side != null && opA.side === opB.side) {
     if (opA.type === opB.type) {
       // Handle same operation parent change before child changes
-      if (docB.path.startsWith(docA.path + sep)) return -1
-      else if (docA.path.startsWith(docB.path + sep)) return 1
+      if (docB.path.startsWith(docA.path + sep)) return A_FIRST
+      else if (docA.path.startsWith(docB.path + sep)) return B_FIRST
     }
 
     if (opA.type === 'DEL' && opB.type === 'MOVE' && docB.moveFrom != null) {
@@ -169,7 +172,7 @@ const compareChanges = (
         docB.moveFrom.path.startsWith(docA.path + sep) &&
         !docB.path.startsWith(docA.path + sep)
       ) {
-        return 1
+        return B_FIRST
       }
     }
     if (opB.type === 'DEL' && opA.type === 'MOVE' && docA.moveFrom != null) {
@@ -178,23 +181,28 @@ const compareChanges = (
         docA.moveFrom.path.startsWith(docB.path + sep) &&
         !docA.path.startsWith(docB.path + sep)
       )
-        return -1
+        return A_FIRST
     }
-    if (opA.type === 'ADD' && opB.type === 'MOVE') {
+
+    if (opA.type === 'ADD' && opB.type === 'MOVE' && docB.moveFrom != null) {
+      // Handle replacement after move
+      if (docA.path === docB.moveFrom.path) return B_FIRST
       // Handle child addtion after parent move
-      if (docA.path.startsWith(docB.path + sep)) return 1
+      if (docA.path.startsWith(docB.path + sep)) return B_FIRST
       // Handle move to dir after dir addition
-      if (docB.path.startsWith(docA.path + sep)) return -1
+      if (docB.path.startsWith(docA.path + sep)) return A_FIRST
     }
-    if (opB.type === 'ADD' && opA.type === 'MOVE') {
+    if (opB.type === 'ADD' && opA.type === 'MOVE' && docA.moveFrom != null) {
+      // Handle replacement after move
+      if (docB.path === docA.moveFrom.path) return A_FIRST
       // Handle child addtion after parent move
-      if (docB.path.startsWith(docA.path + sep)) return -1
+      if (docB.path.startsWith(docA.path + sep)) return A_FIRST
       // Handle move to dir after dir addition
-      if (docA.path.startsWith(docB.path + sep)) return 1
+      if (docA.path.startsWith(docB.path + sep)) return B_FIRST
     }
   }
 
-  return 0
+  return KEEP_ORDER
 }
 
 // Save the given changes' PouchDB records without making any modifications to

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -1650,5 +1650,41 @@ describe('Sync', function() {
         }
       )
     })
+
+    context(
+      'with a file move and an addition at the move source path (replacement)',
+      () => {
+        let move, add
+        beforeEach(async function() {
+          const srcFile = await builders
+            .metafile()
+            .path('file')
+            .upToDate()
+            .create()
+          const dstFile = await builders
+            .metafile()
+            .moveFrom(srcFile)
+            .path('moved-file')
+            .changedSide('local')
+            .create()
+          const newFile = await builders
+            .metafile()
+            .path('file')
+            .sides({ local: 1 })
+            .create()
+
+          move = makeChange(dstFile, 'MOVE', this)
+          add = makeChange(newFile, 'ADD', this)
+        })
+
+        it('returns -1 if move is passed as first argument', () => {
+          should(compareChanges(move, add)).eql(-1)
+        })
+
+        it('returns 1 if move is passed as second argument', () => {
+          should(compareChanges(add, move)).eql(1)
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
  When a file is moved and replaced at the source path, the move operation
  must be propagated before the addition to avoid conflicts with the
  existing source path in PouchDB.

  We introduce named constants (A_FIRST, B_FIRST, KEEP_ORDER) to improve
  code readability and maintainability when comparing change orders.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
