### PR TITLE
feat: Make built binaries names deterministic

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -46,6 +46,7 @@ const config = {
     hardenedRuntime: true,
     entitlements: './build/entitlements.mac.inherit.plist',
     category: 'public.app-category.productivity',
+    artifactName: 'Twake-Desktop-${arch}.${ext}',
     target: [
       {
         target: 'zip', // this is required for the update to work (see https://github.com/electron-userland/electron-builder/issues/2199)
@@ -64,6 +65,7 @@ const config = {
 
   win: {
     target: [{ target: 'nsis', arch: ['x64'] }],
+    artifactName: 'Twake-Desktop-Setup.${ext}',
     publisherName: 'Cozy Cloud SAS',
     // Comment out the following line if the Digicert server starts failing.
     // Electron-Builder will then swtich back to the default Comodoca server.


### PR DESCRIPTION
  Remove the version number from the generated artifact names for macOS
  and Windows so that we can have stable URLs in GitHub releases and
  easily link to the latest binary for each OS.

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
