### PR TITLE
fix: Do not block sync on InvalidMetadata errors

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -478,7 +478,6 @@ class Sync {
         if (
           [
             remoteErrors.INVALID_FOLDER_MOVE_CODE,
-            remoteErrors.INVALID_METADATA_CODE,
             remoteErrors.MISSING_DOCUMENT_CODE,
             remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE,
             remoteErrors.UNKNOWN_REMOTE_ERROR_CODE
@@ -503,7 +502,6 @@ class Sync {
           case syncErrors.NO_DISK_SPACE_CODE:
           case remoteErrors.FILE_TOO_LARGE_CODE:
           case remoteErrors.INVALID_FOLDER_MOVE_CODE:
-          case remoteErrors.INVALID_METADATA_CODE:
           case remoteErrors.INVALID_NAME_CODE:
           case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
           case remoteErrors.NO_COZY_SPACE_CODE:
@@ -528,6 +526,11 @@ class Sync {
             } else {
               await syncErrors.createConflict({ err, change }, this)
             }
+            break
+          case remoteErrors.INVALID_METADATA_CODE:
+            // Content has changed on disk the current change was merged. A new
+            // sync attempt will be triggered by the new content merge.
+            await this.skipChange(change, err)
             break
           case remoteErrors.DOCUMENT_IN_TRASH_CODE:
             delete change.doc.moveFrom
@@ -1133,7 +1136,6 @@ class Sync {
         case syncErrors.MISSING_PERMISSIONS_CODE:
         case syncErrors.NO_DISK_SPACE_CODE:
         case remoteErrors.FILE_TOO_LARGE_CODE:
-        case remoteErrors.INVALID_METADATA_CODE:
         case remoteErrors.INVALID_NAME_CODE:
         case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
         case remoteErrors.NO_COZY_SPACE_CODE:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@babel/runtime": "7.16.7",
     "@electron/remote": "2.1.2",
-    "@parcel/watcher": "https://github.com/taratatach/parcel-watcher.git#cozy-desktop",
+    "@parcel/watcher": "https://github.com/taratatach/parcel-watcher.git#v3.1.0",
     "@sentry/electron": "^5.7.0",
     "@sentry/integrations": "^7.114.0",
     "agent-base": "7.1.0",

--- a/test/integration/add.js
+++ b/test/integration/add.js
@@ -137,6 +137,43 @@ describe('Add', () => {
           }
         ])
       })
+
+      it('recovers when InvalidMetadata error is raised on first sync attempt', async () => {
+        // 1. Create local file (initial checksum will be invalid)
+        await createDoc('local', 'foo.txt', 'v1')
+
+        // 2. First scan: merges file with v1 checksum
+        await helpers.local.scan()
+
+        // 3. File changes on disk: content is now different
+        await helpers.local.syncDir.outputFile('foo.txt', 'v2')
+
+        sinon.spy(helpers.events, 'emit')
+
+        try {
+          // 4. First sync: creation with invalid checksum should fail
+          await helpers.syncAll()
+
+          // File should NOT be on remote (creation was skipped due to InvalidMetadata)
+          await should(helpers.remote.readFile('foo.txt')).be.rejected()
+
+          // No user-alert should have been emitted
+          const userAlertCalls = helpers.events.emit
+            .getCalls()
+            .filter(c => c.args[0] === 'user-alert')
+          should(userAlertCalls).have.length(0)
+        } finally {
+          helpers.events.emit.restore()
+        }
+
+        // 5. Second scan: picks up the modification, computes real checksum
+        await helpers.local.scan()
+
+        // 6. Second sync: should succeed with valid checksum
+        await helpers.syncAll()
+
+        should(await helpers.remote.readFile('foo.txt')).eql('v2')
+      })
     })
 
     describe('remote', () => {

--- a/test/integration/update.js
+++ b/test/integration/update.js
@@ -305,8 +305,6 @@ describe('Update file', () => {
 
   describe('M1, local merge M1, M2, remote sync M1, local merge M2', () => {
     it('fails remote sync M1 & local merge M2', async function() {
-      if (process.env.CI) this.timeout(60 * 1000)
-
       await helpers.remote.createFile('file', 'Initial content')
       await helpers.pullAndSyncAll()
       await helpers.flushLocalAndSyncAll()
@@ -326,11 +324,21 @@ describe('Update file', () => {
       await helpers.local.syncDir.outputFile('file', m2)
 
       log.info('-------- remote sync M1 --------')
-      // We don't await the end of the syncAll() call because it will raise 412
-      // errors that will only be fixed by the next local scan (i.e. the
-      // checksum of the file on the local filesystem is different from the one
-      // stored in PouchDB).
-      helpers.syncAll()
+      sinon.spy(helpers.events, 'emit')
+      try {
+        // Will fail with 412 errors that will only be fixed by the next local
+        // scan (i.e. the checksum of the file on the local filesystem is
+        // different from the one stored in PouchDB).
+        await helpers.syncAll()
+
+        // No user-alert should have been emitted
+        const userAlertCalls = helpers.events.emit
+          .getCalls()
+          .filter(c => c.args[0] === 'user-alert')
+        should(userAlertCalls).have.length(0)
+      } finally {
+        helpers.events.emit.restore()
+      }
 
       log.info('-------- local merge (and remote sync) M2 --------')
       should(await helpers.local.syncDir.checksum('file')).equal(
@@ -338,8 +346,7 @@ describe('Update file', () => {
       )
       await helpers.local.scan()
 
-      // Wait for Sync's retry to complete
-      await helpers._sync.stopped()
+      await helpers.syncAll()
 
       should({
         localTree: await helpers.local.tree(),

--- a/test/support/doubles/side.js
+++ b/test/support/doubles/side.js
@@ -18,7 +18,8 @@ const METHODS = [
   'trashAsync',
   'renameConflictingDocAsync',
   'diskUsage',
-  'resolveConflict'
+  'resolveConflict',
+  'stop'
 ]
 
 module.exports = function stubSide(name /*: SideName */) /*: Writer */ {

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -569,7 +569,12 @@ describe('Sync', function() {
           seq,
           operation: { type: 'EDIT', side: 'remote' }
         }
-        sinon.stub(this.sync, 'getNextChanges').returns([change])
+        sinon
+          .stub(this.sync, 'getNextChanges')
+          .withArgs(previousSeq)
+          .returns([change])
+          .withArgs(seq)
+          .returns([])
       })
       afterEach(function() {
         this.sync.getNextChanges.restore()
@@ -613,6 +618,38 @@ describe('Sync', function() {
             err: { code: remoteErrors.NEEDS_REMOTE_MERGE_CODE },
             change
           })
+        })
+      })
+
+      describe('when apply throws an INVALID_METADATA_CODE error', () => {
+        beforeEach(function() {
+          sinon.spy(this.sync, 'skipChange')
+        })
+        beforeEach('simulate error', async function() {
+          this.sync.lifecycle.transitionTo('done-start')
+          sinon.stub(this.sync, 'apply').rejects(
+            new syncErrors.SyncError({
+              code: remoteErrors.INVALID_METADATA_CODE,
+              sideName,
+              err: new FetchError(
+                { status: 422 },
+                {
+                  errors: [{ status: 422, title: 'Invalid metadata' }]
+                }
+              ),
+              doc: change.doc
+            })
+          )
+          await this.sync.syncBatch()
+          this.sync.apply.restore()
+        })
+        afterEach(function() {
+          this.sync.skipChange.restore()
+        })
+
+        it('skips the change on InvalidMetadata error', async function() {
+          should(this.sync.skipChange).have.been.calledOnce()
+          should(this.sync.skipChange).have.been.calledWithMatch(change)
         })
       })
     })
@@ -996,6 +1033,27 @@ describe('Sync', function() {
 
         this.sync.lifecycle.unblockFor(remoteErrors.UNREACHABLE_COZY_CODE)
         should(this.sync.lifecycle.blockedFor).be.null()
+      })
+    })
+
+    context('when an INVALID_METADATA_CODE error is encountered', () => {
+      const invalidMetadataError = syncErrors.wrapError(
+        new remoteErrors.RemoteError({
+          code: remoteErrors.INVALID_METADATA_CODE,
+          message: 'The local metadata for the document is corrupted',
+          err: new Error('invalid metadata')
+        }),
+        'remote'
+      )
+
+      beforeEach(function() {
+        this.sync.blockSyncFor({
+          err: invalidMetadataError
+        })
+      })
+
+      it('does not emit a user-alert event', function() {
+        should(this.events.emit.calledWith('user-alert')).be.false()
       })
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,9 +1778,9 @@
   dependencies:
     "@opentelemetry/core" "^1.1.0"
 
-"@parcel/watcher@https://github.com/taratatach/parcel-watcher.git#cozy-desktop":
-  version "3.0.0"
-  resolved "https://github.com/taratatach/parcel-watcher.git#9346f734e27901975339f12431b0a78e4f44a6a7"
+"@parcel/watcher@https://github.com/taratatach/parcel-watcher.git#v3.1.0":
+  version "3.1.0"
+  resolved "https://github.com/taratatach/parcel-watcher.git#01fa6d8b6cd1cebd1f61155a6eac98c6d34c57e8"
   dependencies:
     node-addon-api "^3.2.1"
     node-gyp-build "^4.8.1"


### PR DESCRIPTION
  When a local file changes between the scan that computes its metadata
  and the remote synchronization attempt, the checksum sent to the
  remote is stale and the upload fails with an `InvalidMetadata` error.

  Previously this error was treated as a blocking failure, stopping sync
  for that change and showing a user alert. Instead we now skip the
  change and let the next local scan (triggered by the file system
  watcher) pick up the correct checksum for the following sync attempt.

  The error should not as present as it used to (especially on Linux) as
  we've upgraded `@parcel/watcher` to a version that properly coalesces
  multiple edits on the same file into only one event (either `create`
  or `update` depending on whether the file existed before the first
  event or not).

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
