### PR TITLE
fix: Pass alert arg on user-action-command event

### DIFF
--- a/gui/js/tray.window.js
+++ b/gui/js/tray.window.js
@@ -316,9 +316,9 @@ module.exports = class TrayWM extends WindowManager {
       userActionCommand: (
         event /*: ElectronEvent */,
         cmd /*: UserActionCommand */,
-        action /*: UserAlert */
+        alert /*: UserAlert */
       ) => {
-        this.desktop.events.emit('user-action-command', { cmd, action })
+        this.desktop.events.emit('user-action-command', { cmd, alert })
       },
       'reinitialize-synchronization': (event /*: ElectronEvent */) => {
         log.info('Reinitializing synchronization...')

--- a/test/unit/gui/tray.window.js
+++ b/test/unit/gui/tray.window.js
@@ -1,8 +1,10 @@
 /* eslint-env mocha */
 
 const should = require('should')
+const sinon = require('sinon')
 
-const { popoverBounds } = require('../../../gui/js/tray.window')
+const TrayWM = require('../../../gui/js/tray.window')
+const { popoverBounds } = TrayWM
 
 describe('tray.window', () => {
   describe('popoverBounds', () => {
@@ -451,6 +453,27 @@ describe('tray.window', () => {
 
       // TODO: Unity (e.g. Ubuntu LTS)
       // TODO: KDE
+    })
+  })
+
+  describe('userActionCommand handler', () => {
+    it('emits user-action-command with cmd and alert', () => {
+      const emit = sinon.stub()
+      const handlers = TrayWM.prototype.ipcEvents.call({
+        desktop: { events: { emit } }
+      })
+      const alert = {
+        code: 'MISSING_PERMISSIONS',
+        doc: { id: 'file-id', docType: 'file', path: 'missing' }
+      }
+
+      handlers.userActionCommand({}, 'retry', alert)
+
+      should(emit).have.been.calledOnce()
+      should(emit).have.been.calledWith('user-action-command', {
+        cmd: 'retry',
+        alert
+      })
     })
   })
 })


### PR DESCRIPTION
  The tray IPC handler was forwarding the user alert as `action` while
  the sync-side listener (`_onUserActionCommand`) expected `alert`,
  causing the alert to be silently dropped and the matching blocked
  cause to never be resolved.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
