### PR TITLE
feat: Collect blocking errors per batch

### DIFF
--- a/core/sync/dependency_graph.js
+++ b/core/sync/dependency_graph.js
@@ -171,6 +171,15 @@ class DependencyGraph {
 
     return Array.from(visited).map(node => node.change)
   }
+
+  // Return the direct prerequisite changes of `change` — the changes that must
+  // be applied before `change`. Direct edges only; transitivity is handled by
+  // the caller walking the returned changes.
+  directPrerequisites(change /*: Change */) /*: Change[] */ {
+    const node = this.nodes.find(n => n.change === change)
+    if (!node) return []
+    return node.dependentOn.map(n => n.change)
+  }
 }
 
 // Visit the sub-graph represented by the given node and its dependencies to

--- a/core/sync/errors.js
+++ b/core/sync/errors.js
@@ -151,6 +151,12 @@ const retryDelay = (err /*: RemoteError|SyncError */) /*: number */ => {
   }
 }
 
+const minRetryDelay = (
+  causes /*: Array<{| err: RemoteError |} | {| err: SyncError, change: Change |}> */
+) /*: number */ => {
+  return Math.min(...causes.map(c => retryDelay(c.err)))
+}
+
 const retryAll = async (
   causes /*: Array<{| err: RemoteError |} | {| err: SyncError, change: Change |}> */,
   sync /*: Sync */
@@ -352,6 +358,7 @@ module.exports = {
   UnsyncedParentMoveError,
   SyncError,
   retryDelay,
+  minRetryDelay,
   retry,
   retryAll,
   skip,

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -536,153 +536,157 @@ class Sync {
       if (this.lifecycle.willStop()) return
       if (!(err instanceof syncErrors.SyncError)) throw err
 
-      const {
-        sideName,
-        doc: { path }
-      } = err
-
-      if (
-        [
-          remoteErrors.INVALID_FOLDER_MOVE_CODE,
-          remoteErrors.MISSING_DOCUMENT_CODE,
-          remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE,
-          remoteErrors.UNKNOWN_REMOTE_ERROR_CODE
-        ].includes(err.code)
-      ) {
-        log.error(`Sync error: ${err.message}`, {
-          err,
-          change,
-          path,
-          sentry: true
-        })
-      } else {
-        log.warn(`Sync error: ${err.message}`, { err, change, path })
-      }
-      switch (err.code) {
-        case remoteErrors.TWAKE_NOT_FOUND_CODE:
-          this.fatal(err)
-          break
-        case syncErrors.EXCLUDED_DIR_CODE:
-        case syncErrors.INCOMPATIBLE_DOC_CODE:
-        case syncErrors.MISSING_PERMISSIONS_CODE:
-        case syncErrors.NO_DISK_SPACE_CODE:
-        case remoteErrors.FILE_TOO_LARGE_CODE:
-        case remoteErrors.INVALID_FOLDER_MOVE_CODE:
-        case remoteErrors.INVALID_NAME_CODE:
-        case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
-        case remoteErrors.NO_COZY_SPACE_CODE:
-        case remoteErrors.PATH_TOO_DEEP_CODE:
-        case remoteErrors.REMOTE_MAINTENANCE_ERROR_CODE:
-        case remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE:
-        case remoteErrors.UNKNOWN_REMOTE_ERROR_CODE:
-        case remoteErrors.UNREACHABLE_COZY_CODE:
-        case remoteErrors.USER_ACTION_REQUIRED_CODE:
-          // We will keep retrying to apply the change until it's fixed or the
-          // user contacts our support.
-          // See `default` case for other blocking errors for which we'll stop
-          // retrying after 3 failed attempts.
-          await this.blockSyncFor({ err, change })
-          break
-        case remoteErrors.CONFLICTING_NAME_CODE:
-          if (
-            metadata.isFolder(change.doc) &&
-            change.operation.type === 'ADD'
-          ) {
-            await this.skipChange(change, err) // XXX: both directories will be merged in the next merge cycle?!
-          } else {
-            await syncErrors.createConflict({ err, change }, this)
-          }
-          break
-        case remoteErrors.INVALID_METADATA_CODE:
-          // Content has changed on disk the current change was merged. A new
-          // sync attempt will be triggered by the new content merge.
-          await this.skipChange(change, err)
-          break
-        case remoteErrors.DOCUMENT_IN_TRASH_CODE:
-          delete change.doc.moveFrom
-          delete change.doc.overwrite
-
-          // Go ahead and mark remote document as trashed
-          change.doc.remote = remoteDocument.trashedDoc(change.doc.remote)
-
-          await this.updateRevs(change.doc, sideName)
-          break
-        case remoteErrors.MISSING_DOCUMENT_CODE:
-          if (shouldAttemptRetry(change)) {
-            await this.blockSyncFor({ err, change })
-          } else {
-            if (isMarkedForDeletion(change.doc)) {
-              await this.skipChange(change, err)
-            } else if (sideName === 'remote') {
-              // FIXME: what about folder content?
-              delete change.doc.moveFrom
-              delete change.doc.overwrite
-              delete change.doc.remote
-
-              await this.doAdd(this.remote, change.doc)
-              await this.updateRevs(change.doc, 'remote')
-            } else {
-              await this.pouch.eraseDocument(change.doc)
-              if (change.doc.docType === metadata.FILE) {
-                this.events.emit('delete-file', change.doc)
-              }
-            }
-          }
-          break
-        case remoteErrors.MISSING_PARENT_CODE:
-          /* When we fail to apply a change because its parent does not exist on
-           * the Twake Workplace, it means we either:
-           * 1. have another change to apply that will create that parent
-           * 2. have not yet merged the remote change that removed that parent
-           * 3. have failed to sync the creation of the parent and will never
-           *    succeed because we abandoned in the past
-           * 4. have failed to merge its remote deletion and will never succeed
-           *    because we abandoned in the past
-           */
-          if (shouldAttemptRetry(change)) {
-            // Solve 1. & 2.
-            await this.blockSyncFor({ err, change })
-          } else {
-            log.error('Parent directory is missing on Twake Workplace', {
-              path,
-              err,
-              change
-            })
-            const parent = await this.pouch.bySyncedPath(dirname(path))
-            if (!parent) {
-              // Solve 3.
-              // This is a weird situation where we don't have a parent in
-              // PouchDB. This should never be the case though.
-              log.error(
-                'Parent directory could not be found either on Twake Workplace or PouchDB. Abandoning.',
-                { path, err, change, sentry: true }
-              )
-              await this.skipChange(change, err)
-            } else if (parent.remote) {
-              // We're in a fishy situation where we have a folder whose synced
-              // path is the parent path of our document but its remote path is
-              // not and the synchronization did not change this.
-              // The database is corrupted and should be cleaned up.
-              log.error('Parent directory is desynchronized. Abandoning.', {
-                path,
-                err,
-                change,
-                sentry: true
-              })
-              await this.skipChange(change, err)
-            } else {
-              // Solve 3. or 4.
-              await this.remote.addFolderAsync(parent)
-            }
-          }
-          break
-        default:
-          // Unknown error codes block sync indefinitely (rather than skipping
-          // after MAX_SYNC_RETRIES) to surface unexpected failures as alerts.
-          await this.blockSyncFor({ err, change })
-      }
+      await this.handleSyncError(err, change)
     } finally {
       release()
+    }
+  }
+
+  async handleSyncError(err /*: SyncError */, change /*: Change */) {
+    const {
+      sideName,
+      doc: { path }
+    } = err
+
+    if (
+      [
+        remoteErrors.INVALID_FOLDER_MOVE_CODE,
+        remoteErrors.MISSING_DOCUMENT_CODE,
+        remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE,
+        remoteErrors.UNKNOWN_REMOTE_ERROR_CODE
+      ].includes(err.code)
+    ) {
+      log.error(`Sync error: ${err.message}`, {
+        err,
+        change,
+        path,
+        sentry: true
+      })
+    } else {
+      log.warn(`Sync error: ${err.message}`, { err, change, path })
+    }
+    switch (err.code) {
+      case remoteErrors.TWAKE_NOT_FOUND_CODE:
+        this.fatal(err)
+        break
+      case syncErrors.EXCLUDED_DIR_CODE:
+      case syncErrors.INCOMPATIBLE_DOC_CODE:
+      case syncErrors.MISSING_PERMISSIONS_CODE:
+      case syncErrors.NO_DISK_SPACE_CODE:
+      case remoteErrors.FILE_TOO_LARGE_CODE:
+      case remoteErrors.INVALID_FOLDER_MOVE_CODE:
+      case remoteErrors.INVALID_NAME_CODE:
+      case remoteErrors.NEEDS_REMOTE_MERGE_CODE:
+      case remoteErrors.NO_COZY_SPACE_CODE:
+      case remoteErrors.PATH_TOO_DEEP_CODE:
+      case remoteErrors.REMOTE_MAINTENANCE_ERROR_CODE:
+      case remoteErrors.UNKNOWN_INVALID_DATA_ERROR_CODE:
+      case remoteErrors.UNKNOWN_REMOTE_ERROR_CODE:
+      case remoteErrors.UNREACHABLE_COZY_CODE:
+      case remoteErrors.USER_ACTION_REQUIRED_CODE:
+        // We will keep retrying to apply the change until it's fixed or the
+        // user contacts our support.
+        // See `default` case for other blocking errors for which we'll stop
+        // retrying after 3 failed attempts.
+        await this.blockSyncFor({ err, change })
+        break
+      case remoteErrors.CONFLICTING_NAME_CODE:
+        if (
+          metadata.isFolder(change.doc) &&
+          change.operation.type === 'ADD'
+        ) {
+          await this.skipChange(change, err) // XXX: both directories will be merged in the next merge cycle?!
+        } else {
+          await syncErrors.createConflict({ err, change }, this)
+        }
+        break
+      case remoteErrors.INVALID_METADATA_CODE:
+        // Content has changed on disk the current change was merged. A new
+        // sync attempt will be triggered by the new content merge.
+        await this.skipChange(change, err)
+        break
+      case remoteErrors.DOCUMENT_IN_TRASH_CODE:
+        delete change.doc.moveFrom
+        delete change.doc.overwrite
+
+        // Go ahead and mark remote document as trashed
+        change.doc.remote = remoteDocument.trashedDoc(change.doc.remote)
+
+        await this.updateRevs(change.doc, sideName)
+        break
+      case remoteErrors.MISSING_DOCUMENT_CODE:
+        if (shouldAttemptRetry(change)) {
+          await this.blockSyncFor({ err, change })
+        } else {
+          if (isMarkedForDeletion(change.doc)) {
+            await this.skipChange(change, err)
+          } else if (sideName === 'remote') {
+            // FIXME: what about folder content?
+            delete change.doc.moveFrom
+            delete change.doc.overwrite
+            delete change.doc.remote
+
+            await this.doAdd(this.remote, change.doc)
+            await this.updateRevs(change.doc, 'remote')
+          } else {
+            await this.pouch.eraseDocument(change.doc)
+            if (change.doc.docType === metadata.FILE) {
+              this.events.emit('delete-file', change.doc)
+            }
+          }
+        }
+        break
+      case remoteErrors.MISSING_PARENT_CODE:
+        /* When we fail to apply a change because its parent does not exist on
+         * the Twake Workplace, it means we either:
+         * 1. have another change to apply that will create that parent
+         * 2. have not yet merged the remote change that removed that parent
+         * 3. have failed to sync the creation of the parent and will never
+         *    succeed because we abandoned in the past
+         * 4. have failed to merge its remote deletion and will never succeed
+         *    because we abandoned in the past
+         */
+        if (shouldAttemptRetry(change)) {
+          // Solve 1. & 2.
+          await this.blockSyncFor({ err, change })
+        } else {
+          log.error('Parent directory is missing on Twake Workplace', {
+            path,
+            err,
+            change
+          })
+          const parent = await this.pouch.bySyncedPath(dirname(path))
+          if (!parent) {
+            // Solve 3.
+            // This is a weird situation where we don't have a parent in
+            // PouchDB. This should never be the case though.
+            log.error(
+              'Parent directory could not be found either on Twake Workplace or PouchDB. Abandoning.',
+              { path, err, change, sentry: true }
+            )
+            await this.skipChange(change, err)
+          } else if (parent.remote) {
+            // We're in a fishy situation where we have a folder whose synced
+            // path is the parent path of our document but its remote path is
+            // not and the synchronization did not change this.
+            // The database is corrupted and should be cleaned up.
+            log.error('Parent directory is desynchronized. Abandoning.', {
+              path,
+              err,
+              change,
+              sentry: true
+            })
+            await this.skipChange(change, err)
+          } else {
+            // Solve 3. or 4.
+            await this.remote.addFolderAsync(parent)
+          }
+        }
+        break
+      default:
+        // Unknown error codes block sync indefinitely (rather than skipping
+        // after MAX_SYNC_RETRIES) to surface unexpected failures as alerts.
+        await this.blockSyncFor({ err, change })
     }
   }
 

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -1110,13 +1110,11 @@ class Sync {
     }
   }
 
-  async blockSyncFor(
+  async registerBlockingCause(
     cause
     /*: {| err: RemoteError |} | {| err: SyncError, change: Change |} */
   ) {
-    log.info('blocking sync for error', cause)
-
-    this.lifecycle.block()
+    log.info('registering blocking cause for error', cause)
 
     const err = cause.err
     const change = cause.change ? cause.change : undefined
@@ -1126,16 +1124,6 @@ class Sync {
       code: err.code
     })
     this._blockedCauses.set(key, cause)
-
-    // Set the auto-retry interval.
-    // Note: each call clears + resets retryInterval, so when multiple changes
-    // block successively, the last retryDelay wins and earlier timers are
-    // lost. This is accepted given the current boolean lifecycle.
-    clearInterval(this.retryInterval)
-    this.retryInterval = setInterval(
-      () => this._onUserActionCommand({ cmd: 'retry' }),
-      syncErrors.retryDelay(err)
-    )
 
     // In case the error comes from the RemoteWatcher and not a change
     // application, we stop the watcher to avoid more errors.
@@ -1182,6 +1170,31 @@ class Sync {
         // Hide the error from the user as we should be able to solve it
       }
     }
+  }
+
+  async scheduleRetry(
+    causes
+    /*: Array<{| err: RemoteError |} | {| err: SyncError, change: Change |}> */
+  ) {
+    this.lifecycle.block()
+
+    // Set the auto-retry interval.
+    // Note: each call clears + resets retryInterval, so when multiple changes
+    // block successively, the last retryDelay wins and earlier timers are
+    // lost. This is accepted given the current boolean lifecycle.
+    clearInterval(this.retryInterval)
+    this.retryInterval = setInterval(
+      () => this._onUserActionCommand({ cmd: 'retry' }),
+      syncErrors.minRetryDelay(causes)
+    )
+  }
+
+  async blockSyncFor(
+    cause
+    /*: {| err: RemoteError |} | {| err: SyncError, change: Change |} */
+  ) {
+    await this.registerBlockingCause(cause)
+    await this.scheduleRetry([cause])
   }
 
   _blockedCauseKey({ docId, code } /*: { docId: ?string, code: string } */) {

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -484,7 +484,6 @@ class Sync {
 
     const release = await this.pouch.lock(this)
 
-    let change /*: Change */ = {}
     try {
       const seq = await this.pouch.getLocalSeq()
       const changes = await this.getNextChanges(seq)
@@ -493,9 +492,10 @@ class Sync {
         return
       }
 
-      this.currentChangesToApply = new DependencyGraph(changes, {
+      const graph = new DependencyGraph(changes, {
         compare: compareChanges
-      }).toArray()
+      })
+      this.currentChangesToApply = graph.toArray()
 
       // If a change is dependent on another change that was merged later (and
       // thus has a greater sequence number), we reschedule the dependent one
@@ -518,31 +518,71 @@ class Sync {
         await rescheduleChanges(changesToReschedule, this)
       }
 
-      // We can now apply all changes that were not rescheduled
-      for (const changeToApply of this.currentChangesToApply) {
-        // We need to set the value of `change` so it can be reused in the
-        // `catch` block.
-        change = changeToApply
+      // We can now apply all changes that were not rescheduled.
+      //
+      // Each change is applied independently: a blocking error on one change
+      // doesn't stop the whole batch. Independent changes after a failure are
+      // still applied; only the dependants of the failed change are skipped
+      // for this cycle (tracked via `blockedIds`).
+      //
+      // `localSeq` is frozen as soon as a failure happens so the failed change
+      // re-enters the feed on the next cycle. Independent changes already
+      // applied before the failure have advanced `localSeq` past their own
+      // seq; those after the failure are applied but do not advance `localSeq`
+      // (they'll be re-fetched as no-ops next cycle).
+      const blockedIds = new Set()
 
+      for (const change of this.currentChangesToApply) {
         if (wasSkipped(change)) {
-          await this.pouch.setLocalSeq(change.seq)
-        } else {
-          await this.apply(change)
+          if (blockedIds.size === 0) {
+            await this.pouch.setLocalSeq(change.seq)
+          }
+          this.resolveBlockingCause(change.id)
+          continue
         }
 
-        this.resolveBlockingCause(change.id)
+        if (graph.directPrerequisites(change).some(d => blockedIds.has(d.id))) {
+          blockedIds.add(change.id)
+          continue
+        }
+
+        try {
+          await this.apply(change)
+          if (blockedIds.size === 0) {
+            await this.pouch.setLocalSeq(change.seq)
+          }
+          this.resolveBlockingCause(change.id)
+        } catch (err) {
+          if (this.lifecycle.willStop()) return
+          if (!(err instanceof syncErrors.SyncError)) throw err
+
+          const result = await this.handleSyncError(err, change)
+          if (result === 'fatal') return
+          if (result === 'blocked') blockedIds.add(change.id)
+          if (
+            (result === 'skipped' || result === 'recovered') &&
+            blockedIds.size === 0
+          ) {
+            await this.pouch.setLocalSeq(change.seq)
+          }
+        }
+      }
+
+      if (this._blockedCauses.size > 0) {
+        await this.scheduleRetry(Array.from(this._blockedCauses.values()))
       }
     } catch (err) {
       if (this.lifecycle.willStop()) return
-      if (!(err instanceof syncErrors.SyncError)) throw err
-
-      await this.handleSyncError(err, change)
+      throw err
     } finally {
       release()
     }
   }
 
-  async handleSyncError(err /*: SyncError */, change /*: Change */) {
+  async handleSyncError(
+    err /*: SyncError */,
+    change /*: Change */
+  ) /*: Promise<'blocked' | 'skipped' | 'recovered' | 'fatal'> */ {
     const {
       sideName,
       doc: { path }
@@ -568,7 +608,7 @@ class Sync {
     switch (err.code) {
       case remoteErrors.TWAKE_NOT_FOUND_CODE:
         this.fatal(err)
-        break
+        return 'fatal'
       case syncErrors.EXCLUDED_DIR_CODE:
       case syncErrors.INCOMPATIBLE_DOC_CODE:
       case syncErrors.MISSING_PERMISSIONS_CODE:
@@ -588,23 +628,21 @@ class Sync {
         // user contacts our support.
         // See `default` case for other blocking errors for which we'll stop
         // retrying after 3 failed attempts.
-        await this.blockSyncFor({ err, change })
-        break
+        await this.registerBlockingCause({ err, change })
+        return 'blocked'
       case remoteErrors.CONFLICTING_NAME_CODE:
-        if (
-          metadata.isFolder(change.doc) &&
-          change.operation.type === 'ADD'
-        ) {
+        if (metadata.isFolder(change.doc) && change.operation.type === 'ADD') {
           await this.skipChange(change, err) // XXX: both directories will be merged in the next merge cycle?!
+          return 'skipped'
         } else {
           await syncErrors.createConflict({ err, change }, this)
+          return 'recovered'
         }
-        break
       case remoteErrors.INVALID_METADATA_CODE:
         // Content has changed on disk the current change was merged. A new
         // sync attempt will be triggered by the new content merge.
         await this.skipChange(change, err)
-        break
+        return 'skipped'
       case remoteErrors.DOCUMENT_IN_TRASH_CODE:
         delete change.doc.moveFrom
         delete change.doc.overwrite
@@ -613,13 +651,15 @@ class Sync {
         change.doc.remote = remoteDocument.trashedDoc(change.doc.remote)
 
         await this.updateRevs(change.doc, sideName)
-        break
+        return 'recovered'
       case remoteErrors.MISSING_DOCUMENT_CODE:
         if (shouldAttemptRetry(change)) {
-          await this.blockSyncFor({ err, change })
+          await this.registerBlockingCause({ err, change })
+          return 'blocked'
         } else {
           if (isMarkedForDeletion(change.doc)) {
             await this.skipChange(change, err)
+            return 'skipped'
           } else if (sideName === 'remote') {
             // FIXME: what about folder content?
             delete change.doc.moveFrom
@@ -628,14 +668,15 @@ class Sync {
 
             await this.doAdd(this.remote, change.doc)
             await this.updateRevs(change.doc, 'remote')
+            return 'recovered'
           } else {
             await this.pouch.eraseDocument(change.doc)
             if (change.doc.docType === metadata.FILE) {
               this.events.emit('delete-file', change.doc)
             }
+            return 'recovered'
           }
         }
-        break
       case remoteErrors.MISSING_PARENT_CODE:
         /* When we fail to apply a change because its parent does not exist on
          * the Twake Workplace, it means we either:
@@ -648,7 +689,8 @@ class Sync {
          */
         if (shouldAttemptRetry(change)) {
           // Solve 1. & 2.
-          await this.blockSyncFor({ err, change })
+          await this.registerBlockingCause({ err, change })
+          return 'blocked'
         } else {
           log.error('Parent directory is missing on Twake Workplace', {
             path,
@@ -665,6 +707,7 @@ class Sync {
               { path, err, change, sentry: true }
             )
             await this.skipChange(change, err)
+            return 'skipped'
           } else if (parent.remote) {
             // We're in a fishy situation where we have a folder whose synced
             // path is the parent path of our document but its remote path is
@@ -677,16 +720,18 @@ class Sync {
               sentry: true
             })
             await this.skipChange(change, err)
+            return 'skipped'
           } else {
             // Solve 3. or 4.
             await this.remote.addFolderAsync(parent)
+            return 'recovered'
           }
         }
-        break
       default:
         // Unknown error codes block sync indefinitely (rather than skipping
         // after MAX_SYNC_RETRIES) to surface unexpected failures as alerts.
-        await this.blockSyncFor({ err, change })
+        await this.registerBlockingCause({ err, change })
+        return 'blocked'
     }
   }
 
@@ -876,14 +921,14 @@ class Sync {
       const side = this.selectSide(change)
 
       if (metadata.shouldIgnore(doc, this.ignore)) {
-        return this.pouch.setLocalSeq(seq)
+        return
       }
 
       log.info(`Applying change ${seq}...`, { path, seq, doc })
 
       if (!side) {
         log.info('up to date', { path })
-        return this.pouch.setLocalSeq(seq)
+        return
       }
 
       if (!metadata.wasSynced(doc) && isMarkedForDeletion(doc)) {
@@ -891,7 +936,7 @@ class Sync {
         if (doc.docType === metadata.FILE) {
           this.events.emit('delete-file', doc)
         }
-        return this.pouch.setLocalSeq(seq)
+        return
       }
 
       stopMeasure = measureTime('Sync#applyChange:' + side.name)
@@ -904,7 +949,6 @@ class Sync {
 
       this.events.emit('sync-current', change.seq)
 
-      await this.pouch.setLocalSeq(seq)
       log.trace(`Applied change on ${side.name} side`, { path, seq })
 
       // Clean up documents so that we don't mistakenly take action based on

--- a/test/integration/differential_sync.js
+++ b/test/integration/differential_sync.js
@@ -150,23 +150,24 @@ describe('Differential synchronization', () => {
 
     context('and the user chooses to create a conflict', () => {
       beforeEach(function() {
-        const originalBlockSyncFor = helpers._sync.blockSyncFor
-        sinon.stub(helpers._sync, 'blockSyncFor')
+        const originalScheduleRetry = helpers._sync.scheduleRetry
+        sinon.stub(helpers._sync, 'scheduleRetry')
 
-        // Stub Sync.blockSyncFor to execute the create-conflict user action
+        // Stub Sync.scheduleRetry to execute the create-conflict user action
         // command and run the local watcher to pick up the new local changes
         // (i.e. the conflict creation).
-        helpers._sync.blockSyncFor.onFirstCall().callsFake(async cause => {
-          await originalBlockSyncFor(cause)
+        helpers._sync.scheduleRetry.onFirstCall().callsFake(async causes => {
+          await originalScheduleRetry(causes)
+          const cause = causes[0]
           helpers._sync._onUserActionCommand({
             cmd: 'create-conflict',
             alert: makeAlert(cause.err, cause.change.seq, cause.change.side)
           })
         })
-        helpers._sync.blockSyncFor.callThrough()
+        helpers._sync.scheduleRetry.callThrough()
       })
       afterEach(async function() {
-        helpers._sync.blockSyncFor.restore()
+        helpers._sync.scheduleRetry.restore()
         await helpers.local.side.stop()
       })
 
@@ -208,14 +209,15 @@ describe('Differential synchronization', () => {
 
     context('and the user chooses to merge both folders', () => {
       beforeEach(function() {
-        const originalBlockSyncFor = helpers._sync.blockSyncFor
-        sinon.stub(helpers._sync, 'blockSyncFor')
+        const originalScheduleRetry = helpers._sync.scheduleRetry
+        sinon.stub(helpers._sync, 'scheduleRetry')
 
-        // Stub Sync.blockSyncFor to execute the create-conflict user action
+        // Stub Sync.scheduleRetry to execute the create-conflict user action
         // command and run the local watcher to pick up the new local changes
         // (i.e. the conflict creation).
-        helpers._sync.blockSyncFor.onFirstCall().callsFake(async cause => {
-          await originalBlockSyncFor(cause)
+        helpers._sync.scheduleRetry.onFirstCall().callsFake(async causes => {
+          await originalScheduleRetry(causes)
+          const cause = causes[0]
           helpers._sync._onUserActionCommand({
             cmd: 'link-directories',
             alert: makeAlert(cause.err, cause.change.seq, cause.change.side)
@@ -225,10 +227,10 @@ describe('Differential synchronization', () => {
           await Promise.delay(100)
           helpers.remote.pullChanges()
         })
-        helpers._sync.blockSyncFor.callThrough()
+        helpers._sync.scheduleRetry.callThrough()
       })
       afterEach(function() {
-        helpers._sync.blockSyncFor.restore()
+        helpers._sync.scheduleRetry.restore()
       })
 
       it('does not rename the local folder and re-includes the remote one', async function() {

--- a/test/integration/multiple_sync_problems.js
+++ b/test/integration/multiple_sync_problems.js
@@ -116,8 +116,8 @@ describe('Multiple sync problems', () => {
       await helpers.local.syncDir.outputFile('blocked-file', 'modified')
       await helpers.local.scan()
 
-      // Spy on blockSyncFor to verify it was called
-      sinon.spy(helpers._sync, 'blockSyncFor')
+      // Spy on registerBlockingCause to verify it was called
+      sinon.spy(helpers._sync, 'registerBlockingCause')
 
       // Stub the remote API with EACCES so wrapError produces
       // MISSING_PERMISSIONS_CODE → no retry exhaustion, user-alert emitted
@@ -126,8 +126,8 @@ describe('Multiple sync problems', () => {
       permError.code = 'EACCES'
       sinon.stub(helpers.remote.side, 'overwriteFileAsync').rejects(permError)
 
-      // When blockSyncFor emits user-alert, the lifecycle is blocked and a
-      // retry interval has been set. Restore overwriteFileAsync so the
+      // When registerBlockingCause emits user-alert, the lifecycle is blocked
+      // and a retry interval has been set. Restore overwriteFileAsync so the
       // upcoming auto-retry succeeds.
       helpers.events.once('user-alert', () => {
         helpers.remote.side.overwriteFileAsync.restore()
@@ -135,8 +135,51 @@ describe('Multiple sync problems', () => {
 
       await helpers.syncAll()
 
-      should(helpers._sync.blockSyncFor.called).be.true()
-      helpers._sync.blockSyncFor.restore()
+      should(helpers._sync.registerBlockingCause).have.been.called()
+      helpers._sync.registerBlockingCause.restore()
+    })
+  })
+
+  describe('multiple blocking errors in the same batch', () => {
+    it('shows all blocking errors and applies independent changes', async function() {
+      await helpers.local.syncDir.outputFile('blocker-1', 'content 1')
+      await helpers.local.syncDir.outputFile('independent', 'content ind')
+      await helpers.local.syncDir.outputFile('blocker-2', 'content 2')
+      await helpers.local.scan()
+
+      const alertPaths = []
+      helpers.events.on('user-alert', err => {
+        if (err.doc) alertPaths.push(err.doc.path)
+      })
+
+      const originalAddFile = helpers.remote.side.addFileAsync
+      sinon.stub(helpers.remote.side, 'addFileAsync')
+      helpers.remote.side.addFileAsync.callsFake(async (doc, ...args) => {
+        if (
+          doc.path &&
+          (doc.path.includes('blocker-1') || doc.path.includes('blocker-2'))
+        ) {
+          throw new syncErrors.SyncError({
+            code: syncErrors.MISSING_PERMISSIONS_CODE,
+            sideName: 'local',
+            err: new Error('Permission denied'),
+            doc
+          })
+        }
+        return originalAddFile(doc, ...args)
+      })
+
+      await helpers.sync()
+
+      // The independent file was applied despite both blockers failing.
+      should(await helpers.remote.side.exists('/independent')).be.true()
+
+      // Both blockers were registered as blocking causes with alerts.
+      should(helpers._sync._blockedCauses.size).equal(2)
+      should(alertPaths).containEql('blocker-1')
+      should(alertPaths).containEql('blocker-2')
+
+      helpers.remote.side.addFileAsync.restore()
     })
   })
 

--- a/test/unit/sync/dependency_graph.js
+++ b/test/unit/sync/dependency_graph.js
@@ -189,4 +189,68 @@ describe('DependencyGraph', () => {
       ])
     })
   })
+
+  describe('directPrerequisites', () => {
+    it('returns the direct prerequisite changes of a change', () => {
+      const changes = {
+        a: { doc: { path: 'a' } },
+        b: { doc: { path: 'b' } },
+        c: { doc: { path: 'c' } },
+        d: { doc: { path: 'd' } }
+      }
+      const dependencies = {
+        a: ['b', 'c'],
+        b: ['d'],
+        c: [],
+        d: ['c']
+      }
+      const compare = dependencyBasedCompare(dependencies)
+      const graph = new DependencyGraph(
+        [changes.a, changes.b, changes.c, changes.d],
+        { compare }
+      )
+
+      const prereqs = graph.directPrerequisites(changes.a)
+      should(prereqs.map(c => c.doc.path).sort()).deepEqual(['b', 'c'])
+    })
+
+    it('returns an empty array for a change without prerequisites', () => {
+      const changes = {
+        a: { doc: { path: 'a' } },
+        b: { doc: { path: 'b' } }
+      }
+      const dependencies = { a: ['b'], b: [] }
+      const compare = dependencyBasedCompare(dependencies)
+      const graph = new DependencyGraph([changes.a, changes.b], { compare })
+
+      should(graph.directPrerequisites(changes.b)).deepEqual([])
+    })
+
+    it('returns changes and not internal nodes', () => {
+      const changes = {
+        a: { doc: { path: 'a' } },
+        b: { doc: { path: 'b' } }
+      }
+      const dependencies = { a: ['b'], b: [] }
+      const compare = dependencyBasedCompare(dependencies)
+      const graph = new DependencyGraph([changes.a, changes.b], { compare })
+
+      const prereqs = graph.directPrerequisites(changes.a)
+      should(prereqs).have.length(1)
+      should(prereqs[0]).equal(changes.b)
+    })
+
+    it('returns an empty array for an unknown change', () => {
+      const changes = {
+        a: { doc: { path: 'a' } }
+      }
+      const graph = new DependencyGraph([changes.a], {
+        compare: () => 0
+      })
+
+      should(graph.directPrerequisites({ doc: { path: 'unknown' } })).deepEqual(
+        []
+      )
+    })
+  })
 })

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -465,7 +465,7 @@ describe('Sync', function() {
         seq: 123,
         operation: { type: 'EDIT', side: 'remote' }
       }
-      await this.sync.apply(change)
+      await should(this.sync.apply(change)).be.fulfilled()
       should(await this.pouch.bySyncedPath(change.doc.path)).have.properties({
         path: initial.path,
         docType: 'file',
@@ -475,7 +475,6 @@ describe('Sync', function() {
           remote: 4
         }
       })
-      should(await this.pouch.getLocalSeq()).equal(123)
     })
 
     it('calls applyDoc for a modified folder', async function() {
@@ -497,7 +496,7 @@ describe('Sync', function() {
         seq: 124,
         operation: { type: 'EDIT', side: 'remote' }
       }
-      await this.sync.apply(change)
+      await should(this.sync.apply(change)).be.fulfilled()
       should(await this.pouch.bySyncedPath(change.doc.path)).have.properties({
         path: initial.path,
         docType: metadata.FOLDER,
@@ -507,7 +506,6 @@ describe('Sync', function() {
           remote: 4
         }
       })
-      should(await this.pouch.getLocalSeq()).equal(124)
     })
 
     it('calls addFileAsync for an added file', async function() {
@@ -582,9 +580,10 @@ describe('Sync', function() {
 
       describe('when apply throws a NEEDS_REMOTE_MERGE_CODE error', () => {
         beforeEach(function() {
-          sinon.stub(this.sync, 'blockSyncFor').callsFake(async () => {
+          sinon.stub(this.sync, 'scheduleRetry').callsFake(async () => {
             this.sync.lifecycle.transitionTo('done-stop')
           })
+          sinon.spy(this.sync, 'registerBlockingCause')
         })
         beforeEach('simulate error', async function() {
           this.sync.lifecycle.transitionTo('done-start')
@@ -605,7 +604,8 @@ describe('Sync', function() {
           this.sync.apply.restore()
         })
         afterEach(function() {
-          this.sync.blockSyncFor.restore()
+          this.sync.scheduleRetry.restore()
+          this.sync.registerBlockingCause.restore()
         })
 
         it('removes moveFrom and overwrite attributes', async function() {
@@ -613,11 +613,12 @@ describe('Sync', function() {
         })
 
         it('blocks the synchronization so we can retry applying the change', async function() {
-          should(this.sync.blockSyncFor).have.been.calledOnce()
-          should(this.sync.blockSyncFor).have.been.calledWithMatch({
+          should(this.sync.registerBlockingCause).have.been.calledOnce()
+          should(this.sync.registerBlockingCause).have.been.calledWithMatch({
             err: { code: remoteErrors.NEEDS_REMOTE_MERGE_CODE },
             change
           })
+          should(this.sync.scheduleRetry).have.been.calledOnce()
         })
       })
 

--- a/test/unit/sync/multiple_errors.js
+++ b/test/unit/sync/multiple_errors.js
@@ -260,6 +260,73 @@ describe('Multiple sync errors', function() {
     })
   })
 
+  describe('registerBlockingCause', () => {
+    beforeEach(function() {
+      sinon.spy(this.events, 'emit')
+    })
+    afterEach(function() {
+      this.events.emit.restore()
+    })
+
+    it('registers cause and emits alert without blocking lifecycle', async function() {
+      const doc = await builders
+        .metafile()
+        .path('register')
+        .sides({ local: 1 })
+        .create()
+
+      const err = blockingSyncError(doc)
+      const change = {
+        changes: [{ rev: doc._rev }],
+        doc,
+        id: doc._id,
+        seq: 42,
+        operation: { type: 'ADD', side: 'remote' }
+      }
+
+      await this.sync.registerBlockingCause({ err, change })
+
+      should(this.sync._blockedCauses.size).equal(1)
+      should(this.sync._blockedCauses.has(doc._id)).be.true()
+      should(this.events.emit).have.been.calledWith('user-alert')
+      should(this.sync.lifecycle.blocked).be.false()
+      should(this.sync.retryInterval).be.null()
+    })
+  })
+
+  describe('scheduleRetry', () => {
+    let cause
+    beforeEach(async function() {
+      const doc = await builders
+        .metafile()
+        .path('schedule')
+        .sides({ local: 1 })
+        .create()
+
+      cause = {
+        err: blockingSyncError(doc),
+        change: {
+          changes: [{ rev: doc._rev }],
+          doc,
+          id: doc._id,
+          seq: 42,
+          operation: { type: 'ADD', side: 'remote' }
+        }
+      }
+      await this.sync.registerBlockingCause(cause)
+    })
+
+    it('blocks lifecycle and sets retry interval', async function() {
+      should(this.sync.lifecycle.blocked).be.false()
+      should(this.sync.retryInterval).be.null()
+
+      await this.sync.scheduleRetry([cause])
+
+      should(this.sync.lifecycle.blocked).be.true()
+      should(this.sync.retryInterval).not.be.null()
+    })
+  })
+
   describe('blocked cause key', () => {
     it('overwrites existing blocked cause for same doc with latest seq', async function() {
       const doc = await builders

--- a/test/unit/sync/multiple_errors.js
+++ b/test/unit/sync/multiple_errors.js
@@ -84,47 +84,254 @@ describe('Multiple sync errors', function() {
   })
 
   describe('syncBatch error propagation', () => {
-    it('stops applying changes when a blocking error is thrown', async function() {
-      await builders
+    it('collects multiple blocking errors and applies independent changes', async function() {
+      // A (indep, succeed) → B (indep, blocking) → C (depends on B, pending)
+      // → D (indep, blocking)
+      const docA = await builders
         .metafile()
         .path('a')
         .sides({ local: 1 })
         .create()
-      await builders
+      const docB = await builders
         .metafile()
         .path('b')
         .sides({ local: 1 })
         .create()
+      // C depends on B via parent/child path on the same side.
+      const docC = await builders
+        .metafile()
+        .path('b/c')
+        .sides({ local: 1 })
+        .create()
+      const docD = await builders
+        .metafile()
+        .path('d')
+        .sides({ local: 1 })
+        .create()
+
+      const changeA = {
+        changes: [{ rev: docA._rev }],
+        doc: docA,
+        id: docA._id,
+        seq: 10,
+        operation: { type: 'ADD', side: 'local' }
+      }
+      const changeB = {
+        changes: [{ rev: docB._rev }],
+        doc: docB,
+        id: docB._id,
+        seq: 11,
+        operation: { type: 'ADD', side: 'local' }
+      }
+      const changeC = {
+        changes: [{ rev: docC._rev }],
+        doc: docC,
+        id: docC._id,
+        seq: 12,
+        operation: { type: 'ADD', side: 'local' }
+      }
+      const changeD = {
+        changes: [{ rev: docD._rev }],
+        doc: docD,
+        id: docD._id,
+        seq: 13,
+        operation: { type: 'ADD', side: 'local' }
+      }
+
+      sinon
+        .stub(this.sync, 'getNextChanges')
+        .onFirstCall()
+        .resolves([changeA, changeB, changeC, changeD])
+        .onSecondCall()
+        .resolves([])
 
       const applyStub = sinon.stub(this.sync, 'apply')
       applyStub.callsFake(async change => {
-        if (change.doc.path === 'a') {
-          await this.pouch.setLocalSeq(change.seq)
-        } else if (change.doc.path === 'b') {
-          throw blockingSyncError(change.doc)
-        } else {
-          throw new Error(`Unexpected apply call for ${change.doc.path}`)
-        }
+        if (change.id === docA._id) return
+        if (change.id === docB._id) throw blockingSyncError(change.doc)
+        if (change.id === docD._id) throw blockingSyncError(change.doc)
+        throw new Error(`Unexpected apply call for ${change.id}`)
       })
 
-      // Let blockSyncFor run its full logic but stop lifecycle to avoid hang
-      const originalBlockSyncFor = this.sync.blockSyncFor
-      sinon.stub(this.sync, 'blockSyncFor').callsFake(async cause => {
-        await originalBlockSyncFor(cause)
-        this.sync.lifecycle.transitionTo('done-stop')
-      })
+      // Stub scheduleRetry to avoid hanging on the retry interval.
+      sinon.stub(this.sync, 'scheduleRetry').resolves()
+      const emitSpy = sinon.spy(this.events, 'emit')
 
       await this.sync.syncBatch()
 
-      should(applyStub).have.been.calledTwice()
-      should(applyStub.args[0][0].doc.path).equal('a')
-      should(applyStub.args[1][0].doc.path).equal('b')
+      // A, B and D were attempted (C was skipped as a dependant of B).
+      should(applyStub).have.been.calledThrice()
+      const appliedIds = applyStub.args.map(args => args[0].id)
+      should(appliedIds).containEql(docA._id)
+      should(appliedIds).containEql(docB._id)
+      should(appliedIds).containEql(docD._id)
+      should(appliedIds).not.containEql(docC._id)
 
-      const aSeq = applyStub.args[0][0].seq
-      should(await this.pouch.getLocalSeq()).equal(aSeq)
+      // Two blocking causes were registered (B and D), both with alerts.
+      should(this.sync._blockedCauses.size).equal(2)
+      const alertCalls = emitSpy.args.filter(args => args[0] === 'user-alert')
+      should(alertCalls).have.length(2)
 
+      // localSeq frozen at A's seq (last success before first failure).
+      should(await this.pouch.getLocalSeq()).equal(changeA.seq)
+
+      // scheduleRetry was called once at the end with the accumulated causes.
+      should(this.sync.scheduleRetry).have.been.calledOnce()
+      const causes = this.sync.scheduleRetry.args[0][0]
+      should(causes).have.length(2)
+
+      this.sync.getNextChanges.restore()
+      this.sync.apply.restore()
+      this.sync.scheduleRetry.restore()
+      emitSpy.restore()
+    })
+
+    it('applies independent changes after a blocking error without waiting for retry', async function() {
+      const docB = await builders
+        .metafile()
+        .path('blocker')
+        .sides({ local: 1 })
+        .create()
+      const docD = await builders
+        .metafile()
+        .path('independent')
+        .sides({ local: 1 })
+        .create()
+
+      const changeB = {
+        changes: [{ rev: docB._rev }],
+        doc: docB,
+        id: docB._id,
+        seq: 20,
+        operation: { type: 'ADD', side: 'local' }
+      }
+      const changeD = {
+        changes: [{ rev: docD._rev }],
+        doc: docD,
+        id: docD._id,
+        seq: 21,
+        operation: { type: 'ADD', side: 'local' }
+      }
+
+      sinon
+        .stub(this.sync, 'getNextChanges')
+        .onFirstCall()
+        .resolves([changeB, changeD])
+        .onSecondCall()
+        .resolves([])
+
+      let dApplied = false
+      const applyStub = sinon.stub(this.sync, 'apply')
+      applyStub.callsFake(async change => {
+        if (change.id === docB._id) throw blockingSyncError(change.doc)
+        if (change.id === docD._id) {
+          dApplied = true
+          return
+        }
+        throw new Error(`Unexpected apply call for ${change.id}`)
+      })
+
+      sinon.stub(this.sync, 'scheduleRetry').resolves()
+
+      await this.sync.syncBatch()
+
+      // D was applied even though B blocked — independent changes are not
+      // delayed by the retry timer of the failed change.
+      should(dApplied).be.true()
+
+      this.sync.getNextChanges.restore()
+      this.sync.apply.restore()
+      this.sync.scheduleRetry.restore()
+    })
+
+    it('freezes localSeq at last success before first failure (crash recovery)', async function() {
+      const docA = await builders
+        .metafile()
+        .path('recover-a')
+        .sides({ local: 1 })
+        .create()
+      const docB = await builders
+        .metafile()
+        .path('recover-b')
+        .sides({ local: 1 })
+        .create()
+      const docD = await builders
+        .metafile()
+        .path('recover-d')
+        .sides({ local: 1 })
+        .create()
+
+      const changeA = {
+        changes: [{ rev: docA._rev }],
+        doc: docA,
+        id: docA._id,
+        seq: 30,
+        operation: { type: 'ADD', side: 'local' }
+      }
+      const changeB = {
+        changes: [{ rev: docB._rev }],
+        doc: docB,
+        id: docB._id,
+        seq: 31,
+        operation: { type: 'ADD', side: 'local' }
+      }
+      const changeD = {
+        changes: [{ rev: docD._rev }],
+        doc: docD,
+        id: docD._id,
+        seq: 32,
+        operation: { type: 'ADD', side: 'local' }
+      }
+
+      sinon
+        .stub(this.sync, 'getNextChanges')
+        .onFirstCall()
+        .resolves([changeA, changeB, changeD])
+        .onSecondCall()
+        .resolves([])
+
+      const applyStub = sinon.stub(this.sync, 'apply')
+      applyStub.callsFake(async change => {
+        if (change.id === docA._id) return
+        if (change.id === docB._id) throw blockingSyncError(change.doc)
+        if (change.id === docD._id) return
+        throw new Error(`Unexpected apply call for ${change.id}`)
+      })
+
+      sinon.stub(this.sync, 'scheduleRetry').resolves()
+
+      await this.sync.syncBatch()
+
+      // localSeq frozen at A (last success before first failure B).
+      should(await this.pouch.getLocalSeq()).equal(changeA.seq)
+
+      // Simulate a restart: a new syncBatch from the frozen localSeq.
+      // A and D are already up-to-date (no-op), B is re-attempted.
       applyStub.restore()
-      this.sync.blockSyncFor.restore()
+      const applyStub2 = sinon.stub(this.sync, 'apply')
+      applyStub2.callsFake(async change => {
+        if (change.id === docA._id) return
+        if (change.id === docB._id) throw blockingSyncError(change.doc)
+        if (change.id === docD._id) return
+        throw new Error(`Unexpected apply call for ${change.id}`)
+      })
+
+      this.sync.getNextChanges.restore()
+      sinon
+        .stub(this.sync, 'getNextChanges')
+        .onFirstCall()
+        .resolves([changeA, changeB, changeD])
+        .onSecondCall()
+        .resolves([])
+
+      await this.sync.syncBatch()
+
+      // localSeq still frozen at A: B failed again, A/D were no-ops.
+      should(await this.pouch.getLocalSeq()).equal(changeA.seq)
+
+      this.sync.getNextChanges.restore()
+      this.sync.apply.restore()
+      this.sync.scheduleRetry.restore()
     })
   })
 


### PR DESCRIPTION
  `syncBatch` stopped at the first `apply` throw: the outer `catch`
  handled a single `SyncError` and every later change in the batch
  waited for the failed change's retry delay. The GUI can display N
  alerts but only ever received one.

  The loop now catches per-`apply`. Each failed change is registered
  via `registerBlockingCause` (accumulating causes and alerts);
  independent changes after the failure are still applied. Dependents
  of a failed change are skipped for this cycle via `blockedIds`, a
  local `Set` cross-referenced with `DependencyGraph.directPrerequisites`.
  `localSeq` is frozen as soon as `blockedIds` is non-empty so the
  failed change re-enters the feed on the next cycle; already-applied
  independents come back as no-ops. A single `scheduleRetry` at the
  end of the batch starts one global retry timer with
  `minRetryDelay(causes)`.

  `handleSyncError` returns a `'blocked' | 'skipped' | 'recovered' |
  'fatal'` tag and no longer touches `localSeq` — the loop owns it.
  `apply` returns `Promise<void>` and no longer calls
  `setLocalSeq` for the same reason.

  Fixes #2439 and #2441 

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
