### PR TITLE
fix: Chain moveFrom through incompatible moves

### DIFF
--- a/core/move.js
+++ b/core/move.js
@@ -44,7 +44,22 @@ function move(
     }
   }
 
-  dst.moveFrom = src
+  // If the previous move was not applied locally (its `moveFrom` is only
+  // cleared on sync success), `src` still carries its own `moveFrom` pointing
+  // to the original source path. We chain through it so the destination
+  // records the actual local path to move from, not an intermediate path that
+  // was never materialized on the filesystem (e.g. a remote move batched with
+  // a later move of the same doc, or a move blocked by platform
+  // incompatibilities).
+  // We don't chain for child moves: their `moveFrom` is the original path
+  // before the parent move, which the parent's sync will relocate. Chaining
+  // would point at a path the parent move will have already moved away.
+  dst.moveFrom =
+    src.moveFrom &&
+    !src.moveFrom.childMove &&
+    !metadata.isAtLeastUpToDate('local', src)
+      ? src.moveFrom
+      : src
   // TODO: remove `_id` and `_rev` from the exception list above and stop
   // assigning them manually.
   dst._id = src._id

--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -1140,12 +1140,16 @@ class Sync {
     doc /*: SavedMetadata */,
     from /*: SavedMetadata */
   ) /*: Promise<void> */ {
-    const oldParentPath = dirname(from.path)
     const newParentPath = dirname(doc.path)
     const parent = await this.pouch.bySyncedPath(newParentPath)
-    if (parent && parent.moveFrom && parent.moveFrom.path === oldParentPath) {
-      // If the parent move was not successfully synchronized, prevent the child
-      // move synchronization by throwning a SyncError.
+    if (parent && parent.moveFrom) {
+      // The parent move was not successfully synchronized yet (its `moveFrom`
+      // is only cleared on sync success), so the child cannot be at its
+      // destination path on the filesystem. We block until the parent move is
+      // applied.
+      // We don't compare paths here: with moveFrom chaining, the parent's
+      // `moveFrom.path` can point to the original source rather than the
+      // intermediate path, so a path match would be unreliable.
       throw new syncErrors.UnsyncedParentMoveError(parent)
     }
 

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -415,10 +415,9 @@ describe('Platform incompatibilities', () => {
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
       name: 'd:ir'
     })
-    await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual(['dir/', 'dir/file'])
     should(await helpers.incompatibleTree()).deepEqual(['d:ir/', 'd:ir/file'])
-    shouldHaveBlockedFor(['d:ir', 'd:ir/file'])
+    shouldHaveBlockedFor(['d:ir'])
 
     helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
@@ -426,6 +425,34 @@ describe('Platform incompatibilities', () => {
     })
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).deepEqual(['dir/', 'dir/file'])
+    should(await helpers.incompatibleTree()).be.empty()
+    shouldNotHaveBlocked()
+  })
+
+  it('rename dir compatible -> incompatible -> new compatible name', async () => {
+    const { dirs } = await helpers.remote.createTree(['dir/', 'dir/file'])
+    await helpers.pullAndSyncAll()
+    should(await helpers.local.tree()).deepEqual(['dir/', 'dir/file'])
+    should(await helpers.incompatibleTree()).be.empty()
+
+    helpers._sync.scheduleRetry.resetHistory()
+    await helpers.remote.updateAttributesById(dirs['dir/']._id, {
+      name: 'd:ir'
+    })
+    // XXX: try to sync only once as the issue won't resolve itself and we'd
+    // loop indefinitely.
+    await helpers.remote.pullChanges()
+    await helpers.sync()
+    should(await helpers.local.tree()).deepEqual(['dir/', 'dir/file'])
+    should(await helpers.incompatibleTree()).deepEqual(['d:ir/', 'd:ir/file'])
+    shouldHaveBlockedFor(['d:ir', 'd:ir/file'])
+
+    helpers._sync.scheduleRetry.resetHistory()
+    await helpers.remote.updateAttributesById(dirs['dir/']._id, {
+      name: 'dir2'
+    })
+    await helpers.pullAndSyncAll()
+    should(await helpers.local.tree()).deepEqual(['dir2/', 'dir2/file'])
     should(await helpers.incompatibleTree()).be.empty()
     shouldNotHaveBlocked()
   })

--- a/test/integration/platform_incompatibilities.js
+++ b/test/integration/platform_incompatibilities.js
@@ -42,33 +42,43 @@ describe('Platform incompatibilities', () => {
     await helpers.local.setupTrash()
     await helpers.remote.ignorePreviousChanges()
 
-    sinon
-      .stub(helpers._sync, 'blockSyncFor')
-      .callsFake(async ({ change, err }) => {
-        helpers._sync.lifecycle.block()
-        await helpers._sync.skipChange(change, err)
-        helpers._sync.lifecycle.unblock()
-      })
+    sinon.stub(helpers._sync, 'scheduleRetry').callsFake(async causes => {
+      const { change, err } = causes[0]
+      await helpers._sync.skipChange(change, err)
+    })
   })
   afterEach(async function() {
     await helpers.stop()
   })
 
-  const shouldHaveBlockedFor = dpath =>
-    Array.isArray(dpath)
-      ? dpath.forEach(dpath =>
-          should(helpers._sync.blockSyncFor).have.been.calledWithMatch({
-            change: { doc: { path: path.normalize(dpath) } },
-            err: { code: INCOMPATIBLE_DOC_CODE }
-          })
-        )
-      : should(helpers._sync.blockSyncFor).have.been.calledWithMatch({
-          change: { doc: { path: path.normalize(dpath) } },
+  const shouldHaveBlockedFor = dpath => {
+    const paths = Array.isArray(dpath) ? dpath : [dpath]
+    for (const p of paths) {
+      const target = path.normalize(p)
+      const matcher = sinon.match.some(
+        sinon.match({
+          change: { doc: { path: target } },
           err: { code: INCOMPATIBLE_DOC_CODE }
         })
+      )
+      const stub = helpers._sync.scheduleRetry
+      should(stub.calledWithMatch(matcher)).be.true(
+        `scheduleRetry was not called with a cause for "${p}" ` +
+          `(expected change.doc.path=${target}, err.code=${INCOMPATIBLE_DOC_CODE}); ` +
+          `actual blocked paths: ${JSON.stringify(
+            stub
+              .getCalls()
+              .flatMap(c => c.args[0] || [])
+              .map(
+                c => (c && c.change && c.change.doc && c.change.doc.path) || '?'
+              )
+          )}`
+      )
+    }
+  }
 
   const shouldNotHaveBlocked = () =>
-    should(helpers._sync.blockSyncFor).not.have.been.called()
+    should(helpers._sync.scheduleRetry).not.have.been.called()
 
   it('add incompatible dir and file', async () => {
     await builders
@@ -128,7 +138,7 @@ describe('Platform incompatibilities', () => {
     await helpers.remote.createTree(['d:ir/', 'f:ile'])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesByPath('/d:ir', { name: 'di:r' })
     await helpers.remote.updateAttributesByPath('/f:ile', { name: 'fi:le' })
     await helpers.pullAndSyncAll()
@@ -142,7 +152,7 @@ describe('Platform incompatibilities', () => {
     const { dirs, files } = await helpers.remote.createTree(['d:ir/', 'f:ile'])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.trashById(dirs['d:ir/']._id)
     await helpers.remote.trashById(files['f:ile']._id)
     await helpers.pullAndSyncAll()
@@ -152,7 +162,7 @@ describe('Platform incompatibilities', () => {
     should(await helpers.incompatibleTree()).be.empty()
     shouldNotHaveBlocked()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.restoreById(dirs['d:ir/']._id)
     await helpers.remote.restoreById(files['f:ile']._id)
     await helpers.pullAndSyncAll()
@@ -166,7 +176,7 @@ describe('Platform incompatibilities', () => {
     const { dirs, files } = await helpers.remote.createTree(['d:ir/', 'f:ile'])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.trashById(dirs['d:ir/']._id)
     await helpers.remote.trashById(files['f:ile']._id)
     await helpers.remote.destroyById(dirs['d:ir/']._id)
@@ -177,7 +187,7 @@ describe('Platform incompatibilities', () => {
     should(await helpers.incompatibleTree()).be.empty()
     shouldNotHaveBlocked()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.createTree(['d:ir/', 'f:ile'])
     await helpers.pullAndSyncAll()
     should(await helpers.local.tree()).be.empty()
@@ -194,7 +204,7 @@ describe('Platform incompatibilities', () => {
     ])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(files['d:ir/sub:dir/f:ile']._id, {
       name: 'file'
     })
@@ -208,7 +218,7 @@ describe('Platform incompatibilities', () => {
     ])
     shouldHaveBlockedFor('d:ir/sub:dir/file')
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['d:ir/']._id, {
       name: 'dir'
     })
@@ -225,7 +235,7 @@ describe('Platform incompatibilities', () => {
       'dir/sub:dir/subsubdir'
     ])
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['d:ir/sub:dir/']._id, {
       name: 'subdir'
     })
@@ -248,7 +258,7 @@ describe('Platform incompatibilities', () => {
     ])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
       name: 'dir:'
     })
@@ -274,7 +284,7 @@ describe('Platform incompatibilities', () => {
     ])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
       name: 'dir:'
     })
@@ -292,7 +302,7 @@ describe('Platform incompatibilities', () => {
     const { files } = await helpers.remote.createTree(['dir/', 'dir/file'])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(files['dir/file']._id, {
       name: 'fi:le'
     })
@@ -310,7 +320,7 @@ describe('Platform incompatibilities', () => {
     ])
     await helpers.pullAndSyncAll()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
       name: 'dir2'
     })
@@ -332,7 +342,7 @@ describe('Platform incompatibilities', () => {
     await helpers.pullAndSyncAll()
 
     // Simulate local move
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     const dir = await helpers.pouch.byRemoteId(dirs['dir/']._id)
     const dir2 = metadata.buildDir('dir2', {
       atime: new Date(),
@@ -369,7 +379,7 @@ describe('Platform incompatibilities', () => {
     await helpers.pullAndSyncAll()
 
     // Simulate remote move
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     if (dirs['dir/'].type !== DIR_TYPE) {
       throw new Error('Unexpected remote file with dir/ path')
     }
@@ -401,7 +411,7 @@ describe('Platform incompatibilities', () => {
     should(await helpers.local.tree()).deepEqual(['dir/', 'dir/file'])
     should(await helpers.incompatibleTree()).be.empty()
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
       name: 'd:ir'
     })
@@ -410,7 +420,7 @@ describe('Platform incompatibilities', () => {
     should(await helpers.incompatibleTree()).deepEqual(['d:ir/', 'd:ir/file'])
     shouldHaveBlockedFor(['d:ir', 'd:ir/file'])
 
-    helpers._sync.blockSyncFor.resetHistory()
+    helpers._sync.scheduleRetry.resetHistory()
     await helpers.remote.updateAttributesById(dirs['dir/']._id, {
       name: 'dir'
     })

--- a/test/unit/move.js
+++ b/test/unit/move.js
@@ -74,6 +74,97 @@ describe('move', () => {
     })
   })
 
+  describe('chained moveFrom', () => {
+    it('chains through src.moveFrom when local side is not up-to-date', async () => {
+      // Simulates i -> i* (remote move, not synced locally) then i* -> z:
+      // src = i* (carries moveFrom = i, local side out-of-date), dst = z.
+      const originalSrc = await builders
+        .metadata()
+        .path('i')
+        .upToDate()
+        .create()
+      const src = await builders
+        .metadata()
+        .moveFrom(originalSrc)
+        .path('i*')
+        .changedSide('remote')
+        .create()
+      const dst = builders
+        .metadata()
+        .path('z')
+        .build()
+
+      move('remote', src, dst)
+
+      should(dst.moveFrom).eql(originalSrc)
+    })
+
+    it('uses src directly when local side is up-to-date', async () => {
+      // Local move already applied to filesystem: src.moveFrom exists but
+      // local side is up-to-date, so we must not chain through.
+      const originalSrc = await builders
+        .metadata()
+        .path('src')
+        .upToDate()
+        .create()
+      const src = await builders
+        .metadata()
+        .moveFrom(originalSrc)
+        .path('src2')
+        .changedSide('local')
+        .create()
+      const dst = builders
+        .metadata()
+        .path('dst')
+        .build()
+
+      move('local', src, dst)
+
+      should(dst.moveFrom).eql(src)
+    })
+
+    it('uses src directly when src has no moveFrom', async () => {
+      const src = await builders
+        .metadata()
+        .path('src')
+        .upToDate()
+        .create()
+      const dst = builders
+        .metadata()
+        .path('dst')
+        .build()
+
+      move('local', src, dst)
+
+      should(dst.moveFrom).eql(src)
+    })
+
+    it('uses src directly when src.moveFrom is a child move', async () => {
+      // A child move's `moveFrom` points at the path before the parent move.
+      // The parent's sync will relocate that path, so we must not chain
+      // through it — `src` is the actual local path to move from.
+      const originalSrc = await builders
+        .metadata()
+        .path('parent/src')
+        .upToDate()
+        .create()
+      const src = await builders
+        .metadata()
+        .moveFrom(originalSrc, { childMove: true })
+        .path('parent/dst/src')
+        .changedSide('remote')
+        .create()
+      const dst = builders
+        .metadata()
+        .path('parent/dst2/src')
+        .build()
+
+      move('remote', src, dst)
+
+      should(dst.moveFrom).eql(src)
+    })
+  })
+
   describe('convertToDestinationAddition', () => {
     const side = 'local'
     let src, dst

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -814,6 +814,72 @@ describe('Sync', function() {
     })
   })
 
+  describe('doChildMove', () => {
+    context('when parent move is not yet synchronized', () => {
+      it('throws UnsyncedParentMoveError for a simple parent move', async function() {
+        const parent = await builders
+          .metadir()
+          .path('parent/src')
+          .upToDate()
+          .create()
+        await builders
+          .metadir()
+          .moveFrom(parent)
+          .path('parent/dst')
+          .changedSide('remote')
+          .create()
+        const childWas = await builders
+          .metafile()
+          .path('parent/src/child')
+          .upToDate()
+          .create()
+        const child = await builders
+          .metafile()
+          .moveFrom(childWas, { childMove: true })
+          .path('parent/dst/child')
+          .changedSide('remote')
+          .create()
+
+        await should(
+          this.sync.applyDoc(child, this.local, 'local')
+        ).be.rejectedWith(syncErrors.UnsyncedParentMoveError)
+      })
+
+      it('throws UnsyncedParentMoveError when parent moveFrom is chained', async function() {
+        // Parent moved parent/src -> parent/dst -> parent/dst2 (batched).
+        // The parent at dst2 has a chained moveFrom pointing to parent/src,
+        // not the intermediate parent/dst. The child's `from.path` is
+        // parent/dst/child, so the old path-based guard would not match.
+        const originalParent = await builders
+          .metadir()
+          .path('parent/src')
+          .upToDate()
+          .create()
+        await builders
+          .metadir()
+          .moveFrom(originalParent)
+          .path('parent/dst2')
+          .changedSide('remote')
+          .create()
+        const childWas = await builders
+          .metafile()
+          .path('parent/dst/child')
+          .upToDate()
+          .create()
+        const child = await builders
+          .metafile()
+          .moveFrom(childWas, { childMove: true })
+          .path('parent/dst2/child')
+          .changedSide('remote')
+          .create()
+
+        await should(
+          this.sync.applyDoc(child, this.local, 'local')
+        ).be.rejectedWith(syncErrors.UnsyncedParentMoveError)
+      })
+    })
+  })
+
   describe('updateErrors', function() {
     it('retries on first local -> remote sync error', async function() {
       const doc = await builders


### PR DESCRIPTION
  When a remote move renamed `i` to an incompatible path `i*`, then
  again to a compatible path `z`, `move` set `dst.moveFrom = src` (`i*`),
  pointing at a path never materialized on the filesystem. The local
  watcher then tried to move a non-existent `i*` to `z` and failed.

  `move` now chains through `src.moveFrom` when the local side is not
  up-to-date, so `dst.moveFrom` records the actual local path to move
  from (the original `i`) instead of the intermediate incompatible
  path. When the local side is already up-to-date or `src` has no
  `moveFrom`, it uses `src` directly as before.

  The platform incompatibilities integration tests are adapted to the
  per-batch error collection (#2442): `blockSyncFor` is no longer the
  right stub since blocking causes now flow through `scheduleRetry`,
  called once per batch with the accumulated causes array. The new
  `shouldHaveBlockedFor` uses `sinon.match.some` to assert the array
  contains a matching cause, and reports actual blocked paths on
  failure. New integration cases cover the
  compatible → incompatible → compatible rename sequence.

  Fixes #2446 

Please make sure the following boxes are checked:

- [x] PR is not too big
- [x] it improves UX & DX in some way
- [x] it includes unit tests matching the implementation changes
- [x] it includes scenarios matching a new behaviour or has been manually tested
- [x] it includes relevant documentation
