### PR TITLE
fix: Show OAuth onboarding errors

### DIFF
--- a/gui/elm/Window/Onboarding.elm
+++ b/gui/elm/Window/Onboarding.elm
@@ -167,6 +167,13 @@ update msg model =
                     in
                     ( { model | context = context }, Cmd.map EmailMsg cmd )
 
+                OAuthPage ->
+                    let
+                        ( context, cmd ) =
+                            OAuth.update (OAuth.OAuthError error) model.context
+                    in
+                    ( { model | context = context }, Cmd.map OAuthMsg cmd )
+
                 _ ->
                     ( model, Cmd.none )
 

--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -325,6 +325,15 @@ module.exports = class OnboardingWM extends WindowManager {
     const code = deeplink.searchParams.get('code')
     const fqdn = deeplink.searchParams.get('fqdn')
 
+    if (!code || !fqdn) {
+      log.error('invalid OAuth callback', { url })
+      this.win.webContents.send(
+        'registration-error',
+        translate('OAuth Could not login')
+      )
+      return
+    }
+
     try {
       await this.desktop.registerWithDelegationCode(fqdn, code)
     } catch (err) {
@@ -333,6 +342,11 @@ module.exports = class OnboardingWM extends WindowManager {
         fqdn,
         code
       })
+      this.win.webContents.send(
+        'registration-error',
+        translate('OAuth Could not login')
+      )
+      return
     }
 
     await this.sendSyncConfig()

--- a/gui/locales/de.json
+++ b/gui/locales/de.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Warum sehe ich das?",
 
+  "OAuth Could not login": "Wir konnten die Anmeldung nicht abschließen. Bitte versuche es erneut oder prüfe, ob deinem Konto ein Twake Workplace zugeordnet ist.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -217,6 +217,7 @@
   "OAuth Waiting for login": "Waiting for login",
   "OAuth Please check your default browser and log in your Twake account.": "Please check your default browser and log in your Twake account.",
   "OAuth You'll be redirected here once it's done.":"You'll be redirected here once it's done.",
+  "OAuth Could not login": "We could not complete the login. Please retry, or check that this staging account is linked to this Twake Workplace.",
   "OAuth If something went wrong, you can retry the login by clicking on the button below.":"If something went wrong, you can retry the login by clicking on the button below.",
   "OAuth Retry":"Retry",
   "OAuth Contact support":"Contact support",

--- a/gui/locales/en.json
+++ b/gui/locales/en.json
@@ -217,7 +217,7 @@
   "OAuth Waiting for login": "Waiting for login",
   "OAuth Please check your default browser and log in your Twake account.": "Please check your default browser and log in your Twake account.",
   "OAuth You'll be redirected here once it's done.":"You'll be redirected here once it's done.",
-  "OAuth Could not login": "We could not complete the login. Please retry, or check that this staging account is linked to this Twake Workplace.",
+  "OAuth Could not login": "We could not complete the login. Please retry, or check that a Twake Workplace is associated with your account.",
   "OAuth If something went wrong, you can retry the login by clicking on the button below.":"If something went wrong, you can retry the login by clicking on the button below.",
   "OAuth Retry":"Retry",
   "OAuth Contact support":"Contact support",

--- a/gui/locales/eo.json
+++ b/gui/locales/eo.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Why do I see this?",
 
+  "OAuth Could not login": "Ni ne povis fini la ensaluton. Bonvolu reprovi aŭ kontroli, ke Twake Workplace estas asociita kun via konto.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/es.json
+++ b/gui/locales/es.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "¿Por qué veo esto?",
 
+  "OAuth Could not login": "No hemos podido completar el inicio de sesión. Vuelva a intentarlo o compruebe que haya una Twake Workplace asociada a su cuenta.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -217,6 +217,7 @@
   "OAuth Waiting for login": "En attente de connexion",
   "OAuth Please check your default browser and log in your Twake account.": "La page de connexion à votre Twake Workplace s'est ouverte dans votre navigateur.",
   "OAuth You'll be redirected here once it's done.":"Vous serez redirigé ici une fois connecté à votre workplace.",
+  "OAuth Could not login": "Nous n'avons pas pu terminer la connexion. Veuillez réessayer ou vérifier que ce compte de staging est rattaché à ce Twake Workplace.",
   "OAuth If something went wrong, you can retry the login by clicking on the button below.":"En cas de problème, vous pouvez retenter de vous connecter en cliquant sur le bouton ci-dessous.",
   "OAuth Retry":"Réessayer",
   "OAuth Contact support":"Contacter le support",

--- a/gui/locales/fr.json
+++ b/gui/locales/fr.json
@@ -217,7 +217,7 @@
   "OAuth Waiting for login": "En attente de connexion",
   "OAuth Please check your default browser and log in your Twake account.": "La page de connexion à votre Twake Workplace s'est ouverte dans votre navigateur.",
   "OAuth You'll be redirected here once it's done.":"Vous serez redirigé ici une fois connecté à votre workplace.",
-  "OAuth Could not login": "Nous n'avons pas pu terminer la connexion. Veuillez réessayer ou vérifier que ce compte de staging est rattaché à ce Twake Workplace.",
+  "OAuth Could not login": "Nous n'avons pas pu terminer la connexion. Veuillez réessayer ou vérifier que ce compte est associé à une Twake Workplace.",
   "OAuth If something went wrong, you can retry the login by clicking on the button below.":"En cas de problème, vous pouvez retenter de vous connecter en cliquant sur le bouton ci-dessous.",
   "OAuth Retry":"Réessayer",
   "OAuth Contact support":"Contacter le support",

--- a/gui/locales/it_IT.json
+++ b/gui/locales/it_IT.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Why do I see this?",
 
+  "OAuth Could not login": "Non siamo riusciti a completare l'accesso. Riprova o verifica che al tuo account sia associato un Twake Workplace.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/ja.json
+++ b/gui/locales/ja.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "なぜこれが表示されていますか?",
 
+  "OAuth Could not login": "ログインを完了できませんでした。もう一度お試しいただくか、アカウントに Twake Workplace が関連付けられていることを確認してください。",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/nl.json
+++ b/gui/locales/nl.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Why do I see this?",
 
+  "OAuth Could not login": "We konden het aanmelden niet voltooien. Probeer het opnieuw of controleer of er een Twake Workplace aan je account is gekoppeld.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/nl_NL.json
+++ b/gui/locales/nl_NL.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Waarom krijg ik dit te zien?",
 
+  "OAuth Could not login": "We konden het aanmelden niet voltooien. Probeer het opnieuw of controleer of er een Twake Workplace aan je account is gekoppeld.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/pl.json
+++ b/gui/locales/pl.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Why do I see this?",
 
+  "OAuth Could not login": "Nie udało się ukończyć logowania. Spróbuj ponownie albo sprawdź, czy z Twoim kontem jest powiązany Twake Workplace.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/sq.json
+++ b/gui/locales/sq.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Why do I see this?",
 
+  "OAuth Could not login": "Nuk mundëm ta përfundojmë hyrjen. Ju lutemi provoni përsëri ose kontrolloni që një Twake Workplace të jetë lidhur me llogarinë tuaj.",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 

--- a/gui/locales/zh_CN.json
+++ b/gui/locales/zh_CN.json
@@ -214,6 +214,8 @@
 
   "MarkdownViewer Why do I see this?": "Why do I see this?",
 
+  "OAuth Could not login": "我们无法完成登录。请重试，或检查您的账号是否已关联 Twake Workplace。",
+
   "Quotation Start": "“",
   "Quotation End": "”",
 


### PR DESCRIPTION
## Summary
- surface OAuth callback and registration failures on the onboarding OAuth page
- stop the onboarding flow from continuing to sync configuration when OAuth registration fails
- add localized copy for the OAuth failure message across the shipped locale files
