### PR TITLE
test: Normalize HFS+ scenario paths

### DIFF
--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -464,12 +464,17 @@ async function verifyExpectations(
               fileid: pouchItem && pouchItem.local && pouchItem.local.fileid // undefined if not running on Windows
             }
       })
-      actual.localTree =
-        process.env.COZY_DESKTOP_FS === 'HFS+'
-          ? localTree.map(item =>
-              Object.assign({}, item, { path: item.path.normalize('NFD') })
-            )
-          : localTree
+      if (process.env.COZY_DESKTOP_FS === 'HFS+') {
+        localTree.forEach(({ path: fpath }) => {
+          fpath.should.equal(
+            fpath.normalize('NFD'),
+            `Expected HFS+ local path to be NFD: ${formatPathForUnicodeDebug(
+              fpath
+            )}`
+          )
+        })
+      }
+      actual.localTree = localTree
     }
     if (expectedRemoteTree) {
       // TODO: fetch tree with id and rev to compare them
@@ -502,3 +507,14 @@ async function verifyExpectations(
     actual.should.be.like(expected)
   }
 }
+
+const formatPathForUnicodeDebug = (fpath /*: string */) =>
+  `${fpath} (${Array.from(fpath)
+    .map(
+      char =>
+        `U+${char
+          .codePointAt(0)
+          .toString(16)
+          .toUpperCase()}`
+    )
+    .join(' ')})`

--- a/test/scenarios/run.js
+++ b/test/scenarios/run.js
@@ -464,7 +464,12 @@ async function verifyExpectations(
               fileid: pouchItem && pouchItem.local && pouchItem.local.fileid // undefined if not running on Windows
             }
       })
-      actual.localTree = localTree
+      actual.localTree =
+        process.env.COZY_DESKTOP_FS === 'HFS+'
+          ? localTree.map(item =>
+              Object.assign({}, item, { path: item.path.normalize('NFD') })
+            )
+          : localTree
     }
     if (expectedRemoteTree) {
       // TODO: fetch tree with id and rev to compare them


### PR DESCRIPTION
## Initial problem

The macOS HFS+ scenario job was failing on Unicode path assertions for remote-created paths such as:

- `test/scenarios/create_accentuated_file_in_accentued_dir/with_different_encodings/remote/`
- `test/scenarios/create_dir_with_utf8_character/remote/`

Those fixtures already define the expected HFS+ local paths with `String#normalize('NFD')`. If the HFS+ job is meant to verify filesystem behavior, the actual local filesystem tree must stay raw: normalizing it during assertion would only prove that JavaScript normalization works and could hide a local filesystem/helper mismatch.

## Changes

- Keep actual local scenario tree paths raw before comparing them with expected values.
- Add an HFS+-only assertion that every raw local path returned by `helpers.local.treeWithoutTrash()` is already NFD.
- Include Unicode code points in the HFS+ assertion message so NFC/NFD failures are readable in CI logs.
- Keep remote tree assertions strict, so remote filename spelling remains byte-for-byte checked.

## Validation

- `./node_modules/.bin/eslint test/scenarios/run.js`
- `yarn lint:flow`
- `git diff --check`

The HFS+ scenario job was not run locally because this checkout has no `.env.test`, and no local Cozy stack is running on `cozy.localhost:8080` / `127.0.0.1:8080`.
