### PR TITLE
fix: Order child deletion before parent move

### DIFF
--- a/core/sync/index.js
+++ b/core/sync/index.js
@@ -170,22 +170,42 @@ const compareChanges = (
       else if (docA.path.startsWith(docB.path + sep)) return B_FIRST
     }
 
-    if (opA.type === 'DEL' && opB.type === 'MOVE' && docB.moveFrom != null) {
-      // Handle parent deletion after child move outside of parent
-      if (
-        docB.moveFrom.path.startsWith(docA.path + sep) &&
-        !docB.path.startsWith(docA.path + sep)
-      ) {
-        return B_FIRST
+    if (opA.type === 'DEL' && opB.type === 'MOVE') {
+      const moveFromB = docB.moveFrom
+      if (moveFromB != null) {
+        // Handle parent deletion after child move outside of parent
+        if (
+          moveFromB.path.startsWith(docA.path + sep) &&
+          !docB.path.startsWith(docA.path + sep)
+        ) {
+          return B_FIRST
+        }
+        // Handle child deletion before parent move
+        if (
+          metadata.isFolder(docB) &&
+          docA.path.startsWith(moveFromB.path + sep)
+        ) {
+          return A_FIRST
+        }
       }
     }
-    if (opB.type === 'DEL' && opA.type === 'MOVE' && docA.moveFrom != null) {
-      // Handle parent deletion after child move outside of parent
-      if (
-        docA.moveFrom.path.startsWith(docB.path + sep) &&
-        !docA.path.startsWith(docB.path + sep)
-      )
-        return A_FIRST
+    if (opB.type === 'DEL' && opA.type === 'MOVE') {
+      const moveFromA = docA.moveFrom
+      if (moveFromA != null) {
+        // Handle parent deletion after child move outside of parent
+        if (
+          moveFromA.path.startsWith(docB.path + sep) &&
+          !docA.path.startsWith(docB.path + sep)
+        )
+          return A_FIRST
+        // Handle child deletion before parent move
+        if (
+          metadata.isFolder(docA) &&
+          docB.path.startsWith(moveFromA.path + sep)
+        ) {
+          return B_FIRST
+        }
+      }
     }
 
     if (opA.type === 'ADD' && opB.type === 'MOVE' && docB.moveFrom != null) {

--- a/test/unit/sync/index.js
+++ b/test/unit/sync/index.js
@@ -14,6 +14,7 @@ const { FetchError } = require('../../../core/remote/cozy')
 const remoteErrors = require('../../../core/remote/errors')
 const { otherSide } = require('../../../core/side')
 const { Sync, compareChanges } = require('../../../core/sync')
+const { DependencyGraph } = require('../../../core/sync/dependency_graph')
 const syncErrors = require('../../../core/sync/errors')
 const Builders = require('../../support/builders')
 const dbBuilders = require('../../support/builders/db')
@@ -1574,6 +1575,57 @@ describe('Sync', function() {
         it('returns 0', () => {
           should(compareChanges(move, del)).eql(0)
           should(compareChanges(del, move)).eql(0)
+        })
+      }
+    )
+
+    context(
+      'with a directory move and a replaced child deletion from the move source',
+      () => {
+        let moveDir, delFile, addFile
+        beforeEach(async function() {
+          const srcDir = await builders
+            .metadir()
+            .path('src')
+            .upToDate()
+            .create()
+          const dstDir = await builders
+            .metadir()
+            .moveFrom(srcDir)
+            .path('dst')
+            .changedSide('local')
+            .create()
+          const oldFile = await builders
+            .metafile()
+            .path('src/file')
+            .trashed()
+            .changedSide('local')
+            .create()
+          const newFile = await builders
+            .metafile()
+            .path('dst/file')
+            .sides({ local: 1 })
+            .create()
+
+          moveDir = makeChange(dstDir, 'MOVE', this)
+          delFile = makeChange(oldFile, 'DEL', this)
+          addFile = makeChange(newFile, 'ADD', this)
+        })
+
+        it('returns -1 if deletion is passed as first argument', () => {
+          should(compareChanges(delFile, moveDir)).eql(-1)
+        })
+
+        it('returns 1 if deletion is passed as second argument', () => {
+          should(compareChanges(moveDir, delFile)).eql(1)
+        })
+
+        it('orders the deletion before the parent move before the replacement addition', () => {
+          const graph = new DependencyGraph([addFile, moveDir, delFile], {
+            compare: compareChanges
+          })
+
+          should(graph.toArray()).deepEqual([delFile, moveDir, addFile])
         })
       }
     )


### PR DESCRIPTION
## Problem

Fixes #2450.

The stopped-client scenario `test/scenarios/move_dir_and_replace_subfile/local/stopped` can create `dst/file-conflict-...` instead of preserving the replaced child at `dst/file`.

The scenario starts with `src/` and `src/file`. While Twake Desktop is stopped, the user moves `src` to `dst`, replaces `dst/file` with a new file, then starts sync. The final state should keep the new child as `dst/file` and trash the old child identity.

## Root cause

The sync dependency graph knew how to order some parent/child moves and additions, but it did not express that a deleted child from a directory move source must be applied before the parent directory move.

Without that dependency, sync could move the old remote child from `src/file` to `dst/file` as part of the parent directory move. The later upload of the new `dst/file` then saw an active file at the same path and was resolved as a conflict.

## Changes

- Add a same-side dependency rule in `compareChanges`: when a child deletion is inside a directory move source path, the deletion must run before the parent move.
- Add unit coverage for both argument orders.
- Add dependency-graph coverage for the full problematic order: `ADD(dst/file), MOVE(src -> dst), DEL(src/file)` is expanded as `DEL(src/file), MOVE(src -> dst), ADD(dst/file)`.

