### PR TITLE
fix: Focus onboarding after SSO login

### DIFF
--- a/gui/js/onboarding.window.js
+++ b/gui/js/onboarding.window.js
@@ -325,6 +325,8 @@ module.exports = class OnboardingWM extends WindowManager {
     const code = deeplink.searchParams.get('code')
     const fqdn = deeplink.searchParams.get('fqdn')
 
+    this.focus()
+
     if (!code || !fqdn) {
       log.error('invalid OAuth callback', { url })
       this.win.webContents.send(

--- a/gui/js/window_manager.js
+++ b/gui/js/window_manager.js
@@ -117,7 +117,11 @@ module.exports = class WindowManager {
   }
 
   focus() {
-    return this.win && this.win.focus()
+    if (!this.win) return
+
+    if (this.win.isMinimized()) this.win.restore()
+
+    return this.win.focus()
   }
 
   reload() {

--- a/test/unit/gui/onboarding.window.js
+++ b/test/unit/gui/onboarding.window.js
@@ -1,0 +1,41 @@
+const sinon = require('sinon')
+
+const autoLaunch = require('../../../gui/js/autolaunch')
+const OnboardingWM = require('../../../gui/js/onboarding.window')
+
+describe('onboarding.window', () => {
+  describe('handleDeepLink', () => {
+    const sandbox = sinon.createSandbox()
+    let onboardingWindow
+
+    beforeEach(() => {
+      onboardingWindow = Object.create(OnboardingWM.prototype)
+      onboardingWindow.focus = sandbox.spy()
+      onboardingWindow.desktop = {
+        registerWithDelegationCode: sandbox.stub().resolves()
+      }
+      onboardingWindow.sendSyncConfig = sandbox.stub().resolves()
+      sandbox.stub(autoLaunch, 'setEnabled')
+    })
+
+    afterEach(() => sandbox.restore())
+
+    it('focuses the window before registering the OAuth credentials', async () => {
+      await onboardingWindow.handleDeepLink(
+        'cozy://?fqdn=example.mycozy.cloud&code=delegation-code'
+      )
+
+      sinon.assert.callOrder(
+        onboardingWindow.focus,
+        onboardingWindow.desktop.registerWithDelegationCode,
+        onboardingWindow.sendSyncConfig
+      )
+      sinon.assert.calledWithExactly(
+        onboardingWindow.desktop.registerWithDelegationCode,
+        'example.mycozy.cloud',
+        'delegation-code'
+      )
+      sinon.assert.calledOnce(onboardingWindow.sendSyncConfig)
+    })
+  })
+})

--- a/test/unit/gui/window_manager.js
+++ b/test/unit/gui/window_manager.js
@@ -1,0 +1,48 @@
+const sinon = require('sinon')
+
+const WindowManager = require('../../../gui/js/window_manager')
+
+describe('window_manager', () => {
+  describe('focus', () => {
+    const sandbox = sinon.createSandbox()
+    let windowManager
+    let win
+
+    beforeEach(() => {
+      win = {
+        isMinimized: sandbox.stub(),
+        restore: sandbox.spy(),
+        focus: sandbox.spy()
+      }
+      windowManager = Object.create(WindowManager.prototype)
+      windowManager.win = win
+    })
+
+    afterEach(() => sandbox.restore())
+
+    it('does nothing when the window is closed', () => {
+      windowManager.win = null
+
+      windowManager.focus()
+    })
+
+    it('focuses an existing window', () => {
+      win.isMinimized.returns(false)
+
+      windowManager.focus()
+
+      sinon.assert.notCalled(win.restore)
+      sinon.assert.calledOnce(win.focus)
+    })
+
+    it('restores a minimized window before focusing it', () => {
+      win.isMinimized.returns(true)
+
+      windowManager.focus()
+
+      sinon.assert.callOrder(win.restore, win.focus)
+      sinon.assert.calledOnce(win.restore)
+      sinon.assert.calledOnce(win.focus)
+    })
+  })
+})

--- a/test/unit/gui/window_manager.js
+++ b/test/unit/gui/window_manager.js
@@ -24,6 +24,10 @@ describe('window_manager', () => {
       windowManager.win = null
 
       windowManager.focus()
+
+      sinon.assert.notCalled(win.isMinimized)
+      sinon.assert.notCalled(win.restore)
+      sinon.assert.notCalled(win.focus)
     })
 
     it('focuses an existing window', () => {


### PR DESCRIPTION
## Summary

- focus the onboarding window as soon as the SSO OAuth callback returns
- restore the window first when it is minimized
- add regression coverage for focus behavior and OAuth callback ordering

## Root cause

Desktop handled the `cozy://` callback and continued onboarding, but it did not bring the onboarding window back to the foreground after login in the user's browser.



Closes #2451
