### PR TITLE
ci: Propagate yarn dist failure to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,9 @@ build_script:
             ($env:FORCE_CODE_SIGNING -eq "true") -or (($env:APPVEYOR_REPO_BRANCH -eq "master" ) -and ($env:APPVEYOR_REPO_TAG -eq 'true'))
           )
           yarn dist
+          # Propagate yarn's exit code: AppVeyor only fails a pwsh step on an
+          # uncaught exception, not on a non-zero native command exit code.
+          exit $LASTEXITCODE
       }
 
 artifacts:


### PR DESCRIPTION
  AppVeyor only fails a `pwsh` step on an uncaught exception; a
  non-zero exit code from a native command like `yarn dist` leaves the
  build green, as happened when the NSIS installer compilation broke.
  Exit explicitly with `$LASTEXITCODE` so packaging errors mark the
  `build` job as failed.

Please make sure the following boxes are checked:

- [ ] PR is not too big
- [ ] it improves UX & DX in some way
- [ ] it includes unit tests matching the implementation changes
- [ ] it includes scenarios matching a new behaviour or has been manually tested
- [ ] it includes relevant documentation
